### PR TITLE
remove console statements from fern platform with nextjs

### DIFF
--- a/packages/ui/app/src/atoms/location.ts
+++ b/packages/ui/app/src/atoms/location.ts
@@ -52,9 +52,6 @@ export const SLUG_ATOM = atom(
             return;
         }
 
-        // eslint-disable-next-line no-console
-        console.debug("setting location to in slug atom", pathname);
-
         // replaces the current location with the new slug, and removes any hash (from an anchor) that may be present
         set(LOCATION_ATOM, { pathname, searchParams: location.searchParams, hash: "" }, { replace: true });
     },

--- a/packages/ui/docs-bundle/next.config.mjs
+++ b/packages/ui/docs-bundle/next.config.mjs
@@ -145,6 +145,9 @@ const nextConfig = {
         }
         return config;
     },
+    compiler: {
+        removeConsole: true,
+    },
 };
 
 /** @type {import("next").NextConfig} */


### PR DESCRIPTION
## Short description of the changes made

- Adds config to remove console statements from compiled next js code

## What was the motivation & context behind this PR?

- Console statements sometimes leak into prod
