### PR TITLE
fix: production ete flow

### DIFF
--- a/.github/workflows/deploy-docs-bundle-prod.yml
+++ b/.github/workflows/deploy-docs-bundle-prod.yml
@@ -65,8 +65,16 @@ jobs:
           pnpm vercel-scripts deploy app-slash.ferndocs.com --token=${{ secrets.VERCEL_TOKEN }} --environment=production
           echo "deployment_url=$(cat deployment-url.txt)" >> $GITHUB_OUTPUT
 
+  # note: E2E tests should run before the deployment is promoted
+  # but currently tests that rely on javascript are not running successfully b/c of assetPrefix issues
+  # so we we are running the tests after the deployment is promoted for now
+  # TODO: Fix the tests and run them before promoting the deployment
   ete:
-    needs: deploy_app_buildwithfern_com
+    needs:
+      - deploy_app_buildwithfern_com # only the app.buildwithfern.com deployment is an E2E candidate but ideally all deployments should be tested
+      - deploy_app_ferndocs_com
+      - deploy_app-slash_ferndocs_com
+      - promote
     if: needs.deploy_app_buildwithfern_com.outputs.deployment_url
     runs-on: ubuntu-latest
     steps:
@@ -76,13 +84,26 @@ jobs:
           deployment_url: ${{ needs.deploy_app_buildwithfern_com.outputs.deployment_url }}
           token: ${{ secrets.VERCEL_TOKEN }}
           fern_token: ${{ secrets.FERN_TOKEN }}
+      - name: Rollback on failure # remove this step once we switch back to pre-promotion testing
+        if: failure()
+        run: |
+          echo "E2E tests failed. Rolling back deployment"
+          pnpm vercel-scripts rollback app.buildwithfern.com --token ${{ secrets.VERCEL_TOKEN }}
+          pnpm vercel-scripts rollback app.ferndocs.com --token ${{ secrets.VERCEL_TOKEN }}
+          pnpm vercel-scripts rollback app-slash.ferndocs.com --token ${{ secrets.VERCEL_TOKEN }}
+
+          # currently only the custom domains for app.buildwithfern.com deployment should be revalidated
+          # because the other deployments don't have custom domains (yet)
+          pnpm vercel-scripts revalidate-all app.buildwithfern.com --token ${{ secrets.VERCEL_TOKEN }}
+          echo "All docs deployments have been rolled back successfully!"
+          exit 1
 
   promote:
     needs:
       - deploy_app_buildwithfern_com
       - deploy_app_ferndocs_com
       - deploy_app-slash_ferndocs_com
-      - ete # Ensure that the E2E tests are run successful before promoting
+      # - ete # Ensure that the E2E tests are run successful before promoting
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/clis/vercel-scripts/src/cli.ts
+++ b/clis/vercel-scripts/src/cli.ts
@@ -5,6 +5,7 @@ import { deployCommand } from "./commands/deploy.js";
 import { getLastDeployCommand } from "./commands/last-deploy.js";
 import { promoteCommand } from "./commands/promote.js";
 import { revalidateAllCommand } from "./commands/revalidate-all.js";
+import { rollbackCommand } from "./commands/rollback.js";
 import { writefs } from "./cwd.js";
 import { cleanDeploymentId } from "./utils/clean-id.js";
 import { getVercelTokenFromGlobalConfig } from "./utils/global-config.js";
@@ -70,6 +71,15 @@ void yargs(hideBin(process.argv))
             }),
         async ({ deploymentUrl, token, teamId, revalidateAll }) => {
             await promoteCommand({ deploymentIdOrUrl: deploymentUrl, token, teamId, revalidateAll });
+            process.exit(0);
+        },
+    )
+    .command(
+        "rollback <projectId>",
+        "Rollback to the previous deployment",
+        (argv) => argv.positional("projectId", { type: "string", demandOption: true }),
+        async ({ projectId, token }) => {
+            await rollbackCommand({ projectId, token });
             process.exit(0);
         },
     )

--- a/clis/vercel-scripts/src/commands/rollback.ts
+++ b/clis/vercel-scripts/src/commands/rollback.ts
@@ -1,0 +1,40 @@
+import { VercelClient } from "@fern-fern/vercel";
+
+/**
+ * Perform an instant rollback to the previous deployment.
+ *
+ * This should be used ONLY when a production deployment has failed.
+ */
+export async function rollbackCommand({ projectId, token }: { projectId: string; token: string }): Promise<void> {
+    const vercel = new VercelClient({ token });
+
+    const { deployments } = await vercel.deployments.getDeployments({
+        projectId,
+        rollbackCandidate: true,
+        state: "READY",
+        target: "production",
+        limit: 2,
+    });
+
+    if (!deployments[1]) {
+        throw new Error("No rollback candidate found.");
+    }
+
+    const deployment = deployments[1];
+
+    /**
+     * Vercel's OpenAPI doesn't have a rollback endpoint, so we have to use the API directly
+     */
+    await fetch(`/v9/projects/${projectId}/rollback/${deployment.uid}`, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+        },
+        // required
+        body: JSON.stringify({}),
+    });
+
+    // eslint-disable-next-line no-console
+    console.log(`Successfully rolled back ${projectId} to ${deployment.url}`);
+}


### PR DESCRIPTION
switches the order of the ete tests to run _after_ deployment succeeded, which may not pre-empt issues, but will self-resolve issues by rolling back the deployment upon failure