### PR TITLE
fix: export slug generator

### DIFF
--- a/packages/fdr-sdk/src/navigation/versions/v1/index.ts
+++ b/packages/fdr-sdk/src/navigation/versions/v1/index.ts
@@ -13,6 +13,7 @@ export * from "./NavigationNodeWithMetadata";
 export * from "./NavigationNodeWithRedirect";
 export * from "./convertAvailability";
 export * from "./converters/ApiReferenceNavigationConverter";
+export * from "./converters/SlugGenerator";
 export * from "./converters/toRootNode";
 export * from "./followRedirect";
 export * from "./getPageId";


### PR DESCRIPTION
## Short description of the changes made

- Export slug generator from fdr to be able to use type in fern cli

## What was the motivation & context behind this PR?

- CLI imports are broken

## How has this PR been tested?

- In Fern repo