### PR TITLE
fix(fern-bot): update branch naming to not use colons for updates

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  postcss: 8.4.31
-  esbuild: 0.20.2
-
 importers:
 
   .:
@@ -2568,6 +2564,12 @@ importers:
       vitest:
         specifier: ^1.5.0
         version: 1.6.0(@types/node@18.19.33)(jsdom@24.0.0)(less@4.2.0)(sass@1.77.0)(stylus@0.62.0)(terser@5.31.0)
+
+  servers/fern-bot/.esbuild/.build:
+    dependencies:
+      fern-api:
+        specifier: ^0.21.0
+        version: 0.21.0
 
 packages:
 

--- a/servers/fern-bot/src/functions/generator-updates/shared/updateGeneratorInternal.ts
+++ b/servers/fern-bot/src/functions/generator-updates/shared/updateGeneratorInternal.ts
@@ -230,7 +230,7 @@ export async function updateVersionInternal(
                 const branchName = "fern/update/";
                 let additionalName = groupName;
                 if (apiName !== NO_API_FALLBACK_KEY) {
-                    additionalName = `${apiName}:${groupName}`;
+                    additionalName = `${apiName}/${groupName}`;
                 }
                 additionalName = `${generatorName.replace("fernapi/", "")}@${additionalName}`;
 


### PR DESCRIPTION
Our update branch names used to include a `:` when updating a multi-api spec, but this isn't valid for git so updating the branches to not include that

Was: `fern/update/fern-typescript-express@fdr:local`
Now: `fern/update/fern-typescript-express@fdr/local`