### PR TITLE
fix: clear form in api playground

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -106,6 +106,12 @@ module.exports = {
         "tailwindcss/no-custom-classname": "off",
         "@next/next/no-html-link-for-pages": "off",
         "@next/next/no-img-element": "off",
+        "react-hooks/exhaustive-deps": [
+            "warn",
+            {
+                additionalHooks: "(useMemoOne|useCallbackOne)",
+            },
+        ],
     },
     overrides: [
         {

--- a/packages/ui/app/src/api-reference/endpoints/EndpointContent.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointContent.tsx
@@ -101,20 +101,23 @@ export const EndpointContent = memo<EndpointContent.Props>((props) => {
     const [selectedError, setSelectedError] = useState<ResolvedError | undefined>();
 
     useAtomEffect(
-        useCallbackOne((get) => {
-            const anchor = get(ANCHOR_ATOM);
-            const statusCodeOrName = maybeGetErrorStatusCodeOrNameFromAnchor(anchor);
-            if (statusCodeOrName != null) {
-                const error = endpoint.errors.find((e) =>
-                    typeof statusCodeOrName === "number"
-                        ? e.statusCode === statusCodeOrName
-                        : convertNameToAnchorPart(e.name) === statusCodeOrName,
-                );
-                if (error != null) {
-                    setSelectedError(error);
+        useCallbackOne(
+            (get) => {
+                const anchor = get(ANCHOR_ATOM);
+                const statusCodeOrName = maybeGetErrorStatusCodeOrNameFromAnchor(anchor);
+                if (statusCodeOrName != null) {
+                    const error = endpoint.errors.find((e) =>
+                        typeof statusCodeOrName === "number"
+                            ? e.statusCode === statusCodeOrName
+                            : convertNameToAnchorPart(e.name) === statusCodeOrName,
+                    );
+                    if (error != null) {
+                        setSelectedError(error);
+                    }
                 }
-            }
-        }, []),
+            },
+            [endpoint.errors],
+        ),
     );
 
     const examples = useMemo(() => {

--- a/packages/ui/app/src/atoms/playground.ts
+++ b/packages/ui/app/src/atoms/playground.ts
@@ -1,4 +1,5 @@
 import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
+import { EMPTY_OBJECT } from "@fern-ui/core-utils";
 import { useEventCallback } from "@fern-ui/react-commons";
 import { captureMessage } from "@sentry/nextjs";
 import { WritableAtom, atom, useAtom, useAtomValue, useSetAtom } from "jotai";
@@ -301,7 +302,7 @@ export function usePlaygroundEndpointFormState(
 ): [PlaygroundEndpointRequestFormState, Dispatch<SetStateAction<PlaygroundEndpointRequestFormState>>] {
     const formStateAtom = playgroundFormStateFamily(endpoint.nodeId);
     const formState = useAtomValue(playgroundFormStateFamily(endpoint.nodeId));
-    const types = useFlattenedApi(endpoint.apiDefinitionId)?.types ?? {};
+    const types = useFlattenedApi(endpoint.apiDefinitionId)?.types ?? EMPTY_OBJECT;
 
     return [
         formState?.type === "endpoint" ? formState : getInitialEndpointRequestFormState(endpoint, types),
@@ -319,7 +320,7 @@ export function usePlaygroundEndpointFormState(
                             : update;
                     set(formStateAtom, newFormState);
                 },
-                [formStateAtom, endpoint.nodeId],
+                [formStateAtom, endpoint, types],
             ),
         ),
     ];
@@ -330,7 +331,7 @@ export function usePlaygroundWebsocketFormState(
 ): [PlaygroundWebSocketRequestFormState, Dispatch<SetStateAction<PlaygroundWebSocketRequestFormState>>] {
     const formStateAtom = playgroundFormStateFamily(channel.nodeId);
     const formState = useAtomValue(playgroundFormStateFamily(channel.nodeId));
-    const types = useFlattenedApi(channel.apiDefinitionId)?.types ?? {};
+    const types = useFlattenedApi(channel.apiDefinitionId)?.types ?? EMPTY_OBJECT;
 
     return [
         formState?.type === "websocket" ? formState : getInitialWebSocketRequestFormState(channel, types),
@@ -348,7 +349,7 @@ export function usePlaygroundWebsocketFormState(
                             : update;
                     set(formStateAtom, newFormState);
                 },
-                [formStateAtom, channel.nodeId],
+                [formStateAtom, channel, types],
             ),
         ),
     ];

--- a/packages/ui/app/src/playground/PlaygroundDrawer.tsx
+++ b/packages/ui/app/src/playground/PlaygroundDrawer.tsx
@@ -60,21 +60,27 @@ export const PlaygroundDrawer = memo(({ isLoading }: PlaygroundDrawerProps): Rea
     const height = useMotionValue(useAtomValue(VIEWPORT_HEIGHT_ATOM));
 
     const setOffset = useAtomCallback(
-        useCallbackOne((get, _set, y: number) => {
-            const windowHeight = get(VIEWPORT_HEIGHT_ATOM);
-            const isMobileScreen = get(IS_MOBILE_SCREEN_ATOM);
-            const headerHeight = get(HEADER_HEIGHT_ATOM);
-            const maxHeight = isMobileScreen ? windowHeight : windowHeight - headerHeight;
-            const newHeight = Math.min(windowHeight - y, maxHeight);
-            height.jump(newHeight, true);
-        }, []),
+        useCallbackOne(
+            (get, _set, y: number) => {
+                const windowHeight = get(VIEWPORT_HEIGHT_ATOM);
+                const isMobileScreen = get(IS_MOBILE_SCREEN_ATOM);
+                const headerHeight = get(HEADER_HEIGHT_ATOM);
+                const maxHeight = isMobileScreen ? windowHeight : windowHeight - headerHeight;
+                const newHeight = Math.min(windowHeight - y, maxHeight);
+                height.jump(newHeight, true);
+            },
+            [height],
+        ),
     );
 
     useAtomEffect(
-        useCallbackOne((get) => {
-            get(PLAYGROUND_NODE_ID);
-            void animate(height, get.peek(VIEWPORT_HEIGHT_ATOM));
-        }, []),
+        useCallbackOne(
+            (get) => {
+                get(PLAYGROUND_NODE_ID);
+                void animate(height, get.peek(VIEWPORT_HEIGHT_ATOM));
+            },
+            [height],
+        ),
     );
 
     const resizeY = useResizeY(setOffset);

--- a/packages/ui/app/src/playground/endpoint/PlaygroundEndpoint.tsx
+++ b/packages/ui/app/src/playground/endpoint/PlaygroundEndpoint.tsx
@@ -1,11 +1,11 @@
 import { FernTooltipProvider } from "@fern-ui/components";
 import { unknownToString } from "@fern-ui/core-utils";
 import { Loadable, failed, loaded, loading, notStartedLoading } from "@fern-ui/loadable";
+import { useEventCallback } from "@fern-ui/react-commons";
 import { SendSolid } from "iconoir-react";
 import { useSetAtom } from "jotai";
 import { mapValues } from "lodash-es";
 import { FC, ReactElement, useCallback, useState } from "react";
-import { useCallbackOne } from "use-memo-one";
 import { captureSentryError } from "../../analytics/sentry";
 import {
     PLAYGROUND_AUTH_STATE_ATOM,
@@ -43,13 +43,13 @@ interface PlaygroundEndpointProps {
 export const PlaygroundEndpoint: FC<PlaygroundEndpointProps> = ({ endpoint, types }): ReactElement => {
     const [formState, setFormState] = usePlaygroundEndpointFormState(endpoint);
 
-    const resetWithExample = useCallbackOne(() => {
+    const resetWithExample = useEventCallback(() => {
         setFormState(getInitialEndpointRequestFormStateWithExample(endpoint, endpoint.examples[0], types));
-    }, [endpoint, types]);
+    });
 
-    const resetWithoutExample = useCallbackOne(() => {
+    const resetWithoutExample = useEventCallback(() => {
         setFormState(getInitialEndpointRequestFormState(endpoint, types));
-    }, [endpoint, types]);
+    });
 
     const basePath = useBasePath();
     const { usesApplicationJsonInFormDataValue, proxyShouldUseAppBuildwithfernCom } = useFeatureFlags();

--- a/packages/ui/app/src/playground/endpoint/PlaygroundEndpoint.tsx
+++ b/packages/ui/app/src/playground/endpoint/PlaygroundEndpoint.tsx
@@ -49,7 +49,7 @@ export const PlaygroundEndpoint: FC<PlaygroundEndpointProps> = ({ endpoint, type
 
     const resetWithoutExample = useCallbackOne(() => {
         setFormState(getInitialEndpointRequestFormState(endpoint, types));
-    }, []);
+    }, [endpoint, types]);
 
     const basePath = useBasePath();
     const { usesApplicationJsonInFormDataValue, proxyShouldUseAppBuildwithfernCom } = useFeatureFlags();

--- a/packages/ui/app/src/playground/endpoint/PlaygroundEndpointFormButtons.tsx
+++ b/packages/ui/app/src/playground/endpoint/PlaygroundEndpointFormButtons.tsx
@@ -7,6 +7,9 @@ import { CURRENT_NODE_ATOM, useClosePlayground } from "../../atoms";
 import { FernLink } from "../../components/FernLink";
 import { ResolvedEndpointDefinition } from "../../resolver/types";
 
+const USE_EXAMPLE_TEXT = "Use example";
+const CLEAR_FORM_TEXT = "Clear form";
+
 interface PlaygroundEndpointFormButtonsProps {
     endpoint: ResolvedEndpointDefinition;
     resetWithExample: () => void;
@@ -25,10 +28,10 @@ export function PlaygroundEndpointFormButtons({
         <div className="flex justify-between items-center">
             <FernButtonGroup>
                 <FernButton onClick={resetWithExample} size="small" variant="minimal">
-                    Use example
+                    {USE_EXAMPLE_TEXT}
                 </FernButton>
                 <FernButton onClick={resetWithoutExample} size="small" variant="minimal">
-                    Clear form
+                    {CLEAR_FORM_TEXT}
                 </FernButton>
             </FernButtonGroup>
 


### PR DESCRIPTION
Before this PR: When clicking `Clear form` in the API Playground after switching from one endpoint to another, it fails to clear form.

After this PR: fix memoization dependency and add eslint rules to prevent this from happening again