### PR TITLE
fix(docs): format response descriptions

### DIFF
--- a/packages/ui/app/src/api-reference/endpoints/EndpointResponseSection.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointResponseSection.tsx
@@ -104,7 +104,7 @@ function getResponseSummary({
     } else if (responseBody.shape.type === "streamCondition") {
         return "This endpoint returns a stream.";
     } else if (responseBody.shape.type === "stream") {
-        return `This endpoint returns a stream of ${renderTypeShorthand(responseBody.shape.value, { withArticle: false }, types)}`;
+        return `This endpoint returns a stream of ${renderTypeShorthand(responseBody.shape.value, { withArticle: false }, types)}.`;
     }
-    return `This endpoint returns ${renderTypeShorthand(responseBody.shape, { withArticle: true }, types)}`;
+    return `This endpoint returns ${renderTypeShorthand(responseBody.shape, { withArticle: true }, types)}.`;
 }


### PR DESCRIPTION
This PR adds punctuation to consistently format the description of the response payload. 

Testing:
<img width="1728" alt="Screenshot 2024-09-09 at 9 16 44 AM" src="https://github.com/user-attachments/assets/90a1696d-27ba-483a-ac9e-f926be40198a">
