### PR TITLE
fix: syntax highlighter memoization

### DIFF
--- a/packages/ui/app/src/syntax-highlighting/FernSyntaxHighlighterTokens.tsx
+++ b/packages/ui/app/src/syntax-highlighting/FernSyntaxHighlighterTokens.tsx
@@ -35,12 +35,12 @@ export function fernSyntaxHighlighterTokenPropsAreEqual(
 ): boolean {
     return (
         isEqual(prevProps.highlightLines, nextProps.highlightLines) &&
-            isEqual(prevProps.style, nextProps.style) &&
-            prevProps.fontSize === nextProps.fontSize &&
-            prevProps.highlightStyle === nextProps.highlightStyle &&
-            prevProps.className === nextProps.className &&
-            prevProps.maxLines === nextProps.maxLines &&
-            prevProps.tokens === nextProps.tokens,
+        isEqual(prevProps.style, nextProps.style) &&
+        prevProps.fontSize === nextProps.fontSize &&
+        prevProps.highlightStyle === nextProps.highlightStyle &&
+        prevProps.className === nextProps.className &&
+        prevProps.maxLines === nextProps.maxLines &&
+        prevProps.tokens === nextProps.tokens &&
         prevProps.wordWrap === nextProps.wordWrap
     );
 }


### PR DESCRIPTION
Fixes [FER-3230](https://linear.app/buildwithfern/issue/FER-3230/syntax-highlighting-is-not-enabled-on-page-load)