### PR TITLE
fix: resolve padding issues on cohere's hidden pages

### DIFF
--- a/packages/ui/app/src/themes/cohere/index.scss
+++ b/packages/ui/app/src/themes/cohere/index.scss
@@ -158,11 +158,11 @@
     }
 
     .fern-sidebar-hidden:has(.fern-layout-toc) {
-        @apply lg:pl-sidebar-width;
+        @apply xl:pl-sidebar-width;
 
         .fern-guide-layout,
         .fern-overview-layout {
-            @apply lg:pl-3 lg:max-xl:mx-auto;
+            @apply xl:pl-3 xl:pr-0 lg:max-xl:mx-auto;
         }
     }
 }


### PR DESCRIPTION
Before:

<img width="1234" alt="Screenshot 2024-09-09 at 4 32 06 PM" src="https://github.com/user-attachments/assets/3237f3af-94a2-4dda-a0a1-d6ded5ed73b0">

AFter:
<img width="1236" alt="Screenshot 2024-09-09 at 4 32 17 PM" src="https://github.com/user-attachments/assets/ceb1ee8b-cdf7-4017-bdec-5646723a46d4">


- perfectly centered content