### PR TITLE
fix(wss): shorten transition time

### DIFF
--- a/packages/ui/app/src/api-reference/web-socket/WebSocketMessages.scss
+++ b/packages/ui/app/src/api-reference/web-socket/WebSocketMessages.scss
@@ -1,6 +1,6 @@
 @layer components {
     .fern-web-socket-trigger {
-        @apply w-full flex items-center gap-2 px-3 py-2 hover:data-[state=closed]:bg-tag-default cursor-default data-[state=closed]:rounded-[inherit] transition-[background,border-radius] duration-300 ease-[cubic-bezier(0.87,_0,_0.13,_1)];
+        @apply w-full flex items-center gap-2 px-3 py-2 hover:data-[state=closed]:bg-tag-default cursor-default data-[state=closed]:rounded-[inherit] transition-[background,border-radius] duration-75 ease-[cubic-bezier(0.87,_0,_0.13,_1)];
         @apply sticky top-0 z-10 backdrop-blur;
 
         .fern-web-socket-client,


### PR DESCRIPTION
This PR fixes the WebSocket response transition to be more responsive to scrolling. This was reported by Cartesia and fixed using custom CSS. This PR enables that fix globally. 

To see the slow transition, [check out Hume's Chat WebSocket endpoint](https://dev.hume.ai/reference/empathic-voice-interface-evi/chat/chat).

This PR has been tested locally:
 
https://github.com/user-attachments/assets/7b0a8a32-12b7-4baa-b211-d3cb72e8f1db

