### PR TITLE
fix(fern-bot): reset any changes from trying to derive a major version upgrade

### DIFF
--- a/servers/fern-bot/src/functions/generator-updates/shared/updateGeneratorInternal.ts
+++ b/servers/fern-bot/src/functions/generator-updates/shared/updateGeneratorInternal.ts
@@ -336,6 +336,9 @@ async function handleSingleUpgrade({
         const toVersion = await getEntityVersion();
         const parsedFrom = SemVer.parse(fromVersion);
         const parsedTo = SemVer.parse(toVersion);
+        // Clean the branch back up, to remove any unstaged changes
+        await git.reset(["--hard"]);
+
         if (parsedFrom == null || parsedTo == null) {
             console.log("An invalid version was found, quitting", fromVersion, toVersion);
             return;


### PR DESCRIPTION
If a version upgrade is not found within your current major version, we then try to do an upgrade with major and see if there are any upgrades to then create a slack alert for ourselves

The problem was that we'd then leave the repo state dirty and when you check out the next branch, the major version change would persist to the next PR

This now resets the branch after the major version has been derived