### PR TITLE
feat(ci): Add postman generator workflow

### DIFF
--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -1,0 +1,27 @@
+name: Publish FDR Postman Collection
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  publish_fiddle_sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: 📥 Install
+        uses: ./.github/actions/install
+
+      - name: Install Fern
+        run: npm install -g fern-api
+
+      - name: Publish Fiddle FDR SDK
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
+        run: |
+          fern generate --api fdr --group postman --log-level debug

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish_fiddle_sdk:
+  publish_postman_collection:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/fern/apis/fdr/generators.yml
+++ b/fern/apis/fdr/generators.yml
@@ -27,10 +27,20 @@ groups:
           extraDevDependencies:
             "@types/mime": "3.0.4"
 
-  navigation: 
-    audiences: 
+  postman:
+    generators:
+      - name: fernapi/fern-postman
+        version: 0.3.2
+        output:
+          location: postman
+          api-key: ${POSTMAN_API_KEY}
+          workspace-id: 5579b37c-ab1f-4660-90d1-0409e81d57bc
+          collection-id: 30404764-47b97d6f-d2af-439c-bcff-5b75e6c0e5b6
+
+  navigation:
+    audiences:
       - navigation
-    generators:               
+    generators:
       - name: fernapi/fern-typescript-node-sdk
         version: 0.20.9
         output:
@@ -42,7 +52,7 @@ groups:
           outputSourceFiles: true
           useBrandedStringAliases: true
           noSerdeLayer: true
-          neverThrowErrors: true            
+          neverThrowErrors: true
 
   fdr-cjs-sdk:
     generators:

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "fern",
-  "version": "0.40.0"
+  "version": "0.40.4"
 }


### PR DESCRIPTION
This adds a simple workflow for creating a Postman collection using the `fern-api/postman` generator. With this, we can update the FDR postman collection manually using the `workflow_dispatch`, and it can be wired up via automation with the `workflow_call` later (if ever).