### PR TITLE
Updated Callout to take in 2 CTA buttons

### DIFF
--- a/packages/ui/app/src/mdx/components/callout/Callout.tsx
+++ b/packages/ui/app/src/mdx/components/callout/Callout.tsx
@@ -12,6 +12,7 @@ import {
 } from "@radix-ui/react-icons";
 import cn from "clsx";
 import { FC, PropsWithChildren, ReactElement, isValidElement } from "react";
+import { Button } from "../button/Button";
 
 type Intent = "info" | "warning" | "success" | "error" | "note" | "launch" | "tip" | "check";
 
@@ -20,6 +21,10 @@ export declare namespace Callout {
         intent: string;
         title?: string;
         icon?: unknown;
+        primaryCTAHref?: string;
+        primaryCTALabel?: string;
+        secondaryCTAHref?: string;
+        secondaryCTALabel?: string;
     }
 }
 
@@ -31,7 +36,16 @@ function parseIntent(unknownIntent: unknown): Intent {
     return unknownIntent.trim().toLowerCase() as Intent;
 }
 
-export const Callout: FC<PropsWithChildren<Callout.Props>> = ({ intent: intentRaw, title, children, icon }) => {
+export const Callout: FC<PropsWithChildren<Callout.Props>> = ({
+    intent: intentRaw,
+    title,
+    children,
+    icon,
+    primaryCTAHref,
+    primaryCTALabel,
+    secondaryCTAHref,
+    secondaryCTALabel,
+}) => {
     const intent = parseIntent(intentRaw);
     return (
         <div
@@ -80,7 +94,6 @@ export const Callout: FC<PropsWithChildren<Callout.Props>> = ({ intent: intentRa
                         })
                     )}
                 </div>
-
                 <div
                     className={cn(
                         "flex-1 prose-sm prose dark:prose-invert overflow-x-auto -my-4 after:block after:mt-4 before:block before:mb-4", // ::after margin ensures that bottom padding overlaps with botttom margins of internal content
@@ -103,6 +116,16 @@ export const Callout: FC<PropsWithChildren<Callout.Props>> = ({ intent: intentRa
                         {children}
                     </div>
                 </div>
+                <div>
+                    {primaryCTAHref && primaryCTALabel ? (
+                        <Button text={primaryCTALabel} href={primaryCTAHref}></Button>
+                    ) : null}
+                </div>
+                <div>
+                    {secondaryCTAHref && secondaryCTALabel ? (
+                        <Button text={secondaryCTALabel} href={secondaryCTAHref}></Button>
+                    ) : null}
+                </div>
             </div>
         </div>
     );
@@ -110,65 +133,177 @@ export const Callout: FC<PropsWithChildren<Callout.Props>> = ({ intent: intentRa
 
 // aliases
 
-export function InfoCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function InfoCallout({
+    children,
+    title,
+    primaryCTAHref,
+    primaryCTALabel,
+    secondaryCTAHref,
+    secondaryCTALabel,
+}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="info" title={title}>
+        <Callout
+            intent="info"
+            title={title}
+            primaryCTAHref={primaryCTAHref}
+            secondaryCTAHref={secondaryCTAHref}
+            primaryCTALabel={primaryCTALabel}
+            secondaryCTALabel={secondaryCTALabel}
+        >
             {children}
         </Callout>
     );
 }
 
-export function WarningCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function WarningCallout({
+    children,
+    title,
+    primaryCTAHref,
+    primaryCTALabel,
+    secondaryCTAHref,
+    secondaryCTALabel,
+}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="warning" title={title}>
+        <Callout
+            intent="warning"
+            title={title}
+            primaryCTAHref={primaryCTAHref}
+            secondaryCTAHref={secondaryCTAHref}
+            primaryCTALabel={primaryCTALabel}
+            secondaryCTALabel={secondaryCTALabel}
+        >
             {children}
         </Callout>
     );
 }
 
-export function SuccessCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function SuccessCallout({
+    children,
+    title,
+    primaryCTAHref,
+    primaryCTALabel,
+    secondaryCTAHref,
+    secondaryCTALabel,
+}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="success" title={title}>
+        <Callout
+            intent="success"
+            title={title}
+            primaryCTAHref={primaryCTAHref}
+            secondaryCTAHref={secondaryCTAHref}
+            primaryCTALabel={primaryCTALabel}
+            secondaryCTALabel={secondaryCTALabel}
+        >
             {children}
         </Callout>
     );
 }
 
-export function ErrorCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function ErrorCallout({
+    children,
+    title,
+    primaryCTAHref,
+    primaryCTALabel,
+    secondaryCTAHref,
+    secondaryCTALabel,
+}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="error" title={title}>
+        <Callout
+            intent="error"
+            title={title}
+            primaryCTAHref={primaryCTAHref}
+            secondaryCTAHref={secondaryCTAHref}
+            primaryCTALabel={primaryCTALabel}
+            secondaryCTALabel={secondaryCTALabel}
+        >
             {children}
         </Callout>
     );
 }
 
-export function NoteCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function NoteCallout({
+    children,
+    title,
+    primaryCTAHref,
+    primaryCTALabel,
+    secondaryCTAHref,
+    secondaryCTALabel,
+}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="note" title={title}>
+        <Callout
+            intent="note"
+            title={title}
+            primaryCTAHref={primaryCTAHref}
+            secondaryCTAHref={secondaryCTAHref}
+            primaryCTALabel={primaryCTALabel}
+            secondaryCTALabel={secondaryCTALabel}
+        >
             {children}
         </Callout>
     );
 }
 
-export function LaunchNoteCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function LaunchNoteCallout({
+    children,
+    title,
+    primaryCTAHref,
+    primaryCTALabel,
+    secondaryCTAHref,
+    secondaryCTALabel,
+}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="launch" title={title}>
+        <Callout
+            intent="launch"
+            title={title}
+            primaryCTAHref={primaryCTAHref}
+            secondaryCTAHref={secondaryCTAHref}
+            primaryCTALabel={primaryCTALabel}
+            secondaryCTALabel={secondaryCTALabel}
+        >
             {children}
         </Callout>
     );
 }
 
-export function TipCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function TipCallout({
+    children,
+    title,
+    primaryCTAHref,
+    primaryCTALabel,
+    secondaryCTAHref,
+    secondaryCTALabel,
+}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="tip" title={title}>
+        <Callout
+            intent="tip"
+            title={title}
+            primaryCTAHref={primaryCTAHref}
+            secondaryCTAHref={secondaryCTAHref}
+            primaryCTALabel={primaryCTALabel}
+            secondaryCTALabel={secondaryCTALabel}
+        >
             {children}
         </Callout>
     );
 }
 
-export function CheckCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function CheckCallout({
+    children,
+    title,
+    primaryCTAHref,
+    primaryCTALabel,
+    secondaryCTAHref,
+    secondaryCTALabel,
+}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="check" title={title}>
+        <Callout
+            intent="check"
+            title={title}
+            primaryCTAHref={primaryCTAHref}
+            secondaryCTAHref={secondaryCTAHref}
+            primaryCTALabel={primaryCTALabel}
+            secondaryCTALabel={secondaryCTALabel}
+        >
             {children}
         </Callout>
     );


### PR DESCRIPTION
Fixes FER-2440
https://linear.app/buildwithfern/issue/FER-2440/[cohere-humanloop]-mdx-frontmatter-should-accept-jupyter-notebook-url

## Short description of the changes made
Added 4 extra props to allow clients to create 2 CTA buttons on the right side of the callout. 

## What was the motivation & context behind this PR?
Cohere needed something on the top of a landing page. 
Similar to here: https://langfuse.com/docs/integrations/instructor

## How has this PR been tested?

![Remove this, otherwise it will alert all that this template has not been filled out](https://media.giphy.com/media/YO7P8VC7nlQlO/giphy.gif)
