### PR TITLE
fix: canonical url leading slash

### DIFF
--- a/packages/ui/app/src/hooks/__test__/useHref.test.ts
+++ b/packages/ui/app/src/hooks/__test__/useHref.test.ts
@@ -1,0 +1,27 @@
+import { FernNavigation } from "@fern-api/fdr-sdk";
+import { getToHref } from "../useHref";
+
+const toHrefWithLeadingSlash = getToHref(true);
+const toHrefWithoutLeadingSlash = getToHref(false);
+
+describe("toHref", () => {
+    it("should return href without leading slash", () => {
+        expect(toHrefWithoutLeadingSlash(FernNavigation.Slug("slug"))).toBe("/slug");
+        expect(toHrefWithoutLeadingSlash(FernNavigation.Slug("a/b/c"))).toBe("/a/b/c");
+        expect(toHrefWithoutLeadingSlash(FernNavigation.Slug(""))).toBe("/");
+        expect(toHrefWithoutLeadingSlash(FernNavigation.Slug("a/b"), "example.com")).toBe("https://example.com/a/b");
+        expect(toHrefWithoutLeadingSlash(FernNavigation.Slug(""), "example.com")).toBe(
+            "https://example.com/", // trailing slash on root is not removed
+        );
+    });
+
+    it("should return href with leading slash", () => {
+        expect(toHrefWithLeadingSlash(FernNavigation.Slug("slug"))).toBe("/slug/");
+        expect(toHrefWithLeadingSlash(FernNavigation.Slug("a/b/c"))).toBe("/a/b/c/");
+        expect(toHrefWithLeadingSlash(FernNavigation.Slug(""))).toBe("/");
+        expect(toHrefWithLeadingSlash(FernNavigation.Slug("a/b"), "example.com")).toBe("https://example.com/a/b/");
+        expect(toHrefWithLeadingSlash(FernNavigation.Slug(""), "example.com")).toBe(
+            "https://example.com/", // trailing slash on root is not removed
+        );
+    });
+});

--- a/packages/ui/app/src/hooks/useHref.ts
+++ b/packages/ui/app/src/hooks/useHref.ts
@@ -1,9 +1,17 @@
 import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
+import { withDefaultProtocol } from "@fern-ui/core-utils";
 import { Atom, useAtomValue } from "jotai";
+import urlJoin from "url-join";
 import { TRAILING_SLASH_ATOM } from "../atoms";
 
-export function getToHref(includeTrailingSlash: boolean = false): (slug: FernNavigation.Slug) => string {
-    return (slug) => (includeTrailingSlash ? `/${slug}/` : `/${slug}`);
+export function getToHref(includeTrailingSlash: boolean = false): (slug: FernNavigation.Slug, host?: string) => string {
+    return (slug, host) => {
+        const path = slug === "" ? "/" : includeTrailingSlash ? `/${slug}/` : `/${slug}`;
+        if (host == null) {
+            return path;
+        }
+        return urlJoin(withDefaultProtocol(host), path);
+    };
 }
 
 export function useToHref(): (slug: FernNavigation.Slug) => string {
@@ -22,5 +30,5 @@ export function useHref(slug: FernNavigation.Slug | undefined, anchor?: string):
 }
 
 export function selectHref(get: <T>(atom: Atom<T>) => T, slug: FernNavigation.Slug): string {
-    return get(TRAILING_SLASH_ATOM) ? `/${slug}/` : `/${slug}`;
+    return getToHref(get(TRAILING_SLASH_ATOM))(slug);
 }

--- a/packages/ui/app/src/seo/getSeoProp.ts
+++ b/packages/ui/app/src/seo/getSeoProp.ts
@@ -6,6 +6,7 @@ import { trim } from "lodash-es";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { toHast } from "mdast-util-to-hast";
 import { visit } from "unist-util-visit";
+import urlJoin from "url-join";
 import { getToHref } from "../hooks/useHref";
 import { stringHasMarkdown } from "../mdx/common/util";
 import { getFrontmatter } from "../mdx/frontmatter";
@@ -72,7 +73,7 @@ export function getSeoProps(
      */
     // TODO: set canonical domain in docs.yml
     const toHref = getToHref(isTrailingSlashEnabled);
-    seo.canonical = `https://${domain}/${toHref(node.canonicalSlug ?? node.slug)}`;
+    seo.canonical = urlJoin(`https://${domain}`, toHref(node.canonicalSlug ?? node.slug));
 
     const pageId = FernNavigation.getPageId(node);
 

--- a/packages/ui/app/src/seo/getSeoProp.ts
+++ b/packages/ui/app/src/seo/getSeoProp.ts
@@ -6,7 +6,6 @@ import { trim } from "lodash-es";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { toHast } from "mdast-util-to-hast";
 import { visit } from "unist-util-visit";
-import urlJoin from "url-join";
 import { getToHref } from "../hooks/useHref";
 import { stringHasMarkdown } from "../mdx/common/util";
 import { getFrontmatter } from "../mdx/frontmatter";
@@ -73,7 +72,7 @@ export function getSeoProps(
      */
     // TODO: set canonical domain in docs.yml
     const toHref = getToHref(isTrailingSlashEnabled);
-    seo.canonical = urlJoin(`https://${domain}`, toHref(node.canonicalSlug ?? node.slug));
+    seo.canonical = toHref(node.canonicalSlug ?? node.slug, domain);
 
     const pageId = FernNavigation.getPageId(node);
 


### PR DESCRIPTION
gets rid of the leading slash:

<img width="642" alt="Screenshot 2024-09-24 at 6 29 08 PM" src="https://github.com/user-attachments/assets/17314b01-8d58-41a8-be60-cc4836a42a38">

bug introduced in https://github.com/fern-api/fern-platform/pull/1538
