### PR TITLE
fix: remove errant parenthesis

### DIFF
--- a/packages/ui/app/src/playground/endpoint/PlaygroundEndpointRequestCard.tsx
+++ b/packages/ui/app/src/playground/endpoint/PlaygroundEndpointRequestCard.tsx
@@ -62,7 +62,6 @@ export function PlaygroundEndpointRequestCard({
                         Python
                     </FernButton>
                 </FernButtonGroup>
-                )
                 <CopyToClipboardButton
                     content={() => {
                         const authState = store.get(PLAYGROUND_AUTH_STATE_ATOM);


### PR DESCRIPTION
## Short description of the changes made

- There was an added errant parenthesis, we remove this

## What was the motivation & context behind this PR?

- Visual bug

## How has this PR been tested?

Before:
<img width="687" alt="Screenshot 2024-10-01 at 1 10 32 PM" src="https://github.com/user-attachments/assets/967cbe7e-3439-4537-9dcb-2f3d36848026">


After:

<img width="691" alt="Screenshot 2024-10-01 at 1 10 44 PM" src="https://github.com/user-attachments/assets/4d080348-7e1e-47fa-85f7-a2882b7afb20">


