### PR TITLE
fix: remove private flag from package json

### DIFF
--- a/packages/commons/core-utils/package.json
+++ b/packages/commons/core-utils/package.json
@@ -6,7 +6,6 @@
     "url": "https://github.com/fern-api/fern-platform.git",
     "directory": "packages/commons/core-utils"
   },
-  "private": true,
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Removes private flag for public publishing
