### PR TITLE
fix: increase to max height to prevent weird overflow

### DIFF
--- a/packages/ui/app/src/playground/PlaygroundAuthorizationForm.tsx
+++ b/packages/ui/app/src/playground/PlaygroundAuthorizationForm.tsx
@@ -195,9 +195,11 @@ function FoundOAuthReferencedEndpointForm({
             <li className="-mx-4 space-y-2 p-4 pb-2">
                 <FernSegmentedControl
                     options={authenticationOptions}
-                    onValueChange={(value: string) =>
-                        setValue((prev) => ({ ...prev, selectedInputMethod: value as "credentials" | "token" }))
-                    }
+                    onValueChange={(value: string) => {
+                        if (value != null && value.length > 0) {
+                            setValue((prev) => ({ ...prev, selectedInputMethod: value as "credentials" | "token" }));
+                        }
+                    }}
                     value={value.selectedInputMethod}
                     disabled={disabled}
                 />
@@ -548,7 +550,7 @@ export function PlaygroundAuthorizationFormCard({
 
             <FernCollapse isOpen={isOpen.value}>
                 <div className="pt-4">
-                    <div className="fern-dropdown !max-h-full">
+                    <div className="fern-dropdown max-h-full">
                         <PlaygroundAuthorizationForm auth={auth} closeContainer={isOpen.setFalse} disabled={disabled} />
 
                         <div className="flex justify-end p-4 pt-2 gap-2">

--- a/packages/ui/app/src/playground/PlaygroundAuthorizationForm.tsx
+++ b/packages/ui/app/src/playground/PlaygroundAuthorizationForm.tsx
@@ -548,7 +548,7 @@ export function PlaygroundAuthorizationFormCard({
 
             <FernCollapse isOpen={isOpen.value}>
                 <div className="pt-4">
-                    <div className="fern-dropdown !max-h-[500px]">
+                    <div className="fern-dropdown !max-h-full">
                         <PlaygroundAuthorizationForm auth={auth} closeContainer={isOpen.setFalse} disabled={disabled} />
 
                         <div className="flex justify-end p-4 pt-2 gap-2">


### PR DESCRIPTION
## Short description of the changes made

- ensures no weird ouath overflow if long OAuth flow

## What was the motivation & context behind this PR?

- Chariot's OAuth drawer looked strange: 
<img width="714" alt="Screenshot 2024-09-12 at 10 49 58 AM" src="https://github.com/user-attachments/assets/8d15bc9e-4ab2-4215-a8b2-b07ea49f4a92">

## How has this PR been tested?

- Now it doesn't:
<img width="706" alt="Screenshot 2024-09-12 at 10 50 10 AM" src="https://github.com/user-attachments/assets/bd7ce8ef-0281-4bc1-849d-97bdcbac1b9a">
