### PR TITLE
improvement: create a snippet resolver that caches the api definition…

### DIFF
--- a/packages/template-resolver/src/ResolutionUtilities.ts
+++ b/packages/template-resolver/src/ResolutionUtilities.ts
@@ -1,7 +1,10 @@
 import { APIV1Read, FdrClient } from "@fern-api/fdr-sdk";
 
-export async function getApiDefinition(apiDefinitionId: string): Promise<APIV1Read.ApiDefinition | undefined> {
-    const fdr = new FdrClient();
+export async function getApiDefinition(
+    apiDefinitionId: string,
+    environment: string | undefined,
+): Promise<APIV1Read.ApiDefinition | undefined> {
+    const fdr = new FdrClient({ environment });
     const apiDefinitionResponse = await fdr.api.v1.read.getApi(apiDefinitionId);
     if (apiDefinitionResponse.ok) {
         return apiDefinitionResponse.body;

--- a/packages/template-resolver/src/ResolutionUtilities.ts
+++ b/packages/template-resolver/src/ResolutionUtilities.ts
@@ -1,4 +1,13 @@
-import { APIV1Read } from "@fern-api/fdr-sdk";
+import { APIV1Read, FdrClient } from "@fern-api/fdr-sdk";
+
+export async function getApiDefinition(apiDefinitionId: string): Promise<APIV1Read.ApiDefinition | undefined> {
+    const fdr = new FdrClient();
+    const apiDefinitionResponse = await fdr.api.v1.read.getApi(apiDefinitionId);
+    if (apiDefinitionResponse.ok) {
+        return apiDefinitionResponse.body;
+    }
+    return;
+}
 
 export class ObjectFlattener {
     private flattenedObjects: Map<APIV1Read.TypeId, APIV1Read.ObjectProperty[]> = new Map<

--- a/packages/template-resolver/src/SnippetTemplateResolutionHolder.ts
+++ b/packages/template-resolver/src/SnippetTemplateResolutionHolder.ts
@@ -14,8 +14,8 @@ export class SnippetTemplateResolutionHolder {
         maybeApiDefinition,
         maybeApiDefinitionId,
     }: {
-        maybeApiDefinition: APIV1Read.ApiDefinition | undefined;
-        maybeApiDefinitionId: string | undefined;
+        maybeApiDefinition?: APIV1Read.ApiDefinition;
+        maybeApiDefinitionId?: string;
     }) {
         this.maybeApiDefinition = maybeApiDefinition;
         this.maybeApiDefinitionId = maybeApiDefinitionId;

--- a/packages/template-resolver/src/SnippetTemplateResolutionHolder.ts
+++ b/packages/template-resolver/src/SnippetTemplateResolutionHolder.ts
@@ -8,15 +8,21 @@ export class SnippetTemplateResolutionHolder {
     private maybeObjectFlattener: ObjectFlattener | undefined;
     private maybeApiDefinitionId: string | undefined;
 
+    private fdrEnvironmentUrl: string | undefined;
+
     private apiDefinitionHasBeenRequested: boolean;
 
-    constructor({
-        maybeApiDefinition,
-        maybeApiDefinitionId,
-    }: {
-        maybeApiDefinition?: APIV1Read.ApiDefinition;
-        maybeApiDefinitionId?: string;
-    }) {
+    constructor(
+        {
+            maybeApiDefinition,
+            maybeApiDefinitionId,
+        }: {
+            maybeApiDefinition?: APIV1Read.ApiDefinition;
+            maybeApiDefinitionId?: string;
+        },
+        environment?: string,
+    ) {
+        this.fdrEnvironmentUrl = environment;
         this.maybeApiDefinition = maybeApiDefinition;
         this.maybeApiDefinitionId = maybeApiDefinitionId;
 
@@ -37,7 +43,7 @@ export class SnippetTemplateResolutionHolder {
         // If we were not provided an API definition, try to get it from FDR
         if (this.maybeApiDefinitionId != null && !this.apiDefinitionHasBeenRequested) {
             this.apiDefinitionHasBeenRequested = true;
-            this.maybeApiDefinition = await getApiDefinition(this.maybeApiDefinitionId);
+            this.maybeApiDefinition = await getApiDefinition(this.maybeApiDefinitionId, this.fdrEnvironmentUrl);
             return this.maybeApiDefinition;
         }
 

--- a/packages/template-resolver/src/SnippetTemplateResolutionHolder.ts
+++ b/packages/template-resolver/src/SnippetTemplateResolutionHolder.ts
@@ -1,0 +1,101 @@
+import { APIV1Read } from "@fern-api/fdr-sdk";
+import { ObjectFlattener, getApiDefinition } from "./ResolutionUtilities";
+import { SnippetTemplateResolver } from "./SnippetTemplateResolver";
+import { CustomSnippetPayload, EndpointSnippetTemplate, Snippet } from "./generated/api";
+
+export class SnippetTemplateResolutionHolder {
+    private maybeApiDefinition: APIV1Read.ApiDefinition | undefined;
+    private maybeObjectFlattener: ObjectFlattener | undefined;
+    private maybeApiDefinitionId: string | undefined;
+
+    private apiDefinitionHasBeenRequested: boolean;
+
+    constructor({
+        maybeApiDefinition,
+        maybeApiDefinitionId,
+    }: {
+        maybeApiDefinition: APIV1Read.ApiDefinition | undefined;
+        maybeApiDefinitionId: string | undefined;
+    }) {
+        this.maybeApiDefinition = maybeApiDefinition;
+        this.maybeApiDefinitionId = maybeApiDefinitionId;
+
+        if (maybeApiDefinition == null && maybeApiDefinitionId == null) {
+            throw new Error(
+                "Either an API definition or an API definition ID must be provided, if you have neither use the SnippetTemplateResolver directly.",
+            );
+        }
+        this.apiDefinitionHasBeenRequested = false;
+    }
+
+    // Get or create and cache ApiDefinition
+    private async getApiDefinition(): Promise<APIV1Read.ApiDefinition | undefined> {
+        if (this.maybeApiDefinition != null) {
+            return this.maybeApiDefinition;
+        }
+
+        // If we were not provided an API definition, try to get it from FDR
+        if (this.maybeApiDefinitionId != null && !this.apiDefinitionHasBeenRequested) {
+            this.apiDefinitionHasBeenRequested = true;
+            this.maybeApiDefinition = await getApiDefinition(this.maybeApiDefinitionId);
+            return this.maybeApiDefinition;
+        }
+
+        return;
+    }
+
+    // Get or create and cache ObjectFlattener
+    private getObjectFlattener(apiDefinition: APIV1Read.ApiDefinition): ObjectFlattener {
+        if (this.maybeObjectFlattener != null) {
+            return this.maybeObjectFlattener;
+        }
+
+        this.maybeObjectFlattener = new ObjectFlattener(apiDefinition);
+        return this.maybeObjectFlattener;
+    }
+
+    public async getTemplateResolver({
+        payload,
+        endpointSnippetTemplate,
+    }: {
+        payload: CustomSnippetPayload;
+        endpointSnippetTemplate: EndpointSnippetTemplate;
+    }): Promise<SnippetTemplateResolver> {
+        const apiDefinition = await this.getApiDefinition();
+        if (apiDefinition == null) {
+            throw new Error("Failed to get API definition");
+        }
+        const objectFlattener = this.getObjectFlattener(apiDefinition);
+
+        return new SnippetTemplateResolver({
+            apiDefinition,
+            objectFlattener,
+            payload,
+            endpointSnippetTemplate,
+        });
+    }
+
+    public async resolveWithFormatting({
+        payload,
+        endpointSnippetTemplate,
+    }: {
+        payload: CustomSnippetPayload;
+        endpointSnippetTemplate: EndpointSnippetTemplate;
+    }): Promise<Snippet> {
+        const resolver = await this.getTemplateResolver({ payload, endpointSnippetTemplate });
+
+        return resolver.resolveWithFormatting();
+    }
+
+    public async resolve({
+        payload,
+        endpointSnippetTemplate,
+    }: {
+        payload: CustomSnippetPayload;
+        endpointSnippetTemplate: EndpointSnippetTemplate;
+    }): Promise<Snippet> {
+        const resolver = await this.getTemplateResolver({ payload, endpointSnippetTemplate });
+
+        return resolver.resolve();
+    }
+}

--- a/packages/template-resolver/src/SnippetTemplateResolver.ts
+++ b/packages/template-resolver/src/SnippetTemplateResolver.ts
@@ -157,7 +157,7 @@ export class SnippetTemplateResolver {
         // If we were not provided an API definition, try to get it from FDR
         if (this.maybeApiDefinitionId != null && !this.apiDefinitionHasBeenRequested) {
             this.apiDefinitionHasBeenRequested = true;
-            this.maybeApiDefinition = await getApiDefinition(this.maybeApiDefinitionId);
+            this.maybeApiDefinition = await getApiDefinition(this.maybeApiDefinitionId, undefined);
             return this.maybeApiDefinition;
         }
 

--- a/packages/ui/app/src/api-playground/utils.ts
+++ b/packages/ui/app/src/api-playground/utils.ts
@@ -2,6 +2,7 @@ import { APIV1Read, Snippets } from "@fern-api/fdr-sdk";
 import { SnippetTemplateResolver } from "@fern-api/template-resolver";
 import { isNonNullish, isPlainObject, visitDiscriminatedUnion } from "@fern-ui/core-utils";
 import { isEmpty, mapValues } from "lodash-es";
+import { useEffect, useState } from "react";
 import { stringifyHttpRequestExampleToCurl } from "../api-page/examples/stringifyHttpRequestExampleToCurl";
 import {
     ResolvedEndpointDefinition,
@@ -127,6 +128,7 @@ export function stringifyFetch({
     }
 
     const snippetTemplate = endpoint.snippetTemplates?.typescript;
+    const [resolvedTemplateSnippet, setResolvedTemplateSnippet] = useState<Snippets.Snippet | null>(null);
 
     if (snippetTemplate != null && isSnippetTemplatesEnabled) {
         const resolver = new SnippetTemplateResolver({
@@ -144,10 +146,22 @@ export function stringifyFetch({
                 snippetTemplate,
             },
         });
-        const resolvedTemplate = resolver.resolve();
 
-        if (resolvedTemplate.type === "typescript") {
-            return resolvedTemplate.client;
+        // TODO: We should expose a .unresolve() method or similar on
+        // the resolved APIDefinition, so we can just pass that to
+        // .resolveWithFormatting() instead of having the resolver make a DB call
+        useEffect(() => {
+            const resolveTemplate = async () => {
+                const resolvedTemplate = await resolver.resolveWithFormatting();
+
+                setResolvedTemplateSnippet(resolvedTemplate);
+            };
+
+            resolveTemplate();
+        }, []);
+
+        if (resolvedTemplateSnippet && resolvedTemplateSnippet.type === "typescript") {
+            return resolvedTemplateSnippet.client;
         }
     }
 
@@ -251,6 +265,7 @@ export function stringifyPythonRequests({
     }
 
     const snippetTemplate = endpoint.snippetTemplates?.python;
+    const [resolvedTemplateSnippet, setResolvedTemplateSnippet] = useState<Snippets.Snippet | null>(null);
 
     if (snippetTemplate != null && isSnippetTemplatesEnabled) {
         const resolver = new SnippetTemplateResolver({
@@ -269,10 +284,21 @@ export function stringifyPythonRequests({
             },
         });
 
-        const resolvedTemplate = resolver.resolve();
+        // TODO: We should expose a .unresolve() method or similar on
+        // the resolved APIDefinition, so we can just pass that to
+        // .resolveWithFormatting() instead of having the resolver make a DB call
+        useEffect(() => {
+            const resolveTemplate = async () => {
+                const resolvedTemplate = await resolver.resolveWithFormatting();
 
-        if (resolvedTemplate.type === "python") {
-            return resolvedTemplate.sync_client;
+                setResolvedTemplateSnippet(resolvedTemplate);
+            };
+
+            resolveTemplate();
+        }, []);
+
+        if (resolvedTemplateSnippet && resolvedTemplateSnippet.type === "python") {
+            return resolvedTemplateSnippet.sync_client;
         }
     }
 

--- a/packages/ui/app/src/api-playground/utils.ts
+++ b/packages/ui/app/src/api-playground/utils.ts
@@ -2,7 +2,6 @@ import { APIV1Read, Snippets } from "@fern-api/fdr-sdk";
 import { SnippetTemplateResolver } from "@fern-api/template-resolver";
 import { isNonNullish, isPlainObject, visitDiscriminatedUnion } from "@fern-ui/core-utils";
 import { isEmpty, mapValues } from "lodash-es";
-import { useEffect, useState } from "react";
 import { stringifyHttpRequestExampleToCurl } from "../api-page/examples/stringifyHttpRequestExampleToCurl";
 import {
     ResolvedEndpointDefinition,
@@ -128,7 +127,6 @@ export function stringifyFetch({
     }
 
     const snippetTemplate = endpoint.snippetTemplates?.typescript;
-    const [resolvedTemplateSnippet, setResolvedTemplateSnippet] = useState<Snippets.Snippet | null>(null);
 
     if (snippetTemplate != null && isSnippetTemplatesEnabled) {
         const resolver = new SnippetTemplateResolver({
@@ -146,22 +144,10 @@ export function stringifyFetch({
                 snippetTemplate,
             },
         });
+        const resolvedTemplate = resolver.resolve();
 
-        // TODO: We should expose a .unresolve() method or similar on
-        // the resolved APIDefinition, so we can just pass that to
-        // .resolveWithFormatting() instead of having the resolver make a DB call
-        useEffect(() => {
-            const resolveTemplate = async () => {
-                const resolvedTemplate = await resolver.resolveWithFormatting();
-
-                setResolvedTemplateSnippet(resolvedTemplate);
-            };
-
-            resolveTemplate();
-        }, []);
-
-        if (resolvedTemplateSnippet && resolvedTemplateSnippet.type === "typescript") {
-            return resolvedTemplateSnippet.client;
+        if (resolvedTemplate.type === "typescript") {
+            return resolvedTemplate.client;
         }
     }
 
@@ -265,7 +251,6 @@ export function stringifyPythonRequests({
     }
 
     const snippetTemplate = endpoint.snippetTemplates?.python;
-    const [resolvedTemplateSnippet, setResolvedTemplateSnippet] = useState<Snippets.Snippet | null>(null);
 
     if (snippetTemplate != null && isSnippetTemplatesEnabled) {
         const resolver = new SnippetTemplateResolver({
@@ -284,21 +269,10 @@ export function stringifyPythonRequests({
             },
         });
 
-        // TODO: We should expose a .unresolve() method or similar on
-        // the resolved APIDefinition, so we can just pass that to
-        // .resolveWithFormatting() instead of having the resolver make a DB call
-        useEffect(() => {
-            const resolveTemplate = async () => {
-                const resolvedTemplate = await resolver.resolveWithFormatting();
+        const resolvedTemplate = resolver.resolve();
 
-                setResolvedTemplateSnippet(resolvedTemplate);
-            };
-
-            resolveTemplate();
-        }, []);
-
-        if (resolvedTemplateSnippet && resolvedTemplateSnippet.type === "python") {
-            return resolvedTemplateSnippet.sync_client;
+        if (resolvedTemplate.type === "python") {
+            return resolvedTemplate.sync_client;
         }
     }
 

--- a/servers/fdr/src/controllers/snippets/getSnippetsService.ts
+++ b/servers/fdr/src/controllers/snippets/getSnippetsService.ts
@@ -83,7 +83,7 @@ export function getSnippetsService(app: FdrApplication): SnippetsService {
                             endpointSnippetTemplate,
                         });
 
-                        snippets.push(await templateResolver.resolve());
+                        snippets.push(templateResolver.resolve());
                     }
 
                     return res.send(snippets);


### PR DESCRIPTION
… across

## Short description of the changes made
This PR introduces a definition holder wrapping the snippet template resolver, allowing us to only request the api definition once per-api definition ID

Essentially just:
- construct `SnippetTemplateResolutionHolder` with a definition or definition ID
- call `resolve` as you would have instantiated a `SnippetTemplateResolver` before

ex: 
```
const holder = new SnippetTemplateResolutionHolder({ maybeApiDefinitionId: 1 });
const snippet = await holder.resolve({ payload, endpointSnippetTemplate });

// If you still want the template resolver object, you can get that as well

const resolver = await holder.getTemplateResolver({ payload, endpointSnippetTemplate });
```

## What was the motivation & context behind this PR?
Limit calls to FDR for getting the API definition, necessary to resolve Union templates