### PR TITLE
fix: search small slug fix

### DIFF
--- a/packages/commons/search-utils/src/getSlugForSearchRecord.ts
+++ b/packages/commons/search-utils/src/getSlugForSearchRecord.ts
@@ -6,12 +6,7 @@ export function getSlugForSearchRecord(record: Algolia.AlgoliaRecord, basePath: 
     return visitSearchRecord<string>(record)._visit({
         v4: (record) => record.slug,
         v3: (record) => record.slug,
-        v2: (record) =>
-            FernNavigation.slugjoin(
-                basePath || "/",
-                record.version?.urlSlug ?? "",
-                ...getLeadingPathForSearchRecord(record),
-            ),
+        v2: (record) => FernNavigation.slugjoin(basePath || "/", ...getLeadingPathForSearchRecord(record)),
         v1: (record) =>
             FernNavigation.slugjoin(
                 basePath || "/",

--- a/packages/commons/search-utils/src/getSlugForSearchRecord.ts
+++ b/packages/commons/search-utils/src/getSlugForSearchRecord.ts
@@ -6,7 +6,12 @@ export function getSlugForSearchRecord(record: Algolia.AlgoliaRecord, basePath: 
     return visitSearchRecord<string>(record)._visit({
         v4: (record) => record.slug,
         v3: (record) => record.slug,
-        v2: (record) => FernNavigation.slugjoin(basePath || "/", ...getLeadingPathForSearchRecord(record)),
+        v2: (record) =>
+            FernNavigation.slugjoin(
+                basePath || "/",
+                record.version?.urlSlug ?? "",
+                ...getLeadingPathForSearchRecord(record),
+            ),,
         v1: (record) =>
             FernNavigation.slugjoin(
                 basePath || "/",

--- a/packages/commons/search-utils/src/getSlugForSearchRecord.ts
+++ b/packages/commons/search-utils/src/getSlugForSearchRecord.ts
@@ -11,7 +11,7 @@ export function getSlugForSearchRecord(record: Algolia.AlgoliaRecord, basePath: 
                 basePath || "/",
                 record.version?.urlSlug ?? "",
                 ...getLeadingPathForSearchRecord(record),
-            ),,
+            ),
         v1: (record) =>
             FernNavigation.slugjoin(
                 basePath || "/",

--- a/servers/fdr/src/services/algolia/AlgoliaSearchRecordGeneratorV2.ts
+++ b/servers/fdr/src/services/algolia/AlgoliaSearchRecordGeneratorV2.ts
@@ -137,10 +137,11 @@ export class AlgoliaSearchRecordGeneratorV2 extends AlgoliaSearchRecordGenerator
             return [];
         }
 
+        const slug = page.fullSlug && page.fullSlug.length > 0 ? page.fullSlug.join("/") : page.urlSlug;
         const breadcrumbs: BreadcrumbsInfo[] = [
             {
                 title: page.title,
-                slug: page.fullSlug ? page.fullSlug.join("/") : page.urlSlug,
+                slug,
             },
         ];
         const { indexSegment } = context;
@@ -149,7 +150,7 @@ export class AlgoliaSearchRecordGeneratorV2 extends AlgoliaSearchRecordGenerator
             pageContent.markdown,
             breadcrumbs,
             indexSegment,
-            page.urlSlug,
+            slug,
             page.title,
         );
 


### PR DESCRIPTION
## Short description of the changes made

- Adds full slug to breadcrumbs and url slug
- Not plagued by same issue as page v2, as version information is no longer appended to the record

## What was the motivation & context behind this PR?

- manual tests

## How has this PR been tested?

To be tested