### PR TITLE
fix: revalidate all should not be gated

### DIFF
--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v3.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v3.ts
@@ -1,13 +1,9 @@
 import { DocsKVCache } from "@/server/DocsCache";
-import { getAuthEdgeConfig } from "@/server/auth/getAuthEdgeConfig";
+import { DocsLoader } from "@/server/DocsLoader";
 import { Revalidator } from "@/server/revalidator";
-import { pruneWithBasicTokenPublic } from "@/server/withBasicTokenPublic";
 import { getXFernHostNode } from "@/server/xfernhost/node";
-import { FdrAPI } from "@fern-api/fdr-sdk";
-import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import { NodeCollector } from "@fern-api/fdr-sdk/navigation";
 import type { FernDocs } from "@fern-fern/fern-docs-sdk";
-import { provideRegistryService } from "@fern-ui/ui";
 import { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
 
 export const config = {
@@ -35,30 +31,24 @@ const handler: NextApiHandler = async (
 ): Promise<unknown> => {
     const xFernHost = getXFernHostNode(req, true);
 
+    // never proivde a token here because revalidation should only be done on public routes (for now)
+    const loader = DocsLoader.for(xFernHost, undefined);
+
+    const root = await loader.root();
+
+    if (!root) {
+        /**
+         * If the error is UnauthorizedError, we don't need to revalidate, since all the routes require SSR.
+         */
+        return res
+            .status(loader.error?.error === "UnauthorizedError" ? 200 : 404)
+            .json({ successfulRevalidations: [], failedRevalidations: [] });
+    }
+
     const revalidate = new Revalidator(res, xFernHost);
+    const slugs = NodeCollector.collect(root).pageSlugs;
 
     try {
-        const docs = await provideRegistryService().docs.v2.read.getDocsForUrl({ url: FdrAPI.Url(xFernHost) });
-
-        if (!docs.ok) {
-            /**
-             * If the error is UnauthorizedError, we don't need to revalidate, since all the routes require SSR.
-             */
-            return res
-                .status(docs.error.error === "UnauthorizedError" ? 200 : 404)
-                .json({ successfulRevalidations: [], failedRevalidations: [] });
-        }
-
-        let node = FernNavigation.utils.toRootNode(docs.body);
-
-        const auth = await getAuthEdgeConfig(xFernHost);
-        if (auth?.type === "basic_token_verification") {
-            node = pruneWithBasicTokenPublic(auth, node);
-        }
-
-        const collector = NodeCollector.collect(node);
-        const slugs = collector.pageSlugs;
-
         const cache = DocsKVCache.getInstance(xFernHost);
         const previouslyVisitedSlugs = (await cache.getVisitedSlugs()).filter((slug) => !slugs.includes(slug));
 

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v4.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v4.ts
@@ -1,13 +1,9 @@
 import { DocsKVCache } from "@/server/DocsCache";
-import { getAuthEdgeConfig } from "@/server/auth/getAuthEdgeConfig";
+import { DocsLoader } from "@/server/DocsLoader";
 import { Revalidator } from "@/server/revalidator";
-import { pruneWithBasicTokenPublic } from "@/server/withBasicTokenPublic";
 import { getXFernHostNode } from "@/server/xfernhost/node";
-import { FdrAPI } from "@fern-api/fdr-sdk";
-import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import { NodeCollector } from "@fern-api/fdr-sdk/navigation";
 import type { FernDocs } from "@fern-fern/fern-docs-sdk";
-import { provideRegistryService } from "@fern-ui/ui";
 import { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
 
 export const config = {
@@ -21,8 +17,6 @@ const handler: NextApiHandler = async (
     req: NextApiRequest,
     res: NextApiResponse<FernDocs.RevalidateAllV4Response>,
 ): Promise<unknown> => {
-    const xFernHost = getXFernHostNode(req, true);
-
     /**
      * Limit the number of paths to revalidate to max of 100.
      */
@@ -44,23 +38,20 @@ const handler: NextApiHandler = async (
         return res.status(400).json({ total: 0, results: [] });
     }
 
-    const docs = await provideRegistryService().docs.v2.read.getDocsForUrl({ url: FdrAPI.Url(xFernHost) });
+    const xFernHost = getXFernHostNode(req, true);
 
-    if (!docs.ok) {
+    // never proivde a token here because revalidation should only be done on public routes (for now)
+    const loader = DocsLoader.for(xFernHost, undefined);
+    const root = await loader.root();
+
+    if (!root) {
         /**
          * If the error is UnauthorizedError, we don't need to revalidate, since all the routes require SSR.
          */
-        return res.status(docs.error.error === "UnauthorizedError" ? 200 : 404).json({ total: 0, results: [] });
+        return res.status(loader.error?.error === "UnauthorizedError" ? 200 : 404).json({ total: 0, results: [] });
     }
 
-    let node = FernNavigation.utils.toRootNode(docs.body);
-
-    const auth = await getAuthEdgeConfig(xFernHost);
-    if (auth?.type === "basic_token_verification") {
-        node = pruneWithBasicTokenPublic(auth, node);
-    }
-
-    const slugs = NodeCollector.collect(node).pageSlugs;
+    const slugs = NodeCollector.collect(root).pageSlugs;
     const revalidate = new Revalidator(res, xFernHost);
 
     if (offset === 0) {

--- a/packages/ui/docs-bundle/src/server/DocsLoader.ts
+++ b/packages/ui/docs-bundle/src/server/DocsLoader.ts
@@ -1,12 +1,16 @@
 import type { DocsV1Read, DocsV2Read } from "@fern-api/fdr-sdk";
 import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
-import { DEFAULT_FEATURE_FLAGS, FeatureFlags } from "@fern-ui/ui";
 import type { AuthEdgeConfig, FernUser } from "@fern-ui/ui/auth";
 import { verifyFernJWTConfig } from "./auth/FernJWT";
 import { getAuthEdgeConfig } from "./auth/getAuthEdgeConfig";
 import { AuthProps } from "./authProps";
 import { loadWithUrl } from "./loadWithUrl";
 import { pruneWithBasicTokenPublic } from "./withBasicTokenPublic";
+
+interface DocsLoaderFlags {
+    isBatchStreamToggleDisabled: boolean;
+    isApiScrollingDisabled: boolean;
+}
 
 export class DocsLoader {
     static for(xFernHost: string, fernToken: string | undefined): DocsLoader {
@@ -18,8 +22,11 @@ export class DocsLoader {
         private fernToken: string | undefined,
     ) {}
 
-    private featureFlags = DEFAULT_FEATURE_FLAGS;
-    public withFeatureFlags(featureFlags: FeatureFlags): DocsLoader {
+    private featureFlags: DocsLoaderFlags = {
+        isBatchStreamToggleDisabled: false,
+        isApiScrollingDisabled: false,
+    };
+    public withFeatureFlags(featureFlags: DocsLoaderFlags): DocsLoader {
         this.featureFlags = featureFlags;
         return this;
     }

--- a/packages/ui/docs-bundle/src/server/DocsLoader.ts
+++ b/packages/ui/docs-bundle/src/server/DocsLoader.ts
@@ -47,14 +47,20 @@ export class DocsLoader {
         };
     }
 
-    private loadForDocsUrlResponse: DocsV2Read.LoadDocsForUrlResponse | undefined;
+    #loadForDocsUrlResponse: DocsV2Read.LoadDocsForUrlResponse | undefined;
+    #error: DocsV2Read.getDocsForUrl.Error | undefined;
+
+    get error(): DocsV2Read.getDocsForUrl.Error | undefined {
+        return this.#error;
+    }
+
     public withLoadDocsForUrlResponse(loadForDocsUrlResponse: DocsV2Read.LoadDocsForUrlResponse): DocsLoader {
-        this.loadForDocsUrlResponse = loadForDocsUrlResponse;
+        this.#loadForDocsUrlResponse = loadForDocsUrlResponse;
         return this;
     }
 
     private async loadDocs(): Promise<DocsV2Read.LoadDocsForUrlResponse | undefined> {
-        if (!this.loadForDocsUrlResponse) {
+        if (!this.#loadForDocsUrlResponse) {
             const { user } = await this.loadAuth();
             const authProps: AuthProps | undefined =
                 user && this.fernToken ? { user, token: this.fernToken } : undefined;
@@ -62,10 +68,12 @@ export class DocsLoader {
             const response = await loadWithUrl(this.xFernHost, authProps);
 
             if (response.ok) {
-                this.loadForDocsUrlResponse = response.body;
+                this.#loadForDocsUrlResponse = response.body;
+            } else {
+                this.#error = response.error;
             }
         }
-        return this.loadForDocsUrlResponse;
+        return this.#loadForDocsUrlResponse;
     }
 
     public async root(): Promise<FernNavigation.RootNode | undefined> {


### PR DESCRIPTION
Fixes issue where i cannot run `/revalidate-all/v3` or `/revalidate-all/v4` on partially authed docs.