### PR TITLE
fix: migrate changelog classnames to stylesheet

### DIFF
--- a/packages/ui/app/src/changelog/ChangelogContentLayout.tsx
+++ b/packages/ui/app/src/changelog/ChangelogContentLayout.tsx
@@ -9,29 +9,22 @@ interface ChangelogContentLayoutProps {
 
 export function ChangelogContentLayout({ children, stickyContent }: ChangelogContentLayoutProps): ReactElement {
     const fullWidth = useAtomValue(SIDEBAR_ROOT_NODE_ATOM) == null;
+    const asideContent = stickyContent != null && <div className="fern-changelog-date">{stickyContent}</div>;
     return fullWidth ? (
         <>
-            <div className="hidden lg:block flex-initial w-64 shrink-0">
-                {stickyContent != null && (
-                    <div className="sticky top-header-offset-padded t-muted text-base mb-8">{stickyContent}</div>
-                )}
-            </div>
-            <div className="mx-auto relative max-w-content-width min-w-0 shrink flex-auto">
-                {stickyContent != null && <div className="t-muted text-base mb-8 lg:hidden">{stickyContent}</div>}
+            <aside>{asideContent}</aside>
+            <div className="fern-changelog-content">
+                {asideContent}
                 {children}
             </div>
         </>
     ) : (
         <>
-            <div className="relative mr-6 max-w-content-width min-w-0 shrink flex-auto">
-                {stickyContent != null && <div className="t-muted text-base mb-8 xl:hidden">{stickyContent}</div>}
+            <div className="fern-changelog-content">
+                {asideContent}
                 {children}
             </div>
-            {stickyContent != null && (
-                <div className="-mt-2 w-72 pl-4 text-right hidden xl:block">
-                    <span className="t-muted text-base sticky top-header-offset-padded">{stickyContent}</span>
-                </div>
-            )}
+            <aside>{asideContent}</aside>
         </>
     );
 }

--- a/packages/ui/app/src/changelog/ChangelogContentLayout.tsx
+++ b/packages/ui/app/src/changelog/ChangelogContentLayout.tsx
@@ -1,30 +1,26 @@
-import { useAtomValue } from "jotai";
-import { ReactElement, ReactNode } from "react";
-import { SIDEBAR_ROOT_NODE_ATOM } from "../atoms";
+import clsx from "clsx";
+import { ComponentPropsWithoutRef, ReactElement, ReactNode } from "react";
 
-interface ChangelogContentLayoutProps {
+interface ChangelogContentLayoutProps extends ComponentPropsWithoutRef<"div"> {
+    as: "div" | "section" | "article";
     stickyContent?: ReactNode;
     children: ReactNode;
 }
 
-export function ChangelogContentLayout({ children, stickyContent }: ChangelogContentLayoutProps): ReactElement {
-    const fullWidth = useAtomValue(SIDEBAR_ROOT_NODE_ATOM) == null;
+export function ChangelogContentLayout({
+    as: Component,
+    children,
+    stickyContent,
+    ...props
+}: ChangelogContentLayoutProps): ReactElement {
     const asideContent = stickyContent != null && <div className="fern-changelog-date">{stickyContent}</div>;
-    return fullWidth ? (
-        <>
+    return (
+        <Component {...props} className={clsx("fern-changelog-entry", props.className)}>
             <aside>{asideContent}</aside>
             <div className="fern-changelog-content">
                 {asideContent}
                 {children}
             </div>
-        </>
-    ) : (
-        <>
-            <div className="fern-changelog-content">
-                {asideContent}
-                {children}
-            </div>
-            <aside>{asideContent}</aside>
-        </>
+        </Component>
     );
 }

--- a/packages/ui/app/src/changelog/ChangelogPage.tsx
+++ b/packages/ui/app/src/changelog/ChangelogPage.tsx
@@ -123,16 +123,14 @@ export function ChangelogPage({ content }: { content: DocsContent.ChangelogPage 
             })}
         >
             <main>
-                <section className="fern-changelog-entry">
-                    <ChangelogContentLayout>
-                        <PageHeader
-                            title={content.node.title}
-                            breadcrumbs={content.breadcrumbs}
-                            subtitle={typeof overview !== "string" ? overview?.frontmatter.excerpt : undefined}
-                        />
-                        <Markdown mdx={overview} />
-                    </ChangelogContentLayout>
-                </section>
+                <ChangelogContentLayout as="section" className="pb-8">
+                    <PageHeader
+                        title={content.node.title}
+                        breadcrumbs={content.breadcrumbs}
+                        subtitle={typeof overview !== "string" ? overview?.frontmatter.excerpt : undefined}
+                    />
+                    <Markdown mdx={overview} />
+                </ChangelogContentLayout>
 
                 {entries.map((entry) => {
                     const page = content.pages[entry.pageId];
@@ -140,34 +138,32 @@ export function ChangelogPage({ content }: { content: DocsContent.ChangelogPage 
                     return (
                         <Fragment key={entry.id}>
                             <hr />
-                            <article id={entry.date} className="fern-changelog-entry">
-                                <ChangelogContentLayout
-                                    stickyContent={<FernLink href={toHref(entry.slug)}>{entry.title}</FernLink>}
-                                >
-                                    <Markdown
-                                        title={
-                                            title != null ? (
-                                                <h2>
-                                                    <FernLink href={toHref(entry.slug)} className="not-prose">
-                                                        {title}
-                                                    </FernLink>
-                                                </h2>
-                                            ) : undefined
-                                        }
-                                        mdx={page}
-                                    />
-                                </ChangelogContentLayout>
-                            </article>
+                            <ChangelogContentLayout
+                                as="article"
+                                id={entry.date}
+                                stickyContent={<FernLink href={toHref(entry.slug)}>{entry.title}</FernLink>}
+                            >
+                                <Markdown
+                                    title={
+                                        title != null ? (
+                                            <h2>
+                                                <FernLink href={toHref(entry.slug)} className="not-prose">
+                                                    {title}
+                                                </FernLink>
+                                            </h2>
+                                        ) : undefined
+                                    }
+                                    mdx={page}
+                                />
+                            </ChangelogContentLayout>
                         </Fragment>
                     );
                 })}
 
                 {(prev != null || next != null) && (
-                    <div className="flex">
-                        <ChangelogContentLayout>
-                            <BottomNavigationButtons prev={prev} next={next} alwaysShowGrid />
-                        </ChangelogContentLayout>
-                    </div>
+                    <ChangelogContentLayout as="div">
+                        <BottomNavigationButtons prev={prev} next={next} alwaysShowGrid />
+                    </ChangelogContentLayout>
                 )}
 
                 <div className="h-48" />

--- a/packages/ui/app/src/changelog/ChangelogPage.tsx
+++ b/packages/ui/app/src/changelog/ChangelogPage.tsx
@@ -117,60 +117,62 @@ export function ChangelogPage({ content }: { content: DocsContent.ChangelogPage 
     }, [chunkedEntries.length, page]);
 
     return (
-        <div className="flex justify-between px-4 md:px-6 lg:px-8">
-            <div className={clsx("w-full min-w-0", { "pt-12 lg:pt-24": fullWidth, "pt-8": !fullWidth })}>
-                <main className={clsx("mx-auto max-w-screen-lg break-words", { "lg:ml-8": !fullWidth })}>
-                    <section className="flex pb-8">
+        <div
+            className={clsx("fern-changelog", {
+                "full-width": fullWidth,
+            })}
+        >
+            <main>
+                <section className="fern-changelog-entry">
+                    <ChangelogContentLayout>
+                        <PageHeader
+                            title={content.node.title}
+                            breadcrumbs={content.breadcrumbs}
+                            subtitle={typeof overview !== "string" ? overview?.frontmatter.excerpt : undefined}
+                        />
+                        <Markdown mdx={overview} />
+                    </ChangelogContentLayout>
+                </section>
+
+                {entries.map((entry) => {
+                    const page = content.pages[entry.pageId];
+                    const title = typeof page !== "string" ? page?.frontmatter.title : undefined;
+                    return (
+                        <Fragment key={entry.id}>
+                            <hr />
+                            <article id={entry.date} className="fern-changelog-entry">
+                                <ChangelogContentLayout
+                                    stickyContent={<FernLink href={toHref(entry.slug)}>{entry.title}</FernLink>}
+                                >
+                                    <Markdown
+                                        title={
+                                            title != null ? (
+                                                <h2>
+                                                    <FernLink href={toHref(entry.slug)} className="not-prose">
+                                                        {title}
+                                                    </FernLink>
+                                                </h2>
+                                            ) : undefined
+                                        }
+                                        mdx={page}
+                                    />
+                                </ChangelogContentLayout>
+                            </article>
+                        </Fragment>
+                    );
+                })}
+
+                {(prev != null || next != null) && (
+                    <div className="flex">
                         <ChangelogContentLayout>
-                            <PageHeader
-                                title={content.node.title}
-                                breadcrumbs={content.breadcrumbs}
-                                subtitle={typeof overview !== "string" ? overview?.frontmatter.excerpt : undefined}
-                            />
-                            <Markdown mdx={overview} />
+                            <BottomNavigationButtons prev={prev} next={next} alwaysShowGrid />
                         </ChangelogContentLayout>
-                    </section>
+                    </div>
+                )}
 
-                    {entries.map((entry) => {
-                        const page = content.pages[entry.pageId];
-                        const title = typeof page !== "string" ? page?.frontmatter.title : undefined;
-                        return (
-                            <Fragment key={entry.id}>
-                                <hr />
-                                <article id={entry.date} className="flex items-stretch py-8 lg:py-16">
-                                    <ChangelogContentLayout
-                                        stickyContent={<FernLink href={toHref(entry.slug)}>{entry.title}</FernLink>}
-                                    >
-                                        <Markdown
-                                            title={
-                                                title != null ? (
-                                                    <h2>
-                                                        <FernLink href={toHref(entry.slug)} className="not-prose">
-                                                            {title}
-                                                        </FernLink>
-                                                    </h2>
-                                                ) : undefined
-                                            }
-                                            mdx={page}
-                                        />
-                                    </ChangelogContentLayout>
-                                </article>
-                            </Fragment>
-                        );
-                    })}
-
-                    {(prev != null || next != null) && (
-                        <div className="flex">
-                            <ChangelogContentLayout>
-                                <BottomNavigationButtons prev={prev} next={next} alwaysShowGrid />
-                            </ChangelogContentLayout>
-                        </div>
-                    )}
-
-                    <div className="h-48" />
-                    <BuiltWithFern className="w-fit mx-auto my-8" />
-                </main>
-            </div>
+                <div className="h-48" />
+                <BuiltWithFern className="w-fit mx-auto my-8" />
+            </main>
         </div>
     );
 }

--- a/packages/ui/app/src/changelog/index.scss
+++ b/packages/ui/app/src/changelog/index.scss
@@ -8,7 +8,11 @@
     }
 
     .fern-changelog-entry {
-        @apply flex items-stretch py-8 lg:py-16;
+        @apply flex items-stretch;
+
+        &:is(article) {
+            @apply py-8 lg:py-16;
+        }
     }
 
     .fern-changelog.full-width {
@@ -36,6 +40,10 @@
 
         > main {
             @apply lg:ml-8;
+        }
+
+        .fern-changelog-entry {
+            @apply flex-row-reverse;
         }
 
         .fern-changelog-content {

--- a/packages/ui/app/src/changelog/index.scss
+++ b/packages/ui/app/src/changelog/index.scss
@@ -1,0 +1,57 @@
+@layer components {
+    .fern-changelog {
+        @apply flex justify-between px-4 md:px-6 lg:px-8;
+
+        > main {
+            @apply mx-auto max-w-screen-lg break-words;
+        }
+    }
+
+    .fern-changelog-entry {
+        @apply flex items-stretch py-8 lg:py-16;
+    }
+
+    .fern-changelog.full-width {
+        @apply pt-12 lg:pt-24;
+
+        .fern-changelog-content {
+            @apply mx-auto relative max-w-content-width min-w-0 shrink flex-auto;
+
+            .fern-changelog-date {
+                @apply t-muted text-base mb-8 lg:hidden;
+            }
+        }
+
+        .fern-changelog-entry > aside {
+            @apply hidden lg:block flex-initial w-64 shrink-0;
+
+            .fern-changelog-date {
+                @apply sticky top-header-offset-padded t-muted text-base mb-8;
+            }
+        }
+    }
+
+    .fern-changelog:not(.full-width) {
+        @apply pt-8;
+
+        > main {
+            @apply lg:ml-8;
+        }
+
+        .fern-changelog-content {
+            @apply relative mr-6 max-w-content-width min-w-0 shrink flex-auto;
+
+            .fern-changelog-date {
+                @apply t-muted text-base mb-8 xl:hidden;
+            }
+        }
+
+        .fern-changelog-entry > aside {
+            @apply -mt-2 w-72 pl-4 text-right hidden xl:block;
+
+            .fern-changelog-date {
+                @apply sticky t-muted text-base top-header-offset-padded;
+            }
+        }
+    }
+}

--- a/packages/ui/app/src/css/globals.scss
+++ b/packages/ui/app/src/css/globals.scss
@@ -10,6 +10,7 @@
 @import "../playground";
 @import "../components";
 @import "../mdx/components";
+@import "../changelog";
 @import "./utilities";
 @import "../themes";
 @import "../header";

--- a/packages/ui/app/src/sidebar/nodes/SidebarChangelogNode.tsx
+++ b/packages/ui/app/src/sidebar/nodes/SidebarChangelogNode.tsx
@@ -25,7 +25,7 @@ export function SidebarChangelogNode({ node, depth, className }: SidebarChangelo
             className={className}
             selected={selected}
             depth={Math.max(0, depth - 1)}
-            icon={node.icon ?? <Calendar />}
+            icon={node.icon ?? <Calendar className="size-4" />}
             tooltipContent={renderChangelogTooltip(node)}
             hidden={node.hidden}
         />


### PR DESCRIPTION
Cohere's stylesheet is broken due to use of tailwind classes that get overridden by cohere's own.

<img width="1728" alt="Screenshot 2024-09-13 at 3 29 06 PM" src="https://github.com/user-attachments/assets/e2088860-b1fe-40be-bb21-2a408db3507c">

----

After this PR:

<img width="1728" alt="Screenshot 2024-09-13 at 3 30 13 PM" src="https://github.com/user-attachments/assets/781cb9c6-8abe-4ae0-bd42-ac72f4585d59">
