### PR TITLE
fix: speed up revalidation with larger batch sizes

### DIFF
--- a/servers/fdr/src/services/revalidator/RevalidatorService.ts
+++ b/servers/fdr/src/services/revalidator/RevalidatorService.ts
@@ -51,7 +51,7 @@ export class RevalidatorServiceImpl implements RevalidatorService {
                 environment: baseUrl.toURL().toString(),
             });
             app?.logger.log("Revalidating paths at", baseUrl.toURL().toString());
-            const page = await client.revalidation.revalidateAllV4();
+            const page = await client.revalidation.revalidateAllV4({ limit: 100 });
 
             const successful: FernDocs.SuccessfulRevalidation[] = [];
             const failed: FernDocs.FailedRevalidation[] = [];


### PR DESCRIPTION
default batch size for revalidate-all/v4 is 10. this PR bumps the revalidate-all loop in FDR to 100 (the max) to speed up revalidation.