### PR TITLE
feat: update fdr types to accomodate extra properties type reference

### DIFF
--- a/fern/apis/fdr/definition/api/latest/type.yml
+++ b/fern/apis/fdr/definition/api/latest/type.yml
@@ -52,6 +52,7 @@ types:
     properties:
       extends: list<rootCommons.TypeId>
       properties: list<ObjectProperty>
+      extraProperties: optional<TypeReference>
 
   ObjectProperty:
     extends:

--- a/packages/fdr-sdk/src/api-definition/__test__/unwrap.test.ts
+++ b/packages/fdr-sdk/src/api-definition/__test__/unwrap.test.ts
@@ -291,6 +291,7 @@ describe("unwrapObjectType", () => {
                     availability: undefined,
                 },
             ],
+            extraProperties: undefined,
         };
 
         expect(unwrapObjectType(shape, {}).properties.map((p) => p.key)).toStrictEqual([
@@ -323,6 +324,7 @@ describe("unwrapObjectType", () => {
                     availability: undefined,
                 },
             ],
+            extraProperties: undefined,
         };
         const types: Record<TypeId, TypeDefinition> = {
             [TypeId("b")]: {
@@ -338,6 +340,7 @@ describe("unwrapObjectType", () => {
                             availability: undefined,
                         },
                     ],
+                    extraProperties: undefined,
                 },
                 description: undefined,
                 availability: undefined,
@@ -355,6 +358,7 @@ describe("unwrapObjectType", () => {
                             availability: undefined,
                         },
                     ],
+                    extraProperties: undefined,
                 },
                 description: undefined,
                 availability: undefined,
@@ -380,6 +384,7 @@ describe("unwrapObjectType", () => {
                     availability: undefined,
                 },
             ],
+            extraProperties: undefined,
         };
         const types: Record<TypeId, TypeDefinition> = {
             [TypeId("b")]: {
@@ -422,6 +427,7 @@ describe("unwrapObjectType", () => {
                             availability: undefined,
                         },
                     ],
+                    extraProperties: undefined,
                 },
                 description: "description-2",
                 availability: undefined,

--- a/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
+++ b/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
@@ -280,6 +280,7 @@ export class ApiDefinitionV1ToLatest {
                 type: "object",
                 extends: value.extends,
                 properties: this.migrateObjectProperties(value.properties),
+                extraProperties: undefined,
             }),
             alias: (value) => ({
                 type: "alias",
@@ -305,6 +306,7 @@ export class ApiDefinitionV1ToLatest {
                     availability: variant.availability,
                     extends: variant.additionalProperties.extends,
                     properties: this.migrateObjectProperties(variant.additionalProperties.properties),
+                    extraProperties: undefined,
                 })),
             }),
         });
@@ -483,6 +485,7 @@ export class ApiDefinitionV1ToLatest {
                     type: "object",
                     extends: value.extends,
                     properties: this.migrateObjectProperties(value.properties),
+                    extraProperties: undefined,
                 }),
                 reference: (value) => ({
                     type: "alias",
@@ -519,6 +522,7 @@ export class ApiDefinitionV1ToLatest {
                     type: "object",
                     extends: value.extends,
                     properties: this.migrateObjectProperties(value.properties),
+                    extraProperties: undefined,
                 }),
                 reference: (value) => ({
                     type: "alias",

--- a/packages/fdr-sdk/src/client/generated/api/resources/api/resources/latest/resources/type/types/ObjectType.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/api/resources/latest/resources/type/types/ObjectType.ts
@@ -7,4 +7,5 @@ import * as FernRegistry from "../../../../../../../index";
 export interface ObjectType {
     extends: FernRegistry.TypeId[];
     properties: FernRegistry.api.latest.ObjectProperty[];
+    extraProperties: FernRegistry.api.latest.TypeReference | undefined;
 }

--- a/servers/fdr/src/api/generated/api/resources/api/resources/latest/resources/type/types/ObjectType.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/api/resources/latest/resources/type/types/ObjectType.d.ts
@@ -5,4 +5,5 @@ import * as FernRegistry from "../../../../../../../index";
 export interface ObjectType {
     extends: FernRegistry.TypeId[];
     properties: FernRegistry.api.latest.ObjectProperty[];
+    extraProperties: FernRegistry.api.latest.TypeReference | undefined;
 }


### PR DESCRIPTION
Fixes FER-3361

## Short description of the changes made

- Adds `extraProperties` to `ObjectType` in fdr, which allows the plumbing of a value type for `Map<string, valueType>` for use with UI downstream
- `extraProperties` is typed as an `optional<TypeReference>`, since it is either a discrete shape, or `Unknown` type (both handled by existing visitors in UI

## What was the motivation & context behind this PR?

- Product Demo

## How has this PR been tested?

WIP to be pushed to FDR dev for testing
