### PR TITLE
fix: inconsistent deserialization of authprops

### DIFF
--- a/packages/ui/docs-bundle/src/server/getDynamicDocsPageProps.ts
+++ b/packages/ui/docs-bundle/src/server/getDynamicDocsPageProps.ts
@@ -3,7 +3,7 @@ import { type DocsPage } from "@fern-ui/ui";
 import type { NextApiRequestCookies } from "next/dist/server/api-utils";
 import type { GetServerSidePropsResult } from "next/types";
 import type { ComponentProps } from "react";
-import { withAuthProps } from "./authProps";
+import { AuthProps, withAuthProps } from "./authProps";
 import { getDocsPageProps } from "./getDocsPageProps";
 
 type GetServerSideDocsPagePropsResult = GetServerSidePropsResult<ComponentProps<typeof DocsPage>>;
@@ -13,18 +13,20 @@ export async function getDynamicDocsPageProps(
     slug: string[],
     cookies: NextApiRequestCookies,
 ): Promise<GetServerSideDocsPagePropsResult> {
-    if (cookies[COOKIE_FERN_TOKEN] == null) {
-        /**
-         * this only happens when ?error=true is passed in the URL
-         * Note: custom auth (via edge config) is supported via middleware, so we don't need to handle it here
-         */
-        return getDocsPageProps(xFernHost, slug);
+    let authProps: AuthProps | undefined;
+
+    try {
+        if (cookies[COOKIE_FERN_TOKEN]) {
+            authProps = await withAuthProps(xFernHost, cookies[COOKIE_FERN_TOKEN]);
+        }
+    } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error("Failed to get auth props", e);
     }
 
     /**
      * Authenticated user is guaranteed to have a valid token because the middleware
      * would have redirected them to the login page
      */
-    const authProps = await withAuthProps(xFernHost, cookies[COOKIE_FERN_TOKEN]);
     return getDocsPageProps(xFernHost, slug, authProps);
 }

--- a/packages/ui/docs-bundle/src/server/withInitialProps.ts
+++ b/packages/ui/docs-bundle/src/server/withInitialProps.ts
@@ -61,9 +61,9 @@ export async function withInitialProps({
     const featureFlags = await getFeatureFlags(xFernHost);
 
     const authConfig = await getAuthEdgeConfig(xFernHost);
-    const loader = DocsLoader.for(xFernHost, auth?.token)
+    const loader = DocsLoader.for(xFernHost)
         .withFeatureFlags(featureFlags)
-        .withAuth(authConfig)
+        .withAuth(authConfig, auth)
         .withLoadDocsForUrlResponse(docs);
 
     const root = await loader.root();


### PR DESCRIPTION
Note: authProps.token always has a prefix `(like custom_)`