### PR TITLE
fix: accordion icon shrinks

### DIFF
--- a/packages/ui/app/src/mdx/components/accordion/index.scss
+++ b/packages/ui/app/src/mdx/components/accordion/index.scss
@@ -11,7 +11,7 @@
         @apply flex w-full items-center gap-3 rounded-[inherit] p-4 transition-colors hover:transition-none hover:bg-tag-default data-[state=open]:rounded-b-none cursor-pointer;
 
         .fern-accordion-trigger-arrow {
-            @apply duration-[400ms] t-muted size-4 transition-transform ease-shift;
+            @apply duration-[400ms] t-muted size-4 transition-transform ease-shift shrink-0;
         }
 
         &[data-state="open"] .fern-accordion-trigger-arrow {


### PR DESCRIPTION
### Before:

<img width="740" alt="Screenshot 2024-10-01 at 12 11 49 PM" src="https://github.com/user-attachments/assets/a25ad685-6b2c-466b-95ca-02aa29bfa1a8">

### After:

<img width="750" alt="Screenshot 2024-10-01 at 12 12 03 PM" src="https://github.com/user-attachments/assets/7731f0b2-b1c1-47d0-aebe-dabb335e8b92">
