### PR TITLE
feat(docs): update callouts to include icon attribute

### DIFF
--- a/packages/ui/app/src/mdx/components/callout/Callout.tsx
+++ b/packages/ui/app/src/mdx/components/callout/Callout.tsx
@@ -101,53 +101,41 @@ export const Callout: FC<PropsWithChildren<Callout.Props>> = ({ intent: intentRa
 
 // aliases
 
-export function InfoCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function InfoCallout({ children, ...props }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="info" title={title} icon={icon}>
+        <Callout intent="info" {...props}>
             {children}
         </Callout>
     );
 }
 
-export function WarningCallout({
-    children,
-    title,
-    icon,
-}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function WarningCallout({ children, ...props }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="warning" title={title} icon={icon}>
+        <Callout intent="warning" {...props}>
             {children}
         </Callout>
     );
 }
 
-export function SuccessCallout({
-    children,
-    title,
-    icon,
-}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function SuccessCallout({ children, ...props }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="success" title={title} icon={icon}>
+        <Callout intent="success" {...props}>
             {children}
         </Callout>
     );
 }
 
-export function ErrorCallout({
-    children,
-    title,
-    icon,
-}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function ErrorCallout({ children, ...props }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="error" title={title} icon={icon}>
+        <Callout intent="error" {...props}>
             {children}
         </Callout>
     );
 }
 
-export function NoteCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function NoteCallout({ children, ...props }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="note" title={title} icon={icon}>
+        <Callout intent="note" {...props}>
             {children}
         </Callout>
     );
@@ -155,31 +143,26 @@ export function NoteCallout({ children, title, icon }: PropsWithChildren<Omit<Ca
 
 export function LaunchNoteCallout({
     children,
-    title,
-    icon,
+    ...props
 }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="launch" title={title} icon={icon}>
+        <Callout intent="launch" {...props}>
             {children}
         </Callout>
     );
 }
 
-export function TipCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function TipCallout({ children, ...props }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="tip" title={title} icon={icon}>
+        <Callout intent="tip" {...props}>
             {children}
         </Callout>
     );
 }
 
-export function CheckCallout({
-    children,
-    title,
-    icon,
-}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function CheckCallout({ children, ...props }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="check" title={title} icon={icon}>
+        <Callout intent="check" {...props}>
             {children}
         </Callout>
     );

--- a/packages/ui/app/src/mdx/components/callout/Callout.tsx
+++ b/packages/ui/app/src/mdx/components/callout/Callout.tsx
@@ -101,65 +101,65 @@ export const Callout: FC<PropsWithChildren<Callout.Props>> = ({ intent: intentRa
 
 // aliases
 
-export function InfoCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function InfoCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="info" title={title}>
+        <Callout intent="info" title={title} icon={icon}>
             {children}
         </Callout>
     );
 }
 
-export function WarningCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function WarningCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="warning" title={title}>
+        <Callout intent="warning" title={title} icon={icon}>
             {children}
         </Callout>
     );
 }
 
-export function SuccessCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function SuccessCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="success" title={title}>
+        <Callout intent="success" title={title} icon={icon}>
             {children}
         </Callout>
     );
 }
 
-export function ErrorCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function ErrorCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="error" title={title}>
+        <Callout intent="error" title={title} icon={icon}>
             {children}
         </Callout>
     );
 }
 
-export function NoteCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function NoteCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="note" title={title}>
+        <Callout intent="note" title={title} icon={icon}>
             {children}
         </Callout>
     );
 }
 
-export function LaunchNoteCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function LaunchNoteCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="launch" title={title}>
+        <Callout intent="launch" title={title} icon={icon}>
             {children}
         </Callout>
     );
 }
 
-export function TipCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function TipCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="tip" title={title}>
+        <Callout intent="tip" title={title} icon={icon}>
             {children}
         </Callout>
     );
 }
 
-export function CheckCallout({ children, title }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function CheckCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
-        <Callout intent="check" title={title}>
+        <Callout intent="check" title={title} icon={icon}>
             {children}
         </Callout>
     );

--- a/packages/ui/app/src/mdx/components/callout/Callout.tsx
+++ b/packages/ui/app/src/mdx/components/callout/Callout.tsx
@@ -109,7 +109,11 @@ export function InfoCallout({ children, title, icon }: PropsWithChildren<Omit<Ca
     );
 }
 
-export function WarningCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function WarningCallout({
+    children,
+    title,
+    icon,
+}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
         <Callout intent="warning" title={title} icon={icon}>
             {children}
@@ -117,7 +121,11 @@ export function WarningCallout({ children, title, icon }: PropsWithChildren<Omit
     );
 }
 
-export function SuccessCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function SuccessCallout({
+    children,
+    title,
+    icon,
+}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
         <Callout intent="success" title={title} icon={icon}>
             {children}
@@ -125,7 +133,11 @@ export function SuccessCallout({ children, title, icon }: PropsWithChildren<Omit
     );
 }
 
-export function ErrorCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function ErrorCallout({
+    children,
+    title,
+    icon,
+}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
         <Callout intent="error" title={title} icon={icon}>
             {children}
@@ -141,7 +153,11 @@ export function NoteCallout({ children, title, icon }: PropsWithChildren<Omit<Ca
     );
 }
 
-export function LaunchNoteCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function LaunchNoteCallout({
+    children,
+    title,
+    icon,
+}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
         <Callout intent="launch" title={title} icon={icon}>
             {children}
@@ -157,7 +173,11 @@ export function TipCallout({ children, title, icon }: PropsWithChildren<Omit<Cal
     );
 }
 
-export function CheckCallout({ children, title, icon }: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
+export function CheckCallout({
+    children,
+    title,
+    icon,
+}: PropsWithChildren<Omit<Callout.Props, "intent">>): ReactElement {
     return (
         <Callout intent="check" title={title} icon={icon}>
             {children}


### PR DESCRIPTION
This PR adds the `icon` attribute to the Callout options so that custom icons can be used in the various Callout-styled components.  

The example below tests the PR using a custom icon with the <Info> components

<img width="766" alt="Screenshot 2024-10-04 at 9 55 33 AM" src="https://github.com/user-attachments/assets/3cd620ed-f5c3-4ee4-a94c-7bbc90d171c2">

