### PR TITLE
fix: make jwt parsing less strict

### DIFF
--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/callback.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/callback.ts
@@ -62,8 +62,6 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
         });
 
         const fernUser: FernUser = {
-            type: "user",
-            partner: "workos",
             name:
                 user.firstName != null && user.lastName != null
                     ? `${user.firstName} ${user.lastName}`

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/ory/callback.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/ory/callback.ts
@@ -53,8 +53,6 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
         const { access_token, refresh_token } = await oauthClient.getToken(code);
         const token = OryAccessTokenSchema.parse(await oauthClient.decode(access_token));
         const fernUser: FernUser = {
-            type: "user",
-            partner: "ory",
             name: token.ext?.name,
             email: token.ext?.email,
         };

--- a/packages/ui/docs-bundle/src/server/LoadDocsPerformanceTracker.ts
+++ b/packages/ui/docs-bundle/src/server/LoadDocsPerformanceTracker.ts
@@ -3,6 +3,7 @@ import { DocsPage } from "@fern-ui/ui";
 import { track } from "@vercel/analytics/server";
 import { GetServerSidePropsResult } from "next/types";
 import { ComponentProps } from "react";
+import { AuthPartner } from "./authProps";
 import type { LoadWithUrlResponse } from "./loadWithUrl";
 
 export class LoadDocsPerformanceTracker {
@@ -13,7 +14,7 @@ export class LoadDocsPerformanceTracker {
     }: {
         host: string;
         slug: string[];
-        auth: "workos" | "ory" | "custom" | undefined;
+        auth: AuthPartner | undefined;
     }): LoadDocsPerformanceTracker {
         return new LoadDocsPerformanceTracker(host, slug, auth);
     }
@@ -21,7 +22,7 @@ export class LoadDocsPerformanceTracker {
     private constructor(
         private host: string,
         private slug: string[],
-        private auth: "workos" | "ory" | "custom" | undefined,
+        private auth: AuthPartner | undefined,
     ) {}
 
     private loadDocsDurationMs: number | undefined;

--- a/packages/ui/docs-bundle/src/server/auth/FernJWT.ts
+++ b/packages/ui/docs-bundle/src/server/auth/FernJWT.ts
@@ -17,7 +17,8 @@ export async function verifyFernJWT(token: string, secret?: string, issuer?: str
     const verified = await jwtVerify(token, getJwtTokenSecret(secret), {
         issuer: issuer ?? "https://buildwithfern.com",
     });
-    return FernUserSchema.parse(verified.payload.fern);
+    // if the token is undefined, FernUser will be an empty object
+    return FernUserSchema.optional().parse(verified.payload.fern) ?? {};
 }
 
 export async function verifyFernJWTConfig(token: string, authConfig: AuthEdgeConfig | undefined): Promise<FernUser> {

--- a/packages/ui/docs-bundle/src/server/authProps.ts
+++ b/packages/ui/docs-bundle/src/server/authProps.ts
@@ -1,4 +1,4 @@
-import type { FernUser } from "@fern-ui/fern-docs-auth";
+import type { AuthEdgeConfig, FernUser } from "@fern-ui/fern-docs-auth";
 import { getAuthEdgeConfig } from "@fern-ui/fern-docs-edge-config";
 import { verifyFernJWTConfig } from "./auth/FernJWT";
 
@@ -17,11 +17,17 @@ function withPrefix(token: string, partner: AuthPartner): string {
     return `${partner}_${token}`;
 }
 
-export async function withAuthProps(xFernHost: string, fernToken: string | null | undefined): Promise<AuthProps> {
+export async function withAuthProps(
+    xFernHostOrAuthConfig: string | AuthEdgeConfig,
+    fernToken: string | null | undefined,
+): Promise<AuthProps> {
     if (fernToken == null) {
         throw new Error("Missing fern_token cookie");
     }
-    const config = await getAuthEdgeConfig(xFernHost);
+    const config =
+        typeof xFernHostOrAuthConfig === "string"
+            ? await getAuthEdgeConfig(xFernHostOrAuthConfig)
+            : xFernHostOrAuthConfig;
     const partner =
         config?.type === "oauth2" ? config.partner : config?.type === "basic_token_verification" ? "custom" : "workos";
     const user: FernUser = await verifyFernJWTConfig(fernToken, config);

--- a/packages/ui/docs-bundle/src/server/getDocsPageProps.ts
+++ b/packages/ui/docs-bundle/src/server/getDocsPageProps.ts
@@ -23,7 +23,7 @@ export async function getDocsPageProps(
         return { notFound: true };
     }
 
-    const performance = LoadDocsPerformanceTracker.init({ host: xFernHost, slug, auth: auth?.user.partner });
+    const performance = LoadDocsPerformanceTracker.init({ host: xFernHost, slug, auth: auth?.partner });
 
     /**
      * Load the docs for the given URL.

--- a/packages/ui/fern-docs-auth/src/types.ts
+++ b/packages/ui/fern-docs-auth/src/types.ts
@@ -1,8 +1,6 @@
 import { z } from "zod";
 
 export const FernUserSchema = z.object({
-    // type: z.literal("user"),
-    // partner: z.union([z.literal("workos"), z.literal("ory"), z.literal("custom")]),
     name: z.string().optional(),
     email: z.string().optional(),
 });

--- a/packages/ui/fern-docs-auth/src/types.ts
+++ b/packages/ui/fern-docs-auth/src/types.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
 export const FernUserSchema = z.object({
-    type: z.literal("user"),
-    partner: z.union([z.literal("workos"), z.literal("ory"), z.literal("custom")]),
+    // type: z.literal("user"),
+    // partner: z.union([z.literal("workos"), z.literal("ory"), z.literal("custom")]),
     name: z.string().optional(),
     email: z.string().optional(),
 });


### PR DESCRIPTION
if the jwt payload is empty or has a different schema, don't throw.