### PR TITLE
add trailing path to parsed url in playground

### DIFF
--- a/packages/ui/app/src/components/MaybeEnvironmentDropdown.tsx
+++ b/packages/ui/app/src/components/MaybeEnvironmentDropdown.tsx
@@ -11,12 +11,18 @@ interface MaybeEnvironmentDropdownProps {
     protocolTextStyle?: string;
     small?: boolean;
     environmentFilters?: APIV1Read.EnvironmentId[];
+    trailingPath?: boolean;
 }
-export function MaybeEnvironmentDropdown(props: MaybeEnvironmentDropdownProps): ReactElement | null {
+export function MaybeEnvironmentDropdown({
+    selectedEnvironment,
+    urlTextStyle,
+    protocolTextStyle,
+    small,
+    environmentFilters,
+    trailingPath,
+}: MaybeEnvironmentDropdownProps): ReactElement | null {
     const [allEnvironmentIds] = useAtom(ALL_ENVIRONMENTS_ATOM);
     const [selectedEnvironmentId, setSelectedEnvironmentId] = useAtom(SELECTED_ENVIRONMENT_ATOM);
-
-    const { selectedEnvironment, urlTextStyle, protocolTextStyle, small, environmentFilters } = props;
 
     const environmentIds = environmentFilters
         ? environmentFilters.filter((environmentFilter) => allEnvironmentIds.includes(environmentFilter))
@@ -28,38 +34,41 @@ export function MaybeEnvironmentDropdown(props: MaybeEnvironmentDropdownProps): 
     const url = selectedEnvironment?.baseUrl && parse(selectedEnvironment?.baseUrl);
 
     return (
-        <span>
-            {environmentIds && environmentIds.length > 1 ? (
-                <FernDropdown
-                    key="selectedEnvironment-selector"
-                    options={environmentIds.map((env) => ({
-                        value: env,
-                        label: env,
-                        type: "value",
-                    }))}
-                    onValueChange={(value) => {
-                        setSelectedEnvironmentId(value);
-                    }}
-                    value={selectedEnvironmentId ?? selectedEnvironment?.id}
-                >
-                    <FernButton
-                        text={
-                            <span key="protocol" className="whitespace-nowrap max-sm:hidden">
-                                <span className={protocolTextStyle}>{`${url && url.protocol}//`}</span>
-                                <span className={urlTextStyle}>{(url && url.host) ?? selectedEnvironmentId}</span>
-                            </span>
-                        }
-                        size={small ? "small" : "normal"}
-                        variant="outlined"
-                        mono={true}
-                    />
-                </FernDropdown>
-            ) : (
-                <span key="protocol" className="whitespace-nowrap max-sm:hidden">
-                    <span className={protocolTextStyle}>{`${url && url.protocol}//`}</span>
-                    <span className={urlTextStyle}>{(url && url.host) ?? selectedEnvironmentId}</span>
-                </span>
-            )}
-        </span>
+        <>
+            <span>
+                {environmentIds && environmentIds.length > 1 ? (
+                    <FernDropdown
+                        key="selectedEnvironment-selector"
+                        options={environmentIds.map((env) => ({
+                            value: env,
+                            label: env,
+                            type: "value",
+                        }))}
+                        onValueChange={(value) => {
+                            setSelectedEnvironmentId(value);
+                        }}
+                        value={selectedEnvironmentId ?? selectedEnvironment?.id}
+                    >
+                        <FernButton
+                            text={
+                                <span key="protocol" className="whitespace-nowrap max-sm:hidden">
+                                    <span className={protocolTextStyle}>{`${url && url.protocol}//`}</span>
+                                    <span className={urlTextStyle}>{(url && url.host) ?? selectedEnvironmentId}</span>
+                                </span>
+                            }
+                            size={small ? "small" : "normal"}
+                            variant="outlined"
+                            mono={true}
+                        />
+                    </FernDropdown>
+                ) : (
+                    <span key="protocol" className="whitespace-nowrap max-sm:hidden">
+                        <span className={protocolTextStyle}>{`${url && url.protocol}//`}</span>
+                        <span className={urlTextStyle}>{(url && url.host) ?? selectedEnvironmentId}</span>
+                    </span>
+                )}
+            </span>
+            {trailingPath && url && url.pathname !== "/" && <span>{url.pathname}</span>}
+        </>
     );
 }

--- a/packages/ui/app/src/playground/endpoint/PlaygroundEndpointPath.tsx
+++ b/packages/ui/app/src/playground/endpoint/PlaygroundEndpointPath.tsx
@@ -58,6 +58,7 @@ export const PlaygroundEndpointPath: FC<PlaygroundEndpointPathProps> = ({
                                 small
                                 urlTextStyle="playground-endpoint-baseurl max-sm:hidden"
                                 protocolTextStyle="playground-endpoint-baseurl max-sm:hidden"
+                                trailingPath={true}
                             />
                         )}
                     </span>


### PR DESCRIPTION
Fixes FER-3184

## Short description of the changes made

- Add missing trailing path to api playground url

## What was the motivation & context behind this PR?

- monite was broken, see linear ticket

## How has this PR been tested?
<img width="471" alt="Screenshot 2024-09-13 at 6 31 03 PM" src="https://github.com/user-attachments/assets/e2b441b8-46f0-4743-8abf-2f3969a5af34">


