### PR TITLE
fix: correct redirect host for proxied domains in auth

### DIFF
--- a/packages/ui/docs-bundle/src/middleware.ts
+++ b/packages/ui/docs-bundle/src/middleware.ts
@@ -4,7 +4,7 @@ import { rewritePosthog } from "@/server/rewritePosthog";
 import { getXFernHostEdge } from "@/server/xfernhost/edge";
 import type { FernUser } from "@fern-ui/fern-docs-auth";
 import { getAuthEdgeConfig } from "@fern-ui/fern-docs-edge-config";
-import { COOKIE_FERN_TOKEN, HEADER_X_FERN_HOST } from "@fern-ui/fern-docs-utils";
+import { COOKIE_FERN_TOKEN } from "@fern-ui/fern-docs-utils";
 import { removeTrailingSlash } from "next/dist/shared/lib/router/utils/remove-trailing-slash";
 import { NextRequest, NextResponse, type NextMiddleware } from "next/server";
 import urlJoin from "url-join";
@@ -27,13 +27,6 @@ export const middleware: NextMiddleware = async (request) => {
         removeTrailingSlash(request.nextUrl.pathname) === "/500"
     ) {
         return NextResponse.next();
-    }
-
-    /**
-     * Add x-fern-host header to the request
-     */
-    if (!headers.has(HEADER_X_FERN_HOST)) {
-        headers.set(HEADER_X_FERN_HOST, xFernHost);
     }
 
     /**

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/callback.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/callback.ts
@@ -4,7 +4,7 @@ import { getWorkOS, getWorkOSClientId } from "@/server/workos";
 import { getXFernHostEdge } from "@/server/xfernhost/edge";
 import { FernUser } from "@fern-ui/fern-docs-auth";
 import { getAuthEdgeConfig } from "@fern-ui/fern-docs-edge-config";
-import { COOKIE_FERN_TOKEN } from "@fern-ui/fern-docs-utils";
+import { COOKIE_FERN_TOKEN, HEADER_X_FERN_HOST } from "@fern-ui/fern-docs-utils";
 import { NextRequest, NextResponse } from "next/server";
 
 export const runtime = "edge";
@@ -44,7 +44,14 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
             "/api/fern-docs/auth/callback",
             "/api/fern-docs/oauth/ory/callback",
         );
-        // Permanent GET redirect to the Ory callback endpoint
+
+        // Redirect to x-fern-host domain if it exists
+        // this is to ensure proxied origins are used for the redirect
+        if (req.headers.has(HEADER_X_FERN_HOST)) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            nextUrl.host = req.headers.get(HEADER_X_FERN_HOST)!;
+        }
+
         return NextResponse.redirect(nextUrl);
     }
 


### PR DESCRIPTION
Before this PR: redirects on proxied domains are getting sent to `app.buildwithfern.com` instead of the `x-fern-host` location. This is pretty difficult to catch from an ete test so the following cases need to be considered in the future:

- xxx.docs.staging.buildwithfern.com -> x-fern-host is respected
- xxx.docs.buildwithfern.com -> x-fern-host is respected
- custom domain using subpath proxy -> x-fern-host is respected
- vercel.app preview url -> x-fern-host is NOT considered
- custom domain without subpath proxy -> x-fern-host is NOT considered
- localhost development -> x-fern-host is NOT considered