### PR TITLE
feat: added ability to add canonical url to frontmatter

### DIFF
--- a/fern/apis/fdr/definition/docs/latest/frontmatter.yml
+++ b/fern/apis/fdr/definition/docs/latest/frontmatter.yml
@@ -64,7 +64,7 @@ types:
         type: optional<string>
         docs: Use subtitle instead.
       canonical-url:
-        type: string
+        type: optional<string>
         docs: The canonical URL of the page. This is used for the <link rel="canonical"> tag in the HTML.
 
   Layout:

--- a/fern/apis/fdr/definition/docs/latest/frontmatter.yml
+++ b/fern/apis/fdr/definition/docs/latest/frontmatter.yml
@@ -63,6 +63,9 @@ types:
         availability: deprecated
         type: optional<string>
         docs: Use subtitle instead.
+      canonical-url:
+        type: string
+        docs: The canonical URL of the page. This is used for the <link rel="canonical"> tag in the HTML.
 
   Layout:
     enum:

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/latest/resources/frontmatter/types/Frontmatter.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/latest/resources/frontmatter/types/Frontmatter.ts
@@ -43,4 +43,6 @@ export interface Frontmatter
     breadcrumb: FernRegistry.navigation.latest.BreadcrumbItem[] | undefined;
     /** Use subtitle instead. */
     excerpt: string | undefined;
+    /** The canonical URL of the page. This is used for the <link rel="canonical"> tag in the HTML. */
+    "canonical-url": string;
 }

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/latest/resources/frontmatter/types/Frontmatter.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/latest/resources/frontmatter/types/Frontmatter.ts
@@ -44,5 +44,5 @@ export interface Frontmatter
     /** Use subtitle instead. */
     excerpt: string | undefined;
     /** The canonical URL of the page. This is used for the <link rel="canonical"> tag in the HTML. */
-    "canonical-url": string;
+    "canonical-url": string | undefined;
 }

--- a/packages/ui/app/src/seo/getSeoProp.ts
+++ b/packages/ui/app/src/seo/getSeoProp.ts
@@ -84,6 +84,11 @@ export function getSeoProps(
         const page = pages[pageId];
         if (page != null) {
             const { data: frontmatter, content } = getFrontmatter(page.markdown);
+
+            if (frontmatter["canonical-url"] != null) {
+                seo.canonical = frontmatter["canonical-url"];
+            }
+
             ogMetadata = { ...ogMetadata, ...frontmatter };
 
             // retrofit og:image, preferring og:image

--- a/servers/fdr/src/api/generated/api/resources/docs/resources/latest/resources/frontmatter/types/Frontmatter.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/docs/resources/latest/resources/frontmatter/types/Frontmatter.d.ts
@@ -39,4 +39,6 @@ export interface Frontmatter extends FernRegistry.docs.latest.WithMetadataConfig
     breadcrumb: FernRegistry.navigation.latest.BreadcrumbItem[] | undefined;
     /** Use subtitle instead. */
     excerpt: string | undefined;
+    /** The canonical URL of the page. This is used for the <link rel="canonical"> tag in the HTML. */
+    "canonical-url": string;
 }

--- a/servers/fdr/src/api/generated/api/resources/docs/resources/latest/resources/frontmatter/types/Frontmatter.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/docs/resources/latest/resources/frontmatter/types/Frontmatter.d.ts
@@ -40,5 +40,5 @@ export interface Frontmatter extends FernRegistry.docs.latest.WithMetadataConfig
     /** Use subtitle instead. */
     excerpt: string | undefined;
     /** The canonical URL of the page. This is used for the <link rel="canonical"> tag in the HTML. */
-    "canonical-url": string;
+    "canonical-url": string | undefined;
 }


### PR DESCRIPTION
Fixes FER-3342

## Short description of the changes made

- Adds ability to add canonical tag to frontmatter, with `canonical-url`

## What was the motivation & context behind this PR?

- SEO issues

## How has this PR been tested?

<img width="449" alt="Screenshot 2024-10-02 at 2 54 22 PM" src="https://github.com/user-attachments/assets/21178c62-0409-4580-bf81-a11621f7a820">
<img width="572" alt="Screenshot 2024-10-02 at 2 52 58 PM" src="https://github.com/user-attachments/assets/32ec3f11-bfda-405d-b162-1fe211bb6510">

