### PR TITLE
fix: render error snippet without json wrapper

### DIFF
--- a/packages/ui/app/src/api-reference/endpoints/EndpointContentCodeSnippets.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointContentCodeSnippets.tsx
@@ -181,7 +181,7 @@ const UnmemoizedEndpointContentCodeSnippets: React.FC<EndpointContentCodeSnippet
                         e.stopPropagation();
                     }}
                     hoveredPropertyPath={hoveredResponsePropertyPath}
-                    json={selectedErrorExample?.responseBody ?? EMPTY_OBJECT}
+                    json={selectedErrorExample?.responseBody.value ?? EMPTY_OBJECT}
                     intent={statusCodeToIntent(selectedError.statusCode)}
                 />
             )}


### PR DESCRIPTION
errors was previously rendered form ErrorsV1, but when we switched to ErrorsV2, ErrorsV2 nested the value in the following way:
```
{
  "type": "json",
  "value": "my-value"
}
```

this pr changes it to render:
```
"my-value"
```