### PR TITLE
fix: remove breadcrumbs with empty title

### DIFF
--- a/packages/fdr-sdk/src/navigation/utils/createBreadcrumbs.ts
+++ b/packages/fdr-sdk/src/navigation/utils/createBreadcrumbs.ts
@@ -54,5 +54,6 @@ export function createBreadcrumbs(nodes: NavigationNode[]): readonly NavigationB
         });
     });
 
-    return breadcrumb;
+    // Remove breadcrumbs with empty titles
+    return breadcrumb.filter((item) => item.title.trim().length > 0);
 }

--- a/packages/ui/app/src/components/FernBreadcrumbs.tsx
+++ b/packages/ui/app/src/components/FernBreadcrumbs.tsx
@@ -10,14 +10,15 @@ export interface FernBreadcrumbsProps {
 
 export function FernBreadcrumbs({ breadcrumbs }: FernBreadcrumbsProps): ReactElement | null {
     const toHref = useToHref();
+    const filteredBreadcrumbs = breadcrumbs.filter((item) => item.title.trim().length > 0);
 
-    if (breadcrumbs.length === 0) {
+    if (filteredBreadcrumbs.length === 0) {
         return null;
     }
     return (
         <div>
             <span className="fern-breadcrumbs">
-                {breadcrumbs.map((breadcrumb, idx) => (
+                {filteredBreadcrumbs.map((breadcrumb, idx) => (
                     <Fragment key={idx}>
                         {idx > 0 && <NavArrowRight className="fern-breadcrumbs-arrow" />}
                         {breadcrumb.pointsTo != null ? (


### PR DESCRIPTION
Fixes this issue:

<img width="109" alt="Screenshot 2024-09-11 at 2 26 24 AM" src="https://github.com/user-attachments/assets/31e75902-c198-4ffa-9e8c-8bbf4b053931">
