### PR TITLE
fix: prefer the first description when multiple are detected

### DIFF
--- a/packages/ui/app/src/api-reference/endpoints/EndpointParameter.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointParameter.tsx
@@ -5,7 +5,8 @@ import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import { EMPTY_ARRAY } from "@fern-api/ui-core-utils";
 import cn from "clsx";
 import { compact } from "lodash-es";
-import { FC, PropsWithChildren, ReactNode, memo, useRef, useState } from "react";
+import { FC, PropsWithChildren, ReactNode, memo, useEffect, useRef, useState } from "react";
+import { capturePosthogEvent } from "../../analytics/posthog";
 import { useIsApiReferencePaginated, useRouteListener } from "../../atoms";
 import { FernAnchor } from "../../components/FernAnchor";
 import { useHref } from "../../hooks/useHref";
@@ -98,6 +99,21 @@ export const EndpointParameterContent: FC<PropsWithChildren<EndpointParameter.Co
     });
 
     const href = useHref(slug, anchorId);
+    const descriptions = compact([description, ...additionalDescriptions]);
+
+    useEffect(() => {
+        if (descriptions.length > 0) {
+            capturePosthogEvent("api_reference_multiple_descriptions", {
+                name,
+                slug,
+                anchorIdParts,
+                count: descriptions.length,
+                descriptions,
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [descriptions]);
+
     return (
         <div
             ref={ref}
@@ -113,7 +129,7 @@ export const EndpointParameterContent: FC<PropsWithChildren<EndpointParameter.Co
                     {availability != null && <EndpointAvailabilityTag availability={availability} minimal={true} />}
                 </span>
             </FernAnchor>
-            <Markdown mdx={compact([description, ...additionalDescriptions])[0]} className="!t-muted" size="sm" />
+            <Markdown mdx={descriptions[0]} className="!t-muted" size="sm" />
             {children}
         </div>
     );

--- a/packages/ui/app/src/api-reference/endpoints/EndpointParameter.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointParameter.tsx
@@ -113,7 +113,7 @@ export const EndpointParameterContent: FC<PropsWithChildren<EndpointParameter.Co
                     {availability != null && <EndpointAvailabilityTag availability={availability} minimal={true} />}
                 </span>
             </FernAnchor>
-            <Markdown mdx={compact([description, ...additionalDescriptions])} className="!t-muted" size="sm" />
+            <Markdown mdx={compact([description, ...additionalDescriptions])[0]} className="!t-muted" size="sm" />
             {children}
         </div>
     );

--- a/packages/ui/app/src/api-reference/types/discriminated-union/DiscriminatedUnionVariant.tsx
+++ b/packages/ui/app/src/api-reference/types/discriminated-union/DiscriminatedUnionVariant.tsx
@@ -75,7 +75,7 @@ export const DiscriminatedUnionVariant: React.FC<DiscriminatedUnionVariant.Props
                 <EndpointAvailabilityTag availability={unionVariant.availability} minimal={true} />
             )}
             <div className="flex flex-col">
-                <Markdown mdx={compact([unionVariant.description, ...descriptions])} size="sm" />
+                <Markdown mdx={compact([unionVariant.description, ...descriptions])[0]} size="sm" />
                 <TypeDefinitionContext.Provider value={newContextValue}>
                     <InternalTypeDefinition
                         shape={shape}

--- a/packages/ui/app/src/mdx/Markdown.tsx
+++ b/packages/ui/app/src/mdx/Markdown.tsx
@@ -21,7 +21,10 @@ export declare namespace Markdown {
 
 export const Markdown = memo<Markdown.Props>(({ title, mdx, className, size, fallback }) => {
     // If the MDX is empty, return null
-    if (!fallback && (mdx == null || (typeof mdx === "string" && mdx.trim().length === 0))) {
+    if (
+        !fallback &&
+        (mdx == null || (typeof mdx === "string" ? mdx.trim().length === 0 : mdx.code.trim().length === 0))
+    ) {
         return null;
     }
 

--- a/packages/ui/app/src/mdx/Markdown.tsx
+++ b/packages/ui/app/src/mdx/Markdown.tsx
@@ -7,7 +7,8 @@ export declare namespace Markdown {
     export interface Props {
         title?: ReactNode;
 
-        mdx: FernDocs.MarkdownText | FernDocs.MarkdownText[] | undefined;
+        // mdx: FernDocs.MarkdownText | FernDocs.MarkdownText[] | undefined;
+        mdx: FernDocs.MarkdownText | undefined;
         className?: string;
         size?: "xs" | "sm" | "lg";
 


### PR DESCRIPTION
Naively fixes duplicate description bug by choosing only the first description to show. Logs >1 description issues to posthog.