### PR TITLE
feat: add state to logout url

### DIFF
--- a/packages/fdr-sdk/src/converters/db/convertAPIDefinitionToDb.ts
+++ b/packages/fdr-sdk/src/converters/db/convertAPIDefinitionToDb.ts
@@ -677,9 +677,9 @@ class ApiDefinitionTransformationContext {
         for (const environment of environments) {
             const entry = this.uniqueBaseUrls[environment.id];
             if (entry != null) {
-                entry.add(this.getHost(environment.baseUrl));
+                entry.add(this.getHostEdge(environment.baseUrl));
             } else {
-                this.uniqueBaseUrls[environment.id] = new Set([this.getHost(environment.baseUrl)]);
+                this.uniqueBaseUrls[environment.id] = new Set([this.getHostEdge(environment.baseUrl)]);
             }
         }
     }
@@ -693,7 +693,7 @@ class ApiDefinitionTransformationContext {
         return false;
     }
 
-    private getHost(url: string) {
+    private getHostEdge(url: string) {
         const parsedBaseUrl = new URL(url);
         return parsedBaseUrl.host;
     }

--- a/packages/fdr-sdk/src/converters/db/convertAPIDefinitionToDb.ts
+++ b/packages/fdr-sdk/src/converters/db/convertAPIDefinitionToDb.ts
@@ -677,9 +677,9 @@ class ApiDefinitionTransformationContext {
         for (const environment of environments) {
             const entry = this.uniqueBaseUrls[environment.id];
             if (entry != null) {
-                entry.add(this.getHostEdge(environment.baseUrl));
+                entry.add(this.getHost(environment.baseUrl));
             } else {
-                this.uniqueBaseUrls[environment.id] = new Set([this.getHostEdge(environment.baseUrl)]);
+                this.uniqueBaseUrls[environment.id] = new Set([this.getHost(environment.baseUrl)]);
             }
         }
     }
@@ -693,7 +693,7 @@ class ApiDefinitionTransformationContext {
         return false;
     }
 
-    private getHostEdge(url: string) {
+    private getHost(url: string) {
         const parsedBaseUrl = new URL(url);
         return parsedBaseUrl.host;
     }

--- a/packages/ui/docs-bundle/src/middleware.ts
+++ b/packages/ui/docs-bundle/src/middleware.ts
@@ -1,7 +1,7 @@
 import { extractBuildId, extractNextDataPathname } from "@/server/extractNextDataPathname";
 import { getPageRoute, getPageRouteMatch, getPageRoutePath } from "@/server/pageRoutes";
 import { rewritePosthog } from "@/server/rewritePosthog";
-import { getXFernHostEdge } from "@/server/xfernhost/edge";
+import { getDocsDomainEdge } from "@/server/xfernhost/edge";
 import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import type { FernUser } from "@fern-ui/fern-docs-auth";
 import { getAuthEdgeConfig } from "@fern-ui/fern-docs-edge-config";
@@ -16,7 +16,7 @@ const API_FERN_DOCS_PATTERN = /^(?!\/api\/fern-docs\/).*(\/api\/fern-docs\/)/;
 const CHANGELOG_PATTERN = /\.(rss|atom)$/;
 
 export const middleware: NextMiddleware = async (request) => {
-    const xFernHost = getXFernHostEdge(request);
+    const xFernHost = getDocsDomainEdge(request);
     const nextUrl = request.nextUrl.clone();
     const headers = new Headers(request.headers);
 
@@ -138,7 +138,7 @@ export const middleware: NextMiddleware = async (request) => {
     }
 
     /**
-     * Rewrite all other requests to /static/[host]/[[...slug]] or /dynamic/[host]/[[...slug]]
+     * Rewrite all other requests to /static/[domain]/[[...slug]] or /dynamic/[domain]/[[...slug]]
      */
 
     nextUrl.pathname = getPageRoute(!isDynamic, xFernHost, pathname);

--- a/packages/ui/docs-bundle/src/pages/_error.tsx
+++ b/packages/ui/docs-bundle/src/pages/_error.tsx
@@ -3,7 +3,7 @@ import Error, { ErrorProps } from "next/error";
 import { ReactElement } from "react";
 
 export function parseResolvedUrl(resolvedUrl: string): string {
-    // if resolvedUrl is `/static/[host]/[...slug]` or `/dynamic/[host]/[..slug]` then return '/[...slug]`
+    // if resolvedUrl is `/static/[domain]/[...slug]` or `/dynamic/[domain]/[..slug]` then return '/[...slug]`
     const match = resolvedUrl.match(/\/(static|dynamic)\/[^/]+(.*)/);
     return match?.[2] ?? resolvedUrl;
 }

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/api-definition/[api]/endpoint/[endpoint].ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/api-definition/[api]/endpoint/[endpoint].ts
@@ -1,4 +1,4 @@
-import { getXFernHostNode } from "@/server/xfernhost/node";
+import { getDocsDomainNode } from "@/server/xfernhost/node";
 import * as ApiDefinition from "@fern-api/fdr-sdk/api-definition";
 import { getFeatureFlags } from "@fern-ui/fern-docs-edge-config";
 import { ApiDefinitionLoader } from "@fern-ui/fern-docs-server";
@@ -6,7 +6,7 @@ import { getMdxBundler } from "@fern-ui/ui/bundlers";
 import { NextApiHandler, NextApiResponse } from "next";
 
 const resolveApiHandler: NextApiHandler = async (req, res: NextApiResponse<ApiDefinition.ApiDefinition>) => {
-    const xFernHost = getXFernHostNode(req);
+    const xFernHost = getDocsDomainNode(req);
     const { api, endpoint } = req.query;
     if (req.method !== "GET" || typeof api !== "string" || typeof endpoint !== "string") {
         res.status(400).end();

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/api-definition/[api]/webhook/[webhook].ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/api-definition/[api]/webhook/[webhook].ts
@@ -1,4 +1,4 @@
-import { getXFernHostNode } from "@/server/xfernhost/node";
+import { getDocsDomainNode } from "@/server/xfernhost/node";
 import * as ApiDefinition from "@fern-api/fdr-sdk/api-definition";
 import { getFeatureFlags } from "@fern-ui/fern-docs-edge-config";
 import { ApiDefinitionLoader } from "@fern-ui/fern-docs-server";
@@ -6,7 +6,7 @@ import { getMdxBundler } from "@fern-ui/ui/bundlers";
 import { NextApiHandler, NextApiResponse } from "next";
 
 const resolveApiHandler: NextApiHandler = async (req, res: NextApiResponse<ApiDefinition.ApiDefinition>) => {
-    const xFernHost = getXFernHostNode(req);
+    const xFernHost = getDocsDomainNode(req);
     const { api, webhook } = req.query;
     if (req.method !== "GET" || typeof api !== "string" || typeof webhook !== "string") {
         res.status(400).end();

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/api-definition/[api]/websocket/[websocket].ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/api-definition/[api]/websocket/[websocket].ts
@@ -1,4 +1,4 @@
-import { getXFernHostNode } from "@/server/xfernhost/node";
+import { getDocsDomainNode } from "@/server/xfernhost/node";
 import * as ApiDefinition from "@fern-api/fdr-sdk/api-definition";
 import { getFeatureFlags } from "@fern-ui/fern-docs-edge-config";
 import { ApiDefinitionLoader } from "@fern-ui/fern-docs-server";
@@ -6,7 +6,7 @@ import { getMdxBundler } from "@fern-ui/ui/bundlers";
 import { NextApiHandler, NextApiResponse } from "next";
 
 const resolveApiHandler: NextApiHandler = async (req, res: NextApiResponse<ApiDefinition.ApiDefinition>) => {
-    const xFernHost = getXFernHostNode(req);
+    const xFernHost = getDocsDomainNode(req);
     const { api, websocket } = req.query;
     if (req.method !== "GET" || typeof api !== "string" || typeof websocket !== "string") {
         res.status(400).end();

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/api-key-injection.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/api-key-injection.ts
@@ -1,7 +1,7 @@
 import { OAuth2Client } from "@/server/auth/OAuth2Client";
 import { getAPIKeyInjectionConfig } from "@/server/auth/getApiKeyInjectionConfig";
 import { withSecureCookie } from "@/server/auth/withSecure";
-import { getXFernHostEdge } from "@/server/xfernhost/edge";
+import { getDocsDomainEdge } from "@/server/xfernhost/edge";
 import { APIKeyInjectionConfig, OryAccessTokenSchema } from "@fern-ui/fern-docs-auth";
 import { getAuthEdgeConfig } from "@fern-ui/fern-docs-edge-config";
 import { COOKIE_FERN_TOKEN } from "@fern-ui/fern-docs-utils";
@@ -12,7 +12,7 @@ import type { OauthScope } from "webflow-api/api/types/OAuthScope";
 export const runtime = "edge";
 
 export default async function handler(req: NextRequest): Promise<NextResponse<APIKeyInjectionConfig>> {
-    const domain = getXFernHostEdge(req);
+    const domain = getDocsDomainEdge(req);
     const edgeConfig = await getAuthEdgeConfig(domain);
 
     // assume that if the edge config is set for webflow, api key injection is always enabled

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/jwt/callback.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/jwt/callback.ts
@@ -1,7 +1,8 @@
 import { verifyFernJWTConfig } from "@/server/auth/FernJWT";
 import { withSecureCookie } from "@/server/auth/withSecure";
+import { redirectWithLoginError } from "@/server/redirectWithLoginError";
 import { safeUrl } from "@/server/safeUrl";
-import { getXFernHostEdge, getXFernHostHeaderFallbackOrigin } from "@/server/xfernhost/edge";
+import { getDocsDomainEdge, getHostEdge } from "@/server/xfernhost/edge";
 import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import { getAuthEdgeConfig } from "@fern-ui/fern-docs-edge-config";
 import { COOKIE_FERN_TOKEN } from "@fern-ui/fern-docs-utils";
@@ -9,25 +10,18 @@ import { NextRequest, NextResponse } from "next/server";
 
 export const runtime = "edge";
 
-function redirectWithLoginError(location: string, errorMessage: string): NextResponse {
-    const url = new URL(location);
-    url.searchParams.set("loginError", errorMessage);
-    // TODO: validate allowlist of domains to prevent open redirects
-    return NextResponse.redirect(url.toString());
-}
-
 export default async function handler(req: NextRequest): Promise<NextResponse> {
     if (req.method !== "GET") {
         return new NextResponse(null, { status: 405 });
     }
 
-    const domain = getXFernHostEdge(req);
+    const domain = getDocsDomainEdge(req);
     const edgeConfig = await getAuthEdgeConfig(domain);
 
     // since we expect the callback to be redirected to, the token will be in the query params
     const token = req.nextUrl.searchParams.get(COOKIE_FERN_TOKEN);
     const state = req.nextUrl.searchParams.get("state");
-    const redirectLocation = safeUrl(state) ?? withDefaultProtocol(getXFernHostHeaderFallbackOrigin(req));
+    const redirectLocation = safeUrl(state) ?? safeUrl(withDefaultProtocol(getHostEdge(req)));
 
     if (edgeConfig?.type !== "basic_token_verification" || token == null) {
         // eslint-disable-next-line no-console
@@ -39,7 +33,7 @@ export default async function handler(req: NextRequest): Promise<NextResponse> {
         await verifyFernJWTConfig(token, edgeConfig);
 
         // TODO: validate allowlist of domains to prevent open redirects
-        const res = NextResponse.redirect(redirectLocation);
+        const res = redirectLocation ? NextResponse.redirect(redirectLocation) : NextResponse.next();
         res.cookies.set(COOKIE_FERN_TOKEN, token, withSecureCookie());
         return res;
     } catch (e) {

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/logout.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/logout.ts
@@ -1,5 +1,5 @@
 import { safeUrl } from "@/server/safeUrl";
-import { getXFernHostEdge, getXFernHostHeaderFallbackOrigin } from "@/server/xfernhost/edge";
+import { getDocsDomainEdge, getHostEdge } from "@/server/xfernhost/edge";
 import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import { getAuthEdgeConfig } from "@fern-ui/fern-docs-edge-config";
 import { COOKIE_ACCESS_TOKEN, COOKIE_FERN_TOKEN, COOKIE_REFRESH_TOKEN } from "@fern-ui/fern-docs-utils";
@@ -8,17 +8,21 @@ import { NextRequest, NextResponse } from "next/server";
 export const runtime = "edge";
 
 export default async function GET(req: NextRequest): Promise<NextResponse> {
-    const domain = getXFernHostEdge(req);
+    const domain = getDocsDomainEdge(req);
 
     const authConfig = await getAuthEdgeConfig(domain);
-    const logoutUrl = authConfig?.type === "basic_token_verification" ? authConfig.logout : undefined;
+    const logoutUrl = authConfig?.type === "basic_token_verification" ? safeUrl(authConfig.logout) : undefined;
 
-    const state = req.nextUrl.searchParams.get("state");
+    const state = safeUrl(req.nextUrl.searchParams.get("state"));
 
-    const redirectLocation =
-        safeUrl(logoutUrl) ?? safeUrl(state) ?? withDefaultProtocol(getXFernHostHeaderFallbackOrigin(req));
+    // if logout url is provided, append the state to it before redirecting
+    if (logoutUrl != null && state != null) {
+        logoutUrl?.searchParams.set("state", state.toString());
+    }
 
-    const res = NextResponse.redirect(redirectLocation);
+    const redirectLocation = logoutUrl ?? state ?? safeUrl(withDefaultProtocol(getHostEdge(req)));
+
+    const res = redirectLocation ? NextResponse.redirect(redirectLocation) : NextResponse.next();
     res.cookies.delete(COOKIE_FERN_TOKEN);
     res.cookies.delete(COOKIE_ACCESS_TOKEN);
     res.cookies.delete(COOKIE_REFRESH_TOKEN);

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/changelog.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/changelog.ts
@@ -1,5 +1,5 @@
 import { DocsLoader } from "@/server/DocsLoader";
-import { getXFernHostNode } from "@/server/xfernhost/node";
+import { getDocsDomainNode } from "@/server/xfernhost/node";
 import type { DocsV1Read } from "@fern-api/fdr-sdk/client/types";
 import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import { NodeCollector } from "@fern-api/fdr-sdk/navigation";
@@ -24,7 +24,7 @@ export default async function responseApiHandler(req: NextApiRequest, res: NextA
         return res.status(400).end();
     }
 
-    const xFernHost = getXFernHostNode(req);
+    const xFernHost = getDocsDomainNode(req);
 
     const fernToken = req.cookies[COOKIE_FERN_TOKEN];
     const loader = DocsLoader.for(xFernHost, fernToken);

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/feature-flags.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/feature-flags.ts
@@ -1,4 +1,4 @@
-import { getXFernHostEdge } from "@/server/xfernhost/edge";
+import { getDocsDomainEdge } from "@/server/xfernhost/edge";
 import { getFeatureFlags } from "@fern-ui/fern-docs-edge-config";
 import { FeatureFlags } from "@fern-ui/fern-docs-utils";
 import { NextRequest, NextResponse } from "next/server";
@@ -6,6 +6,6 @@ import { NextRequest, NextResponse } from "next/server";
 export const runtime = "edge";
 
 export default async function handler(req: NextRequest): Promise<NextResponse<FeatureFlags>> {
-    const domain = getXFernHostEdge(req);
+    const domain = getDocsDomainEdge(req);
     return NextResponse.json(await getFeatureFlags(domain));
 }

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/integrations/launchdarkly.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/integrations/launchdarkly.ts
@@ -1,5 +1,5 @@
 import { verifyFernJWTConfig } from "@/server/auth/FernJWT";
-import { getXFernHostEdge } from "@/server/xfernhost/edge";
+import { getDocsDomainEdge } from "@/server/xfernhost/edge";
 import { LaunchDarklyEdgeConfig, getAuthEdgeConfig, getLaunchDarklySettings } from "@fern-ui/fern-docs-edge-config";
 import { COOKIE_EMAIL, COOKIE_FERN_TOKEN } from "@fern-ui/fern-docs-utils";
 import { randomUUID } from "crypto";
@@ -24,7 +24,7 @@ interface LaunchDarklyInfo {
 }
 
 export default async function handler(req: NextRequest): Promise<NextResponse<LaunchDarklyInfo | undefined>> {
-    const domain = getXFernHostEdge(req);
+    const domain = getDocsDomainEdge(req);
 
     const config = await safeGetLaunchDarklySettings(domain);
     const clientSideId = config?.["client-side-id"];
@@ -68,7 +68,7 @@ async function getUserContext(req: NextRequest): Promise<LaunchDarklyInfo["user"
 
     if (fernToken) {
         try {
-            const user = await verifyFernJWTConfig(fernToken, await getAuthEdgeConfig(getXFernHostEdge(req)));
+            const user = await verifyFernJWTConfig(fernToken, await getAuthEdgeConfig(getDocsDomainEdge(req)));
             const key = (await hashString(user.email)) ?? randomUUID();
             return { key: `fern-docs-user-${key}`, email: user.email, name: user.name };
         } catch (e) {

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/integrations/launchdarkly/identify.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/integrations/launchdarkly/identify.ts
@@ -1,4 +1,4 @@
-import { getXFernHostHeaderFallbackOrigin } from "@/server/xfernhost/edge";
+import { getHostEdge } from "@/server/xfernhost/edge";
 import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import { COOKIE_EMAIL } from "@fern-ui/fern-docs-utils";
 import { NextRequest, NextResponse } from "next/server";
@@ -9,7 +9,7 @@ export default async function handler(req: NextRequest): Promise<NextResponse> {
     const email = req.nextUrl.searchParams.get(COOKIE_EMAIL);
 
     // TODO: validate allowlist of domains to prevent open redirects
-    const res = NextResponse.redirect(withDefaultProtocol(getXFernHostHeaderFallbackOrigin(req)));
+    const res = NextResponse.redirect(withDefaultProtocol(getHostEdge(req)));
 
     if (email) {
         res.cookies.set({ name: COOKIE_EMAIL, value: email });

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/ory/callback.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/ory/callback.ts
@@ -25,10 +25,6 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
     const error_description = req.nextUrl.searchParams.get("error_description");
     const redirectLocation = safeUrl(state) ?? safeUrl(withDefaultProtocol(getHostEdge(req)));
 
-    if (redirectLocation == null) {
-        return new NextResponse(null, { status: 500 });
-    }
-
     if (error != null) {
         // eslint-disable-next-line no-console
         console.error(`OAuth2 error: ${error} - ${error_description}`);
@@ -59,7 +55,7 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
         };
         const expires = token.exp == null ? undefined : new Date(token.exp * 1000);
         // TODO: validate allowlist of domains to prevent open redirects
-        const res = NextResponse.redirect(redirectLocation);
+        const res = redirectLocation ? NextResponse.redirect(redirectLocation) : NextResponse.next();
         res.cookies.set(COOKIE_FERN_TOKEN, await signFernJWT(fernUser), withSecureCookie({ expires }));
         res.cookies.set(COOKIE_ACCESS_TOKEN, access_token, withSecureCookie({ expires }));
         if (refresh_token != null) {

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/ory/callback.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/ory/callback.ts
@@ -1,8 +1,9 @@
 import { signFernJWT } from "@/server/auth/FernJWT";
 import { OAuth2Client } from "@/server/auth/OAuth2Client";
 import { withSecureCookie } from "@/server/auth/withSecure";
+import { redirectWithLoginError } from "@/server/redirectWithLoginError";
 import { safeUrl } from "@/server/safeUrl";
-import { getXFernHostEdge, getXFernHostHeaderFallbackOrigin } from "@/server/xfernhost/edge";
+import { getDocsDomainEdge, getHostEdge } from "@/server/xfernhost/edge";
 import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import { FernUser, OryAccessTokenSchema } from "@fern-ui/fern-docs-auth";
 import { getAuthEdgeConfig } from "@fern-ui/fern-docs-edge-config";
@@ -11,25 +12,22 @@ import { NextRequest, NextResponse } from "next/server";
 
 export const runtime = "edge";
 
-function redirectWithLoginError(location: string, errorMessage: string): NextResponse {
-    const url = new URL(location);
-    url.searchParams.set("loginError", errorMessage);
-    // TODO: validate allowlist of domains to prevent open redirects
-    return NextResponse.redirect(url.toString());
-}
-
 export default async function GET(req: NextRequest): Promise<NextResponse> {
     if (req.method !== "GET") {
         return new NextResponse(null, { status: 405 });
     }
 
-    const domain = getXFernHostEdge(req);
+    const domain = getDocsDomainEdge(req);
 
     const code = req.nextUrl.searchParams.get("code");
     const state = req.nextUrl.searchParams.get("state");
     const error = req.nextUrl.searchParams.get("error");
     const error_description = req.nextUrl.searchParams.get("error_description");
-    const redirectLocation = safeUrl(state) ?? withDefaultProtocol(getXFernHostHeaderFallbackOrigin(req));
+    const redirectLocation = safeUrl(state) ?? safeUrl(withDefaultProtocol(getHostEdge(req)));
+
+    if (redirectLocation == null) {
+        return new NextResponse(null, { status: 500 });
+    }
 
     if (error != null) {
         // eslint-disable-next-line no-console

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/webflow/callback.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/webflow/callback.ts
@@ -1,6 +1,7 @@
 import { withSecureCookie } from "@/server/auth/withSecure";
+import { redirectWithLoginError } from "@/server/redirectWithLoginError";
 import { safeUrl } from "@/server/safeUrl";
-import { getXFernHostEdge, getXFernHostHeaderFallbackOrigin } from "@/server/xfernhost/edge";
+import { getDocsDomainEdge, getHostEdge } from "@/server/xfernhost/edge";
 import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import { getAuthEdgeConfig } from "@fern-ui/fern-docs-edge-config";
 import { NextRequest, NextResponse } from "next/server";
@@ -8,25 +9,22 @@ import { WebflowClient } from "webflow-api";
 
 export const runtime = "edge";
 
-function redirectWithLoginError(location: string, errorMessage: string): NextResponse {
-    const url = new URL(location);
-    url.searchParams.set("loginError", errorMessage);
-    // TODO: validate allowlist of domains to prevent open redirects
-    return NextResponse.redirect(url.toString());
-}
-
 export default async function GET(req: NextRequest): Promise<NextResponse> {
     if (req.method !== "GET") {
         return new NextResponse(null, { status: 405 });
     }
 
-    const domain = getXFernHostEdge(req);
+    const domain = getDocsDomainEdge(req);
 
     const code = req.nextUrl.searchParams.get("code");
     const state = req.nextUrl.searchParams.get("state");
     const error = req.nextUrl.searchParams.get("error");
     const error_description = req.nextUrl.searchParams.get("error_description");
-    const redirectLocation = safeUrl(state) ?? withDefaultProtocol(getXFernHostHeaderFallbackOrigin(req));
+    const redirectLocation = safeUrl(state) ?? safeUrl(withDefaultProtocol(getHostEdge(req)));
+
+    if (redirectLocation == null) {
+        return new NextResponse(null, { status: 500 });
+    }
 
     if (error != null) {
         // eslint-disable-next-line no-console

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/webflow/callback.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/oauth/webflow/callback.ts
@@ -22,10 +22,6 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
     const error_description = req.nextUrl.searchParams.get("error_description");
     const redirectLocation = safeUrl(state) ?? safeUrl(withDefaultProtocol(getHostEdge(req)));
 
-    if (redirectLocation == null) {
-        return new NextResponse(null, { status: 500 });
-    }
-
     if (error != null) {
         // eslint-disable-next-line no-console
         console.error(`OAuth2 error: ${error} - ${error_description}`);
@@ -55,7 +51,7 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
         });
 
         // TODO: validate allowlist of domains to prevent open redirects
-        const res = NextResponse.redirect(redirectLocation);
+        const res = redirectLocation ? NextResponse.redirect(redirectLocation) : NextResponse.next();
         res.cookies.set("access_token", accessToken, withSecureCookie());
         return res;
     } catch (error) {

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v3.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v3.ts
@@ -1,7 +1,7 @@
 import { DocsKVCache } from "@/server/DocsCache";
 import { DocsLoader } from "@/server/DocsLoader";
 import { Revalidator } from "@/server/revalidator";
-import { getXFernHostNode } from "@/server/xfernhost/node";
+import { getDocsDomainNode } from "@/server/xfernhost/node";
 import { NodeCollector } from "@fern-api/fdr-sdk/navigation";
 import type { FernDocs } from "@fern-fern/fern-docs-sdk";
 import { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
@@ -29,7 +29,7 @@ const handler: NextApiHandler = async (
     req: NextApiRequest,
     res: NextApiResponse<FernDocs.RevalidateAllV3Response>,
 ): Promise<unknown> => {
-    const xFernHost = getXFernHostNode(req, true);
+    const xFernHost = getDocsDomainNode(req, true);
 
     // never proivde a token here because revalidation should only be done on public routes (for now)
     const loader = DocsLoader.for(xFernHost, undefined);

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v4.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v4.ts
@@ -1,7 +1,7 @@
 import { DocsKVCache } from "@/server/DocsCache";
 import { DocsLoader } from "@/server/DocsLoader";
 import { Revalidator } from "@/server/revalidator";
-import { getXFernHostNode } from "@/server/xfernhost/node";
+import { getDocsDomainNode } from "@/server/xfernhost/node";
 import { NodeCollector } from "@fern-api/fdr-sdk/navigation";
 import type { FernDocs } from "@fern-fern/fern-docs-sdk";
 import { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
@@ -38,7 +38,7 @@ const handler: NextApiHandler = async (
         return res.status(400).json({ total: 0, results: [] });
     }
 
-    const xFernHost = getXFernHostNode(req, true);
+    const xFernHost = getDocsDomainNode(req, true);
 
     // never proivde a token here because revalidation should only be done on public routes (for now)
     const loader = DocsLoader.for(xFernHost, undefined);

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-path.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-path.ts
@@ -1,5 +1,5 @@
 import { Revalidator } from "@/server/revalidator";
-import { getXFernHostNode } from "@/server/xfernhost/node";
+import { getDocsDomainNode } from "@/server/xfernhost/node";
 import { FernDocs } from "@fern-fern/fern-docs-sdk";
 import { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
 
@@ -11,7 +11,7 @@ const handler: NextApiHandler = async (
     req: NextApiRequest,
     res: NextApiResponse<FernDocs.RevalidationResult>,
 ): Promise<unknown> => {
-    const xFernHost = getXFernHostNode(req, true);
+    const xFernHost = getDocsDomainNode(req, true);
     const revalidate = new Revalidator(res, xFernHost);
 
     const path = req.query.path;

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/robots.txt.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/robots.txt.ts
@@ -1,4 +1,4 @@
-import { getXFernHostEdge } from "@/server/xfernhost/edge";
+import { getDocsDomainEdge } from "@/server/xfernhost/edge";
 import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import { getSeoDisabled } from "@fern-ui/fern-docs-edge-config";
 import { NextRequest, NextResponse } from "next/server";
@@ -7,7 +7,7 @@ import urlJoin from "url-join";
 export const runtime = "edge";
 
 export default async function GET(req: NextRequest): Promise<NextResponse> {
-    const xFernHost = getXFernHostEdge(req);
+    const xFernHost = getDocsDomainEdge(req);
     const basePath = req.nextUrl.pathname.split("/robots.txt")[0] || "";
     const sitemap = urlJoin(withDefaultProtocol(xFernHost), basePath, "/sitemap.xml");
 

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/search.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/search.ts
@@ -1,6 +1,6 @@
 import { checkViewerAllowedEdge } from "@/server/auth/checkViewerAllowed";
 import { loadWithUrl } from "@/server/loadWithUrl";
-import { getXFernHostEdge } from "@/server/xfernhost/edge";
+import { getDocsDomainEdge } from "@/server/xfernhost/edge";
 import { getAuthEdgeConfig, getInkeepSettings } from "@fern-ui/fern-docs-edge-config";
 import { SearchConfig, getSearchConfig } from "@fern-ui/search-utils";
 import { provideRegistryService } from "@fern-ui/ui";
@@ -13,7 +13,7 @@ export default async function handler(req: NextRequest): Promise<NextResponse<Se
         return NextResponse.json({ isAvailable: false }, { status: 405 });
     }
 
-    const domain = getXFernHostEdge(req);
+    const domain = getDocsDomainEdge(req);
     const auth = await getAuthEdgeConfig(domain);
 
     try {

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/search/cohere.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/search/cohere.ts
@@ -1,4 +1,4 @@
-import { getXFernHostEdge } from "@/server/xfernhost/edge";
+import { getDocsDomainEdge } from "@/server/xfernhost/edge";
 import { createFetchRequester } from "@algolia/requester-fetch";
 import { Algolia, FdrAPI } from "@fern-api/fdr-sdk/client/types";
 import { assertNonNullish } from "@fern-api/ui-core-utils";
@@ -63,7 +63,7 @@ export default async function handler(req: NextRequest): Promise<Response> {
         return new Response(null, { status: 405 });
     }
 
-    const docsUrl = getXFernHostEdge(req);
+    const docsUrl = getDocsDomainEdge(req);
 
     // HACK: only allow requests from cohere
     if (!docsUrl.includes("cohere")) {

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/sitemap.xml.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/sitemap.xml.ts
@@ -1,6 +1,6 @@
 import { DocsLoader } from "@/server/DocsLoader";
 import { conformTrailingSlash } from "@/server/trailingSlash";
-import { getXFernHostEdge } from "@/server/xfernhost/edge";
+import { getDocsDomainEdge } from "@/server/xfernhost/edge";
 import { NodeCollector } from "@fern-api/fdr-sdk/navigation";
 import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import { COOKIE_FERN_TOKEN } from "@fern-ui/fern-docs-utils";
@@ -14,7 +14,7 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
     if (req.method !== "GET") {
         return new NextResponse(null, { status: 405 });
     }
-    const xFernHost = getXFernHostEdge(req);
+    const xFernHost = getDocsDomainEdge(req);
 
     // load the root node
     const fernToken = req.cookies.get(COOKIE_FERN_TOKEN)?.value;

--- a/packages/ui/docs-bundle/src/pages/dynamic/[domain]/[[...slug]].tsx
+++ b/packages/ui/docs-bundle/src/pages/dynamic/[domain]/[[...slug]].tsx
@@ -1,4 +1,5 @@
 import { getDynamicDocsPageProps } from "@/server/getDynamicDocsPageProps";
+import { getHostNodeStatic } from "@/server/xfernhost/node";
 import { DocsPage } from "@fern-ui/ui";
 import { GetServerSideProps } from "next";
 
@@ -9,8 +10,9 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res, query, 
         res.statusCode = 500;
     }
 
-    const xFernHost = params.host as string;
+    const domain = params.domain as string;
+    const host = getHostNodeStatic() ?? domain;
     const slugArray = params.slug == null ? [] : Array.isArray(params.slug) ? params.slug : [params.slug];
 
-    return getDynamicDocsPageProps(xFernHost, slugArray, req.cookies);
+    return getDynamicDocsPageProps(domain, host, slugArray, req.cookies);
 };

--- a/packages/ui/docs-bundle/src/pages/static/[domain]/[[...slug]].tsx
+++ b/packages/ui/docs-bundle/src/pages/static/[domain]/[[...slug]].tsx
@@ -1,6 +1,7 @@
 import { DocsKVCache } from "@/server/DocsCache";
 import { getDocsPageProps } from "@/server/getDocsPageProps";
 import { withSSGProps } from "@/server/withSSGProps";
+import { getHostNodeStatic } from "@/server/xfernhost/node";
 import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import { DocsPage } from "@fern-ui/ui";
 import { GetStaticPaths, GetStaticProps } from "next";
@@ -10,12 +11,13 @@ export default DocsPage;
 
 export const getStaticProps: GetStaticProps<ComponentProps<typeof DocsPage>> = async (context) => {
     const { params = {} } = context;
-    const xFernHost = params.host as string;
+    const domain = params.domain as string;
+    const host = getHostNodeStatic() ?? domain;
     const slugArray = params.slug == null ? [] : Array.isArray(params.slug) ? params.slug : [params.slug];
 
-    const props = await withSSGProps(getDocsPageProps(xFernHost, slugArray));
+    const props = await withSSGProps(getDocsPageProps(domain, host, slugArray));
 
-    const cache = DocsKVCache.getInstance(xFernHost);
+    const cache = DocsKVCache.getInstance(domain);
     const slug = FernNavigation.slugjoin(...slugArray);
 
     if ("props" in props) {

--- a/packages/ui/docs-bundle/src/server/LoadDocsPerformanceTracker.ts
+++ b/packages/ui/docs-bundle/src/server/LoadDocsPerformanceTracker.ts
@@ -8,15 +8,15 @@ import type { LoadWithUrlResponse } from "./loadWithUrl";
 
 export class LoadDocsPerformanceTracker {
     static init({
-        host,
+        domain,
         slug,
         auth,
     }: {
-        host: string;
+        domain: string;
         slug: string[];
         auth: AuthPartner | undefined;
     }): LoadDocsPerformanceTracker {
-        return new LoadDocsPerformanceTracker(host, slug, auth);
+        return new LoadDocsPerformanceTracker(domain, slug, auth);
     }
 
     private constructor(

--- a/packages/ui/docs-bundle/src/server/getDocsPageProps.ts
+++ b/packages/ui/docs-bundle/src/server/getDocsPageProps.ts
@@ -15,25 +15,28 @@ export interface User {
 }
 
 export async function getDocsPageProps(
-    xFernHost: string | undefined,
+    domain: string | undefined,
+    host: string,
     slug: string[],
     auth?: AuthProps,
 ): Promise<SSGDocsPageProps> {
-    if (xFernHost == null || Array.isArray(xFernHost)) {
+    if (domain == null || Array.isArray(domain)) {
         return { notFound: true };
     }
 
-    const performance = LoadDocsPerformanceTracker.init({ host: xFernHost, slug, auth: auth?.partner });
+    const performance = LoadDocsPerformanceTracker.init({ domain, slug, auth: auth?.partner });
 
     /**
      * Load the docs for the given URL.
      */
-    const docs = await performance.trackLoadDocsPromise(loadWithUrl(xFernHost, auth));
+    const docs = await performance.trackLoadDocsPromise(loadWithUrl(domain, auth));
 
     /**
      * Convert the docs into initial props for the page.
      */
-    const initialProps = await performance.trackInitialPropsPromise(withInitialProps({ docs, slug, xFernHost, auth }));
+    const initialProps = await performance.trackInitialPropsPromise(
+        withInitialProps({ docs, slug, domain, host, auth }),
+    );
 
     /**
      * Send performance data to Vercel Analytics.

--- a/packages/ui/docs-bundle/src/server/getDynamicDocsPageProps.ts
+++ b/packages/ui/docs-bundle/src/server/getDynamicDocsPageProps.ts
@@ -9,7 +9,8 @@ import { getDocsPageProps } from "./getDocsPageProps";
 type GetServerSideDocsPagePropsResult = GetServerSidePropsResult<ComponentProps<typeof DocsPage>>;
 
 export async function getDynamicDocsPageProps(
-    xFernHost: string,
+    domain: string,
+    host: string,
     slug: string[],
     cookies: NextApiRequestCookies,
 ): Promise<GetServerSideDocsPagePropsResult> {
@@ -17,7 +18,7 @@ export async function getDynamicDocsPageProps(
 
     try {
         if (cookies[COOKIE_FERN_TOKEN]) {
-            authProps = await withAuthProps(xFernHost, cookies[COOKIE_FERN_TOKEN]);
+            authProps = await withAuthProps(domain, cookies[COOKIE_FERN_TOKEN]);
         }
     } catch (e) {
         // eslint-disable-next-line no-console
@@ -28,5 +29,5 @@ export async function getDynamicDocsPageProps(
      * Authenticated user is guaranteed to have a valid token because the middleware
      * would have redirected them to the login page
      */
-    return getDocsPageProps(xFernHost, slug, authProps);
+    return getDocsPageProps(domain, host, slug, authProps);
 }

--- a/packages/ui/docs-bundle/src/server/pageRoutes.ts
+++ b/packages/ui/docs-bundle/src/server/pageRoutes.ts
@@ -2,16 +2,16 @@ import getAssetPathFromRoute from "next/dist/shared/lib/router/utils/get-asset-p
 import { removeTrailingSlash } from "next/dist/shared/lib/router/utils/remove-trailing-slash";
 import urlJoin from "url-join";
 
-export function getPageRoute(ssg: boolean, host: string, pathname: string): string {
+export function getPageRoute(ssg: boolean, domain: string, pathname: string): string {
     const prefix = ssg ? "static" : "dynamic";
-    return urlJoin("/", prefix, host, pathname);
+    return urlJoin("/", prefix, domain, pathname);
 }
 
 export function getPageRouteMatch(ssg: boolean, buildId: string): string {
-    return `/_next/data/${buildId}/${ssg ? "static" : "dynamic"}/[host]/[[...slug]].json`;
+    return `/_next/data/${buildId}/${ssg ? "static" : "dynamic"}/[domain]/[[...slug]].json`;
 }
 
-export function getPageRoutePath(ssg: boolean, buildId: string, host: string, pathname: string): string {
+export function getPageRoutePath(ssg: boolean, buildId: string, domain: string, pathname: string): string {
     const dataRoute = getAssetPathFromRoute(removeTrailingSlash(pathname), ".json");
 
     /**
@@ -21,5 +21,5 @@ export function getPageRoutePath(ssg: boolean, buildId: string, host: string, pa
         return `/_next/data/${buildId}${dataRoute}`;
     }
 
-    return `/_next/data/${buildId}/${ssg ? "static" : "dynamic"}/${host}${dataRoute}`;
+    return `/_next/data/${buildId}/${ssg ? "static" : "dynamic"}/${domain}${dataRoute}`;
 }

--- a/packages/ui/docs-bundle/src/server/redirectWithLoginError.ts
+++ b/packages/ui/docs-bundle/src/server/redirectWithLoginError.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+export function redirectWithLoginError(location: URL | undefined, errorMessage: string): NextResponse {
+    if (location == null) {
+        return new NextResponse(null, { status: 500 });
+    }
+
+    const url = new URL(location);
+    url.searchParams.set("loginError", errorMessage);
+    // TODO: validate allowlist of domains to prevent open redirects
+    return NextResponse.redirect(url.toString());
+}

--- a/packages/ui/docs-bundle/src/server/safeUrl.ts
+++ b/packages/ui/docs-bundle/src/server/safeUrl.ts
@@ -1,6 +1,6 @@
 import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 
-export function safeUrl(url: string | null | undefined): string | undefined {
+export function safeUrl(url: string | null | undefined): URL | undefined {
     if (url == null) {
         return undefined;
     }
@@ -8,8 +8,7 @@ export function safeUrl(url: string | null | undefined): string | undefined {
     url = withDefaultProtocol(url);
 
     try {
-        new URL(url);
-        return url;
+        return new URL(url);
     } catch (e) {
         // eslint-disable-next-line no-console
         console.error(e);

--- a/packages/ui/docs-bundle/src/server/xfernhost/edge.ts
+++ b/packages/ui/docs-bundle/src/server/xfernhost/edge.ts
@@ -6,7 +6,7 @@ import { cleanHost } from "./util";
 /**
  * Note: x-fern-host is always appended to the request header by cloudfront for all *.docs.buildwithfern.com requests.
  */
-export function getXFernHostEdge(req: NextRequest, useSearchParams = false): string {
+export function getDocsDomainEdge(req: NextRequest, useSearchParams = false): string {
     const hosts = [
         useSearchParams ? req.nextUrl.searchParams.get("host") : undefined,
         getNextPublicDocsDomain(),
@@ -26,7 +26,7 @@ export function getXFernHostEdge(req: NextRequest, useSearchParams = false): str
 }
 
 // use this for testing auth-based redirects on development and preview environments
-export function getXFernHostHeaderFallbackOrigin(req: NextRequest): string {
+export function getHostEdge(req: NextRequest): string {
     if (
         process.env.NODE_ENV === "development" ||
         process.env.VERCEL_ENV === "preview" ||
@@ -34,5 +34,5 @@ export function getXFernHostHeaderFallbackOrigin(req: NextRequest): string {
     ) {
         return req.nextUrl.host;
     }
-    return cleanHost(req.headers.get(HEADER_X_FERN_HOST)) ?? req.nextUrl.host;
+    return getDocsDomainEdge(req);
 }

--- a/packages/ui/docs-bundle/src/server/xfernhost/node.ts
+++ b/packages/ui/docs-bundle/src/server/xfernhost/node.ts
@@ -6,7 +6,7 @@ import { cleanHost } from "./util";
 /**
  * Note: x-fern-host is always appended to the request header by cloudfront for all *.docs.buildwithfern.com requests.
  */
-export function getXFernHostNode(req: NextApiRequest, useSearchParams = false): string {
+export function getDocsDomainNode(req: NextApiRequest, useSearchParams = false): string {
     const hosts = [
         useSearchParams ? req.query["host"] : undefined,
         getNextPublicDocsDomain(),
@@ -27,4 +27,17 @@ export function getXFernHostNode(req: NextApiRequest, useSearchParams = false): 
     }
 
     throw new Error("Could not determine xFernHost from request.");
+}
+
+// attempts to construct the host from environment variables, when the req object is not available
+export function getHostNodeStatic(): string | undefined {
+    if (process.env.NODE_ENV === "development") {
+        return `${process.env.HOST || "localhost"}:${process.env.PORT || 3000}`;
+    }
+
+    if (process.env.VERCEL_ENV === "preview" || process.env.VERCEL_ENV === "development") {
+        return process.env.VERCEL_URL;
+    }
+
+    return undefined;
 }


### PR DESCRIPTION
Forwards the `state` query parameter to the logout url, so that after logging out, the client's knows where to return the user to in the docs side, if they re-login.