### PR TITLE
init: webflow oauth integration

### DIFF
--- a/packages/ui/app/src/auth/OAuth2Client.ts
+++ b/packages/ui/app/src/auth/OAuth2Client.ts
@@ -2,7 +2,7 @@ import { JWTPayload, createRemoteJWKSet, decodeJwt, jwtVerify } from "jose";
 import { NextApiRequestCookies } from "next/dist/server/api-utils";
 import type { NextRequest } from "next/server";
 import urlJoin from "url-join";
-import { AuthEdgeConfigOAuth2, OAuthTokenResponse, OAuthTokenResponseSchema } from "./types";
+import { AuthEdgeConfigOAuth2Ory, OAuthTokenResponse, OAuthTokenResponseSchema } from "./types";
 
 interface TokenInfo {
     access_token: string;
@@ -18,7 +18,7 @@ export class OAuth2Client {
     private readonly jwks: string | undefined;
 
     constructor(
-        config: AuthEdgeConfigOAuth2,
+        config: AuthEdgeConfigOAuth2Ory,
         private readonly redirect_uri?: string,
     ) {
         this.clientId = config.clientId;

--- a/packages/ui/app/src/auth/getApiKeyInjectionConfig.ts
+++ b/packages/ui/app/src/auth/getApiKeyInjectionConfig.ts
@@ -26,13 +26,14 @@ export type APIKeyInjectionConfig =
     | APIKeyInjectionConfigEnabledUnauthorized
     | APIKeyInjectionConfigEnabledAuthorized;
 
+// TODO: since this is for ORY (rightbrain) only, lets refactor
 export async function getAPIKeyInjectionConfig(
     domain: string,
     cookies?: NextRequest["cookies"],
     state?: string,
 ): Promise<APIKeyInjectionConfig> {
     const config = await getAuthEdgeConfig(domain);
-    if (config?.type === "oauth2" && config["api-key-injection-enabled"]) {
+    if (config?.type === "oauth2" && config.partner === "ory" && config["api-key-injection-enabled"]) {
         const client = new OAuth2Client(config, `https://${domain}/api/auth/callback`);
         const tokens = cookies != null ? await client.getOrRefreshAccessTokenEdge(cookies) : undefined;
 
@@ -61,13 +62,15 @@ export async function getAPIKeyInjectionConfig(
         enabled: false,
     };
 }
+
+// TODO: since this is for ORY (rightbrain) only, lets refactor
 export async function getAPIKeyInjectionConfigNode(
     domain: string,
     cookies?: NextApiRequestCookies,
     state?: string,
 ): Promise<APIKeyInjectionConfig> {
     const config = await getAuthEdgeConfig(domain);
-    if (config?.type === "oauth2" && config["api-key-injection-enabled"]) {
+    if (config?.type === "oauth2" && config.partner === "ory" && config["api-key-injection-enabled"]) {
         const client = new OAuth2Client(config, `https://${domain}/api/auth/callback`);
         const tokens = cookies != null ? await client.getOrRefreshAccessTokenNode(cookies) : undefined;
 

--- a/packages/ui/app/src/auth/types.ts
+++ b/packages/ui/app/src/auth/types.ts
@@ -9,7 +9,7 @@ export const FernUserSchema = z.object({
 
 export type FernUser = z.infer<typeof FernUserSchema>;
 
-export const AuthEdgeConfigOAuth2Schema = z.object({
+export const AuthEdgeConfigOAuth2OrySchema = z.object({
     type: z.literal("oauth2"),
     partner: z.literal("ory"),
     environment: z.string(),
@@ -19,6 +19,13 @@ export const AuthEdgeConfigOAuth2Schema = z.object({
     clientSecret: z.string(),
     "api-key-injection-enabled": z.optional(z.boolean()),
 });
+export const AuthEdgeConfigOAuth2WebflowSchema = z.object({
+    type: z.literal("oauth2"),
+    partner: z.literal("webflow"),
+    scope: z.optional(z.union([z.string(), z.array(z.string())])),
+    clientId: z.string(),
+    clientSecret: z.string(),
+});
 
 export const AuthEdgeConfigBasicTokenVerificationSchema = z.object({
     type: z.literal("basic_token_verification"),
@@ -27,10 +34,16 @@ export const AuthEdgeConfigBasicTokenVerificationSchema = z.object({
     redirect: z.string(),
 });
 
-export const AuthEdgeConfigSchema = z.union([AuthEdgeConfigOAuth2Schema, AuthEdgeConfigBasicTokenVerificationSchema]);
+export const AuthEdgeConfigSchema = z.union([
+    AuthEdgeConfigOAuth2OrySchema,
+    AuthEdgeConfigOAuth2WebflowSchema,
+    AuthEdgeConfigBasicTokenVerificationSchema,
+    AuthEdgeConfigBasicTokenVerificationSchema,
+]);
 
 export type AuthEdgeConfig = z.infer<typeof AuthEdgeConfigSchema>;
-export type AuthEdgeConfigOAuth2 = z.infer<typeof AuthEdgeConfigOAuth2Schema>;
+export type AuthEdgeConfigOAuth2Ory = z.infer<typeof AuthEdgeConfigOAuth2OrySchema>;
+export type AuthEdgeConfigOAuth2Webflow = z.infer<typeof AuthEdgeConfigOAuth2WebflowSchema>;
 export type AuthEdgeConfigBasicTokenVerification = z.infer<typeof AuthEdgeConfigBasicTokenVerificationSchema>;
 
 export const OAuthTokenResponseSchema = z.object({

--- a/packages/ui/docs-bundle/package.json
+++ b/packages/ui/docs-bundle/package.json
@@ -24,7 +24,6 @@
     "lint": "pnpm lint:eslint && pnpm lint:style"
   },
   "dependencies": {
-    "@fern-ui/fern-docs-utils": "workspace:*",
     "@algolia/requester-fetch": "^4.24.0",
     "@aws-sdk/client-s3": "^3.335.0",
     "@aws-sdk/s3-request-presigner": "^3.574.0",
@@ -36,6 +35,7 @@
     "@fern-ui/components": "workspace:*",
     "@fern-ui/core-utils": "workspace:*",
     "@fern-ui/fdr-utils": "workspace:*",
+    "@fern-ui/fern-docs-utils": "workspace:*",
     "@fern-ui/search-utils": "workspace:*",
     "@fern-ui/ui": "workspace:*",
     "@sentry/nextjs": "^8.30.0",
@@ -59,6 +59,7 @@
     "ts-essentials": "^10.0.1",
     "url-join": "5.0.0",
     "uuid": "^9.0.0",
+    "webflow-api": "^2.4.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/api-key-injection.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/api-key-injection.ts
@@ -9,15 +9,43 @@ import {
 } from "@fern-ui/ui/auth";
 import { NextRequest, NextResponse } from "next/server";
 import urlJoin from "url-join";
+import { WebflowClient } from "webflow-api";
+import type { OauthScope } from "webflow-api/api/types/OAuthScope";
 
 export const runtime = "edge";
 
 export default async function handler(req: NextRequest): Promise<NextResponse<APIKeyInjectionConfig>> {
     const domain = getXFernHostEdge(req);
+    const edgeConfig = await getAuthEdgeConfig(domain);
+
+    // assume that if the edge config is set for webflow, api key injection is always enabled
+    if (edgeConfig?.type === "oauth2" && edgeConfig.partner === "webflow") {
+        const accessToken = req.nextUrl.searchParams.get("access_token");
+        if (accessToken == null) {
+            return NextResponse.json({
+                enabled: true,
+                authenticated: false,
+                url: WebflowClient.authorizeURL({
+                    clientId: edgeConfig.clientId,
+
+                    // TODO: subpaths will not work
+                    redirectUri: `https://${domain}/api/fern-docs/oauth/webflow/callback`,
+
+                    // note: this is not validated
+                    scope: (edgeConfig.scope as OauthScope | OauthScope[]) ?? "authorized_user:read",
+                }),
+            });
+        }
+        return NextResponse.json({
+            enabled: true,
+            authenticated: true,
+            access_token: accessToken,
+        });
+    }
+
     const fern_token = req.cookies.get("fern_token")?.value;
 
     const config = await getAPIKeyInjectionConfig(domain, req.cookies);
-    const edgeConfig = await getAuthEdgeConfig(domain);
     const response = NextResponse.json(config);
 
     if (config.enabled && config.authenticated) {

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/api-key-injection.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/api-key-injection.ts
@@ -20,7 +20,7 @@ export default async function handler(req: NextRequest): Promise<NextResponse<AP
 
     // assume that if the edge config is set for webflow, api key injection is always enabled
     if (edgeConfig?.type === "oauth2" && edgeConfig.partner === "webflow") {
-        const accessToken = req.nextUrl.searchParams.get("access_token");
+        const accessToken = req.cookies.get("access_token")?.value;
         if (accessToken == null) {
             return NextResponse.json({
                 enabled: true,

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/api-key-injection.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/api-key-injection.ts
@@ -29,7 +29,7 @@ export default async function handler(req: NextRequest): Promise<NextResponse<AP
                     clientId: edgeConfig.clientId,
 
                     // TODO: subpaths will not work
-                    redirectUri: `https://${domain}/api/fern-docs/oauth/webflow/callback`,
+                    // redirectUri: `https://${domain}/api/fern-docs/oauth/webflow/callback`,
 
                     // note: this is not validated
                     scope: (edgeConfig.scope as OauthScope | OauthScope[]) ?? "authorized_user:read",

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/callback.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/callback.ts
@@ -41,7 +41,7 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
             "/api/fern-docs/oauth/ory/callback",
         );
         // Permanent GET redirect to the Ory callback endpoint
-        return NextResponse.redirect(nextUrl, { status: 301 });
+        return NextResponse.redirect(nextUrl, { status: 307 });
     }
 
     try {

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/logout.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/logout.ts
@@ -1,21 +1,14 @@
-import { getXFernHostEdge } from "@/server/xfernhost/edge";
-import { getAuthEdgeConfig } from "@fern-ui/ui/auth";
 import { NextRequest, NextResponse } from "next/server";
 
 export const runtime = "edge";
 
 export default async function GET(req: NextRequest): Promise<NextResponse> {
-    const domain = getXFernHostEdge(req);
-    const config = await getAuthEdgeConfig(domain);
-
     const state = req.nextUrl.searchParams.get("state");
     const redirectLocation = state ?? req.nextUrl.origin;
 
     const res = NextResponse.redirect(redirectLocation);
-    if (config != null && config.type === "oauth2" && config.partner === "ory") {
-        res.cookies.delete("fern_token");
-        res.cookies.delete("access_token");
-        res.cookies.delete("refresh_token");
-    }
+    res.cookies.delete("fern_token");
+    res.cookies.delete("access_token");
+    res.cookies.delete("refresh_token");
     return res;
 }

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/ory/callback.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/ory/callback.ts
@@ -1,7 +1,14 @@
-import { getWorkOS, getWorkOSClientId } from "@/server/workos";
 import { getXFernHostEdge } from "@/server/xfernhost/edge";
-import { FernUser, getAuthEdgeConfig, signFernJWT, withSecureCookie } from "@fern-ui/ui/auth";
+import {
+    FernUser,
+    OAuth2Client,
+    OryAccessTokenSchema,
+    getAuthEdgeConfig,
+    signFernJWT,
+    withSecureCookie,
+} from "@fern-ui/ui/auth";
 import { NextRequest, NextResponse } from "next/server";
+import urlJoin from "url-join";
 
 export const runtime = "edge";
 
@@ -16,7 +23,6 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
         return new NextResponse(null, { status: 405 });
     }
 
-    // The authorization code returned by AuthKit
     const code = req.nextUrl.searchParams.get("code");
     const state = req.nextUrl.searchParams.get("state");
     const error = req.nextUrl.searchParams.get("error");
@@ -34,36 +40,29 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
     const domain = getXFernHostEdge(req);
     const config = await getAuthEdgeConfig(domain);
 
-    if (config != null && config.type === "oauth2" && config.partner === "ory") {
-        const nextUrl = req.nextUrl.clone();
-        nextUrl.pathname = nextUrl.pathname.replace(
-            "/api/fern-docs/auth/callback",
-            "/api/fern-docs/oauth/ory/callback",
-        );
-        // Permanent GET redirect to the Ory callback endpoint
-        return NextResponse.redirect(nextUrl, { status: 301 });
+    if (config == null || config.type !== "oauth2" || config.partner === "ory") {
+        return redirectWithLoginError(redirectLocation, "Couldn't login, please try again");
     }
 
+    const oauthClient = new OAuth2Client(config, urlJoin(`https://${domain}`, req.nextUrl.pathname));
     try {
-        const { user } = await getWorkOS().userManagement.authenticateWithCode({
-            code,
-            clientId: getWorkOSClientId(),
-        });
-
+        const { access_token, refresh_token } = await oauthClient.getToken(code);
+        const token = OryAccessTokenSchema.parse(await oauthClient.decode(access_token));
         const fernUser: FernUser = {
             type: "user",
-            partner: "workos",
-            name:
-                user.firstName != null && user.lastName != null
-                    ? `${user.firstName} ${user.lastName}`
-                    : user.firstName ?? user.email.split("@")[0],
-            email: user.email,
+            partner: "ory",
+            name: token.ext?.name,
+            email: token.ext?.email,
         };
-
-        const token = await signFernJWT(fernUser, user);
-
+        const expires = token.exp == null ? undefined : new Date(token.exp * 1000);
         const res = NextResponse.redirect(redirectLocation);
-        res.cookies.set("fern_token", token, withSecureCookie());
+        res.cookies.set("fern_token", await signFernJWT(fernUser), withSecureCookie({ expires }));
+        res.cookies.set("access_token", access_token, withSecureCookie({ expires }));
+        if (refresh_token != null) {
+            res.cookies.set("refresh_token", refresh_token, withSecureCookie({ expires }));
+        } else {
+            res.cookies.delete("refresh_token");
+        }
         return res;
     } catch (error) {
         // eslint-disable-next-line no-console

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/ory/callback.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/ory/callback.ts
@@ -40,7 +40,7 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
     const domain = getXFernHostEdge(req);
     const config = await getAuthEdgeConfig(domain);
 
-    if (config == null || config.type !== "oauth2" || config.partner === "ory") {
+    if (config == null || config.type !== "oauth2" || config.partner !== "ory") {
         return redirectWithLoginError(redirectLocation, "Couldn't login, please try again");
     }
 

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/webflow/callback.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/webflow/callback.ts
@@ -1,7 +1,7 @@
-import { getWorkOS, getWorkOSClientId } from "@/server/workos";
 import { getXFernHostEdge } from "@/server/xfernhost/edge";
-import { FernUser, getAuthEdgeConfig, signFernJWT, withSecureCookie } from "@fern-ui/ui/auth";
+import { getAuthEdgeConfig, withSecureCookie } from "@fern-ui/ui/auth";
 import { NextRequest, NextResponse } from "next/server";
+import { WebflowClient } from "webflow-api";
 
 export const runtime = "edge";
 
@@ -16,7 +16,6 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
         return new NextResponse(null, { status: 405 });
     }
 
-    // The authorization code returned by AuthKit
     const code = req.nextUrl.searchParams.get("code");
     const state = req.nextUrl.searchParams.get("state");
     const error = req.nextUrl.searchParams.get("error");
@@ -34,36 +33,19 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
     const domain = getXFernHostEdge(req);
     const config = await getAuthEdgeConfig(domain);
 
-    if (config != null && config.type === "oauth2" && config.partner === "ory") {
-        const nextUrl = req.nextUrl.clone();
-        nextUrl.pathname = nextUrl.pathname.replace(
-            "/api/fern-docs/auth/callback",
-            "/api/fern-docs/oauth/ory/callback",
-        );
-        // Permanent GET redirect to the Ory callback endpoint
-        return NextResponse.redirect(nextUrl, { status: 301 });
+    if (config == null || config.type !== "oauth2" || config.partner === "ory") {
+        return redirectWithLoginError(redirectLocation, "Couldn't login, please try again");
     }
 
     try {
-        const { user } = await getWorkOS().userManagement.authenticateWithCode({
+        const accessToken = await WebflowClient.getAccessToken({
+            clientId: config.clientId,
+            clientSecret: config.clientSecret,
             code,
-            clientId: getWorkOSClientId(),
         });
 
-        const fernUser: FernUser = {
-            type: "user",
-            partner: "workos",
-            name:
-                user.firstName != null && user.lastName != null
-                    ? `${user.firstName} ${user.lastName}`
-                    : user.firstName ?? user.email.split("@")[0],
-            email: user.email,
-        };
-
-        const token = await signFernJWT(fernUser, user);
-
         const res = NextResponse.redirect(redirectLocation);
-        res.cookies.set("fern_token", token, withSecureCookie());
+        res.cookies.set("access_token", accessToken, withSecureCookie());
         return res;
     } catch (error) {
         // eslint-disable-next-line no-console

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,7 +446,7 @@ importers:
         version: 3.3.2
       simple-git:
         specifier: ^3.24.0
-        version: 3.24.0
+        version: 3.24.0(supports-color@8.1.1)
       stylelint:
         specifier: ^16.1.0
         version: 16.5.0(typescript@5.4.3)
@@ -1847,6 +1847,9 @@ importers:
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
+      webflow-api:
+        specifier: ^2.4.2
+        version: 2.4.2
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -2651,7 +2654,7 @@ importers:
         version: 3.21.0(serverless@3.38.0)
       simple-git:
         specifier: ^3.24.0
-        version: 3.24.0
+        version: 3.24.0(supports-color@8.1.1)
       tmp-promise:
         specifier: ^3.0.3
         version: 3.0.3
@@ -16280,6 +16283,9 @@ packages:
   web-vitals@4.2.3:
     resolution: {integrity: sha512-/CFAm1mNxSmOj6i0Co+iGFJ58OS4NRGVP+AWS/l509uIK5a1bSoIVaHz/ZumpHTfHSZBpgrJ+wjfpAOrTHok5Q==}
 
+  webflow-api@2.4.2:
+    resolution: {integrity: sha512-+znE6V6E6YULwZIGIk8NLFZaimGFH7xVEAjCeivHz4gV13Zcg4FRXyhWxxTHnOYBwKjcjDoaWl8ZK1H9mUA5mQ==}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -17003,10 +17009,10 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.572.0
-      '@aws-sdk/client-sts': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0)
+      '@aws-sdk/client-sso-oidc': 3.572.0(@aws-sdk/client-sts@3.572.0)
+      '@aws-sdk/client-sts': 3.572.0
       '@aws-sdk/core': 3.572.0
-      '@aws-sdk/credential-provider-node': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0)(@aws-sdk/client-sts@3.572.0(@aws-sdk/client-sso-oidc@3.572.0))
+      '@aws-sdk/credential-provider-node': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0(@aws-sdk/client-sts@3.572.0))(@aws-sdk/client-sts@3.572.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.568.0
       '@aws-sdk/middleware-expect-continue': 3.572.0
       '@aws-sdk/middleware-flexible-checksums': 3.572.0
@@ -17067,7 +17073,7 @@ snapshots:
       '@aws-crypto/sha256-js': 3.0.0
       '@aws-sdk/client-sts': 3.572.0
       '@aws-sdk/core': 3.572.0
-      '@aws-sdk/credential-provider-node': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0)(@aws-sdk/client-sts@3.572.0(@aws-sdk/client-sso-oidc@3.572.0))
+      '@aws-sdk/credential-provider-node': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0)(@aws-sdk/client-sts@3.572.0)
       '@aws-sdk/middleware-host-header': 3.567.0
       '@aws-sdk/middleware-logger': 3.568.0
       '@aws-sdk/middleware-recursion-detection': 3.567.0
@@ -17201,7 +17207,7 @@ snapshots:
       '@aws-crypto/sha256-js': 3.0.0
       '@aws-sdk/client-sso-oidc': 3.572.0
       '@aws-sdk/core': 3.572.0
-      '@aws-sdk/credential-provider-node': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0)(@aws-sdk/client-sts@3.572.0)
+      '@aws-sdk/credential-provider-node': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0(@aws-sdk/client-sts@3.572.0))(@aws-sdk/client-sts@3.572.0)
       '@aws-sdk/middleware-host-header': 3.567.0
       '@aws-sdk/middleware-logger': 3.568.0
       '@aws-sdk/middleware-recursion-detection': 3.567.0
@@ -17238,52 +17244,6 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/client-sts@3.572.0(@aws-sdk/client-sso-oidc@3.572.0)':
-    dependencies:
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.572.0
-      '@aws-sdk/core': 3.572.0
-      '@aws-sdk/credential-provider-node': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0)(@aws-sdk/client-sts@3.572.0(@aws-sdk/client-sso-oidc@3.572.0))
-      '@aws-sdk/middleware-host-header': 3.567.0
-      '@aws-sdk/middleware-logger': 3.568.0
-      '@aws-sdk/middleware-recursion-detection': 3.567.0
-      '@aws-sdk/middleware-user-agent': 3.572.0
-      '@aws-sdk/region-config-resolver': 3.572.0
-      '@aws-sdk/types': 3.567.0
-      '@aws-sdk/util-endpoints': 3.572.0
-      '@aws-sdk/util-user-agent-browser': 3.567.0
-      '@aws-sdk/util-user-agent-node': 3.568.0
-      '@smithy/config-resolver': 2.2.0
-      '@smithy/core': 1.4.2
-      '@smithy/fetch-http-handler': 2.5.0
-      '@smithy/hash-node': 2.2.0
-      '@smithy/invalid-dependency': 2.2.0
-      '@smithy/middleware-content-length': 2.2.0
-      '@smithy/middleware-endpoint': 2.5.1
-      '@smithy/middleware-retry': 2.3.1
-      '@smithy/middleware-serde': 2.3.0
-      '@smithy/middleware-stack': 2.2.0
-      '@smithy/node-config-provider': 2.3.0
-      '@smithy/node-http-handler': 2.5.0
-      '@smithy/protocol-http': 3.3.0
-      '@smithy/smithy-client': 2.5.1
-      '@smithy/types': 2.12.0
-      '@smithy/url-parser': 2.2.0
-      '@smithy/util-base64': 2.3.0
-      '@smithy/util-body-length-browser': 2.2.0
-      '@smithy/util-body-length-node': 2.3.0
-      '@smithy/util-defaults-mode-browser': 2.2.1
-      '@smithy/util-defaults-mode-node': 2.3.1
-      '@smithy/util-endpoints': 1.2.0
-      '@smithy/util-middleware': 2.2.0
-      '@smithy/util-retry': 2.2.0
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/core@3.572.0':
@@ -17332,23 +17292,6 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-ini@3.572.0(@aws-sdk/client-sso-oidc@3.572.0)(@aws-sdk/client-sts@3.572.0(@aws-sdk/client-sso-oidc@3.572.0))':
-    dependencies:
-      '@aws-sdk/client-sts': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0)
-      '@aws-sdk/credential-provider-env': 3.568.0
-      '@aws-sdk/credential-provider-process': 3.572.0
-      '@aws-sdk/credential-provider-sso': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0)
-      '@aws-sdk/credential-provider-web-identity': 3.568.0(@aws-sdk/client-sts@3.572.0)
-      '@aws-sdk/types': 3.567.0
-      '@smithy/credential-provider-imds': 2.3.0
-      '@smithy/property-provider': 2.2.0
-      '@smithy/shared-ini-file-loader': 2.4.0
-      '@smithy/types': 2.12.0
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - aws-crt
-
   '@aws-sdk/credential-provider-ini@3.572.0(@aws-sdk/client-sso-oidc@3.572.0)(@aws-sdk/client-sts@3.572.0)':
     dependencies:
       '@aws-sdk/client-sts': 3.572.0
@@ -17373,25 +17316,6 @@ snapshots:
       '@aws-sdk/credential-provider-ini': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0(@aws-sdk/client-sts@3.572.0))(@aws-sdk/client-sts@3.572.0)
       '@aws-sdk/credential-provider-process': 3.572.0
       '@aws-sdk/credential-provider-sso': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0(@aws-sdk/client-sts@3.572.0))
-      '@aws-sdk/credential-provider-web-identity': 3.568.0(@aws-sdk/client-sts@3.572.0)
-      '@aws-sdk/types': 3.567.0
-      '@smithy/credential-provider-imds': 2.3.0
-      '@smithy/property-provider': 2.2.0
-      '@smithy/shared-ini-file-loader': 2.4.0
-      '@smithy/types': 2.12.0
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - '@aws-sdk/client-sts'
-      - aws-crt
-
-  '@aws-sdk/credential-provider-node@3.572.0(@aws-sdk/client-sso-oidc@3.572.0)(@aws-sdk/client-sts@3.572.0(@aws-sdk/client-sso-oidc@3.572.0))':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.568.0
-      '@aws-sdk/credential-provider-http': 3.568.0
-      '@aws-sdk/credential-provider-ini': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0)(@aws-sdk/client-sts@3.572.0(@aws-sdk/client-sso-oidc@3.572.0))
-      '@aws-sdk/credential-provider-process': 3.572.0
-      '@aws-sdk/credential-provider-sso': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0)
       '@aws-sdk/credential-provider-web-identity': 3.568.0(@aws-sdk/client-sts@3.572.0)
       '@aws-sdk/types': 3.567.0
       '@smithy/credential-provider-imds': 2.3.0
@@ -17459,7 +17383,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.568.0(@aws-sdk/client-sts@3.572.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.572.0(@aws-sdk/client-sso-oidc@3.572.0)
+      '@aws-sdk/client-sts': 3.572.0
       '@aws-sdk/types': 3.567.0
       '@smithy/property-provider': 2.2.0
       '@smithy/types': 2.12.0
@@ -17672,7 +17596,7 @@ snapshots:
       '@babel/traverse': 7.24.5
       '@babel/types': 7.24.5
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -18471,7 +18395,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.24.5
       '@babel/parser': 7.24.5
       '@babel/types': 7.24.5
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -18486,7 +18410,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.24.5
       '@babel/parser': 7.24.5
       '@babel/types': 7.24.5
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -18710,7 +18634,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -18973,7 +18897,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -19440,12 +19364,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
-
-  '@kwsites/file-exists@1.1.1':
-    dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
 
   '@kwsites/file-exists@1.1.1(supports-color@8.1.1)':
     dependencies:
@@ -24162,7 +24080,7 @@ snapshots:
       '@typescript-eslint/type-utils': 7.3.1(eslint@8.57.0)(typescript@5.4.3)
       '@typescript-eslint/utils': 7.3.1(eslint@8.57.0)(typescript@5.4.3)
       '@typescript-eslint/visitor-keys': 7.3.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -24180,7 +24098,7 @@ snapshots:
       '@typescript-eslint/types': 7.17.0
       '@typescript-eslint/typescript-estree': 7.17.0(typescript@5.4.3)
       '@typescript-eslint/visitor-keys': 7.17.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.4.3
@@ -24193,7 +24111,7 @@ snapshots:
       '@typescript-eslint/types': 7.2.0
       '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.4.3)
       '@typescript-eslint/visitor-keys': 7.2.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.4.3
@@ -24206,7 +24124,7 @@ snapshots:
       '@typescript-eslint/types': 7.3.1
       '@typescript-eslint/typescript-estree': 7.3.1(typescript@5.4.3)
       '@typescript-eslint/visitor-keys': 7.3.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.4.3
@@ -24259,7 +24177,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.3.1(typescript@5.4.3)
       '@typescript-eslint/utils': 7.3.1(eslint@8.57.0)(typescript@5.4.3)
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.4.3)
     optionalDependencies:
@@ -24342,7 +24260,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.3.1
       '@typescript-eslint/visitor-keys': 7.3.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -27426,7 +27344,7 @@ snapshots:
       callsite: 1.0.0
       camelcase: 6.3.0
       cosmiconfig: 7.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       deps-regex: 0.2.0
       findup-sync: 5.0.0
       ignore: 5.3.1
@@ -27916,7 +27834,7 @@ snapshots:
 
   eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
@@ -28130,7 +28048,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -29562,7 +29480,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -30525,7 +30443,7 @@ snapshots:
     dependencies:
       chalk: 5.3.0
       commander: 11.0.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       execa: 7.2.0
       lilconfig: 2.1.0
       listr2: 6.6.1
@@ -33963,14 +33881,6 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
-  simple-git@3.24.0:
-    dependencies:
-      '@kwsites/file-exists': 1.1.1
-      '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.4(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
-
   simple-git@3.24.0(supports-color@8.1.1):
     dependencies:
       '@kwsites/file-exists': 1.1.1(supports-color@8.1.1)
@@ -34411,7 +34321,7 @@ snapshots:
       cosmiconfig: 9.0.0(typescript@5.4.3)
       css-functions-list: 3.2.2
       css-tree: 2.3.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
       file-entry-cache: 8.0.0
@@ -34449,7 +34359,7 @@ snapshots:
   stylus@0.62.0:
     dependencies:
       '@adobe/css-tools': 4.3.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       glob: 7.2.3
       sax: 1.3.0
       source-map: 0.7.4
@@ -35046,7 +34956,7 @@ snapshots:
       bundle-require: 4.1.0(esbuild@0.20.2)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       esbuild: 0.20.2
       execa: 5.1.1
       globby: 11.1.0
@@ -35568,7 +35478,7 @@ snapshots:
   vite-node@1.6.0(@types/node@18.19.33)(less@4.2.0)(sass@1.77.0)(stylus@0.62.0)(terser@5.31.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.0
       vite: 5.2.11(@types/node@18.19.33)(less@4.2.0)(sass@1.77.0)(stylus@0.62.0)(terser@5.31.0)
@@ -35585,7 +35495,7 @@ snapshots:
   vite-node@1.6.0(@types/node@22.5.5)(less@4.2.0)(sass@1.77.0)(stylus@0.62.0)(terser@5.31.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.0
       vite: 5.2.11(@types/node@22.5.5)(less@4.2.0)(sass@1.77.0)(stylus@0.62.0)(terser@5.31.0)
@@ -35709,7 +35619,7 @@ snapshots:
       '@vitest/utils': 1.6.0
       acorn-walk: 8.3.2
       chai: 4.4.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       execa: 8.0.1
       local-pkg: 0.5.0
       magic-string: 0.30.10
@@ -35744,7 +35654,7 @@ snapshots:
       '@vitest/utils': 1.6.0
       acorn-walk: 8.3.2
       chai: 4.4.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       execa: 8.0.1
       local-pkg: 0.5.0
       magic-string: 0.30.10
@@ -35868,6 +35778,18 @@ snapshots:
   web-streams-polyfill@4.0.0-beta.3: {}
 
   web-vitals@4.2.3: {}
+
+  webflow-api@2.4.2:
+    dependencies:
+      form-data: 4.0.0
+      formdata-node: 6.0.3
+      js-base64: 3.7.2
+      node-fetch: 2.7.0
+      qs: 6.11.2
+      readable-stream: 4.5.2
+      url-join: 4.0.1
+    transitivePeerDependencies:
+      - encoding
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
Integrates oauth callback using webflow.

notes:
- new api route `/api/fern-docs/oauth/webflow/callback` is created to disambiguate from the `ory` and `workos` callback urls. this is important so that webflowclient is compiled separately from ory and workos, otherwise the edge function will eventually blow up in size (and fail to compile)
- new api route `/api/fern-docs/oauth/ory/callback` is created with a permanent redirect to it from `/api/fern-docs/auth/callback`. someone needs to reach out to rightbrain to update their actual callback urls, but this should work in the interim.

what's next:
- testing the oauth callback flow. the edge config is set for https://webflow-migration.docs.buildwithfern.com

what i'm not a fan of:
- theres some weird hackery magic going on in the ory-based oauth flow that needs to be reconsidered. @RohinBhargava i've added some TODO comments to indicate where.
- i'm not really sure what the error stuff does (if it does anything) and whether or not it is ory-specific. need to double check webflow's docs on oauth
- i actually think we have a really convoluted setup. we should really have a centralized `auth.ferndocs.com` for all the auth and oauth logic. Mainly because redirect urls are really really hard to change once they're set.
- the nice thing about vercel edge functions is that it has ultra low-latency, and runs globally. if we were to migrate to a central source of truth, we should consider using cloudflare workers.