### PR TITLE
feat: additional properties UX

### DIFF
--- a/fern/apis/fdr/generators.yml
+++ b/fern/apis/fdr/generators.yml
@@ -50,6 +50,7 @@ groups:
         config:
           useBrandedStringAliases: true
           noSerdeLayer: true
+          noOptionalProperties: true
           outputSourceFiles: true
           neverThrowErrors: true
           timeoutInSeconds: infinity

--- a/packages/fdr-sdk/src/api-definition/unwrap.ts
+++ b/packages/fdr-sdk/src/api-definition/unwrap.ts
@@ -18,6 +18,7 @@ export type UnwrappedReference = {
 
 export type UnwrappedObjectType = {
     properties: Latest.ObjectProperty[];
+    extraProperties: Latest.TypeReference | undefined;
     descriptions: FernDocs.MarkdownText[];
 };
 
@@ -169,6 +170,7 @@ export function unwrapObjectType(
     types: Record<string, Latest.TypeDefinition>,
 ): UnwrappedObjectType {
     const directProperties = object.properties;
+    const extraProperties = object.extraProperties;
     const descriptions: FernDocs.MarkdownText[] = [];
     const extendedProperties = object.extends.flatMap((typeId): Latest.ObjectProperty[] => {
         const typeDef = types[typeId];
@@ -230,7 +232,7 @@ export function unwrapObjectType(
             (property) => unwrapReference(property.valueShape, types)?.isOptional,
             (property) => AvailabilityOrder.indexOf(property.availability ?? Latest.Availability.Stable),
         );
-        return { properties, descriptions };
+        return { properties, extraProperties, descriptions };
     }
     const propertyKeys = new Set(object.properties.map((property) => property.key));
     const filteredExtendedProperties = extendedProperties.filter(
@@ -245,7 +247,7 @@ export function unwrapObjectType(
         (property) => AvailabilityOrder.indexOf(property.availability ?? Latest.Availability.Stable),
         (property) => property.key,
     );
-    return { properties, descriptions };
+    return { properties, extraProperties, descriptions };
 }
 
 /**
@@ -270,6 +272,7 @@ export function unwrapDiscriminatedUnionVariant(
             },
             ...properties,
         ],
+        extraProperties: undefined,
         descriptions,
     };
 }

--- a/packages/ui/app/src/api-reference/types/discriminated-union/DiscriminatedUnionVariant.tsx
+++ b/packages/ui/app/src/api-reference/types/discriminated-union/DiscriminatedUnionVariant.tsx
@@ -56,6 +56,7 @@ export const DiscriminatedUnionVariant: React.FC<DiscriminatedUnionVariant.Props
                 },
                 ...dereferenceObjectProperties(unionVariant, types),
             ],
+            extraProperties: undefined,
             name: undefined,
             description: undefined,
             availability: undefined,

--- a/packages/ui/app/src/api-reference/types/type-reference/InternalTypeReferenceDefinitions.tsx
+++ b/packages/ui/app/src/api-reference/types/type-reference/InternalTypeReferenceDefinitions.tsx
@@ -37,16 +37,15 @@ export function hasInlineEnum(shape: ResolvedTypeShape, types: Record<string, Re
         literal: () => true,
         unknown: () => false,
         _other: () => false,
-        reference: (reference) => {
-            return hasInlineEnum(
+        reference: (reference) =>
+            hasInlineEnum(
                 types[reference.typeId] ?? {
                     type: "unknown",
                     description: undefined,
                     availability: undefined,
                 },
                 types,
-            );
-        },
+            ),
         alias: (alias) => hasInlineEnum(alias.shape, types),
     });
 }

--- a/packages/ui/app/src/api-reference/types/type-reference/InternalTypeReferenceDefinitions.tsx
+++ b/packages/ui/app/src/api-reference/types/type-reference/InternalTypeReferenceDefinitions.tsx
@@ -1,6 +1,8 @@
 import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import { visitDiscriminatedUnion } from "@fern-api/ui-core-utils";
+import { Plus } from "iconoir-react";
 import React, { ReactElement } from "react";
+import { Markdown } from "../../../mdx/Markdown";
 import { ResolvedTypeDefinition, ResolvedTypeShape, unwrapReference } from "../../../resolver/types";
 import { InternalTypeDefinition } from "../type-definition/InternalTypeDefinition";
 import { InternalTypeDefinitionError } from "../type-definition/InternalTypeDefinitionError";
@@ -35,15 +37,16 @@ export function hasInlineEnum(shape: ResolvedTypeShape, types: Record<string, Re
         literal: () => true,
         unknown: () => false,
         _other: () => false,
-        reference: (reference) =>
-            hasInlineEnum(
+        reference: (reference) => {
+            return hasInlineEnum(
                 types[reference.typeId] ?? {
                     type: "unknown",
                     description: undefined,
                     availability: undefined,
                 },
                 types,
-            ),
+            );
+        },
         alias: (alias) => hasInlineEnum(alias.shape, types),
     });
 }
@@ -90,13 +93,21 @@ export const InternalTypeReferenceDefinitions: React.FC<InternalTypeReferenceDef
     const InternalShapeRenderer = applyErrorStyles ? InternalTypeDefinitionError : InternalTypeDefinition;
     return visitDiscriminatedUnion(unwrapReference(shape, types), "type")._visit<ReactElement | null>({
         object: (object) => (
-            <InternalShapeRenderer
-                typeShape={object}
-                isCollapsible={isCollapsible}
-                anchorIdParts={anchorIdParts}
-                slug={slug}
-                types={types}
-            />
+            <div>
+                <InternalShapeRenderer
+                    typeShape={object}
+                    isCollapsible={isCollapsible}
+                    anchorIdParts={anchorIdParts}
+                    slug={slug}
+                    types={types}
+                />
+                {object.extraProperties != null && (
+                    <div className="flex pt-2">
+                        <Plus />
+                        <Markdown mdx="Optional Additional Properties" className="!t-muted" size="sm" />
+                    </div>
+                )}
+            </div>
         ),
         enum: (enum_) => (
             <InternalShapeRenderer

--- a/packages/ui/app/src/playground/PlaygroundWebSocketHandshakeForm.tsx
+++ b/packages/ui/app/src/playground/PlaygroundWebSocketHandshakeForm.tsx
@@ -84,6 +84,7 @@ export const PlaygroundWebSocketHandshakeForm: FC<PlaygroundWebSocketHandshakeFo
                             <PlaygroundObjectPropertiesForm
                                 id="header"
                                 properties={channel.requestHeaders}
+                                extraProperties={undefined}
                                 onChange={setHeaders}
                                 value={formState?.headers}
                                 types={types}
@@ -102,6 +103,7 @@ export const PlaygroundWebSocketHandshakeForm: FC<PlaygroundWebSocketHandshakeFo
                             <PlaygroundObjectPropertiesForm
                                 id="path"
                                 properties={channel.pathParameters}
+                                extraProperties={undefined}
                                 onChange={setPathParameters}
                                 value={formState?.pathParameters}
                                 types={types}
@@ -120,6 +122,7 @@ export const PlaygroundWebSocketHandshakeForm: FC<PlaygroundWebSocketHandshakeFo
                             <PlaygroundObjectPropertiesForm
                                 id="query"
                                 properties={channel.queryParameters}
+                                extraProperties={undefined}
                                 onChange={setQueryParameters}
                                 value={formState?.queryParameters}
                                 types={types}

--- a/packages/ui/app/src/playground/endpoint/PlaygroundEndpointForm.tsx
+++ b/packages/ui/app/src/playground/endpoint/PlaygroundEndpointForm.tsx
@@ -102,6 +102,7 @@ export const PlaygroundEndpointForm: FC<PlaygroundEndpointFormProps> = ({
                     <PlaygroundObjectPropertiesForm
                         id="header"
                         properties={endpoint.requestHeaders ?? EMPTY_ARRAY}
+                        extraProperties={undefined}
                         onChange={setHeaders}
                         value={formState?.headers}
                         types={types}
@@ -114,6 +115,7 @@ export const PlaygroundEndpointForm: FC<PlaygroundEndpointFormProps> = ({
                     <PlaygroundObjectPropertiesForm
                         id="path"
                         properties={endpoint.pathParameters ?? EMPTY_ARRAY}
+                        extraProperties={undefined}
                         onChange={setPathParameters}
                         value={formState?.pathParameters}
                         types={types}
@@ -126,6 +128,7 @@ export const PlaygroundEndpointForm: FC<PlaygroundEndpointFormProps> = ({
                     <PlaygroundObjectPropertiesForm
                         id="query"
                         properties={endpoint.queryParameters ?? EMPTY_ARRAY}
+                        extraProperties={undefined}
                         onChange={setQueryParameters}
                         value={formState?.queryParameters}
                         types={types}
@@ -162,26 +165,32 @@ export const PlaygroundEndpointForm: FC<PlaygroundEndpointFormProps> = ({
                             />
                         </PlaygroundEndpointFormSection>
                     ),
-                    object: (value) => (
-                        <PlaygroundEndpointFormSection ignoreHeaders={ignoreHeaders} title="Body Parameters">
-                            <PlaygroundObjectPropertiesForm
-                                id="body"
-                                properties={unwrapObjectType(value, types).properties}
-                                onChange={setBodyJson}
-                                value={formState?.body?.value}
-                                types={types}
-                            />
-                        </PlaygroundEndpointFormSection>
-                    ),
+                    object: (value) => {
+                        const unwrappedObjectType = unwrapObjectType(value, types);
+                        return (
+                            <PlaygroundEndpointFormSection ignoreHeaders={ignoreHeaders} title="Body Parameters">
+                                <PlaygroundObjectPropertiesForm
+                                    id="body"
+                                    properties={unwrappedObjectType.properties}
+                                    extraProperties={unwrappedObjectType.extraProperties}
+                                    onChange={setBodyJson}
+                                    value={formState?.body?.value}
+                                    types={types}
+                                />
+                            </PlaygroundEndpointFormSection>
+                        );
+                    },
                     alias: (alias) => {
                         const { shape, isOptional } = unwrapReference(alias.value, types);
 
                         if (shape.type === "object" && !isOptional) {
+                            const unwrappedObjectType = unwrapObjectType(shape, types);
                             return (
                                 <PlaygroundEndpointFormSection ignoreHeaders={ignoreHeaders} title="Body Parameters">
                                     <PlaygroundObjectPropertiesForm
                                         id="body"
-                                        properties={unwrapObjectType(shape, types).properties}
+                                        properties={unwrappedObjectType.properties}
+                                        extraProperties={unwrappedObjectType.extraProperties}
                                         onChange={setBodyJson}
                                         value={formState?.body?.value}
                                         types={types}

--- a/packages/ui/app/src/playground/form/PlaygroundDescriminatedUnionForm.tsx
+++ b/packages/ui/app/src/playground/form/PlaygroundDescriminatedUnionForm.tsx
@@ -103,6 +103,7 @@ export const PlaygroundDiscriminatedUnionForm = memo<PlaygroundDiscriminatedUnio
                 <div className="border-l border-border-default-soft pl-4">
                     <PlaygroundObjectPropertiesForm
                         properties={properties}
+                        extraProperties={undefined}
                         value={value}
                         onChange={onChange}
                         id={id}

--- a/packages/ui/app/src/playground/form/PlaygroundObjectPropertyForm.tsx
+++ b/packages/ui/app/src/playground/form/PlaygroundObjectPropertyForm.tsx
@@ -1,4 +1,10 @@
-import { ObjectProperty, TypeDefinition, unwrapReference } from "@fern-api/fdr-sdk/api-definition";
+import {
+    ObjectProperty,
+    PropertyKey,
+    TypeDefinition,
+    TypeReference,
+    unwrapReference,
+} from "@fern-api/fdr-sdk/api-definition";
 import { FernButton, FernDropdown } from "@fern-ui/components";
 import { useBooleanState } from "@fern-ui/react-commons";
 import cn from "clsx";
@@ -75,6 +81,7 @@ export const PlaygroundObjectPropertyForm: FC<PlaygroundObjectPropertyFormProps>
 interface PlaygroundObjectPropertiesFormProps {
     id: string;
     properties: readonly ObjectProperty[];
+    extraProperties: TypeReference | undefined;
     onChange: (value: unknown) => void;
     value: unknown;
     indent?: boolean;
@@ -83,7 +90,8 @@ interface PlaygroundObjectPropertiesFormProps {
 }
 
 export const PlaygroundObjectPropertiesForm = memo<PlaygroundObjectPropertiesFormProps>((props) => {
-    const { id, properties, onChange, value, indent = false, types, disabled } = props;
+    const { id, properties, onChange, value, indent = false, types, disabled, extraProperties } = props;
+
     const onChangeObjectProperty = useCallback(
         (key: string, newValue: unknown) => {
             onChange((oldValue: unknown) => {
@@ -101,6 +109,43 @@ export const PlaygroundObjectPropertiesForm = memo<PlaygroundObjectPropertiesFor
         },
         [onChange],
     );
+
+    const [additionalProperties, setAdditionalProperties] = useState<unknown>({});
+
+    const onChangeAdditionalObjectProperty = useCallback(
+        (key: string, newValue: unknown) => {
+            onChange((oldValue: unknown) => {
+                const oldObject = castToRecord(oldValue);
+                const val = castToRecord(newValue);
+
+                if (newValue === undefined) {
+                    return Object.fromEntries(
+                        Object.entries(oldObject).filter(
+                            ([k]) => !Object.keys(castToRecord(additionalProperties)).includes(k),
+                        ),
+                    );
+                } else {
+                    if (
+                        JSON.stringify(Object.keys(castToRecord(additionalProperties))) !==
+                        JSON.stringify(Object.keys(val))
+                    ) {
+                        setAdditionalProperties(newValue);
+                    }
+
+                    return {
+                        ...Object.fromEntries(
+                            Object.entries(oldObject).filter(
+                                ([k]) => !Object.keys(castToRecord(additionalProperties)).includes(k),
+                            ),
+                        ),
+                        ...newValue,
+                    };
+                }
+            });
+        },
+        [onChange, additionalProperties],
+    );
+
     const shownProperties = useMemo(() => {
         return properties.filter((property) =>
             shouldShowProperty(property.valueShape, castToRecord(value)[property.key]),
@@ -206,6 +251,55 @@ export const PlaygroundObjectPropertiesForm = memo<PlaygroundObjectPropertiesFor
                         className="mt-8 w-full text-left first:mt-0"
                     />
                 </FernDropdown>
+            )}
+
+            {extraProperties != null && (
+                <div className={cn("flex-1 shrink min-w-0 mt-8")}>
+                    <PlaygroundObjectPropertyForm
+                        id={"extraProperties"}
+                        property={{
+                            key: PropertyKey("Optional Extra Properties"),
+                            valueShape: {
+                                type: "optional",
+                                shape: {
+                                    type: "map",
+                                    keyShape: {
+                                        type: "primitive",
+                                        value: {
+                                            type: "string",
+                                            regex: undefined,
+                                            minLength: undefined,
+                                            maxLength: undefined,
+                                            default: undefined,
+                                        },
+                                    },
+                                    valueShape: {
+                                        type: "primitive",
+                                        value: {
+                                            type: "string",
+                                            regex: undefined,
+                                            minLength: undefined,
+                                            maxLength: undefined,
+                                            default: undefined,
+                                        },
+                                    },
+                                },
+                                default: undefined,
+                            },
+                            description: undefined,
+                            availability: undefined,
+                        }}
+                        onChange={onChangeAdditionalObjectProperty}
+                        value={Object.keys(castToRecord(value)).reduce((acc: Record<string, unknown>, key) => {
+                            if (!properties.some((p) => p.key === key)) {
+                                acc[key] = castToRecord(value)[key];
+                            }
+                            return acc;
+                        }, {})}
+                        types={types}
+                        disabled={disabled}
+                    />
+                </div>
             )}
         </div>
     );

--- a/packages/ui/app/src/playground/form/PlaygroundTypeReferenceForm.tsx
+++ b/packages/ui/app/src/playground/form/PlaygroundTypeReferenceForm.tsx
@@ -41,19 +41,23 @@ export const PlaygroundTypeReferenceForm = memo<PlaygroundTypeReferenceFormProps
         onChange(undefined);
     }, [onChange]);
     return visitDiscriminatedUnion(unwrapReference(shape, types).shape)._visit<ReactElement | null>({
-        object: (object) => (
-            <WithLabel property={property} value={value} onRemove={onRemove} types={types}>
-                <PlaygroundObjectPropertiesForm
-                    properties={unwrapObjectType(object, types).properties}
-                    onChange={onChange}
-                    value={value}
-                    indent={indent}
-                    id={id}
-                    types={types}
-                    disabled={disabled}
-                />
-            </WithLabel>
-        ),
+        object: (object) => {
+            const unwrappedObjectType = unwrapObjectType(object, types);
+            return (
+                <WithLabel property={property} value={value} onRemove={onRemove} types={types}>
+                    <PlaygroundObjectPropertiesForm
+                        properties={unwrappedObjectType.properties}
+                        extraProperties={unwrappedObjectType.extraProperties}
+                        onChange={onChange}
+                        value={value}
+                        indent={indent}
+                        id={id}
+                        types={types}
+                        disabled={disabled}
+                    />
+                </WithLabel>
+            );
+        },
         enum: ({ values }) => (
             <WithLabel property={property} value={value} onRemove={onRemove} types={types}>
                 <PlaygroundEnumForm enumValues={values} onChange={onChange} value={value} id={id} disabled={disabled} />

--- a/packages/ui/app/src/resolver/ApiEndpointResolver.ts
+++ b/packages/ui/app/src/resolver/ApiEndpointResolver.ts
@@ -514,6 +514,9 @@ export class ApiEndpointResolver {
                 name: undefined,
                 extends: object.extends,
                 properties: await this.typeResolver.resolveObjectProperties(object),
+                extraProperties: object.extraProperties
+                    ? await this.typeResolver.resolveTypeReference(object.extraProperties)
+                    : undefined,
                 description: undefined,
                 availability: undefined,
             }),
@@ -534,6 +537,9 @@ export class ApiEndpointResolver {
                 name: undefined,
                 extends: object.extends,
                 properties: await this.typeResolver.resolveObjectProperties(object),
+                extraProperties: object.extraProperties
+                    ? await this.typeResolver.resolveTypeReference(object.extraProperties)
+                    : undefined,
                 description: undefined,
                 availability: undefined,
             }),
@@ -618,6 +624,9 @@ export class ApiEndpointResolver {
                     name: undefined,
                     extends: object.extends,
                     properties: await this.typeResolver.resolveObjectProperties(object),
+                    extraProperties: object.extraProperties
+                        ? await this.typeResolver.resolveTypeReference(object.extraProperties)
+                        : undefined,
                     description: undefined,
                     availability: undefined,
                 }),
@@ -639,6 +648,9 @@ export class ApiEndpointResolver {
                             name: undefined,
                             extends: stream.shape.extends,
                             properties: await this.typeResolver.resolveObjectProperties(stream.shape),
+                            extraProperties: stream.shape.extraProperties
+                                ? await this.typeResolver.resolveTypeReference(stream.shape.extraProperties)
+                                : undefined,
                             description: undefined,
                             availability: undefined,
                         },

--- a/packages/ui/app/src/resolver/ApiTypeResolver.ts
+++ b/packages/ui/app/src/resolver/ApiTypeResolver.ts
@@ -1,5 +1,5 @@
 import { FernNavigation } from "@fern-api/fdr-sdk";
-import type { APIV1Read } from "@fern-api/fdr-sdk/client/types";
+import { APIV1Read } from "@fern-api/fdr-sdk/client/types";
 import { visitDiscriminatedUnion } from "@fern-api/ui-core-utils";
 import { once } from "lodash-es";
 import { MDX_SERIALIZER } from "../mdx/bundler";
@@ -74,6 +74,9 @@ export class ApiTypeResolver {
                 name,
                 extends: object.extends,
                 properties: await this.resolveObjectProperties(object),
+                extraProperties: object.extraProperties
+                    ? await this.resolveTypeReference(object.extraProperties)
+                    : undefined,
                 description: await this.serializeMdx(description, {
                     files: this.mdxOptions?.files,
                 }),

--- a/packages/ui/app/src/resolver/__test__/__snapshots__/ApiDefinitionResolver.test.ts.snap
+++ b/packages/ui/app/src/resolver/__test__/__snapshots__/ApiDefinitionResolver.test.ts.snap
@@ -75,6 +75,7 @@ exports[`resolveApiDefinition > should finish resolving 1`] = `
       "availability": undefined,
       "description": undefined,
       "extends": [],
+      "extraProperties": undefined,
       "name": "Merchant",
       "properties": [
         {
@@ -104,6 +105,7 @@ exports[`resolveApiDefinition > should finish resolving 1`] = `
       "availability": undefined,
       "description": undefined,
       "extends": [],
+      "extraProperties": undefined,
       "name": "Offer",
       "properties": [
         {
@@ -183,6 +185,7 @@ exports[`resolveApiDefinition > should resolve authed and unauthed endpoints 1`]
           "availability": undefined,
           "description": undefined,
           "extends": [],
+          "extraProperties": undefined,
           "name": undefined,
           "properties": [
             {
@@ -400,6 +403,7 @@ exports[`resolveApiDefinition > should resolve authed and unauthed endpoints 1`]
       "availability": undefined,
       "description": undefined,
       "extends": [],
+      "extraProperties": undefined,
       "name": "AuthResponse",
       "properties": [
         {

--- a/packages/ui/app/src/resolver/types.ts
+++ b/packages/ui/app/src/resolver/types.ts
@@ -625,6 +625,7 @@ export interface ResolvedObjectShape extends WithMetadata {
     type: "object";
     extends: string[];
     properties: ResolvedObjectProperty[];
+    extraProperties: ResolvedTypeShape | undefined;
 }
 
 /**


### PR DESCRIPTION
Fixes FER-3363

## Short description of the changes made

- Adds small markdown based marker for objects with additional properties in API reference
- Adds Map of string to string for additional properties in the playground
- Live updates the playground payload, enabling for send-request
- Persists state of additional properties via atom and subtraction

## What was the motivation & context behind this PR?

- Customer Demos

## How has this PR been tested?


https://github.com/user-attachments/assets/7397fc5e-fdb7-439f-99c2-d7ca28c26617


