### PR TITLE
fix: stream-nonstream toggle appears on paginated docs

### DIFF
--- a/packages/ui/app/src/api-reference/endpoints/EndpointContent.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointContent.tsx
@@ -24,6 +24,7 @@ import { CodeExample, generateCodeExamples } from "../examples/code-example";
 import { useApiPageCenterElement } from "../useApiPageCenterElement";
 import { EndpointContentHeader } from "./EndpointContentHeader";
 import { EndpointContentLeft, convertNameToAnchorPart } from "./EndpointContentLeft";
+import { EndpointStreamingEnabledToggle } from "./EndpointStreamingEnabledToggle";
 
 const EndpointContentCodeSnippets = dynamic(
     () => import("./EndpointContentCodeSnippets").then((mod) => mod.EndpointContentCodeSnippets),
@@ -251,7 +252,14 @@ export const EndpointContent = memo<EndpointContent.Props>((props) => {
                     "border-default border-b mb-px pb-12": !hideBottomSeparator,
                 })}
             >
-                <EndpointContentHeader endpoint={endpointProp} container={ref} />
+                <EndpointContentHeader
+                    endpoint={endpoint}
+                    streamToggle={
+                        endpointProp.stream != null && (
+                            <EndpointStreamingEnabledToggle endpoint={endpointProp} container={ref} />
+                        )
+                    }
+                />
                 <div className="md:grid md:grid-cols-2 md:gap-8 lg:gap-12">
                     <div
                         className="flex min-w-0 max-w-content-width flex-1 flex-col pt-8 md:py-8"

--- a/packages/ui/app/src/api-reference/endpoints/EndpointContentHeader.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointContentHeader.tsx
@@ -1,27 +1,23 @@
-import { memo } from "react";
+import { memo, type ReactNode } from "react";
 import { useSelectedEnvironmentId } from "../../atoms/environment";
 import { FernBreadcrumbs } from "../../components/FernBreadcrumbs";
 import { ResolvedEndpointDefinition, resolveEnvironment } from "../../resolver/types";
 import { EndpointAvailabilityTag } from "./EndpointAvailabilityTag";
-import { EndpointStreamingEnabledToggle } from "./EndpointStreamingEnabledToggle";
 import { EndpointUrlWithOverflow } from "./EndpointUrlWithOverflow";
 
 interface EndpointContentHeaderProps {
     endpoint: ResolvedEndpointDefinition;
-    container: React.MutableRefObject<HTMLElement | null>;
+    streamToggle?: ReactNode;
 }
 
-export const EndpointContentHeader = memo<EndpointContentHeaderProps>(({ endpoint, container }) => {
+export const EndpointContentHeader = memo<EndpointContentHeaderProps>(({ endpoint, streamToggle }) => {
     const selectedEnvironmentId = useSelectedEnvironmentId();
     return (
         <header className="space-y-1 pb-2 pt-8">
             <FernBreadcrumbs breadcrumbs={endpoint.breadcrumbs} />
             <div className="flex items-center justify-between">
                 <span>
-                    <h1 className="fern-page-heading">
-                        {/* <AnimatedTitle>{endpoint.title}</AnimatedTitle> */}
-                        {endpoint.title}
-                    </h1>
+                    <h1 className="fern-page-heading">{endpoint.title}</h1>
                     {endpoint.availability != null && (
                         <span className="inline-block ml-2 align-text-bottom">
                             <EndpointAvailabilityTag availability={endpoint.availability} minimal={true} />
@@ -29,9 +25,7 @@ export const EndpointContentHeader = memo<EndpointContentHeaderProps>(({ endpoin
                     )}
                 </span>
 
-                {endpoint.stream != null && (
-                    <EndpointStreamingEnabledToggle endpoint={endpoint} container={container} />
-                )}
+                {streamToggle}
             </div>
             <EndpointUrlWithOverflow
                 path={endpoint.path}


### PR DESCRIPTION
Fixes bug introduced from https://github.com/fern-api/fern-platform/pull/1379 where the stream and nonstream toggle disappeared on paginated api references