### PR TITLE
fix: added server sent events text on sse example

### DIFF
--- a/packages/ui/app/src/api-reference/endpoints/EndpointContent.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointContent.tsx
@@ -288,6 +288,7 @@ export const EndpointContent = memo<EndpointContent.Props>((props) => {
                     >
                         <EndpointContentLeft
                             endpoint={endpoint}
+                            example={selectedClient.exampleCall}
                             showErrors={showErrors}
                             onHoverRequestProperty={onHoverRequestProperty}
                             onHoverResponseProperty={onHoverResponseProperty}

--- a/packages/ui/app/src/api-reference/endpoints/EndpointContentLeft.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointContentLeft.tsx
@@ -4,9 +4,11 @@ import { camelCase, sortBy, upperFirst } from "lodash-es";
 import { memo } from "react";
 import { useFeatureFlags } from "../../atoms";
 import { Markdown } from "../../mdx/Markdown";
+import { mergeEndpointSchemaWithExample } from "../../resolver/SchemaWithExample";
 import {
     ResolvedEndpointDefinition,
     ResolvedError,
+    ResolvedExampleEndpointCall,
     ResolvedObjectProperty,
     ResolvedTypeDefinition,
     getParameterDescription,
@@ -26,6 +28,7 @@ export interface HoveringProps {
 export declare namespace EndpointContentLeft {
     export interface Props {
         endpoint: ResolvedEndpointDefinition;
+        example: ResolvedExampleEndpointCall;
         showErrors: boolean;
         onHoverRequestProperty: (jsonPropertyPath: JsonPropertyPath, hovering: HoveringProps) => void;
         onHoverResponseProperty: (jsonPropertyPath: JsonPropertyPath, hovering: HoveringProps) => void;
@@ -48,6 +51,7 @@ const RESPONSE_ERROR = ["response", "error"];
 
 const UnmemoizedEndpointContentLeft: React.FC<EndpointContentLeft.Props> = ({
     endpoint,
+    example,
     showErrors,
     onHoverRequestProperty,
     onHoverResponseProperty,
@@ -272,6 +276,7 @@ const UnmemoizedEndpointContentLeft: React.FC<EndpointContentLeft.Props> = ({
                 <EndpointSection title="Response" anchorIdParts={RESPONSE} slug={endpoint.slug}>
                     <EndpointResponseSection
                         responseBody={endpoint.responseBody}
+                        exampleResponseBody={mergeEndpointSchemaWithExample(endpoint, example).responseBody}
                         onHoverProperty={onHoverResponseProperty}
                         anchorIdParts={RESPONSE_BODY}
                         slug={endpoint.slug}

--- a/packages/ui/app/src/api-reference/endpoints/EndpointResponseSection.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointResponseSection.tsx
@@ -1,7 +1,9 @@
 import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
+import { assertNever } from "@fern-ui/core-utils";
 import { useFeatureFlags } from "../../atoms";
 import { FernErrorTag } from "../../components/FernErrorBoundary";
 import { Markdown } from "../../mdx/Markdown";
+import { ResolvedExampleEndpointResponseWithSchema } from "../../resolver/SchemaWithExample";
 import { ResolvedResponseBody, ResolvedTypeDefinition, visitResolvedHttpResponseBodyShape } from "../../resolver/types";
 import { JsonPropertyPath } from "../examples/JsonPropertyPath";
 import { TypeReferenceDefinitions } from "../types/type-reference/TypeReferenceDefinitions";
@@ -10,6 +12,7 @@ import { renderTypeShorthand } from "../types/type-shorthand/TypeShorthand";
 export declare namespace EndpointResponseSection {
     export interface Props {
         responseBody: ResolvedResponseBody;
+        exampleResponseBody: ResolvedExampleEndpointResponseWithSchema | undefined;
         onHoverProperty?: (path: JsonPropertyPath, opts: { isHovering: boolean }) => void;
         anchorIdParts: readonly string[];
         slug: FernNavigation.Slug;
@@ -19,6 +22,7 @@ export declare namespace EndpointResponseSection {
 
 export const EndpointResponseSection: React.FC<EndpointResponseSection.Props> = ({
     responseBody,
+    exampleResponseBody,
     onHoverProperty,
     anchorIdParts,
     slug,
@@ -32,7 +36,12 @@ export const EndpointResponseSection: React.FC<EndpointResponseSection.Props> = 
                 size="sm"
                 className="!t-muted border-default border-b pb-5 leading-6"
                 mdx={responseBody.description}
-                fallback={getResponseSummary({ responseBody, types, isAudioFileDownloadSpanSummary })}
+                fallback={getResponseSummary({
+                    responseBody,
+                    exampleResponseBody,
+                    types,
+                    isAudioFileDownloadSpanSummary,
+                })}
             />
             {visitResolvedHttpResponseBodyShape(responseBody.shape, {
                 fileDownload: () => null,
@@ -85,28 +94,47 @@ export const EndpointResponseSection: React.FC<EndpointResponseSection.Props> = 
 
 function getResponseSummary({
     responseBody,
+    exampleResponseBody,
     types,
     isAudioFileDownloadSpanSummary,
 }: {
     responseBody: ResolvedResponseBody;
+    exampleResponseBody: ResolvedExampleEndpointResponseWithSchema | undefined;
     types: Record<string, ResolvedTypeDefinition>;
     isAudioFileDownloadSpanSummary: boolean;
 }) {
-    if (responseBody.shape.type === "fileDownload") {
-        if (isAudioFileDownloadSpanSummary) {
-            return (
-                <span>
-                    This endpoint returns an <code>audio/mpeg</code> file.
-                </span>
-            );
+    switch (responseBody.shape.type) {
+        case "fileDownload": {
+            if (isAudioFileDownloadSpanSummary) {
+                return (
+                    <span>
+                        This endpoint returns an <code>audio/mpeg</code> file.
+                    </span>
+                );
+            }
+            return "This endpoint returns a file.";
         }
-        return "This endpoint returns a file.";
-    } else if (responseBody.shape.type === "streamingText") {
-        return "This endpoint sends text responses over a long-lived HTTP connection.";
-    } else if (responseBody.shape.type === "streamCondition") {
-        return "This endpoint returns a stream.";
-    } else if (responseBody.shape.type === "stream") {
-        return `This endpoint returns a stream of ${renderTypeShorthand(responseBody.shape.value, { withArticle: false }, types)}.`;
+        case "streamingText":
+            return "This endpoint sends text responses over a long-lived HTTP connection.";
+        case "streamCondition":
+            return "This endpoint returns a stream.";
+        case "stream":
+            return `This endpoint returns a stream of ${exampleResponseBody?.type === "sse" ? "server sent events" : renderTypeShorthand(responseBody.shape.value, { withArticle: false }, types)}.`;
+        case "alias":
+        case "discriminatedUnion":
+        case "enum":
+        case "primitive":
+        case "optional":
+        case "map":
+        case "list":
+        case "literal":
+        case "object":
+        case "reference":
+        case "set":
+        case "unknown":
+        case "undiscriminatedUnion":
+            return `This endpoint returns ${renderTypeShorthand(responseBody.shape, { withArticle: true }, types)}.`;
+        default:
+            assertNever(responseBody.shape);
     }
-    return `This endpoint returns ${renderTypeShorthand(responseBody.shape, { withArticle: true }, types)}.`;
 }

--- a/packages/ui/app/src/api-reference/endpoints/EndpointResponseSection.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointResponseSection.tsx
@@ -1,5 +1,5 @@
 import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
-import { assertNever } from "@fern-ui/core-utils";
+import { UnreachableCaseError } from "ts-essentials";
 import { useFeatureFlags } from "../../atoms";
 import { FernErrorTag } from "../../components/FernErrorBoundary";
 import { Markdown } from "../../mdx/Markdown";
@@ -135,6 +135,6 @@ function getResponseSummary({
         case "undiscriminatedUnion":
             return `This endpoint returns ${renderTypeShorthand(responseBody.shape, { withArticle: true }, types)}.`;
         default:
-            assertNever(responseBody.shape);
+            throw new UnreachableCaseError(responseBody.shape);
     }
 }

--- a/packages/ui/app/src/api-reference/types/type-shorthand/TypeShorthand.tsx
+++ b/packages/ui/app/src/api-reference/types/type-shorthand/TypeShorthand.tsx
@@ -99,7 +99,6 @@ export function renderTypeShorthand(
     },
     types: Record<string, ResolvedTypeDefinition>,
 ): string {
-    console.log(shape);
     const maybeWithArticle = (article: string, stringWithoutArticle: string) =>
         withArticle ? `${article} ${stringWithoutArticle}` : stringWithoutArticle;
     return visitDiscriminatedUnion(unwrapReference(shape, types), "type")._visit({

--- a/packages/ui/app/src/api-reference/types/type-shorthand/TypeShorthand.tsx
+++ b/packages/ui/app/src/api-reference/types/type-shorthand/TypeShorthand.tsx
@@ -99,6 +99,7 @@ export function renderTypeShorthand(
     },
     types: Record<string, ResolvedTypeDefinition>,
 ): string {
+    console.log(shape);
     const maybeWithArticle = (article: string, stringWithoutArticle: string) =>
         withArticle ? `${article} ${stringWithoutArticle}` : stringWithoutArticle;
     return visitDiscriminatedUnion(unwrapReference(shape, types), "type")._visit({


### PR DESCRIPTION
Fixes FER-3337

## Short description of the changes made

- Adds "server side events" to the response text for SSE typed example responses.

## What was the motivation & context behind this PR?

- Cohere ask

## How has this PR been tested?

<img width="677" alt="Screenshot 2024-10-01 at 3 17 50 PM" src="https://github.com/user-attachments/assets/d9bd67f2-6e32-48a0-a0e4-1b30cbda8aff">

