### PR TITLE
feat: editable playground environment

### DIFF
--- a/packages/ui/app/src/api-reference/endpoints/EndpointContentCodeSnippets.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointContentCodeSnippets.tsx
@@ -4,7 +4,7 @@ import { FernButton, FernButtonGroup, FernScrollArea } from "@fern-ui/components
 import { EMPTY_OBJECT, visitDiscriminatedUnion } from "@fern-ui/core-utils";
 import { useResizeObserver } from "@fern-ui/react-commons";
 import { ReactNode, memo, useMemo, useRef, useState } from "react";
-import { useNavigationNodes } from "../../atoms";
+import { useNavigationNodes, usePlaygroundEnvironment } from "../../atoms";
 import { useSelectedEnvironmentId } from "../../atoms/environment";
 import { FernErrorTag } from "../../components/FernErrorBoundary";
 import { StatusCodeTag, statusCodeToIntent } from "../../components/StatusCodeTag";
@@ -128,6 +128,7 @@ const UnmemoizedEndpointContentCodeSnippets: React.FC<EndpointContentCodeSnippet
     );
 
     const selectedEnvironmentId = useSelectedEnvironmentId();
+    const playgroundEnvironment = usePlaygroundEnvironment();
 
     return (
         <div className="fern-endpoint-code-snippets" ref={ref}>
@@ -180,7 +181,7 @@ const UnmemoizedEndpointContentCodeSnippets: React.FC<EndpointContentCodeSnippet
                         ) : undefined}
                     </>
                 }
-                code={resolveEnvironmentUrlInCodeSnippet(endpoint, requestCodeSnippet)}
+                code={resolveEnvironmentUrlInCodeSnippet(endpoint, requestCodeSnippet, playgroundEnvironment)}
                 language={selectedClient.language}
                 hoveredPropertyPath={selectedClient.language === "curl" ? hoveredRequestPropertyPath : undefined}
                 json={requestCurlJson}

--- a/packages/ui/app/src/api-reference/web-socket/WebSocket.tsx
+++ b/packages/ui/app/src/api-reference/web-socket/WebSocket.tsx
@@ -4,7 +4,7 @@ import { CopyToClipboardButton, FernScrollArea } from "@fern-ui/components";
 import cn from "clsx";
 import { ArrowDown, ArrowUp, Wifi } from "iconoir-react";
 import { Children, FC, HTMLAttributes, ReactNode, useMemo, useRef } from "react";
-import { useNavigationNodes } from "../../atoms";
+import { useNavigationNodes, usePlaygroundEnvironment } from "../../atoms";
 import { useSelectedEnvironmentId } from "../../atoms/environment";
 import { FernAnchor } from "../../components/FernAnchor";
 import { FernBreadcrumbs } from "../../components/FernBreadcrumbs";
@@ -56,6 +56,7 @@ const WebhookContent: FC<WebSocket.Props> = ({ websocket, isLastInApi, types }) 
     const selectedEnvironmentId = useSelectedEnvironmentId();
     const maybeNode = nodes.get(websocket.nodeId);
     const node = maybeNode != null && FernNavigation.isApiLeaf(maybeNode) ? maybeNode : undefined;
+    const playgroundEnvironment = usePlaygroundEnvironment();
 
     const ref = useRef<HTMLDivElement>(null);
     useApiPageCenterElement(ref, websocket.slug);
@@ -153,7 +154,7 @@ const WebhookContent: FC<WebSocket.Props> = ({ websocket, isLastInApi, types }) 
                                         <CopyToClipboardButton
                                             className="-mr-1"
                                             content={() =>
-                                                `${resolveEnvironment(websocket, selectedEnvironmentId)?.baseUrl}${websocket.path.map((path) => (path.type === "literal" ? path.value : `:${path.key}`)).join("/")}`
+                                                `${playgroundEnvironment ?? resolveEnvironment(websocket, selectedEnvironmentId)?.baseUrl}${websocket.path.map((path) => (path.type === "literal" ? path.value : `:${path.key}`)).join("/")}`
                                             }
                                         />
                                     </div>
@@ -314,7 +315,7 @@ const WebhookContent: FC<WebSocket.Props> = ({ websocket, isLastInApi, types }) 
                                                     <tr>
                                                         <td className="text-left align-top">URL</td>
                                                         <td className="text-left align-top">
-                                                            {`${resolveEnvironment(websocket, selectedEnvironmentId)?.baseUrl ?? ""}${example?.path ?? stringifyResolvedEndpointPathParts(websocket.path)}`}
+                                                            {`${playgroundEnvironment ?? resolveEnvironment(websocket, selectedEnvironmentId)?.baseUrl ?? ""}${example?.path ?? stringifyResolvedEndpointPathParts(websocket.path)}`}
                                                         </td>
                                                     </tr>
                                                     <tr>

--- a/packages/ui/app/src/atoms/playground.ts
+++ b/packages/ui/app/src/atoms/playground.ts
@@ -359,3 +359,9 @@ export const PLAYGROUND_REQUEST_TYPE_ATOM = atomWithStorage<"curl" | "typescript
     "api-playground-atom-alpha",
     "curl",
 );
+
+export const PLAYGROUND_ENVIRONMENT_ATOM = atom<string | undefined>(undefined);
+
+export const usePlaygroundEnvironment = (): string | undefined => {
+    return useAtomValue(PLAYGROUND_ENVIRONMENT_ATOM);
+};

--- a/packages/ui/app/src/components/MaybeEnvironmentDropdown.tsx
+++ b/packages/ui/app/src/components/MaybeEnvironmentDropdown.tsx
@@ -1,8 +1,11 @@
 import type { APIV1Read } from "@fern-api/fdr-sdk/client/types";
-import { FernButton, FernDropdown } from "@fern-ui/components";
+import { FernButton, FernDropdown, FernInput } from "@fern-ui/components";
+import { useBooleanState } from "@fern-ui/react-commons";
+import cn from "clsx";
 import { useAtom } from "jotai";
-import { ReactElement } from "react";
+import { ReactElement, useState } from "react";
 import { parse } from "url";
+import { PLAYGROUND_ENVIRONMENT_ATOM } from "../atoms";
 import { ALL_ENVIRONMENTS_ATOM, SELECTED_ENVIRONMENT_ATOM } from "../atoms/environment";
 
 interface MaybeEnvironmentDropdownProps {
@@ -12,7 +15,10 @@ interface MaybeEnvironmentDropdownProps {
     small?: boolean;
     environmentFilters?: APIV1Read.EnvironmentId[];
     trailingPath?: boolean;
+    editable?: boolean;
+    isEditingEnvironment: useBooleanState.Return;
 }
+
 export function MaybeEnvironmentDropdown({
     selectedEnvironment,
     urlTextStyle,
@@ -20,9 +26,12 @@ export function MaybeEnvironmentDropdown({
     small,
     environmentFilters,
     trailingPath,
+    editable,
+    isEditingEnvironment,
 }: MaybeEnvironmentDropdownProps): ReactElement | null {
     const [allEnvironmentIds] = useAtom(ALL_ENVIRONMENTS_ATOM);
     const [selectedEnvironmentId, setSelectedEnvironmentId] = useAtom(SELECTED_ENVIRONMENT_ATOM);
+    const [playgroundEnvironment, setPlaygroundEnvironment] = useAtom(PLAYGROUND_ENVIRONMENT_ATOM);
 
     const environmentIds = environmentFilters
         ? environmentFilters.filter((environmentFilter) => allEnvironmentIds.includes(environmentFilter))
@@ -31,45 +40,98 @@ export function MaybeEnvironmentDropdown({
     if (environmentFilters && selectedEnvironment && !environmentFilters.includes(selectedEnvironment.id)) {
         setSelectedEnvironmentId(environmentIds[0]);
     }
-    const url = selectedEnvironment?.baseUrl && parse(selectedEnvironment?.baseUrl);
+    const preParsedUrl = playgroundEnvironment ?? selectedEnvironment?.baseUrl;
+    const url = preParsedUrl && parse(preParsedUrl);
+
+    const [inputValue, setInputValue] = useState(preParsedUrl);
+    const isValidInput = inputValue != null && inputValue !== "" && parse(inputValue).host != null;
 
     return (
         <>
-            <span className="max-sm:hidden">
-                {environmentIds && environmentIds.length > 1 ? (
-                    <FernDropdown
-                        key="selectedEnvironment-selector"
-                        options={environmentIds.map((env) => ({
-                            value: env,
-                            label: env,
-                            type: "value",
-                        }))}
-                        onValueChange={(value) => {
-                            setSelectedEnvironmentId(value);
-                        }}
-                        value={selectedEnvironmentId ?? selectedEnvironment?.id}
-                    >
-                        <FernButton
-                            className="py-0 px-1 h-auto"
-                            text={
-                                <span key="protocol" className="whitespace-nowrap max-sm:hidden">
-                                    <span className={protocolTextStyle}>{`${url && url.protocol}//`}</span>
-                                    <span className={urlTextStyle}>{(url && url.host) ?? selectedEnvironmentId}</span>
-                                </span>
-                            }
-                            size={small ? "small" : "normal"}
-                            variant="outlined"
-                            mono={true}
-                        />
-                    </FernDropdown>
-                ) : (
-                    <span key="protocol" className="whitespace-nowrap max-sm:hidden">
-                        <span className={protocolTextStyle}>{`${url && url.protocol}//`}</span>
-                        <span className={urlTextStyle}>{(url && url.host) ?? selectedEnvironmentId}</span>
+            {isEditingEnvironment.value ? (
+                <FernInput
+                    autoFocus={isEditingEnvironment.value}
+                    size={(inputValue?.length ?? 0) + 1}
+                    placeholder={inputValue}
+                    value={inputValue}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                    }}
+                    onValueChange={(value) => {
+                        if (value === "" || parse(value).host == null) {
+                            setInputValue(value);
+                        } else {
+                            setInputValue(value);
+                            setPlaygroundEnvironment(value);
+                        }
+                    }}
+                    onKeyDown={(e) => {
+                        if ((e.key === "Enter" || e.key === "Escape") && isValidInput) {
+                            setInputValue(playgroundEnvironment);
+                            isEditingEnvironment.setFalse();
+                        }
+                    }}
+                    className={isValidInput ? "" : "error"}
+                    inputClassName={"p-0 pl-2"}
+                />
+            ) : (
+                <>
+                    <span className="max-sm:hidden">
+                        {environmentIds && environmentIds.length > 1 ? (
+                            <FernDropdown
+                                key="selectedEnvironment-selector"
+                                options={environmentIds.map((env) => ({
+                                    value: env,
+                                    label: env,
+                                    type: "value",
+                                }))}
+                                onValueChange={(value) => {
+                                    setPlaygroundEnvironment(undefined);
+                                    setInputValue(value);
+                                    setSelectedEnvironmentId(value);
+                                }}
+                                value={selectedEnvironmentId ?? selectedEnvironment?.id}
+                            >
+                                <FernButton
+                                    className="py-0 px-1 h-auto"
+                                    text={
+                                        <span key="protocol" className="whitespace-nowrap max-sm:hidden">
+                                            {url && url.protocol && (
+                                                <span className={protocolTextStyle}>{`${url.protocol}//`}</span>
+                                            )}
+                                            <span className={urlTextStyle}>{(url && url.host) ?? ""}</span>
+                                        </span>
+                                    }
+                                    size={small ? "small" : "normal"}
+                                    variant="outlined"
+                                    mono={true}
+                                    onDoubleClick={editable ? isEditingEnvironment.setTrue : () => undefined}
+                                />
+                            </FernDropdown>
+                        ) : (
+                            <span key="protocol" className="whitespace-nowrap max-sm:hidden font-mono">
+                                {url && url.protocol && (
+                                    <span
+                                        className={cn(protocolTextStyle, small ? "text-xs" : "text-sm")}
+                                    >{`${url.protocol}//`}</span>
+                                )}
+                                {editable ? (
+                                    <FernButton
+                                        variant="minimal"
+                                        className={cn(urlTextStyle, "p-0", small ? "text-xs" : "text-sm")}
+                                        onDoubleClick={isEditingEnvironment.setTrue}
+                                    >
+                                        {(url && url.host) ?? ""}
+                                    </FernButton>
+                                ) : (
+                                    <span className={urlTextStyle}>{(url && url.host) ?? ""}</span>
+                                )}
+                            </span>
+                        )}
                     </span>
-                )}
-            </span>
-            {trailingPath && url && url.pathname !== "/" && <span>{url.pathname}</span>}
+                    {trailingPath && url && url.pathname !== "/" && <span>{url.pathname}</span>}
+                </>
+            )}
         </>
     );
 }

--- a/packages/ui/app/src/playground/PlaygroundWebSocket.tsx
+++ b/packages/ui/app/src/playground/PlaygroundWebSocket.tsx
@@ -2,7 +2,7 @@ import { FernTooltipProvider } from "@fern-ui/components";
 import { usePrevious } from "@fern-ui/react-commons";
 import { Wifi, WifiOff } from "iconoir-react";
 import { FC, ReactElement, useCallback, useEffect, useRef, useState } from "react";
-import { PLAYGROUND_AUTH_STATE_ATOM, store, usePlaygroundWebsocketFormState } from "../atoms";
+import { PLAYGROUND_AUTH_STATE_ATOM, store, usePlaygroundEnvironment, usePlaygroundWebsocketFormState } from "../atoms";
 import { useSelectedEnvironmentId } from "../atoms/environment";
 import { usePlaygroundSettings } from "../hooks/usePlaygroundSettings";
 import {
@@ -26,6 +26,7 @@ interface PlaygroundWebSocketProps {
 
 export const PlaygroundWebSocket: FC<PlaygroundWebSocketProps> = ({ websocket, types }): ReactElement => {
     const [formState, setFormState] = usePlaygroundWebsocketFormState(websocket);
+    const playgroundEnvironment = usePlaygroundEnvironment();
 
     const [connectedState, setConnectedState] = useState<"opening" | "opened" | "closed">("closed");
     const { messages, pushMessage, clearMessages } = useWebsocketMessages(websocket.id);
@@ -47,7 +48,7 @@ export const PlaygroundWebSocket: FC<PlaygroundWebSocketProps> = ({ websocket, t
 
     const selectedEnvironmentId = useSelectedEnvironmentId();
     const settings = usePlaygroundSettings();
-    const baseUrl = resolveEnvironment(websocket, selectedEnvironmentId)?.baseUrl;
+    const baseUrl = playgroundEnvironment ?? resolveEnvironment(websocket, selectedEnvironmentId)?.baseUrl;
 
     const startSession = useCallback(async () => {
         return new Promise<boolean>((resolve) => {

--- a/packages/ui/app/src/playground/code-snippets/useSnippet.ts
+++ b/packages/ui/app/src/playground/code-snippets/useSnippet.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { usePlaygroundEnvironment } from "../../atoms";
 import { useSelectedEnvironmentId } from "../../atoms/environment";
 import { resolveEnvironmentUrlInCodeSnippet } from "../../resolver/types";
 import { PlaygroundCodeSnippetResolver } from "./resolver";
@@ -6,9 +7,10 @@ import { useApiDefinition } from "./useApiDefinition";
 
 export function useSnippet(resolver: PlaygroundCodeSnippetResolver, lang: "curl" | "python" | "typescript"): string {
     const selectedEnvironmentId = useSelectedEnvironmentId();
+    const playgroundEnvironment = usePlaygroundEnvironment();
     const apiDefinition = useApiDefinition(resolver.endpoint.apiDefinitionId, resolver.isSnippetTemplatesEnabled);
 
     // Resolve the code snippet
     const code = useMemo(() => resolver.resolve(lang, apiDefinition), [resolver, lang, apiDefinition]);
-    return resolveEnvironmentUrlInCodeSnippet(resolver.endpoint, code, selectedEnvironmentId);
+    return resolveEnvironmentUrlInCodeSnippet(resolver.endpoint, code, playgroundEnvironment, selectedEnvironmentId);
 }

--- a/packages/ui/app/src/playground/endpoint/PlaygroundEndpoint.tsx
+++ b/packages/ui/app/src/playground/endpoint/PlaygroundEndpoint.tsx
@@ -14,6 +14,7 @@ import {
     useBasePath,
     useFeatureFlags,
     usePlaygroundEndpointFormState,
+    usePlaygroundEnvironment,
 } from "../../atoms";
 import { useSelectedEnvironmentId } from "../../atoms/environment";
 import { useApiRoute } from "../../hooks/useApiRoute";
@@ -58,6 +59,7 @@ export const PlaygroundEndpoint: FC<PlaygroundEndpointProps> = ({ endpoint, type
     const proxyBasePath = proxyShouldUseAppBuildwithfernCom ? getAppBuildwithfernCom() : basePath;
     const proxyEnvironment = useApiRoute("/api/fern-docs/proxy", { basepath: proxyBasePath });
     const uploadEnvironment = useApiRoute("/api/fern-docs/upload", { basepath: proxyBasePath });
+    const playgroundEnvironment = usePlaygroundEnvironment();
 
     const setOAuthValue = useSetAtom(PLAYGROUND_AUTH_STATE_OAUTH_ATOM);
 
@@ -97,7 +99,7 @@ export const PlaygroundEndpoint: FC<PlaygroundEndpointProps> = ({ endpoint, type
             }
 
             const req: ProxyRequest = {
-                url: buildEndpointUrl(endpoint, formState),
+                url: buildEndpointUrl(endpoint, formState, playgroundEnvironment),
                 method: endpoint.method,
                 headers,
                 body: await serializeFormStateBody(
@@ -163,7 +165,15 @@ export const PlaygroundEndpoint: FC<PlaygroundEndpointProps> = ({ endpoint, type
                 },
             });
         }
-    }, [endpoint, formState, proxyEnvironment, uploadEnvironment, usesApplicationJsonInFormDataValue, setOAuthValue]);
+    }, [
+        endpoint,
+        formState,
+        proxyEnvironment,
+        uploadEnvironment,
+        usesApplicationJsonInFormDataValue,
+        playgroundEnvironment,
+        setOAuthValue,
+    ]);
 
     const selectedEnvironmentId = useSelectedEnvironmentId();
 

--- a/packages/ui/app/src/playground/endpoint/PlaygroundEndpointPath.tsx
+++ b/packages/ui/app/src/playground/endpoint/PlaygroundEndpointPath.tsx
@@ -1,11 +1,13 @@
 import type { APIV1Read } from "@fern-api/fdr-sdk/client/types";
 import { CopyToClipboardButton, FernButton } from "@fern-ui/components";
 import { unknownToString, visitDiscriminatedUnion } from "@fern-ui/core-utils";
+import { useBooleanState } from "@fern-ui/react-commons";
 import * as Dialog from "@radix-ui/react-dialog";
 import cn from "clsx";
 import { Xmark } from "iconoir-react";
 import { isUndefined, omitBy } from "lodash-es";
 import { FC, Fragment, ReactNode } from "react";
+import { usePlaygroundEnvironment } from "../../atoms";
 import { useAllEnvironmentIds } from "../../atoms/environment";
 import { HttpMethodTag } from "../../components/HttpMethodTag";
 import { MaybeEnvironmentDropdown } from "../../components/MaybeEnvironmentDropdown";
@@ -38,17 +40,21 @@ export const PlaygroundEndpointPath: FC<PlaygroundEndpointPathProps> = ({
     sendRequestIcon,
 }) => {
     const environmentIds = useAllEnvironmentIds();
+    const isEditingEnvironment = useBooleanState(false);
+    const playgroundEnvironment = usePlaygroundEnvironment();
 
     return (
         <div className="playground-endpoint">
             <div className="flex h-10 min-w-0 flex-1 shrink gap-2 rounded-lg bg-tag-default px-4 py-2 max-sm:h-8 max-sm:px-2 max-sm:py-1 sm:rounded-[20px] items-center">
                 {method != null && <HttpMethodTag method={method} className="playground-endpoint-method" />}
                 <span
-                    className={
+                    className={cn(
                         environment != null && environmentIds.length > 1
                             ? "playground-endpoint-url-with-switcher"
-                            : "playground-endpoint-url"
-                    }
+                            : "playground-endpoint-url",
+                        "flex flex-row w-full",
+                        "items-baseline",
+                    )}
                 >
                     <span className="playground-endpoint-baseurl max-sm:hidden">
                         {environment != null && (
@@ -59,6 +65,8 @@ export const PlaygroundEndpointPath: FC<PlaygroundEndpointPathProps> = ({
                                 urlTextStyle="playground-endpoint-baseurl max-sm:hidden"
                                 protocolTextStyle="playground-endpoint-baseurl max-sm:hidden"
                                 trailingPath={true}
+                                editable
+                                isEditingEnvironment={isEditingEnvironment}
                             />
                         )}
                     </span>
@@ -109,7 +117,12 @@ export const PlaygroundEndpointPath: FC<PlaygroundEndpointPathProps> = ({
                 <CopyToClipboardButton
                     className="playground-endpoint-copy-button"
                     content={() =>
-                        buildRequestUrl(environment?.baseUrl, path, formState.pathParameters, formState.queryParameters)
+                        buildRequestUrl(
+                            playgroundEnvironment ?? environment?.baseUrl,
+                            path,
+                            formState.pathParameters,
+                            formState.queryParameters,
+                        )
                     }
                 />
             </div>

--- a/packages/ui/app/src/playground/utils/url.ts
+++ b/packages/ui/app/src/playground/utils/url.ts
@@ -39,9 +39,10 @@ export function buildRequestUrl(
 export function buildEndpointUrl(
     endpoint: ResolvedEndpointDefinition | undefined,
     formState: PlaygroundRequestFormState | undefined,
+    playgroundEnvironment: string | undefined,
 ): string {
     return buildRequestUrl(
-        endpoint && resolveEnvironment(endpoint)?.baseUrl,
+        playgroundEnvironment ?? (endpoint && resolveEnvironment(endpoint)?.baseUrl),
         endpoint?.path,
         formState?.pathParameters,
         formState?.queryParameters,

--- a/packages/ui/app/src/resolver/resolveCodeSnippets.ts
+++ b/packages/ui/app/src/resolver/resolveCodeSnippets.ts
@@ -35,6 +35,7 @@ export async function resolveCodeSnippets(
     isHttpSnippetsEnabled: boolean,
     useJavaScriptAsTypeScript: boolean,
     alwaysEnableJavaScriptFetch: boolean,
+    playgroundEnvironment: string | undefined,
 ): Promise<ResolvedCodeSnippet[]> {
     let toRet: ResolvedCodeSnippet[] = [];
 
@@ -114,7 +115,7 @@ export async function resolveCodeSnippets(
 
     try {
         if (isHttpSnippetsEnabled) {
-            const snippet = new HTTPSnippet(getHarRequest(endpoint, example, requestBody));
+            const snippet = new HTTPSnippet(getHarRequest(endpoint, example, requestBody, playgroundEnvironment));
             for (const { clientId, targetId } of CLIENTS) {
                 if (!alwaysEnableJavaScriptFetch) {
                     if (toRet.some((snippet) => cleanLanguage(snippet.language) === targetId)) {
@@ -180,6 +181,7 @@ function getHarRequest(
     endpoint: ResolvedEndpointDefinition,
     example: APIV1Read.ExampleEndpointCall,
     requestBody: ResolvedExampleEndpointRequest | undefined,
+    playgroundEnvironment: string | undefined,
 ): HarRequest {
     const request: HarRequest = {
         httpVersion: "1.1",
@@ -191,7 +193,11 @@ function getHarRequest(
         cookies: [],
         bodySize: -1,
     };
-    request.url = buildRequestUrl(resolveEnvironment(endpoint)?.baseUrl, endpoint.path, example.pathParameters);
+    request.url = buildRequestUrl(
+        playgroundEnvironment ?? resolveEnvironment(endpoint)?.baseUrl,
+        endpoint.path,
+        example.pathParameters,
+    );
     request.method = endpoint.method;
     request.queryString = Object.entries(example.queryParameters).map(([name, value]) => ({
         name,

--- a/packages/ui/app/src/resolver/types.ts
+++ b/packages/ui/app/src/resolver/types.ts
@@ -804,12 +804,13 @@ export const resolveEnvironment = (
 export const resolveEnvironmentUrlInCodeSnippet = (
     endpoint: ResolvedEndpointDefinition,
     requestCodeSnippet: string,
+    playgroundEnvironment: string | undefined,
     selectedEnvironmentId?: string,
 ): string => {
     const urlToReplace = endpoint.environments.find((env) => requestCodeSnippet.includes(env.baseUrl))?.baseUrl;
     const resolvedEnvironment = resolveEnvironment(endpoint, selectedEnvironmentId);
     return urlToReplace && resolvedEnvironment
-        ? requestCodeSnippet.replace(urlToReplace, resolvedEnvironment.baseUrl)
+        ? requestCodeSnippet.replace(urlToReplace, playgroundEnvironment ?? resolvedEnvironment.baseUrl)
         : requestCodeSnippet;
 };
 

--- a/packages/ui/app/src/util/endpoint.ts
+++ b/packages/ui/app/src/util/endpoint.ts
@@ -12,8 +12,11 @@ export type EndpointPathPart =
           name: string;
       };
 
-export function getEndpointEnvironmentUrl(endpoint: ResolvedEndpointDefinition): string | undefined {
-    return resolveEnvironment(endpoint)?.baseUrl;
+export function getEndpointEnvironmentUrl(
+    endpoint: ResolvedEndpointDefinition,
+    playgroundEnvironment: string | undefined,
+): string | undefined {
+    return playgroundEnvironment ?? resolveEnvironment(endpoint)?.baseUrl;
 }
 
 export function getEndpointTitleAsString(endpoint: APIV1Read.EndpointDefinition): string {

--- a/packages/ui/components/src/FernInput.scss
+++ b/packages/ui/components/src/FernInput.scss
@@ -72,4 +72,8 @@
     input.fern-input[type="number"] {
         appearance: textfield;
     }
+
+    .fern-input-group.error {
+        background: rgba(252, 100, 100, 0.63);
+    }
 }


### PR DESCRIPTION
Fixes FER-3328

## Short description of the changes made

- Allows environments to be edited in api reference and api playground; updates snippets and resolution for use in other methods.
- Introduces `PLAYGROUND_ENVIRONMENT_ATOM`, which allows for the storage of an environment URL that persists across loads.
- Basic validation on input url (make sure it is well formatted for parsing downstream logic).

## What was the motivation & context behind this PR?

- Customer asks

## How has this PR been tested?

https://github.com/user-attachments/assets/c2a7ec9a-35d1-4cee-b9b8-6e9a42962d32


