### PR TITLE
fix: restore functionality for dropdowns, switchers and other API_ATOM derivatives

### DIFF
--- a/packages/ui/app/src/api-reference/ApiEndpointPage.tsx
+++ b/packages/ui/app/src/api-reference/ApiEndpointPage.tsx
@@ -1,3 +1,5 @@
+import { useSetAtom } from "jotai";
+import { ALL_ENVIRONMENTS_ATOM } from "../atoms/environment";
 import { ApiPageContext } from "../contexts/api-page";
 import type { ResolvedApiEndpoint, ResolvedTypeDefinition } from "../resolver/types";
 import { BuiltWithFern } from "../sidebar/BuiltWithFern";
@@ -12,6 +14,11 @@ export declare namespace ApiEndpointPage {
 }
 
 export const ApiEndpointPage: React.FC<ApiEndpointPage.Props> = ({ item, showErrors, types }) => {
+    const setEnvironmentIds = useSetAtom(ALL_ENVIRONMENTS_ATOM);
+    if (item.type === "endpoint" || item.type === "websocket") {
+        setEnvironmentIds(item.environments.map((env) => env.id));
+    }
+
     return (
         <ApiPageContext.Provider value={true}>
             <SingleApiPageContent item={item} showErrors={showErrors} types={types} />

--- a/packages/ui/app/src/api-reference/endpoints/EndpointUrl.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointUrl.tsx
@@ -96,7 +96,7 @@ export const EndpointUrl = React.forwardRef<HTMLDivElement, PropsWithChildren<En
                                     })}
                                 >
                                     {showEnvironment && (
-                                        <span className="inline-flex whitespace-nowrap max-sm:hidden">
+                                        <span className="whitespace-nowrap max-sm:hidden">
                                             <MaybeEnvironmentDropdown
                                                 selectedEnvironment={selectedEnvironment}
                                                 urlTextStyle="t-muted"

--- a/packages/ui/app/src/atoms/environment.ts
+++ b/packages/ui/app/src/atoms/environment.ts
@@ -1,24 +1,13 @@
-import type { APIV1Read } from "@fern-api/fdr-sdk";
-import { atom, useAtomValue } from "jotai";
+import { atom, useAtomValue, useSetAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
-import { isEndpoint, isWebSocket } from "../resolver/types";
-import { DEPRECATED_FLATTENED_APIS_ATOM } from "./apis";
 
 // Capture all possible environments in a list, in useEffect at top level
-export const ALL_ENVIRONMENTS_ATOM = atom((get) => {
-    const flatApis = get(DEPRECATED_FLATTENED_APIS_ATOM);
-    const allEnvironmentIds = new Set<string>();
-    Object.values(flatApis).forEach((api) => {
-        api.endpoints.forEach((endpoint) => {
-            if (isEndpoint(endpoint) || isWebSocket(endpoint)) {
-                endpoint.environments.forEach((environment: APIV1Read.Environment) => {
-                    allEnvironmentIds.add(environment.id);
-                });
-            }
-        });
-    });
-    return Array.from(allEnvironmentIds);
-});
+export const ALL_ENVIRONMENTS_ATOM = atom<string[]>([]);
+
+export const useSetAllEnvironments = (allEnvironmentIds: string[]): void => {
+    const setAllEnvironments = useSetAtom(ALL_ENVIRONMENTS_ATOM);
+    setAllEnvironments(allEnvironmentIds);
+};
 
 // Get or select an environment
 export const SELECTED_ENVIRONMENT_ATOM = atomWithStorage<string | undefined>("selected-environment", undefined);

--- a/packages/ui/app/src/playground/code-snippets/useSnippet.ts
+++ b/packages/ui/app/src/playground/code-snippets/useSnippet.ts
@@ -1,25 +1,10 @@
-import { EndpointDefinition } from "@fern-api/fdr-sdk/api-definition";
 import { useMemo } from "react";
-import { usePlaygroundBaseUrl } from "../utils/select-environment";
 import { PlaygroundCodeSnippetResolver } from "./resolver";
 import { useApiDefinition } from "./useApiDefinition";
 
-export const resolveEnvironmentUrlInCodeSnippet = (
-    endpoint: EndpointDefinition,
-    replacementBaseUrl: string | undefined,
-    requestCodeSnippet: string,
-): string => {
-    const urlToReplace = endpoint.environments?.find((env) => requestCodeSnippet.includes(env.baseUrl))?.baseUrl;
-    return urlToReplace && replacementBaseUrl
-        ? requestCodeSnippet.replace(urlToReplace, replacementBaseUrl)
-        : requestCodeSnippet;
-};
-
 export function useSnippet(resolver: PlaygroundCodeSnippetResolver, lang: "curl" | "python" | "typescript"): string {
     const apiDefinition = useApiDefinition(resolver.context.node.apiDefinitionId, resolver.isSnippetTemplatesEnabled);
-    const baseUrl = usePlaygroundBaseUrl(resolver.context.endpoint);
 
     // Resolve the code snippet
-    const code = useMemo(() => resolver.resolve(lang, apiDefinition), [resolver, lang, apiDefinition]);
-    return resolveEnvironmentUrlInCodeSnippet(resolver.context.endpoint, baseUrl, code);
+    return useMemo(() => resolver.resolve(lang, apiDefinition), [resolver, lang, apiDefinition]);
 }

--- a/packages/ui/app/src/playground/utils/select-environment.ts
+++ b/packages/ui/app/src/playground/utils/select-environment.ts
@@ -22,5 +22,5 @@ export function useSelectedEnvironment(endpoint: WebSocketChannel | EndpointDefi
 export function usePlaygroundBaseUrl(endpoint: WebSocketChannel | EndpointDefinition): string | undefined {
     const environment = useSelectedEnvironment(endpoint);
     const playgroundBaseUrl = usePlaygroundEnvironment();
-    return environment?.baseUrl ?? playgroundBaseUrl;
+    return playgroundBaseUrl ?? environment?.baseUrl;
 }


### PR DESCRIPTION
## Short description of the changes made

- Fixes visual and functional issues related to playground v2 migration

## What was the motivation & context behind this PR?

- Broken state

## How has this PR been tested?


https://github.com/user-attachments/assets/683e4fef-3d50-4aeb-b3c1-bcb4d22e00f3


