### PR TITLE
fix: remove version information from ui slug joining in page-record-v2

### DIFF
--- a/packages/commons/search-utils/src/getSlugForSearchRecord.ts
+++ b/packages/commons/search-utils/src/getSlugForSearchRecord.ts
@@ -6,12 +6,7 @@ export function getSlugForSearchRecord(record: Algolia.AlgoliaRecord, basePath: 
     return visitSearchRecord<string>(record)._visit({
         v4: (record) => record.slug,
         v3: (record) => record.slug,
-        v2: (record) =>
-            FernNavigation.slugjoin(
-                basePath || "/",
-                record.version?.urlSlug ?? "",
-                ...getLeadingPathForSearchRecord(record),
-            ),
+        v2: (record) => FernNavigation.slugjoin(basePath || "/", ...getLeadingPathForSearchRecord(record)),
         v1: (record) =>
             FernNavigation.slugjoin(
                 basePath || "/",


### PR DESCRIPTION
Fixes Incident

## Short description of the changes made

- Removes version slug appending from V2 navigation on search record

## What was the motivation & context behind this PR?

- incident

## How has this PR been tested?


https://github.com/user-attachments/assets/4ba8eb1d-a155-46b7-9625-8667988107c2


