### PR TITLE
fix: initialize atoms at the root level

### DIFF
--- a/packages/ui/app/src/api-reference/endpoints/Endpoint.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/Endpoint.tsx
@@ -17,19 +17,19 @@ export declare namespace Endpoint {
 
 const UnmemoizedEndpoint: React.FC<Endpoint.Props> = ({ api, showErrors, endpoint, isLastInApi, types }) => {
     const [isStream, setStream] = useAtom(FERN_STREAM_ATOM);
-    const resolvedPath = useResolvedPath();
+    const content = useResolvedPath();
 
     const endpointSlug = endpoint.stream != null && isStream ? endpoint.stream.slug : endpoint.slug;
 
     useEffect(() => {
         if (endpoint.stream != null) {
-            if (endpoint.slug === resolvedPath.slug) {
+            if (endpoint.slug === content.slug) {
                 setStream(false);
-            } else if (endpoint.stream.slug === resolvedPath.slug) {
+            } else if (endpoint.stream.slug === content.slug) {
                 setStream(true);
             }
         }
-    }, [endpoint.slug, endpoint.stream, resolvedPath.slug, setStream]);
+    }, [endpoint.slug, endpoint.stream, content.slug, setStream]);
 
     // TODO: this is a temporary fix to only SSG the content that is requested by the requested route.
     // - webcrawlers will accurately determine the canonical URL (right now every page "returns" the same full-length content)

--- a/packages/ui/app/src/api-reference/endpoints/Endpoint.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/Endpoint.tsx
@@ -1,6 +1,6 @@
 import { useAtom } from "jotai";
 import { memo, useEffect } from "react";
-import { FERN_STREAM_ATOM, useResolvedPath } from "../../atoms";
+import { FERN_STREAM_ATOM, useDocsContent } from "../../atoms";
 import { useShouldLazyRender } from "../../hooks/useShouldLazyRender";
 import { ResolvedEndpointDefinition, ResolvedTypeDefinition } from "../../resolver/types";
 import { EndpointContent } from "./EndpointContent";
@@ -17,7 +17,7 @@ export declare namespace Endpoint {
 
 const UnmemoizedEndpoint: React.FC<Endpoint.Props> = ({ api, showErrors, endpoint, isLastInApi, types }) => {
     const [isStream, setStream] = useAtom(FERN_STREAM_ATOM);
-    const content = useResolvedPath();
+    const content = useDocsContent();
 
     const endpointSlug = endpoint.stream != null && isStream ? endpoint.stream.slug : endpoint.slug;
 

--- a/packages/ui/app/src/atoms/apis.ts
+++ b/packages/ui/app/src/atoms/apis.ts
@@ -23,8 +23,8 @@ export function useFlattenedApi(apiId: string): FlattenedRootPackage | undefined
 }
 
 const IS_API_REFERENCE_PAGINATED = atom<boolean>((get) => {
-    const resolvedPath = get(RESOLVED_PATH_ATOM);
-    if (resolvedPath.type === "api-endpoint-page") {
+    const content = get(RESOLVED_PATH_ATOM);
+    if (content.type === "api-endpoint-page") {
         return true;
     }
     return get(FEATURE_FLAGS_ATOM).isApiScrollingDisabled;

--- a/packages/ui/app/src/atoms/docs.ts
+++ b/packages/ui/app/src/atoms/docs.ts
@@ -57,7 +57,7 @@ const EMPTY_DOCS_STATE: DocsProps = {
     logoHeight: undefined,
     logoHref: undefined,
     files: {},
-    resolvedPath: {
+    content: {
         type: "custom-markdown-page",
         slug: FernNavigation.Slug(""),
         title: "",

--- a/packages/ui/app/src/atoms/navigation.ts
+++ b/packages/ui/app/src/atoms/navigation.ts
@@ -67,35 +67,33 @@ export const SIDEBAR_ROOT_NODE_ATOM = selectAtom(
 SIDEBAR_ROOT_NODE_ATOM.debugLabel = "SIDEBAR_ROOT_NODE_ATOM";
 
 // the initial path that was hard-navigated to
-export const RESOLVED_PATH_ATOM = atom<ResolvedPath>((get) => get(DOCS_ATOM).resolvedPath);
+export const RESOLVED_PATH_ATOM = atom<ResolvedPath>((get) => get(DOCS_ATOM).content);
 RESOLVED_PATH_ATOM.debugLabel = "RESOLVED_PATH_ATOM";
 
 export const RESOLVED_PATH_SLUG_ATOM = atom((get) => get(RESOLVED_PATH_ATOM).slug);
 
 export const RESOLVED_PATH_TITLE_ATOM = atom((get) => {
-    const resolvedPath = get(RESOLVED_PATH_ATOM);
-    if (resolvedPath.type === "api-endpoint-page") {
-        return resolvedPath.item.title;
+    const content = get(RESOLVED_PATH_ATOM);
+    if (content.type === "api-endpoint-page") {
+        return content.item.title;
     }
-    return resolvedPath.title;
+    return content.title;
 });
 
 export const NEIGHBORS_ATOM = atom((get) => {
-    const resolvedPath = get(RESOLVED_PATH_ATOM);
-    if (resolvedPath.type === "api-reference-page" || resolvedPath.type === "changelog") {
+    const content = get(RESOLVED_PATH_ATOM);
+    if (content.type === "api-reference-page" || content.type === "changelog") {
         return {
             prev: null,
             next: null,
         };
     }
-    return resolvedPath.neighbors;
+    return content.neighbors;
 });
 
 export const RESOLVED_API_DEFINITION_ATOM = atom((get) => {
-    const resolvedPath = get(RESOLVED_PATH_ATOM);
-    return resolvedPath.type === "api-endpoint-page" || resolvedPath.type === "api-reference-page"
-        ? resolvedPath.api
-        : undefined;
+    const content = get(RESOLVED_PATH_ATOM);
+    return content.type === "api-endpoint-page" || content.type === "api-reference-page" ? content.api : undefined;
 });
 
 export const NAVIGATION_NODES_ATOM = atom<FernNavigation.NodeCollector>((get) => {

--- a/packages/ui/app/src/atoms/navigation.ts
+++ b/packages/ui/app/src/atoms/navigation.ts
@@ -4,7 +4,7 @@ import { SidebarTab, SidebarVersionInfo } from "@fern-ui/fdr-utils";
 import { atom, useAtomValue } from "jotai";
 import { selectAtom } from "jotai/utils";
 import { isEqual } from "lodash-es";
-import { ResolvedPath } from "../resolver/ResolvedPath";
+import { DocsContent } from "../resolver/DocsContent";
 import { DOCS_ATOM } from "./docs";
 import { SLUG_ATOM } from "./location";
 
@@ -67,7 +67,7 @@ export const SIDEBAR_ROOT_NODE_ATOM = selectAtom(
 SIDEBAR_ROOT_NODE_ATOM.debugLabel = "SIDEBAR_ROOT_NODE_ATOM";
 
 // the initial path that was hard-navigated to
-export const RESOLVED_PATH_ATOM = atom<ResolvedPath>((get) => get(DOCS_ATOM).content);
+export const RESOLVED_PATH_ATOM = atom<DocsContent>((get) => get(DOCS_ATOM).content);
 RESOLVED_PATH_ATOM.debugLabel = "RESOLVED_PATH_ATOM";
 
 export const RESOLVED_PATH_SLUG_ATOM = atom((get) => get(RESOLVED_PATH_ATOM).slug);
@@ -127,7 +127,7 @@ export function useCurrentNodeId(): FernNavigation.NodeId | undefined {
     return useAtomValue(CURRENT_NODE_ID_ATOM);
 }
 
-export function useResolvedPath(): ResolvedPath {
+export function useDocsContent(): DocsContent {
     return useAtomValue(RESOLVED_PATH_ATOM);
 }
 

--- a/packages/ui/app/src/atoms/sidebar.ts
+++ b/packages/ui/app/src/atoms/sidebar.ts
@@ -252,13 +252,13 @@ export const SIDEBAR_DISMISSABLE_ATOM = atom((get) => {
 
     // always hide sidebar on changelog entries
     // this may be a bit too aggressive, but it's a good starting point
-    const resolvedPath = get(RESOLVED_PATH_ATOM);
-    if (resolvedPath.type === "changelog-entry") {
+    const content = get(RESOLVED_PATH_ATOM);
+    if (content.type === "changelog-entry") {
         return true;
     }
 
-    if (resolvedPath.type === "custom-markdown-page" && typeof resolvedPath.mdx !== "string") {
-        const layout = resolvedPath.mdx.frontmatter.layout;
+    if (content.type === "custom-markdown-page" && typeof content.mdx !== "string") {
+        const layout = content.mdx.frontmatter.layout;
 
         if (layout === "page" || layout === "custom") {
             return true;

--- a/packages/ui/app/src/atoms/store.ts
+++ b/packages/ui/app/src/atoms/store.ts
@@ -1,3 +1,3 @@
-import { createStore } from "jotai";
+import { getDefaultStore } from "jotai";
 
-export const store = createStore();
+export const store = getDefaultStore();

--- a/packages/ui/app/src/atoms/types.ts
+++ b/packages/ui/app/src/atoms/types.ts
@@ -5,7 +5,7 @@ import { NextSeoProps } from "@fern-ui/next-seo";
 import { CustomerAnalytics } from "../analytics/types";
 import { FernUser } from "../auth";
 import type { BundledMDX } from "../mdx/types";
-import { ResolvedPath } from "../resolver/ResolvedPath";
+import { DocsContent } from "../resolver/DocsContent";
 import { FernTheme } from "../themes/ThemedDocs";
 
 export interface FeatureFlags {
@@ -64,7 +64,7 @@ export interface DocsProps {
     logoHeight: DocsV1Read.Height | undefined;
     logoHref: DocsV1Read.Url | undefined;
     files: Record<DocsV1Read.FileId, DocsV1Read.File_>;
-    content: ResolvedPath;
+    content: DocsContent;
     featureFlags: FeatureFlags;
     apis: FdrAPI.ApiDefinitionId[];
     seo: NextSeoProps;

--- a/packages/ui/app/src/atoms/types.ts
+++ b/packages/ui/app/src/atoms/types.ts
@@ -64,7 +64,7 @@ export interface DocsProps {
     logoHeight: DocsV1Read.Height | undefined;
     logoHref: DocsV1Read.Url | undefined;
     files: Record<DocsV1Read.FileId, DocsV1Read.File_>;
-    resolvedPath: ResolvedPath;
+    content: ResolvedPath;
     featureFlags: FeatureFlags;
     apis: FdrAPI.ApiDefinitionId[];
     seo: NextSeoProps;

--- a/packages/ui/app/src/changelog/ChangelogEntryPage.tsx
+++ b/packages/ui/app/src/changelog/ChangelogEntryPage.tsx
@@ -6,29 +6,29 @@ import { useHref } from "../hooks/useHref";
 import { MdxContent } from "../mdx/MdxContent";
 import { ResolvedPath } from "../resolver/ResolvedPath";
 
-export function ChangelogEntryPage({ resolvedPath }: { resolvedPath: ResolvedPath.ChangelogEntryPage }): ReactElement {
-    const page = resolvedPath.page;
+export function ChangelogEntryPage({ content }: { content: ResolvedPath.ChangelogEntryPage }): ReactElement {
+    const page = content.page;
     const title = typeof page !== "string" ? page?.frontmatter.title : undefined;
     const excerpt = typeof page !== "string" ? page?.frontmatter.subtitle ?? page?.frontmatter.excerpt : undefined;
     return (
         <div className="flex justify-between px-4 md:px-6 lg:pl-8 lg:pr-16 xl:pr-0">
             <div className="w-full min-w-0 pt-8">
                 <article className="mx-auto break-words lg:ml-0 xl:mx-auto">
-                    <section id={resolvedPath.date} className="flex items-stretch justify-between">
+                    <section id={content.date} className="flex items-stretch justify-between">
                         <div className="max-xl:hidden w-sidebar-width" />
                         <div className="relative mr-6 max-w-content-width min-w-0 shrink flex-1 max-xl:mx-auto">
                             <header className="mb-8">
                                 <div className="space-y-1">
                                     <div className="not-prose">
-                                        <FernLink href={useHref(resolvedPath.changelogSlug)}>
+                                        <FernLink href={useHref(content.changelogSlug)}>
                                             <span className="t-accent shrink truncate whitespace-nowrap text-sm font-semibold inline-flex gap-1 items-center">
                                                 <ArrowLeft className="size-icon" />
-                                                Back to {resolvedPath.changelogTitle}
+                                                Back to {content.changelogTitle}
                                             </span>
                                         </FernLink>
                                     </div>
 
-                                    <h1 className="my-0 inline-block leading-tight">{title ?? resolvedPath.title}</h1>
+                                    <h1 className="my-0 inline-block leading-tight">{title ?? content.title}</h1>
                                 </div>
 
                                 {excerpt != null && (

--- a/packages/ui/app/src/changelog/ChangelogEntryPage.tsx
+++ b/packages/ui/app/src/changelog/ChangelogEntryPage.tsx
@@ -4,9 +4,9 @@ import { BottomNavigationButtons } from "../components/BottomNavigationButtons";
 import { FernLink } from "../components/FernLink";
 import { useHref } from "../hooks/useHref";
 import { MdxContent } from "../mdx/MdxContent";
-import { ResolvedPath } from "../resolver/ResolvedPath";
+import { DocsContent } from "../resolver/DocsContent";
 
-export function ChangelogEntryPage({ content }: { content: ResolvedPath.ChangelogEntryPage }): ReactElement {
+export function ChangelogEntryPage({ content }: { content: DocsContent.ChangelogEntryPage }): ReactElement {
     const page = content.page;
     const title = typeof page !== "string" ? page?.frontmatter.title : undefined;
     const excerpt = typeof page !== "string" ? page?.frontmatter.subtitle ?? page?.frontmatter.excerpt : undefined;

--- a/packages/ui/app/src/changelog/ChangelogPage.tsx
+++ b/packages/ui/app/src/changelog/ChangelogPage.tsx
@@ -8,12 +8,11 @@ import { MdxContent } from "../mdx/MdxContent";
 import { ResolvedPath } from "../resolver/ResolvedPath";
 import { BuiltWithFern } from "../sidebar/BuiltWithFern";
 
-export function ChangelogPage({ resolvedPath }: { resolvedPath: ResolvedPath.ChangelogPage }): ReactElement {
+export function ChangelogPage({ content }: { content: ResolvedPath.ChangelogPage }): ReactElement {
     const sidebar = useSidebarNodes();
     const toHref = useToHref();
     const fullWidth = sidebar == null;
-    const overview =
-        resolvedPath.node.overviewPageId != null ? resolvedPath.pages[resolvedPath.node.overviewPageId] : undefined;
+    const overview = content.node.overviewPageId != null ? content.pages[content.node.overviewPageId] : undefined;
     return (
         <div className="flex justify-between px-4 md:px-6 lg:px-8">
             <div className={clsx("w-full min-w-0 pt-8", { "sm:pt-8 lg:pt-24": fullWidth })}>
@@ -24,8 +23,8 @@ export function ChangelogPage({ resolvedPath }: { resolvedPath: ResolvedPath.Cha
                                 <div className="flex-initial max-md:hidden w-64" />
                                 <div className="relative mr-6 max-w-content-width min-w-0 shrink flex-auto">
                                     <PageHeader
-                                        title={resolvedPath.node.title}
-                                        breadcrumbs={resolvedPath.breadcrumbs}
+                                        title={content.node.title}
+                                        breadcrumbs={content.breadcrumbs}
                                         subtitle={
                                             typeof overview !== "string" ? overview?.frontmatter.excerpt : undefined
                                         }
@@ -40,8 +39,8 @@ export function ChangelogPage({ resolvedPath }: { resolvedPath: ResolvedPath.Cha
                         ) : (
                             <div className="relative mr-6 max-w-content-width min-w-0 shrink flex-auto">
                                 <PageHeader
-                                    title={resolvedPath.node.title}
-                                    breadcrumbs={resolvedPath.breadcrumbs}
+                                    title={content.node.title}
+                                    breadcrumbs={content.breadcrumbs}
                                     subtitle={typeof overview !== "string" ? overview?.frontmatter.excerpt : undefined}
                                 />
                                 {overview != null && (
@@ -53,10 +52,10 @@ export function ChangelogPage({ resolvedPath }: { resolvedPath: ResolvedPath.Cha
                         )}
                     </section>
 
-                    {resolvedPath.node.children.flatMap((year) =>
+                    {content.node.children.flatMap((year) =>
                         year.children.flatMap((month) =>
                             month.children.map((entry) => {
-                                const page = resolvedPath.pages[entry.pageId];
+                                const page = content.pages[entry.pageId];
                                 const title = typeof page !== "string" ? page?.frontmatter.title : undefined;
                                 return (
                                     <Fragment key={entry.id}>

--- a/packages/ui/app/src/changelog/ChangelogPage.tsx
+++ b/packages/ui/app/src/changelog/ChangelogPage.tsx
@@ -5,10 +5,10 @@ import { FernLink } from "../components/FernLink";
 import { PageHeader } from "../components/PageHeader";
 import { useToHref } from "../hooks/useHref";
 import { MdxContent } from "../mdx/MdxContent";
-import { ResolvedPath } from "../resolver/ResolvedPath";
+import { DocsContent } from "../resolver/DocsContent";
 import { BuiltWithFern } from "../sidebar/BuiltWithFern";
 
-export function ChangelogPage({ content }: { content: ResolvedPath.ChangelogPage }): ReactElement {
+export function ChangelogPage({ content }: { content: DocsContent.ChangelogPage }): ReactElement {
     const sidebar = useSidebarNodes();
     const toHref = useToHref();
     const fullWidth = sidebar == null;

--- a/packages/ui/app/src/components/ApiReferenceButton.tsx
+++ b/packages/ui/app/src/components/ApiReferenceButton.tsx
@@ -1,21 +1,20 @@
 import { FernNavigation } from "@fern-api/fdr-sdk";
-import { FernButton, FernTooltip, FernTooltipProvider } from "@fern-ui/components";
+import { FernTooltip, FernTooltipProvider } from "@fern-ui/components";
 import { ArrowUpRight } from "iconoir-react";
-import { useRouter } from "next/router";
-import { useToHref } from "../hooks/useHref";
+import { useHref } from "../hooks/useHref";
+import { FernLinkButton } from "./FernLinkButton";
 
 export const ApiReferenceButton: React.FC<{ slug: FernNavigation.Slug }> = ({ slug }) => {
-    const router = useRouter();
-    const toHref = useToHref();
+    const href = useHref(slug);
     return (
         <FernTooltipProvider>
             <FernTooltip content="View API reference">
-                <FernButton
+                <FernLinkButton
                     className="-m-1"
                     rounded
                     variant="minimal"
                     icon={<ArrowUpRight className="size-icon" />}
-                    onClick={() => router.push(toHref(slug))}
+                    href={href}
                 />
             </FernTooltip>
         </FernTooltipProvider>

--- a/packages/ui/app/src/components/BottomNavigationButton.tsx
+++ b/packages/ui/app/src/components/BottomNavigationButton.tsx
@@ -1,12 +1,12 @@
 import { NavArrowLeft, NavArrowRight } from "iconoir-react";
 import { useHref } from "../hooks/useHref";
 import { MdxContent } from "../mdx/MdxContent";
-import { ResolvedPath } from "../resolver/ResolvedPath";
+import { DocsContent } from "../resolver/DocsContent";
 import { FernLinkCard } from "./FernLinkCard";
 
 export declare namespace BottomNavigationButton {
     export interface Props {
-        neighbor: ResolvedPath.Neighbor;
+        neighbor: DocsContent.Neighbor;
         dir: "prev" | "next";
     }
 }

--- a/packages/ui/app/src/docs/DocsMainContent.tsx
+++ b/packages/ui/app/src/docs/DocsMainContent.tsx
@@ -4,7 +4,7 @@ import { useSearchParams } from "next/navigation";
 import { Fragment, ReactElement, memo } from "react";
 import { useFeatureFlags, useIsReady } from "../atoms";
 import { FernErrorBoundary } from "../components/FernErrorBoundary";
-import { ResolvedPath } from "../resolver/ResolvedPath";
+import { DocsContent } from "../resolver/DocsContent";
 
 const MdxContent = dynamic(() => import("../mdx/MdxContent").then(({ MdxContent }) => MdxContent), {
     ssr: true,
@@ -34,7 +34,7 @@ const FeedbackPopover = dynamic(
     { ssr: false },
 );
 
-const DocsMainContentRenderer = memo(({ content }: { content: ResolvedPath }) => {
+const DocsMainContentRenderer = memo(({ content }: { content: DocsContent }) => {
     return visitDiscriminatedUnion(content)._visit({
         "custom-markdown-page": (content) => <MdxContent mdx={content.mdx} />,
         "api-reference-page": (content) => (
@@ -50,12 +50,12 @@ const DocsMainContentRenderer = memo(({ content }: { content: ResolvedPath }) =>
 });
 DocsMainContentRenderer.displayName = "DocsMainContentRenderer";
 
-function LazyDocsMainContentRenderer({ content }: { content: ResolvedPath }): ReactElement | null {
+function LazyDocsMainContentRenderer({ content }: { content: DocsContent }): ReactElement | null {
     const hydrated = useIsReady();
     return hydrated ? <DocsMainContentRenderer content={content} /> : null;
 }
 
-export const DocsMainContent = memo(function DocsMainContent({ content }: { content: ResolvedPath }): ReactElement {
+export const DocsMainContent = memo(function DocsMainContent({ content }: { content: DocsContent }): ReactElement {
     const { isInlineFeedbackEnabled } = useFeatureFlags();
     const searchParams = useSearchParams();
     const FeedbackPopoverProvider = isInlineFeedbackEnabled ? FeedbackPopover : Fragment;

--- a/packages/ui/app/src/docs/DocsPage.tsx
+++ b/packages/ui/app/src/docs/DocsPage.tsx
@@ -1,7 +1,6 @@
-import { useHydrateAtoms } from "jotai/utils";
 import dynamic from "next/dynamic";
 import { ReactElement } from "react";
-import { DOCS_ATOM, useMessageHandler, useSetJustNavigated, type DocsProps } from "../atoms";
+import { useMessageHandler, useSetJustNavigated, type DocsProps } from "../atoms";
 import { BgImageGradient } from "../components/BgImageGradient";
 import { JavascriptProvider } from "../components/JavascriptProvider";
 import { useBeforePopState } from "../hooks/useBeforePopState";
@@ -22,7 +21,6 @@ export function DocsPage(pageProps: DocsProps): ReactElement | null {
     useConsoleMessage();
     useMessageHandler();
     useBeforePopState();
-    useHydrateAtoms([[DOCS_ATOM, pageProps]], { dangerouslyForceHydrate: true });
 
     const [setJustNavigated, destroy] = useSetJustNavigated();
     useRouteChangeStart(setJustNavigated, destroy);
@@ -50,7 +48,7 @@ export function DocsPage(pageProps: DocsProps): ReactElement | null {
             <InitializeTheme />
             <SearchDialog />
             <BgImageGradient />
-            <ThemedDocs theme={pageProps.theme} />
+            <ThemedDocs theme={pageProps.theme} content={pageProps.content} />
             <PlaygroundContextProvider />
             <JavascriptProvider />
         </>

--- a/packages/ui/app/src/docs/NextApp.tsx
+++ b/packages/ui/app/src/docs/NextApp.tsx
@@ -1,12 +1,12 @@
 import { FernTooltipProvider, Toaster } from "@fern-ui/components";
 import { EMPTY_OBJECT } from "@fern-ui/core-utils";
-import { Provider as JotaiProvider } from "jotai";
+import { useHydrateAtoms } from "jotai/utils";
 import type { AppProps } from "next/app";
 import PageLoader from "next/dist/client/page-loader";
 import { Router } from "next/router";
-import { ReactElement, useEffect } from "react";
+import { PropsWithChildren, ReactElement, useEffect } from "react";
 import { SWRConfig } from "swr";
-import { DocsProps, store } from "../atoms";
+import { DOCS_ATOM, DocsProps } from "../atoms";
 import { FernErrorBoundary } from "../components/FernErrorBoundary";
 import "../css/globals.scss";
 import { NextNProgress } from "../header/NProgress";
@@ -22,21 +22,24 @@ export function NextApp({ Component, pageProps, router }: AppProps<DocsProps | u
     });
 
     return (
-        <>
+        <HydrateAtoms pageProps={pageProps}>
             <ThemeScript colors={pageProps?.colors} />
             <NextNProgress options={{ showSpinner: false, speed: 400 }} showOnShallow={false} />
             <Toaster />
-            <JotaiProvider store={store}>
-                <FernTooltipProvider>
-                    <SWRConfig value={{ fallback: pageProps?.fallback ?? EMPTY_OBJECT }}>
-                        <FernErrorBoundary className="flex h-screen items-center justify-center" refreshOnError>
-                            <Component {...pageProps} />
-                        </FernErrorBoundary>
-                    </SWRConfig>
-                </FernTooltipProvider>
-            </JotaiProvider>
-        </>
+            <FernTooltipProvider>
+                <SWRConfig value={{ fallback: pageProps?.fallback ?? EMPTY_OBJECT }}>
+                    <FernErrorBoundary className="flex h-screen items-center justify-center" refreshOnError>
+                        <Component {...pageProps} />
+                    </FernErrorBoundary>
+                </SWRConfig>
+            </FernTooltipProvider>
+        </HydrateAtoms>
     );
+}
+
+function HydrateAtoms({ pageProps, children }: PropsWithChildren<{ pageProps: DocsProps | undefined }>) {
+    useHydrateAtoms(new Map([[DOCS_ATOM, pageProps]]), { dangerouslyForceHydrate: true });
+    return children;
 }
 
 // hack for basepath: https://github.com/vercel/next.js/discussions/25681#discussioncomment-2026813

--- a/packages/ui/app/src/index.ts
+++ b/packages/ui/app/src/index.ts
@@ -18,7 +18,7 @@ export { getBreadcrumbList } from "./seo/getBreadcrumbList";
 export { getSeoProps } from "./seo/getSeoProp";
 export { getRegistryServiceWithToken, provideRegistryService } from "./services/registry";
 export { renderThemeStylesheet } from "./themes/stylesheet/renderThemeStylesheet";
-export { convertNavigatableToDocsContent } from "./util/convertNavigatableToDocsContent";
 export { getRedirectForPath } from "./util/getRedirectForPath";
 export { getGitHubInfo, getGitHubRepo } from "./util/github";
+export { resolveDocsContent } from "./util/resolveDocsContent";
 export { unknownToString } from "./util/unknownToString";

--- a/packages/ui/app/src/index.ts
+++ b/packages/ui/app/src/index.ts
@@ -18,7 +18,7 @@ export { getBreadcrumbList } from "./seo/getBreadcrumbList";
 export { getSeoProps } from "./seo/getSeoProp";
 export { getRegistryServiceWithToken, provideRegistryService } from "./services/registry";
 export { renderThemeStylesheet } from "./themes/stylesheet/renderThemeStylesheet";
-export { convertNavigatableToResolvedPath } from "./util/convertNavigatableToResolvedPath";
+export { convertNavigatableToDocsContent } from "./util/convertNavigatableToDocsContent";
 export { getRedirectForPath } from "./util/getRedirectForPath";
 export { getGitHubInfo, getGitHubRepo } from "./util/github";
 export { unknownToString } from "./util/unknownToString";

--- a/packages/ui/app/src/mdx/components/snippets/EndpointRequestSnippet.tsx
+++ b/packages/ui/app/src/mdx/components/snippets/EndpointRequestSnippet.tsx
@@ -30,15 +30,15 @@ const EndpointRequestSnippetInternal: React.FC<React.PropsWithChildren<RequestSn
     path,
     example,
 }) => {
-    const resolvedPath = useResolvedPath();
+    const content = useResolvedPath();
     const selectedEnvironmentId = useSelectedEnvironmentId();
 
     const endpoint = useMemo(() => {
-        if (resolvedPath.type !== "custom-markdown-page") {
+        if (content.type !== "custom-markdown-page") {
             return;
         }
         let endpoint: ResolvedEndpointDefinition | undefined;
-        for (const api of Object.values(resolvedPath.apis)) {
+        for (const api of Object.values(content.apis)) {
             endpoint = findEndpoint({
                 api,
                 path,
@@ -49,7 +49,7 @@ const EndpointRequestSnippetInternal: React.FC<React.PropsWithChildren<RequestSn
             }
         }
         return endpoint;
-    }, [method, path, resolvedPath]);
+    }, [method, path, content]);
 
     const clients = useMemo(() => generateCodeExamples(endpoint?.examples ?? []), [endpoint?.examples]);
     const [selectedClient, setSelectedClient] = useSelectedClient(clients, example);

--- a/packages/ui/app/src/mdx/components/snippets/EndpointRequestSnippet.tsx
+++ b/packages/ui/app/src/mdx/components/snippets/EndpointRequestSnippet.tsx
@@ -4,7 +4,7 @@ import { CodeExampleClientDropdown } from "../../../api-reference/endpoints/Code
 import { EndpointUrlWithOverflow } from "../../../api-reference/endpoints/EndpointUrlWithOverflow";
 import { CodeSnippetExample } from "../../../api-reference/examples/CodeSnippetExample";
 import { generateCodeExamples } from "../../../api-reference/examples/code-example";
-import { useResolvedPath } from "../../../atoms";
+import { useDocsContent } from "../../../atoms";
 import { useSelectedEnvironmentId } from "../../../atoms/environment";
 import { ApiReferenceButton } from "../../../components/ApiReferenceButton";
 import { ResolvedEndpointDefinition, resolveEnvironment } from "../../../resolver/types";
@@ -30,7 +30,7 @@ const EndpointRequestSnippetInternal: React.FC<React.PropsWithChildren<RequestSn
     path,
     example,
 }) => {
-    const content = useResolvedPath();
+    const content = useDocsContent();
     const selectedEnvironmentId = useSelectedEnvironmentId();
 
     const endpoint = useMemo(() => {

--- a/packages/ui/app/src/mdx/components/snippets/EndpointResponseSnippet.tsx
+++ b/packages/ui/app/src/mdx/components/snippets/EndpointResponseSnippet.tsx
@@ -25,14 +25,14 @@ const EndpointResponseSnippetInternal: React.FC<React.PropsWithChildren<RequestS
     method,
     example,
 }) => {
-    const resolvedPath = useResolvedPath();
+    const content = useResolvedPath();
 
     const endpoint = useMemo(() => {
-        if (resolvedPath.type !== "custom-markdown-page") {
+        if (content.type !== "custom-markdown-page") {
             return;
         }
         let endpoint: ResolvedEndpointDefinition | undefined;
-        for (const api of Object.values(resolvedPath.apis)) {
+        for (const api of Object.values(content.apis)) {
             endpoint = findEndpoint({
                 api,
                 path,
@@ -43,7 +43,7 @@ const EndpointResponseSnippetInternal: React.FC<React.PropsWithChildren<RequestS
             }
         }
         return endpoint;
-    }, [method, path, resolvedPath]);
+    }, [method, path, content]);
 
     const clients = useMemo(() => generateCodeExamples(endpoint?.examples ?? []), [endpoint?.examples]);
     const [selectedClient] = useSelectedClient(clients, example);

--- a/packages/ui/app/src/mdx/components/snippets/EndpointResponseSnippet.tsx
+++ b/packages/ui/app/src/mdx/components/snippets/EndpointResponseSnippet.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { CodeSnippetExample } from "../../../api-reference/examples/CodeSnippetExample";
 import { generateCodeExamples } from "../../../api-reference/examples/code-example";
-import { useResolvedPath } from "../../../atoms";
+import { useDocsContent } from "../../../atoms";
 import { ResolvedEndpointDefinition } from "../../../resolver/types";
 import { findEndpoint } from "../../../util/processRequestSnippetComponents";
 import { RequestSnippet } from "./types";
@@ -25,7 +25,7 @@ const EndpointResponseSnippetInternal: React.FC<React.PropsWithChildren<RequestS
     method,
     example,
 }) => {
-    const content = useResolvedPath();
+    const content = useDocsContent();
 
     const endpoint = useMemo(() => {
         if (content.type !== "custom-markdown-page") {

--- a/packages/ui/app/src/resolver/DocsContent.ts
+++ b/packages/ui/app/src/resolver/DocsContent.ts
@@ -3,7 +3,7 @@ import type * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import type { BundledMDX } from "../mdx/types";
 import type { ResolvedApiEndpoint, ResolvedRootPackage, ResolvedTypeDefinition } from "./types";
 
-export declare namespace ResolvedPath {
+export declare namespace DocsContent {
     export interface Neighbor {
         slug: FernNavigation.Slug;
         title: string;
@@ -66,9 +66,9 @@ export declare namespace ResolvedPath {
     }
 }
 
-export type ResolvedPath =
-    | ResolvedPath.CustomMarkdownPage
-    | ResolvedPath.ApiEndpointPage
-    | ResolvedPath.ApiReferencePage
-    | ResolvedPath.ChangelogPage
-    | ResolvedPath.ChangelogEntryPage;
+export type DocsContent =
+    | DocsContent.CustomMarkdownPage
+    | DocsContent.ApiEndpointPage
+    | DocsContent.ApiReferencePage
+    | DocsContent.ChangelogPage
+    | DocsContent.ChangelogEntryPage;

--- a/packages/ui/app/src/themes/ThemedDocs.tsx
+++ b/packages/ui/app/src/themes/ThemedDocs.tsx
@@ -1,5 +1,6 @@
 import dynamic from "next/dynamic";
 import { ReactElement } from "react";
+import { ResolvedPath } from "../resolver/ResolvedPath";
 
 const THEMES = {
     default: dynamic(() => import("./default/DefaultDocs").then(({ DefaultDocs }) => DefaultDocs), { ssr: true }),
@@ -8,7 +9,7 @@ const THEMES = {
 
 export type FernTheme = keyof typeof THEMES;
 
-export function ThemedDocs({ theme }: { theme: FernTheme }): ReactElement {
+export function ThemedDocs({ theme, content }: { theme: FernTheme; content: ResolvedPath }): ReactElement {
     const Docs = THEMES[theme];
-    return <Docs />;
+    return <Docs content={content} />;
 }

--- a/packages/ui/app/src/themes/ThemedDocs.tsx
+++ b/packages/ui/app/src/themes/ThemedDocs.tsx
@@ -1,6 +1,6 @@
 import dynamic from "next/dynamic";
 import { ReactElement } from "react";
-import { ResolvedPath } from "../resolver/ResolvedPath";
+import { DocsContent } from "../resolver/DocsContent";
 
 const THEMES = {
     default: dynamic(() => import("./default/DefaultDocs").then(({ DefaultDocs }) => DefaultDocs), { ssr: true }),
@@ -9,7 +9,7 @@ const THEMES = {
 
 export type FernTheme = keyof typeof THEMES;
 
-export function ThemedDocs({ theme, content }: { theme: FernTheme; content: ResolvedPath }): ReactElement {
+export function ThemedDocs({ theme, content }: { theme: FernTheme; content: DocsContent }): ReactElement {
     const Docs = THEMES[theme];
     return <Docs content={content} />;
 }

--- a/packages/ui/app/src/themes/cohere/CohereDocs.tsx
+++ b/packages/ui/app/src/themes/cohere/CohereDocs.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../atoms";
 import { DocsMainContent } from "../../docs/DocsMainContent";
 import { Announcement } from "../../header/Announcement";
-import { ResolvedPath } from "../../resolver/ResolvedPath";
+import { DocsContent } from "../../resolver/DocsContent";
 import { Sidebar } from "../../sidebar/Sidebar";
 import { HeaderContainer } from "./HeaderContainer";
 
@@ -46,7 +46,7 @@ const CohereDocsStyle = () => {
     );
 };
 
-function UnmemoizedCohereDocs({ content }: { content: ResolvedPath }): ReactElement {
+function UnmemoizedCohereDocs({ content }: { content: DocsContent }): ReactElement {
     const showHeader = useAtomValue(SHOW_HEADER_ATOM);
     const announcementHeight = useAtomValue(ANNOUNCEMENT_HEIGHT_ATOM);
 

--- a/packages/ui/app/src/themes/cohere/CohereDocs.tsx
+++ b/packages/ui/app/src/themes/cohere/CohereDocs.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../atoms";
 import { DocsMainContent } from "../../docs/DocsMainContent";
 import { Announcement } from "../../header/Announcement";
+import { ResolvedPath } from "../../resolver/ResolvedPath";
 import { Sidebar } from "../../sidebar/Sidebar";
 import { HeaderContainer } from "./HeaderContainer";
 
@@ -45,7 +46,7 @@ const CohereDocsStyle = () => {
     );
 };
 
-function UnmemoizedCohereDocs(): ReactElement {
+function UnmemoizedCohereDocs({ content }: { content: ResolvedPath }): ReactElement {
     const showHeader = useAtomValue(SHOW_HEADER_ATOM);
     const announcementHeight = useAtomValue(ANNOUNCEMENT_HEIGHT_ATOM);
 
@@ -89,7 +90,7 @@ function UnmemoizedCohereDocs(): ReactElement {
                     ref={mainRef}
                     scrollbars="vertical"
                 >
-                    <DocsMainContent />
+                    <DocsMainContent content={content} />
 
                     {/* Enables footer DOM injection */}
                     <footer id="fern-footer" />

--- a/packages/ui/app/src/themes/default/DefaultDocs.tsx
+++ b/packages/ui/app/src/themes/default/DefaultDocs.tsx
@@ -11,6 +11,7 @@ import {
     useTheme,
 } from "../../atoms";
 import { DocsMainContent } from "../../docs/DocsMainContent";
+import { ResolvedPath } from "../../resolver/ResolvedPath";
 import { Sidebar } from "../../sidebar/Sidebar";
 import { HeaderContainer } from "./HeaderContainer";
 
@@ -30,7 +31,7 @@ const DefaultDocsStyle = () => {
     );
 };
 
-function UnmemoizedDefaultDocs(): ReactElement {
+function UnmemoizedDefaultDocs({ content }: { content: ResolvedPath }): ReactElement {
     const colors = useColors();
     const layout = useAtomValue(DOCS_LAYOUT_ATOM);
     const showHeader = useAtomValue(SHOW_HEADER_ATOM);
@@ -65,7 +66,7 @@ function UnmemoizedDefaultDocs(): ReactElement {
                         "fern-sidebar-disabled": isSidebarDismissable,
                     })}
                 >
-                    <DocsMainContent />
+                    <DocsMainContent content={content} />
                 </div>
             </div>
 

--- a/packages/ui/app/src/themes/default/DefaultDocs.tsx
+++ b/packages/ui/app/src/themes/default/DefaultDocs.tsx
@@ -11,7 +11,7 @@ import {
     useTheme,
 } from "../../atoms";
 import { DocsMainContent } from "../../docs/DocsMainContent";
-import { ResolvedPath } from "../../resolver/ResolvedPath";
+import { DocsContent } from "../../resolver/DocsContent";
 import { Sidebar } from "../../sidebar/Sidebar";
 import { HeaderContainer } from "./HeaderContainer";
 
@@ -31,7 +31,7 @@ const DefaultDocsStyle = () => {
     );
 };
 
-function UnmemoizedDefaultDocs({ content }: { content: ResolvedPath }): ReactElement {
+function UnmemoizedDefaultDocs({ content }: { content: DocsContent }): ReactElement {
     const colors = useColors();
     const layout = useAtomValue(DOCS_LAYOUT_ATOM);
     const showHeader = useAtomValue(SHOW_HEADER_ATOM);

--- a/packages/ui/app/src/util/convertNavigatableToResolvedPath.ts
+++ b/packages/ui/app/src/util/convertNavigatableToResolvedPath.ts
@@ -10,7 +10,7 @@ import type { BundledMDX, FernSerializeMdxOptions } from "../mdx/types";
 import { ApiDefinitionResolver } from "../resolver/ApiDefinitionResolver";
 import { ApiEndpointResolver } from "../resolver/ApiEndpointResolver";
 import { ApiTypeResolver } from "../resolver/ApiTypeResolver";
-import type { ResolvedPath } from "../resolver/ResolvedPath";
+import type { DocsContent } from "../resolver/DocsContent";
 import type { ResolvedApiEndpoint, ResolvedRootPackage } from "../resolver/types";
 
 async function getSubtitle(
@@ -49,7 +49,7 @@ async function getSubtitle(
     }
 }
 
-export async function convertNavigatableToResolvedPath({
+export async function convertNavigatableToDocsContent({
     found,
     apis,
     pages,
@@ -63,7 +63,7 @@ export async function convertNavigatableToResolvedPath({
     mdxOptions?: FernSerializeMdxOptions;
     domain: string;
     featureFlags: FeatureFlags;
-}): Promise<ResolvedPath | undefined> {
+}): Promise<DocsContent | undefined> {
     const neighbors = await getNeighbors(found, pages);
     const { node, apiReference, parents } = found;
 
@@ -231,8 +231,8 @@ async function resolveMarkdownPage(
     mdxOptions: FernSerializeMdxOptions | undefined,
     featureFlags: FeatureFlags,
     domain: string,
-    neighbors: ResolvedPath.Neighbors,
-): Promise<ResolvedPath.CustomMarkdownPage | undefined> {
+    neighbors: DocsContent.Neighbors,
+): Promise<DocsContent.CustomMarkdownPage | undefined> {
     const pageId = FernNavigation.utils.getPageId(node);
     if (pageId == null) {
         return;
@@ -312,7 +312,7 @@ async function resolveMarkdownPage(
 async function getNeighbor(
     node: FernNavigation.NavigationNodeNeighbor | undefined,
     pages: Record<string, DocsV1Read.PageContent>,
-): Promise<ResolvedPath.Neighbor | null> {
+): Promise<DocsContent.Neighbor | null> {
     if (node == null) {
         return null;
     }
@@ -327,7 +327,7 @@ async function getNeighbor(
 async function getNeighbors(
     node: FernNavigation.utils.Node.Found,
     pages: Record<string, DocsV1Read.PageContent>,
-): Promise<ResolvedPath.Neighbors> {
+): Promise<DocsContent.Neighbors> {
     const [prev, next] = await Promise.all([getNeighbor(node.prev, pages), getNeighbor(node.next, pages)]);
     return { prev, next };
 }

--- a/packages/ui/app/src/util/resolveDocsContent.ts
+++ b/packages/ui/app/src/util/resolveDocsContent.ts
@@ -49,7 +49,7 @@ async function getSubtitle(
     }
 }
 
-export async function convertNavigatableToDocsContent({
+export async function resolveDocsContent({
     found,
     apis,
     pages,

--- a/packages/ui/docs-bundle/src/utils/getDocsPageProps.ts
+++ b/packages/ui/docs-bundle/src/utils/getDocsPageProps.ts
@@ -279,7 +279,7 @@ async function convertDocsToDocsPageProps({
 
     setMdxBundler(await getMdxBundler(featureFlags.useMdxBundler ? "mdx-bundler" : "next-mdx-remote"));
 
-    const resolvedPath = await convertNavigatableToResolvedPath({
+    const content = await convertNavigatableToResolvedPath({
         found: node,
         apis: docs.definition.apis,
         pages: docs.definition.pages,
@@ -290,7 +290,7 @@ async function convertDocsToDocsPageProps({
         },
     });
 
-    if (resolvedPath == null) {
+    if (content == null) {
         // eslint-disable-next-line no-console
         console.error(`Failed to resolve path for ${url}`);
         return { notFound: true };
@@ -341,7 +341,7 @@ async function convertDocsToDocsPageProps({
             docs.definition.config.logoHref ??
             (node.landingPage?.slug != null && !node.landingPage.hidden ? `/${node.landingPage.slug}` : undefined),
         files: docs.definition.filesV2,
-        resolvedPath,
+        content,
         announcement:
             docs.definition.config.announcement != null
                 ? {

--- a/packages/ui/docs-bundle/src/utils/getDocsPageProps.ts
+++ b/packages/ui/docs-bundle/src/utils/getDocsPageProps.ts
@@ -7,7 +7,6 @@ import { SidebarTab, buildUrl } from "@fern-ui/fdr-utils";
 import { getSearchConfig } from "@fern-ui/search-utils";
 import {
     DocsPage,
-    convertNavigatableToDocsContent,
     getApiRouteSupplier,
     getGitHubInfo,
     getGitHubRepo,
@@ -16,6 +15,7 @@ import {
     getSeoProps,
     provideRegistryService,
     renderThemeStylesheet,
+    resolveDocsContent,
     serializeMdx,
     setMdxBundler,
 } from "@fern-ui/ui";
@@ -279,7 +279,7 @@ async function convertDocsToDocsPageProps({
 
     setMdxBundler(await getMdxBundler(featureFlags.useMdxBundler ? "mdx-bundler" : "next-mdx-remote"));
 
-    const content = await convertNavigatableToDocsContent({
+    const content = await resolveDocsContent({
         found: node,
         apis: docs.definition.apis,
         pages: docs.definition.pages,

--- a/packages/ui/docs-bundle/src/utils/getDocsPageProps.ts
+++ b/packages/ui/docs-bundle/src/utils/getDocsPageProps.ts
@@ -7,7 +7,7 @@ import { SidebarTab, buildUrl } from "@fern-ui/fdr-utils";
 import { getSearchConfig } from "@fern-ui/search-utils";
 import {
     DocsPage,
-    convertNavigatableToResolvedPath,
+    convertNavigatableToDocsContent,
     getApiRouteSupplier,
     getGitHubInfo,
     getGitHubRepo,
@@ -279,7 +279,7 @@ async function convertDocsToDocsPageProps({
 
     setMdxBundler(await getMdxBundler(featureFlags.useMdxBundler ? "mdx-bundler" : "next-mdx-remote"));
 
-    const content = await convertNavigatableToResolvedPath({
+    const content = await convertNavigatableToDocsContent({
         found: node,
         apis: docs.definition.apis,
         pages: docs.definition.pages,

--- a/packages/ui/local-preview-bundle/src/utils/getDocsPageProps.ts
+++ b/packages/ui/local-preview-bundle/src/utils/getDocsPageProps.ts
@@ -6,12 +6,12 @@ import {
     DEFAULT_FEATURE_FLAGS,
     DocsPage,
     FeatureFlags,
-    convertNavigatableToDocsContent,
     getGitHubInfo,
     getGitHubRepo,
     getRedirectForPath,
     getSeoProps,
     renderThemeStylesheet,
+    resolveDocsContent,
     serializeMdx,
 } from "@fern-ui/ui";
 import type { GetServerSidePropsResult } from "next";
@@ -66,7 +66,7 @@ export async function getDocsPageProps(
     // TODO: get feature flags from the API
     const featureFlags: FeatureFlags = DEFAULT_FEATURE_FLAGS;
 
-    const content = await convertNavigatableToDocsContent({
+    const content = await resolveDocsContent({
         found: node,
         apis: docs.definition.apis,
         pages: docs.definition.pages,

--- a/packages/ui/local-preview-bundle/src/utils/getDocsPageProps.ts
+++ b/packages/ui/local-preview-bundle/src/utils/getDocsPageProps.ts
@@ -6,7 +6,7 @@ import {
     DEFAULT_FEATURE_FLAGS,
     DocsPage,
     FeatureFlags,
-    convertNavigatableToResolvedPath,
+    convertNavigatableToDocsContent,
     getGitHubInfo,
     getGitHubRepo,
     getRedirectForPath,
@@ -66,7 +66,7 @@ export async function getDocsPageProps(
     // TODO: get feature flags from the API
     const featureFlags: FeatureFlags = DEFAULT_FEATURE_FLAGS;
 
-    const content = await convertNavigatableToResolvedPath({
+    const content = await convertNavigatableToDocsContent({
         found: node,
         apis: docs.definition.apis,
         pages: docs.definition.pages,

--- a/packages/ui/local-preview-bundle/src/utils/getDocsPageProps.ts
+++ b/packages/ui/local-preview-bundle/src/utils/getDocsPageProps.ts
@@ -66,7 +66,7 @@ export async function getDocsPageProps(
     // TODO: get feature flags from the API
     const featureFlags: FeatureFlags = DEFAULT_FEATURE_FLAGS;
 
-    const resolvedPath = await convertNavigatableToResolvedPath({
+    const content = await convertNavigatableToResolvedPath({
         found: node,
         apis: docs.definition.apis,
         pages: docs.definition.pages,
@@ -77,7 +77,7 @@ export async function getDocsPageProps(
         },
     });
 
-    if (resolvedPath == null) {
+    if (content == null) {
         // eslint-disable-next-line no-console
         console.error(`Failed to resolve path for ${slug}`);
         return { notFound: true };
@@ -126,7 +126,7 @@ export async function getDocsPageProps(
         logoHeight: docs.definition.config.logoHeight,
         logoHref: docs.definition.config.logoHref,
         files: docs.definition.filesV2,
-        resolvedPath,
+        content,
         announcement:
             docs.definition.config.announcement != null
                 ? {


### PR DESCRIPTION
This PR fixes an issue with `useHydrateAtoms`, which actually defers rendering by 1 frame.

Effectively, the content captured in the useHydrateAtoms hook will get rendered _after_ nextjs's client side router completes navigation to another page.

### Changes in this PR:
- rename "resolvedPath" to "content" and `ResolvedPath` to `DocsContent` clarity
- removes the root-level jotai `<Provider>` in favor of using the DefaultStore
- pass docs content directly to the content renderer, which gets rendered at the 0th frame

### Motivations
https://buildwithfern.slack.com/archives/C06QKJWD4VD/p1725625436049009
This issue occurs because scroll occurs on the 0th frame, before the content has a chance to render on the 1st frame. With this change, the content renders on the 0th frame which coincides with when the scroll position is computed.