### PR TITLE
fix: type shorthand improvements

### DIFF
--- a/packages/ui/app/src/api-reference/types/type-shorthand/TypeShorthand.tsx
+++ b/packages/ui/app/src/api-reference/types/type-shorthand/TypeShorthand.tsx
@@ -151,7 +151,7 @@ export function renderTypeShorthand(
         literal: (literal) =>
             visitDiscriminatedUnion(literal.value, "type")._visit({
                 stringLiteral: ({ value }) => `"${value}"`,
-                booleanLiteral: ({ value }) => `"${value.toString()}"`,
+                booleanLiteral: ({ value }) => value.toString(),
                 _other: () => "<unknown>",
             }),
         // other

--- a/packages/ui/app/src/api-reference/types/type-shorthand/TypeShorthand.tsx
+++ b/packages/ui/app/src/api-reference/types/type-shorthand/TypeShorthand.tsx
@@ -123,20 +123,15 @@ export function renderTypeShorthand(
         // referenced shapes
         object: () => (plural ? "objects" : maybeWithArticle("an", "object")),
         undiscriminatedUnion: (union) => {
-            if (union.variants.length > 0 && union.variants.length < 3) {
-                return uniq(
-                    union.variants.map((variant) => renderTypeShorthand(variant.shape, { plural, withArticle }, types)),
-                ).join(" or ");
-            }
-
-            return plural ? "objects" : maybeWithArticle("an", "object");
+            return uniq(
+                union.variants.map((variant) => renderTypeShorthand(variant.shape, { plural, withArticle }, types)),
+            ).join(" or ");
         },
         discriminatedUnion: () => (plural ? "objects" : maybeWithArticle("an", "object")),
         enum: (enumValue) => {
+            // if there are only 1 or 2 values, we can list them like literals (e.g. "apple" or "banana")
             if (enumValue.values.length > 0 && enumValue.values.length < 3) {
-                return uniq(enumValue.values.map((value) => value.value))
-                    .map((value) => `"${value}"`)
-                    .join(" or ");
+                return enumValue.values.map((value) => `"${value.value}"`).join(" or ");
             }
             return plural ? "enums" : maybeWithArticle("an", "enum");
         },


### PR DESCRIPTION
- remove quotes around boolean literals
- change "union" to "object" for discriminated unions, since the union is implied by the variants
- change "union" to `string or number or object` for undiscriminated unions
- for enums, if there are only one or two options, treat them like literals