### PR TITLE
fix: api switching bug in ui

### DIFF
--- a/packages/ui/app/src/api-reference/examples/useHighlightJsonLines.ts
+++ b/packages/ui/app/src/api-reference/examples/useHighlightJsonLines.ts
@@ -1,5 +1,6 @@
 import { isPlainObject } from "@fern-ui/core-utils";
 import { useEffect, useRef, useState } from "react";
+import { lazyjsonpath } from "../../util/lazyjsonpath";
 import { JsonPropertyPath, JsonPropertyPathPart } from "./JsonPropertyPath";
 import { lineNumberOf } from "./utils";
 
@@ -115,7 +116,7 @@ export function useHighlightJsonLines(
                 // https://nextjs.org/docs/pages/building-your-application/optimizing/lazy-loading#with-external-libraries
                 // Note: there's a bug in nextjs that causes the import to fail inside of an jotai atom.
                 // The workaround is to import the module inside of the useEffect.
-                const jq = await import("jsonpath");
+                const jq = await lazyjsonpath();
                 if (currentNonce !== nonce.current) {
                     return;
                 }

--- a/packages/ui/app/src/api-reference/examples/useHighlightJsonLines.ts
+++ b/packages/ui/app/src/api-reference/examples/useHighlightJsonLines.ts
@@ -101,7 +101,7 @@ export function useHighlightJsonLines(
     jsonStartLine = 0,
 ): HighlightLineResult[] {
     const [results, setResults] = useState<HighlightLineResult[]>([]);
-    const nonce = useRef(0);
+    const nonce = useRef(0); // this is used to cancel the async call if the hoveredPropertyPath changes
 
     useEffect(() => {
         const currentNonce = ++nonce.current;

--- a/packages/ui/app/src/playground/utils.ts
+++ b/packages/ui/app/src/playground/utils.ts
@@ -17,6 +17,7 @@ import {
     unwrapReference,
     visitResolvedHttpRequestBodyShape,
 } from "../resolver/types";
+import { lazyjsonpath } from "../util/lazyjsonpath";
 import { unknownToString } from "../util/unknownToString";
 import { blobToDataURL } from "./fetch-utils/blobToDataURL";
 import { executeProxyRest } from "./fetch-utils/executeProxyRest";
@@ -598,7 +599,7 @@ export const oAuthClientCredentialReferencedEndpointLoginFlow = async ({
         json: async (jsonRes) => {
             if (jsonRes.response.ok) {
                 try {
-                    const jsonpath = await import("jsonpath");
+                    const jsonpath = await lazyjsonpath();
                     const accessToken = jsonpath.query(
                         jsonRes.response,
                         oAuthClientCredentialsReferencedEndpoint.accessTokenLocator,

--- a/packages/ui/app/src/util/lazyjsonpath.ts
+++ b/packages/ui/app/src/util/lazyjsonpath.ts
@@ -1,0 +1,11 @@
+let jq: Awaited<typeof import("jsonpath")>;
+
+/**
+ * This is a workaround to lazily import the jsonpath library, but also ensure that the lazy loading doesn't happen multiple times.
+ */
+export async function lazyjsonpath(): Promise<Awaited<typeof import("jsonpath")>> {
+    if (!jq) {
+        jq = (await import("jsonpath")).default;
+    }
+    return jq;
+}


### PR DESCRIPTION
This PR fixes a super weird bug with how nextjs handles dynamically imported third party libraries inside of a lazily imported component.

learnings:
1. this bug only appears on production
2. `import()` statement inside of a jotai atom will cause the entire component to fail to update
3. `import()` statement inside of useEffect will cause only the code snippets component to fail to update between navigation

As a workaround, we have a `lazyjsonpath.ts` file that will dynamically import and then memoize itself