### PR TITLE
fix: changelog entry titles are rendered with <h2> rather than <h1>

### DIFF
--- a/packages/ui/app/src/changelog/ChangelogPage.tsx
+++ b/packages/ui/app/src/changelog/ChangelogPage.tsx
@@ -64,7 +64,21 @@ export function ChangelogPage({ content }: { content: DocsContent.ChangelogPage 
                                                         <div className="t-muted text-base mb-8 xl:hidden md:hidden">
                                                             <FernLink href={toHref(entry.slug)}>{entry.title}</FernLink>
                                                         </div>
-                                                        <Markdown title={title} mdx={page} />
+                                                        <Markdown
+                                                            title={
+                                                                title != null ? (
+                                                                    <h2>
+                                                                        <FernLink
+                                                                            href={toHref(entry.slug)}
+                                                                            className="no-underline"
+                                                                        >
+                                                                            {title}
+                                                                        </FernLink>
+                                                                    </h2>
+                                                                ) : undefined
+                                                            }
+                                                            mdx={page}
+                                                        />
                                                     </div>
                                                 </>
                                             ) : (
@@ -73,7 +87,21 @@ export function ChangelogPage({ content }: { content: DocsContent.ChangelogPage 
                                                         <div className="t-muted text-base mb-8 xl:hidden">
                                                             <FernLink href={toHref(entry.slug)}>{entry.title}</FernLink>
                                                         </div>
-                                                        <Markdown title={title} mdx={page} />
+                                                        <Markdown
+                                                            title={
+                                                                title != null ? (
+                                                                    <h2>
+                                                                        <FernLink
+                                                                            href={toHref(entry.slug)}
+                                                                            className="no-underline"
+                                                                        >
+                                                                            {title}
+                                                                        </FernLink>
+                                                                    </h2>
+                                                                ) : undefined
+                                                            }
+                                                            mdx={page}
+                                                        />
                                                     </div>
                                                     <div className="-mt-2 w-72 pl-4 text-right max-xl:hidden">
                                                         <span className="t-muted text-base sticky top-header-offset-padded">

--- a/packages/ui/app/src/changelog/ChangelogPage.tsx
+++ b/packages/ui/app/src/changelog/ChangelogPage.tsx
@@ -70,7 +70,7 @@ export function ChangelogPage({ content }: { content: DocsContent.ChangelogPage 
                                                                     <h2>
                                                                         <FernLink
                                                                             href={toHref(entry.slug)}
-                                                                            className="no-underline"
+                                                                            className="not-prose"
                                                                         >
                                                                             {title}
                                                                         </FernLink>
@@ -93,7 +93,7 @@ export function ChangelogPage({ content }: { content: DocsContent.ChangelogPage 
                                                                     <h2>
                                                                         <FernLink
                                                                             href={toHref(entry.slug)}
-                                                                            className="no-underline"
+                                                                            className="not-prose"
                                                                         >
                                                                             {title}
                                                                         </FernLink>

--- a/packages/ui/app/src/mdx/Markdown.tsx
+++ b/packages/ui/app/src/mdx/Markdown.tsx
@@ -34,7 +34,7 @@ export const Markdown = memo<Markdown.Props>(({ title, mdx, className, size, fal
                 "prose-lg": size === "lg",
             })}
         >
-            {title != null && <h1>{title}</h1>}
+            {title}
             <MdxContent mdx={mdx} fallback={fallback} />
         </div>
     );


### PR DESCRIPTION
This addresses an SEO problem where multiple \<h1\> are appearing on the same page