### PR TITLE
chore(ui): refactor resolve-api to take serializeMdx as input

### DIFF
--- a/packages/ui/app/src/index.ts
+++ b/packages/ui/app/src/index.ts
@@ -6,6 +6,7 @@ export * from "./docs/NextApp";
 export { getApiRouteSupplier } from "./hooks/useApiRoute";
 export { serializeMdx, setMdxBundler } from "./mdx/bundler";
 export { getFrontmatter } from "./mdx/frontmatter";
+export * from "./mdx/types";
 export { Stream } from "./playground/Stream";
 export { ProxyRequestSchema } from "./playground/types";
 export type { ProxyRequest, ProxyResponse, SerializableFile, SerializableFormDataEntryValue } from "./playground/types";

--- a/packages/ui/app/src/mdx/bundler.ts
+++ b/packages/ui/app/src/mdx/bundler.ts
@@ -27,3 +27,8 @@ export async function serializeMdx(
     const bundler = await getMdxBundler();
     return bundler(content, options);
 }
+
+export type MDX_SERIALIZER = {
+    (content: string, options?: FernSerializeMdxOptions): Promise<BundledMDX>;
+    (content: string | undefined, options?: FernSerializeMdxOptions): Promise<BundledMDX | undefined>;
+};

--- a/packages/ui/app/src/resolver/ApiDefinitionResolver.ts
+++ b/packages/ui/app/src/resolver/ApiDefinitionResolver.ts
@@ -50,7 +50,7 @@ export class ApiDefinitionResolver {
         private pages: Record<string, DocsV1Read.PageContent>,
         private featureFlags: FeatureFlags,
         private mdxOptions: FernSerializeMdxOptions | undefined,
-        private serializeMdx: MDX_SERIALIZER = serializeMdx,
+        private serializeMdx: MDX_SERIALIZER,
     ) {
         this.definitionResolver = new ApiEndpointResolver(
             this.collector,

--- a/packages/ui/app/src/resolver/ApiDefinitionResolver.ts
+++ b/packages/ui/app/src/resolver/ApiDefinitionResolver.ts
@@ -22,9 +22,9 @@ export class ApiDefinitionResolver {
         holder: FernNavigation.ApiDefinitionHolder,
         typeResolver: ApiTypeResolver,
         pages: Record<string, DocsV1Read.PageContent>,
-        serializeMdx: MDX_SERIALIZER,
         mdxOptions: FernSerializeMdxOptions | undefined,
         featureFlags: FeatureFlags,
+        serializeMdx: MDX_SERIALIZER,
     ): Promise<ResolvedRootPackage> {
         const resolver = new ApiDefinitionResolver(
             collector,
@@ -50,7 +50,7 @@ export class ApiDefinitionResolver {
         private pages: Record<string, DocsV1Read.PageContent>,
         private featureFlags: FeatureFlags,
         private mdxOptions: FernSerializeMdxOptions | undefined,
-        private serializeMdx: MDX_SERIALIZER,
+        private serializeMdx: MDX_SERIALIZER = serializeMdx,
     ) {
         this.definitionResolver = new ApiEndpointResolver(
             this.collector,
@@ -59,7 +59,7 @@ export class ApiDefinitionResolver {
             this.resolvedTypes,
             featureFlags,
             mdxOptions,
-            serializeMdx
+            serializeMdx,
         );
     }
 

--- a/packages/ui/app/src/resolver/ApiEndpointResolver.ts
+++ b/packages/ui/app/src/resolver/ApiEndpointResolver.ts
@@ -42,7 +42,7 @@ export class ApiEndpointResolver {
         private resolvedTypes: Record<string, ResolvedTypeDefinition>,
         private featureFlags: FeatureFlags,
         private mdxOptions: FernSerializeMdxOptions | undefined,
-        private serializeMdx: MDX_SERIALIZER = serializeMdx,
+        private serializeMdx: MDX_SERIALIZER,
     ) {}
 
     async resolveEndpointDefinition(node: FernNavigation.EndpointNode): Promise<ResolvedEndpointDefinition> {

--- a/packages/ui/app/src/resolver/ApiEndpointResolver.ts
+++ b/packages/ui/app/src/resolver/ApiEndpointResolver.ts
@@ -42,7 +42,7 @@ export class ApiEndpointResolver {
         private resolvedTypes: Record<string, ResolvedTypeDefinition>,
         private featureFlags: FeatureFlags,
         private mdxOptions: FernSerializeMdxOptions | undefined,
-        private serializeMdx: MDX_SERIALIZER,
+        private serializeMdx: MDX_SERIALIZER = serializeMdx,
     ) {}
 
     async resolveEndpointDefinition(node: FernNavigation.EndpointNode): Promise<ResolvedEndpointDefinition> {

--- a/packages/ui/app/src/resolver/ApiTypeResolver.ts
+++ b/packages/ui/app/src/resolver/ApiTypeResolver.ts
@@ -15,7 +15,7 @@ export class ApiTypeResolver {
     public constructor(
         private types: Record<string, APIV1Read.TypeDefinition>,
         private mdxOptions: FernSerializeMdxOptions | undefined,
-        private serializeMdx: MDX_SERIALIZER,
+        private serializeMdx: MDX_SERIALIZER = serializeMdx,
     ) {}
 
     public resolve = once(async (): Promise<Record<string, ResolvedTypeDefinition>> => {

--- a/packages/ui/app/src/resolver/ApiTypeResolver.ts
+++ b/packages/ui/app/src/resolver/ApiTypeResolver.ts
@@ -15,7 +15,7 @@ export class ApiTypeResolver {
     public constructor(
         private types: Record<string, APIV1Read.TypeDefinition>,
         private mdxOptions: FernSerializeMdxOptions | undefined,
-        private serializeMdx: MDX_SERIALIZER = serializeMdx,
+        private serializeMdx: MDX_SERIALIZER,
     ) {}
 
     public resolve = once(async (): Promise<Record<string, ResolvedTypeDefinition>> => {

--- a/packages/ui/app/src/resolver/__test__/ApiDefinitionResolver.test.ts
+++ b/packages/ui/app/src/resolver/__test__/ApiDefinitionResolver.test.ts
@@ -15,7 +15,7 @@ describe("resolveApiDefinition", () => {
 
         const fixture = JSON.parse(content) as APIV1Read.ApiDefinition;
         const holder = FernNavigation.ApiDefinitionHolder.create(fixture);
-        const typeResolver = new ApiTypeResolver(fixture.types, undefined);
+        const typeResolver = new ApiTypeResolver(fixture.types, undefined, serializeMdx);
 
         // mocked node
         const node = FernNavigation.ApiReferenceNavigationConverter.convert(
@@ -60,7 +60,7 @@ describe("resolveApiDefinition", () => {
 
         const fixture = JSON.parse(content) as APIV1Read.ApiDefinition;
         const holder = FernNavigation.ApiDefinitionHolder.create(fixture);
-        const typeResolver = new ApiTypeResolver(fixture.types, undefined);
+        const typeResolver = new ApiTypeResolver(fixture.types, undefined, serializeMdx);
 
         // mocked node
         const node = FernNavigation.ApiReferenceNavigationConverter.convert(

--- a/packages/ui/app/src/resolver/__test__/ApiDefinitionResolver.test.ts
+++ b/packages/ui/app/src/resolver/__test__/ApiDefinitionResolver.test.ts
@@ -3,6 +3,7 @@ import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import fs from "fs";
 import path from "path";
 import { DEFAULT_FEATURE_FLAGS } from "../../atoms";
+import { serializeMdx } from "../../mdx/bundler";
 import { ApiDefinitionResolver } from "../ApiDefinitionResolver";
 import { ApiTypeResolver } from "../ApiTypeResolver";
 import { ResolvedEndpointDefinition } from "../types";
@@ -48,6 +49,7 @@ describe("resolveApiDefinition", () => {
             {},
             undefined,
             DEFAULT_FEATURE_FLAGS,
+            serializeMdx,
         );
         expect(resolved).toMatchSnapshot();
     });
@@ -92,6 +94,7 @@ describe("resolveApiDefinition", () => {
             {},
             undefined,
             DEFAULT_FEATURE_FLAGS,
+            serializeMdx,
         );
         expect(resolved).toMatchSnapshot();
         expect((resolved.items[0] as ResolvedEndpointDefinition).auth).toBeUndefined();

--- a/packages/ui/app/src/util/resolveDocsContent.ts
+++ b/packages/ui/app/src/util/resolveDocsContent.ts
@@ -183,7 +183,7 @@ export async function resolveDocsContent({
                 await typeResolver.resolve(),
                 featureFlags,
                 mdxOptions,
-                serializeMdx
+                serializeMdx,
             );
             return {
                 type: "api-endpoint-page",

--- a/packages/ui/app/src/util/resolveDocsContent.ts
+++ b/packages/ui/app/src/util/resolveDocsContent.ts
@@ -175,7 +175,7 @@ export async function resolveDocsContent({
             const parent = found.parents[found.parents.length - 1];
             api = pruner.prune(parent?.type === "endpointPair" ? parent : node);
             const holder = FernNavigation.ApiDefinitionHolder.create(api);
-            const typeResolver = new ApiTypeResolver(api.types, mdxOptions);
+            const typeResolver = new ApiTypeResolver(api.types, mdxOptions, serializeMdx);
             const defResolver = new ApiEndpointResolver(
                 found.collector,
                 holder,
@@ -183,6 +183,7 @@ export async function resolveDocsContent({
                 await typeResolver.resolve(),
                 featureFlags,
                 mdxOptions,
+                serializeMdx,
             );
             return {
                 type: "api-endpoint-page",
@@ -210,13 +211,14 @@ export async function resolveDocsContent({
             };
         }
         const holder = FernNavigation.ApiDefinitionHolder.create(api);
-        const typeResolver = new ApiTypeResolver(api.types, mdxOptions);
+        const typeResolver = new ApiTypeResolver(api.types, mdxOptions, serializeMdx);
         const apiDefinition = await ApiDefinitionResolver.resolve(
             found.collector,
             apiReference,
             holder,
             typeResolver,
             pages,
+            serializeMdx,
             mdxOptions,
             featureFlags,
         );
@@ -296,7 +298,7 @@ async function resolveMarkdownPage(
                     ];
                 }
                 const holder = FernNavigation.ApiDefinitionHolder.create(definition);
-                const typeResolver = new ApiTypeResolver(definition.types, mdxOptions);
+                const typeResolver = new ApiTypeResolver(definition.types, mdxOptions, serializeMdx);
                 return [
                     apiNode.title,
                     await ApiDefinitionResolver.resolve(
@@ -305,6 +307,7 @@ async function resolveMarkdownPage(
                         holder,
                         typeResolver,
                         pages,
+                        serializeMdx,
                         mdxOptions,
                         featureFlags,
                     ),

--- a/packages/ui/app/src/util/resolveDocsContent.ts
+++ b/packages/ui/app/src/util/resolveDocsContent.ts
@@ -175,7 +175,7 @@ export async function resolveDocsContent({
             const parent = found.parents[found.parents.length - 1];
             api = pruner.prune(parent?.type === "endpointPair" ? parent : node);
             const holder = FernNavigation.ApiDefinitionHolder.create(api);
-            const typeResolver = new ApiTypeResolver(api.types, mdxOptions);
+            const typeResolver = new ApiTypeResolver(api.types, mdxOptions, serializeMdx);
             const defResolver = new ApiEndpointResolver(
                 found.collector,
                 holder,
@@ -183,6 +183,7 @@ export async function resolveDocsContent({
                 await typeResolver.resolve(),
                 featureFlags,
                 mdxOptions,
+                serializeMdx
             );
             return {
                 type: "api-endpoint-page",
@@ -210,7 +211,7 @@ export async function resolveDocsContent({
             };
         }
         const holder = FernNavigation.ApiDefinitionHolder.create(api);
-        const typeResolver = new ApiTypeResolver(api.types, mdxOptions);
+        const typeResolver = new ApiTypeResolver(api.types, mdxOptions, serializeMdx);
         const apiDefinition = await ApiDefinitionResolver.resolve(
             found.collector,
             apiReference,
@@ -297,7 +298,7 @@ async function resolveMarkdownPage(
                     ];
                 }
                 const holder = FernNavigation.ApiDefinitionHolder.create(definition);
-                const typeResolver = new ApiTypeResolver(definition.types, mdxOptions);
+                const typeResolver = new ApiTypeResolver(definition.types, mdxOptions, serializeMdx);
                 return [
                     apiNode.title,
                     await ApiDefinitionResolver.resolve(

--- a/packages/ui/app/src/util/resolveDocsContent.ts
+++ b/packages/ui/app/src/util/resolveDocsContent.ts
@@ -175,7 +175,7 @@ export async function resolveDocsContent({
             const parent = found.parents[found.parents.length - 1];
             api = pruner.prune(parent?.type === "endpointPair" ? parent : node);
             const holder = FernNavigation.ApiDefinitionHolder.create(api);
-            const typeResolver = new ApiTypeResolver(api.types, mdxOptions, serializeMdx);
+            const typeResolver = new ApiTypeResolver(api.types, mdxOptions);
             const defResolver = new ApiEndpointResolver(
                 found.collector,
                 holder,
@@ -183,7 +183,6 @@ export async function resolveDocsContent({
                 await typeResolver.resolve(),
                 featureFlags,
                 mdxOptions,
-                serializeMdx,
             );
             return {
                 type: "api-endpoint-page",
@@ -211,16 +210,16 @@ export async function resolveDocsContent({
             };
         }
         const holder = FernNavigation.ApiDefinitionHolder.create(api);
-        const typeResolver = new ApiTypeResolver(api.types, mdxOptions, serializeMdx);
+        const typeResolver = new ApiTypeResolver(api.types, mdxOptions);
         const apiDefinition = await ApiDefinitionResolver.resolve(
             found.collector,
             apiReference,
             holder,
             typeResolver,
             pages,
-            serializeMdx,
             mdxOptions,
             featureFlags,
+            serializeMdx,
         );
         return {
             type: "api-reference-page",
@@ -298,7 +297,7 @@ async function resolveMarkdownPage(
                     ];
                 }
                 const holder = FernNavigation.ApiDefinitionHolder.create(definition);
-                const typeResolver = new ApiTypeResolver(definition.types, mdxOptions, serializeMdx);
+                const typeResolver = new ApiTypeResolver(definition.types, mdxOptions);
                 return [
                     apiNode.title,
                     await ApiDefinitionResolver.resolve(
@@ -307,9 +306,9 @@ async function resolveMarkdownPage(
                         holder,
                         typeResolver,
                         pages,
-                        serializeMdx,
                         mdxOptions,
                         featureFlags,
+                        serializeMdx,
                     ),
                 ];
             }),

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/resolve-api.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/resolve-api.ts
@@ -9,12 +9,13 @@ import {
     provideRegistryService,
     serializeMdx,
     setMdxBundler,
+    type BundledMDX,
+    type FernSerializeMdxOptions,
     type ResolvedRootPackage,
 } from "@fern-ui/ui";
 import { checkViewerAllowedNode } from "@fern-ui/ui/auth";
 import { getMdxBundler } from "@fern-ui/ui/bundlers";
 import { NextApiHandler, NextApiResponse } from "next";
-import { BundledMDX, FernSerializeMdxOptions } from "../../../../../app/src/mdx/types";
 import { getFeatureFlags } from "./feature-flags";
 
 export const dynamic = "force-dynamic";


### PR DESCRIPTION
## Short description of the changes made
Extracts `serializeMdx` from the APIResolver. 

## What was the motivation & context behind this PR?
By extracting `serializeMdx` into an interface, we can optionally have other callers provide a cached implementation to improve performance. 
