### PR TITLE
fix: nested expansion css issue

### DIFF
--- a/packages/ui/app/src/sidebar/index.scss
+++ b/packages/ui/app/src/sidebar/index.scss
@@ -46,7 +46,7 @@
     }
 
     .fern-sidebar-group[data-state="open"] {
-        animation: slide-down 0.18s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+        animation: slide-down 0.18s cubic-bezier(0.25, 0.46, 0.45, 0.94) none;
     }
 
     .fern-sidebar-group[data-state="closed"] {


### PR DESCRIPTION
Fixes a CSS bug caused by https://github.com/fern-api/fern-platform/pull/1410 where the nested expansion is hidden because the height is fixed by animation-fill-mode=forwards