### PR TITLE
fix(fern-bot): Fix state machine in serverless.yml

### DIFF
--- a/servers/fern-bot/serverless.yml
+++ b/servers/fern-bot/serverless.yml
@@ -131,7 +131,7 @@ functions:
 
   # gRPC proxy endpooint, exposed as an endpoint (not scheduled).
   proxyGrpc:
-    timeout: 900
+    timeout: 30
     memorySize: 5120
     ephemeralStorageSize: 10240
     handler: "src/functions/grpc-proxy/proxyGrpc.handler"
@@ -227,7 +227,7 @@ stepFunctions:
                           OutputPath: null
               - StartAt: UpdateFDRRepoDataBranch
                 States:
-                  UpdateGeneratorsBranch:
+                  UpdateFDRRepoDataBranch:
                     Type: Map
                     End: true
                     MaxConcurrency: 50


### PR DESCRIPTION
This fixes a small typo in the `serverless.yml` and reconfigures the HTTP endpoint timeout.
