### PR TITLE
fix: add javascript check for snippet resolver for back compat

### DIFF
--- a/packages/ui/app/src/playground/code-snippets/resolver.ts
+++ b/packages/ui/app/src/playground/code-snippets/resolver.ts
@@ -59,10 +59,13 @@ export class PlaygroundCodeSnippetResolver {
     private typescriptSdkResolver: SnippetTemplateResolver | undefined;
     private pythonRequestsResolver: SnippetTemplateResolver | undefined;
 
-    public resolve(lang: "curl" | "python" | "typescript", apiDefinition?: APIV1Read.ApiDefinition): string {
+    public resolve(
+        lang: "curl" | "python" | "typescript" | "javascript",
+        apiDefinition?: APIV1Read.ApiDefinition,
+    ): string {
         if (lang === "curl") {
             return this.toCurl();
-        } else if (lang === "typescript") {
+        } else if (lang === "typescript" || lang === "javascript") {
             return this.toTypescriptSdkSnippet(apiDefinition) ?? this.toTypescriptFetch();
         } else if (lang === "python") {
             return this.toPythonSdkSnippet(apiDefinition) ?? this.toPythonRequests();


### PR DESCRIPTION
Fixes FER-3298

## Short description of the changes made

- Adds javascript check for snippet resolver for back compat

## What was the motivation & context behind this PR?

- Workato playground was unable to open on machines where the snippet lang atom is set to "javascript"

## How has this PR been tested?

https://github.com/user-attachments/assets/20733ab3-17d8-4b4f-a2c7-374c8e089c3f

