### PR TITLE
fix: scrollToCenter offsetTop/offsetParent behavior

### DIFF
--- a/packages/ui/app/src/atoms/apis.ts
+++ b/packages/ui/app/src/atoms/apis.ts
@@ -48,7 +48,7 @@ export function useWriteApiDefinitionsAtom(
         Object.values(apis).forEach((api) => {
             set(api, isLocalPreview);
         });
-    }, [apis, set]);
+    }, [apis, isLocalPreview, set]);
 }
 
 export const READ_APIS_ATOM = atom((get) => get(SETTABLE_APIS_ATOM));

--- a/packages/ui/app/src/util/scrollToCenter.ts
+++ b/packages/ui/app/src/util/scrollToCenter.ts
@@ -15,7 +15,6 @@ export function scrollToCenter(
         fastdom.clear(stopMeasuring);
         stopMeasuring = fastdom.measure(() => {
             const offsetTop = getOffsetTopRelativeToScrollContainer(target, scrollContainer);
-            console.log(offsetTop, scrollContainer.scrollTop);
 
             // if the target is not a child of the scroll container, bail
             if (offsetTop == null) {

--- a/packages/ui/app/src/util/scrollToCenter.ts
+++ b/packages/ui/app/src/util/scrollToCenter.ts
@@ -15,6 +15,7 @@ export function scrollToCenter(
         fastdom.clear(stopMeasuring);
         stopMeasuring = fastdom.measure(() => {
             const offsetTop = getOffsetTopRelativeToScrollContainer(target, scrollContainer);
+            console.log(offsetTop, scrollContainer.scrollTop);
 
             // if the target is not a child of the scroll container, bail
             if (offsetTop == null) {
@@ -51,6 +52,13 @@ function getOffsetTopRelativeToScrollContainer(targetElement: HTMLElement, scrol
     while (currentElement && currentElement !== scrollContainer) {
         offsetTop += currentElement.offsetTop;
         currentElement = currentElement.offsetParent as HTMLElement | null;
+        if (!currentElement) {
+            // if the offset parent is null, we've accidentally reached the root element
+            return undefined;
+        } else if (!scrollContainer.contains(currentElement)) {
+            // if the offset parent jumps beyond the scroll container, bail
+            break;
+        }
     }
 
     return offsetTop;


### PR DESCRIPTION
Turns out offsetParent isn't always the immediate parent, but the one where offset is non-zero. If the while loop goes beyond the container, stop traversing.