### PR TITLE
fix: hidden pages should not disable the sidebar

### DIFF
--- a/packages/ui/app/src/atoms/sidebar.ts
+++ b/packages/ui/app/src/atoms/sidebar.ts
@@ -6,13 +6,7 @@ import { useCallbackOne, useMemoOne } from "use-memo-one";
 import { FEATURE_FLAGS_ATOM } from "./flags";
 import { useAtomEffect } from "./hooks";
 import { DOCS_LAYOUT_ATOM } from "./layout";
-import {
-    CURRENT_NODE_ATOM,
-    CURRENT_NODE_ID_ATOM,
-    NAVIGATION_NODES_ATOM,
-    RESOLVED_PATH_ATOM,
-    SIDEBAR_ROOT_NODE_ATOM,
-} from "./navigation";
+import { CURRENT_NODE_ID_ATOM, NAVIGATION_NODES_ATOM, RESOLVED_PATH_ATOM, SIDEBAR_ROOT_NODE_ATOM } from "./navigation";
 import { THEME_ATOM } from "./theme";
 import { IS_MOBILE_SCREEN_ATOM, MOBILE_SIDEBAR_ENABLED_ATOM } from "./viewport";
 
@@ -267,29 +261,12 @@ export const useDismissSidebar = (): (() => void) => {
     });
 };
 
-// in certain cases, the sidebar should be completely removed from the DOM.
-export const SIDEBAR_DISMISSABLE_ATOM = atom((get) => {
-    // sidebar is always enabled on mobile, because of search + tabs
-    const isMobileSidebarEnabled = get(MOBILE_SIDEBAR_ENABLED_ATOM);
-    if (isMobileSidebarEnabled) {
-        return true;
-    }
-
-    // sidebar is always enabled if the header is disabled
-    const layout = get(DOCS_LAYOUT_ATOM);
-    if (layout?.disableHeader) {
-        return false;
-    }
-
-    // sidebar is always enabled if vertical tabs are enabled
-    if (layout?.tabsPlacement !== "HEADER") {
-        return false;
-    }
-
-    // sidebar can be null when viewing a tabbed changelog
+export const DISABLE_SIDEBAR_ATOM = atom((get) => {
     const sidebar = get(SIDEBAR_ROOT_NODE_ATOM);
+    const layout = get(DOCS_LAYOUT_ATOM);
+
     if (sidebar == null) {
-        return true;
+        return !layout?.disableHeader;
     }
 
     // If there is only one pageGroup with only one page, hide the sidebar content
@@ -305,6 +282,33 @@ export const SIDEBAR_DISMISSABLE_ATOM = atom((get) => {
         return true;
     }
 
+    return false;
+});
+
+// in certain cases, the sidebar should be completely removed from the DOM.
+export const SIDEBAR_DISMISSABLE_ATOM = atom((get) => {
+    // sidebar is always enabled on mobile, because of search + tabs
+    const isMobileSidebarEnabled = get(MOBILE_SIDEBAR_ENABLED_ATOM);
+    if (isMobileSidebarEnabled) {
+        return true;
+    }
+
+    const isSidebarDisabled = get(DISABLE_SIDEBAR_ATOM);
+    if (isSidebarDisabled) {
+        return true;
+    }
+
+    // sidebar is always enabled if the header is disabled
+    const layout = get(DOCS_LAYOUT_ATOM);
+    if (layout?.disableHeader) {
+        return false;
+    }
+
+    // sidebar is always enabled if vertical tabs are enabled
+    if (layout?.tabsPlacement !== "HEADER") {
+        return false;
+    }
+
     // always hide sidebar on changelog entries
     // this may be a bit too aggressive, but it's a good starting point
     const content = get(RESOLVED_PATH_ATOM);
@@ -318,12 +322,6 @@ export const SIDEBAR_DISMISSABLE_ATOM = atom((get) => {
         if (layout === "page" || layout === "custom") {
             return true;
         }
-    }
-
-    const node = get(CURRENT_NODE_ATOM);
-
-    if (node?.hidden) {
-        return true;
     }
 
     return false;

--- a/packages/ui/app/src/sidebar/Sidebar.tsx
+++ b/packages/ui/app/src/sidebar/Sidebar.tsx
@@ -1,29 +1,20 @@
 import clsx from "clsx";
 import { useAtomValue } from "jotai";
 import { ReactElement, memo } from "react";
-import { SIDEBAR_DISMISSABLE_ATOM } from "../atoms";
+import { DISABLE_SIDEBAR_ATOM, SIDEBAR_DISMISSABLE_ATOM } from "../atoms";
 import { DismissableSidebar } from "./DismissableSidebar";
 import { SidebarContainer } from "./SidebarContainer";
 
 export const Sidebar = memo(function Sidebar({ className }: { className?: string }): ReactElement | null {
     const showDismissableSidebar = useAtomValue(SIDEBAR_DISMISSABLE_ATOM);
+    const disableSidebar = useAtomValue(DISABLE_SIDEBAR_ATOM);
 
-    // We don't want dismissable sidebars showing up on large screens
-    //
-    // Theoretically, they should show up as fixed SidebarContainers in large viewports
-    // but if we want to omit them, and the sidebar data is still there,
-    // the SIDEBAR_DISSMISSABLE_ATOM returns true, which results in this dismissable sidebar rendering.
-    //
-    // Because the implicit expectation is that dismissable sidebar will only render on mobile,
-    // its contents are set to be hidden on larger screens, so the content looks invisible, and an empty sidebar appears
-    // when the side of the page is hovered.
-    //
-    // changing the underlying state logic could have unexpected cascading effects,
-    // so we hide this sidebar on larger screens instead.
+    if (disableSidebar) {
+        return null;
+    }
+
     return showDismissableSidebar ? (
-        <div className="lg:hidden">
-            <DismissableSidebar className={className} />
-        </div>
+        <DismissableSidebar className={className} />
     ) : (
         <SidebarContainer className={clsx("desktop", className)} />
     );


### PR DESCRIPTION
https://github.com/fern-api/fern-platform/pull/1304 change is not necessarily true. we do want to sometimes render dismissible sidebars in certain cases. for example: when the markdown is `page` or `custom`.

This fixes the problem where sometimes hidden pages do not render a sidebar at all, which causes users to be unable to navigate to other pages on the same tab.