### PR TITLE
fix: revalidator, global-config

### DIFF
--- a/.github/workflows/deploy-docs-bundle-prod.yml
+++ b/.github/workflows/deploy-docs-bundle-prod.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./github/actions/ete-docs-bundle
+      - uses: ./.github/actions/ete-docs-bundle
         with:
           deployment_url: ${{ needs.deploy_app_buildwithfern_com.outputs.deployment_url }}
           token: ${{ secrets.VERCEL_TOKEN }}

--- a/clis/vercel-scripts/src/utils/global-config.ts
+++ b/clis/vercel-scripts/src/utils/global-config.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+const DARWIN_AUTH_PATH = "~/Library/Application Support/com.vercel.cli/auth.json";
+const LINUX_AUTH_PATH = "~/.local/share/com.vercel.cli/auth.json";
+
+function getAuthJson(): string | undefined {
+    try {
+        if (process.platform === "darwin") {
+            return String(readFileSync(join(homedir(), DARWIN_AUTH_PATH.slice(1))));
+        } else if (process.platform === "linux") {
+            return String(readFileSync(join(homedir(), LINUX_AUTH_PATH.slice(1))));
+        }
+    } catch (_e) {
+        // do nothing
+    }
+    return undefined;
+}
+
+export function getVercelTokenFromGlobalConfig(): string | undefined {
+    const authJson = getAuthJson();
+
+    if (authJson == null) {
+        return undefined;
+    }
+    try {
+        const auth = JSON.parse(authJson);
+        return auth.token;
+    } catch (_e) {
+        return undefined;
+    }
+}

--- a/clis/vercel-scripts/src/utils/revalidator.ts
+++ b/clis/vercel-scripts/src/utils/revalidator.ts
@@ -14,7 +14,7 @@ export class FernDocsRevalidator {
         this.teamId = teamId;
     }
 
-    private async *getProductionDomains(): AsyncGenerator<Vercel.GetProjectDomainsResponseDomainsItem> {
+    private async *getProductionDomains(): AsyncGenerator<Vercel.GetProjectDomainsResponseDomainsItem, void, unknown> {
         let cursor: number | undefined = undefined;
         do {
             const res = await this.vercel.projects.getProjectDomains(this.project, {
@@ -26,7 +26,9 @@ export class FernDocsRevalidator {
                 since: cursor ? cursor + 1 : undefined,
             });
 
-            yield* res.domains.filter((domain) => !BANNED_DOMAINS.includes(domain.apexName));
+            for (const domain of res.domains.filter((domain) => !BANNED_DOMAINS.includes(domain.apexName))) {
+                yield domain;
+            }
             cursor = res.pagination.next;
         } while (cursor);
     }
@@ -56,6 +58,7 @@ export class FernDocsRevalidator {
         logCommand("Revalidating all docs");
 
         const summary: Record<string, { success: number; failed: number }> = {};
+        const failedDomains: string[] = [];
 
         for await (const domain of this.getProductionDomains()) {
             // eslint-disable-next-line no-console
@@ -66,17 +69,24 @@ export class FernDocsRevalidator {
                 environment: `https://${domain.name}`,
             });
 
-            const revalidationSummary = { success: 0, failed: 0 };
-            const results = await client.revalidation.revalidateAllV4({ limit: 50 });
+            try {
+                const results = await client.revalidation.revalidateAllV4({ limit: 100 });
 
-            for await (const result of results) {
-                if (!result.success) {
-                    // eslint-disable-next-line no-console
-                    console.warn(`[${domain.name}] Failed to revalidate ${result.url}: ${result.error}`);
-                    revalidationSummary.failed++;
-                } else {
-                    revalidationSummary.success++;
+                const revalidationSummary = (summary[domain.name] = { success: 0, failed: 0 });
+                for await (const result of results) {
+                    if (!result.success) {
+                        // eslint-disable-next-line no-console
+                        console.warn(`[${domain.name}] Failed to revalidate ${result.url}: ${result.error}`);
+                        revalidationSummary.failed++;
+                    } else {
+                        revalidationSummary.success++;
+                    }
                 }
+                summary[domain.name] = revalidationSummary;
+            } catch (error) {
+                // eslint-disable-next-line no-console
+                console.error(`Failed to revalidate ${domain.name}: ${error}`);
+                failedDomains.push(domain.name);
             }
         }
 
@@ -85,6 +95,10 @@ export class FernDocsRevalidator {
         Object.entries(summary).forEach(([domain, { success, failed }]) => {
             // eslint-disable-next-line no-console
             console.log(`- ${domain}: ${success} successful, ${failed} failed`);
+        });
+        failedDomains.forEach((domain) => {
+            // eslint-disable-next-line no-console
+            console.error(`- ${domain}: Failed to revalidate`);
         });
     }
 }

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v3.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v3.ts
@@ -30,10 +30,7 @@ const handler: NextApiHandler = async (
     req: NextApiRequest,
     res: NextApiResponse<FernDocs.RevalidateAllV3Response>,
 ): Promise<unknown> => {
-    // when we call res.revalidate() nextjs uses
-    // req.headers.host to make the network request
     const xFernHost = getXFernHostNode(req, true);
-    req.headers.host = xFernHost;
 
     const revalidate = new Revalidator(res, xFernHost);
 

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v4.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v4.ts
@@ -74,7 +74,8 @@ const handler: NextApiHandler = async (
     const node = FernNavigation.utils.convertLoadDocsForUrlResponse(docs.body);
     const slugs = NodeCollector.collect(node).getPageSlugs();
     const total = slugs.length;
-    const batch = slugs.slice(offset, offset + limit);
+    const start = offset * limit;
+    const batch = slugs.slice(start, start + limit);
 
     const revalidate = new Revalidator(res, xFernHost);
     const results = await revalidate.batch(batch);

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v4.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v4.ts
@@ -18,10 +18,7 @@ const handler: NextApiHandler = async (
     req: NextApiRequest,
     res: NextApiResponse<FernDocs.RevalidateAllV4Response>,
 ): Promise<unknown> => {
-    // when we call res.revalidate() nextjs uses
-    // req.headers.host to make the network request
     const xFernHost = getXFernHostNode(req, true);
-    req.headers.host = xFernHost;
 
     /**
      * Limit the number of paths to revalidate to max of 100.


### PR DESCRIPTION
- Fixes revalidate-all/v4 pagination (offset * limit)
- Allows you to run `pnpm vercel-scripts` without an explicit token parameter
- Fixes production deployment action script
- Removes `req.headers.host` from revalidation script