### PR TITLE
fix: add branded aliases to fern-cjs-sdk

### DIFF
--- a/fern/apis/fdr/generators.yml
+++ b/fern/apis/fdr/generators.yml
@@ -48,6 +48,7 @@ groups:
           url: npm.buildwithfern.com
           package-name: "@fern-fern/fdr-cjs-sdk"
         config:
+          useBrandedStringAliases: true
           noSerdeLayer: true
           outputSourceFiles: true
           neverThrowErrors: true


### PR DESCRIPTION
## Short description of the changes made

- Add branded aliases to fern-cjs-sdk

## What was the motivation & context behind this PR?

- Resolve compiler errors on fern side

## How has this PR been tested?

- Manually generated
