### PR TITLE
fix: cache endpoint definitions in `resolve-api` route

### DIFF
--- a/packages/ui/app/src/index.ts
+++ b/packages/ui/app/src/index.ts
@@ -10,7 +10,7 @@ export * from "./mdx/types";
 export { Stream } from "./playground/Stream";
 export { ProxyRequestSchema } from "./playground/types";
 export type { ProxyRequest, ProxyResponse, SerializableFile, SerializableFormDataEntryValue } from "./playground/types";
-export { ApiDefinitionResolver } from "./resolver/ApiDefinitionResolver";
+export { ApiDefinitionResolver, type ApiDefinitionResolverCache } from "./resolver/ApiDefinitionResolver";
 export { ApiEndpointResolver } from "./resolver/ApiEndpointResolver";
 export { ApiTypeResolver } from "./resolver/ApiTypeResolver";
 export * from "./resolver/types";

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/resolve-api.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/resolve-api.ts
@@ -1,3 +1,4 @@
+import { DocsKVCache } from "@/server/DocsCache";
 import { buildUrlFromApiNode } from "@/server/buildUrlFromApi";
 import { getXFernHostNode } from "@/server/xfernhost/node";
 import { FdrAPI } from "@fern-api/fdr-sdk";
@@ -100,6 +101,7 @@ const resolveApiHandler: NextApiHandler = async (
                 { files: docs.definition.jsFiles },
                 featureFlags,
                 serializeMdxWithCaching,
+                DocsKVCache.getInstance(xFernHost),
             );
             packagesPromise.push(resolved);
         });

--- a/packages/ui/docs-bundle/src/server/DocsCache.ts
+++ b/packages/ui/docs-bundle/src/server/DocsCache.ts
@@ -37,15 +37,32 @@ export class DocsKVCache implements ApiDefinitionResolverCache {
         await kv.srem(`${PREFIX}:${this.domain}:visited-slugs`, ...slug);
     }
 
-    public async putResolvedEndpoint(endpoint: ResolvedEndpointDefinition): Promise<void> {
-        await kv.sadd(this.getResovledEndpointId(endpoint.id), endpoint);
+    async putResolvedEndpoint({
+        apiDefinitionId,
+        endpoint,
+    }: {
+        apiDefinitionId: APIV1Read.ApiDefinitionId;
+        endpoint: ResolvedEndpointDefinition;
+    }): Promise<void> {
+        await kv.sadd(this.getResovledEndpointId({ apiDefinitionId, endpointId: endpoint.id }), endpoint);
+    }
+    async getResolvedEndpoint({
+        apiDefinitionId,
+        endpointId,
+    }: {
+        apiDefinitionId: APIV1Read.ApiDefinitionId;
+        endpointId: APIV1Read.EndpointId;
+    }): Promise<ResolvedEndpointDefinition | null | undefined> {
+        return await kv.get(this.getResovledEndpointId({ apiDefinitionId, endpointId }));
     }
 
-    public getResolvedEndpoint(id: APIV1Read.EndpointId): Promise<ResolvedEndpointDefinition | null | undefined> {
-        return kv.get(this.getResovledEndpointId(id));
-    }
-
-    private getResovledEndpointId(id: APIV1Read.EndpointId): string {
-        return `${PREFIX}:${this.domain}:resolved-endpoint:${id}`;
+    private getResovledEndpointId({
+        apiDefinitionId,
+        endpointId,
+    }: {
+        apiDefinitionId: APIV1Read.ApiDefinitionId;
+        endpointId: APIV1Read.EndpointId;
+    }): string {
+        return `${PREFIX}:${this.domain}:${apiDefinitionId}:endpoint:${endpointId}`;
     }
 }

--- a/packages/ui/docs-bundle/src/server/DocsCache.ts
+++ b/packages/ui/docs-bundle/src/server/DocsCache.ts
@@ -44,7 +44,7 @@ export class DocsKVCache implements ApiDefinitionResolverCache {
         apiDefinitionId: APIV1Read.ApiDefinitionId;
         endpoint: ResolvedEndpointDefinition;
     }): Promise<void> {
-        await kv.sadd(this.getResovledEndpointId({ apiDefinitionId, endpointId: endpoint.id }), endpoint);
+        await kv.set(this.getResovledEndpointId({ apiDefinitionId, endpointId: endpoint.id }), endpoint);
     }
     async getResolvedEndpoint({
         apiDefinitionId,

--- a/packages/ui/fern-dashboard/src/lib/utils.ts
+++ b/packages/ui/fern-dashboard/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/packages/ui/fern-dashboard/src/lib/utils.ts
+++ b/packages/ui/fern-dashboard/src/lib/utils.ts
@@ -1,6 +1,0 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}


### PR DESCRIPTION
## Short description of the changes made
This PR introduces a caching layer to `APIDefinitionResolver`. 

## What was the motivation & context behind this PR?
The playground is way too slow to load. 

## How has this PR been tested?
It has not really been tested, hoping to use staging links. 
