### PR TITLE
feat: plumb through navigation v1

### DIFF
--- a/fern/apis/fdr/definition/docs/v1/db/__package__.yml
+++ b/fern/apis/fdr/definition/docs/v1/db/__package__.yml
@@ -6,6 +6,7 @@ imports:
   apiReadV1Endpoint: ../../../api/v1/read/endpoint.yml
   docsReadV1: ../read/__package__.yml
   commons: ../commons/commons.yml
+  navigationV1: ../../../navigation/v1/__package__.yml
 
 types:
   DocsDefinitionDb:
@@ -52,7 +53,10 @@ types:
       announcement: optional<commons.AnnouncementConfig>
 
       # navigation
-      navigation: NavigationConfig
+      navigation:
+        type: optional<NavigationConfig>
+        availability: deprecated
+      root: optional<navigationV1.RootNode>
       navbarLinks: optional<list<commons.NavbarLink>>
       footerLinks: optional<list<commons.FooterLink>>
 

--- a/fern/apis/fdr/definition/docs/v1/read/__package__.yml
+++ b/fern/apis/fdr/definition/docs/v1/read/__package__.yml
@@ -6,7 +6,7 @@ imports:
   apiReadV1: ../../../api/v1/read/__package__.yml
   apiCommonsV1: ../../../api/v1/commons.yml
   commons: ../commons/commons.yml
-  navigation: ../../../navigation/v1/__package__.yml
+  navigationV1: ../../../navigation/v1/__package__.yml
 
 service:
   base-path: /registry/docs
@@ -90,7 +90,10 @@ types:
       announcement: optional<commons.AnnouncementConfig>
 
       # navigation
-      navigation: NavigationConfig
+      navigation:
+        type: optional<NavigationConfig>
+        availability: deprecated
+      root: optional<navigationV1.RootNode>
       navbarLinks: optional<list<commons.NavbarLink>>
       footerLinks: optional<list<commons.FooterLink>>
 
@@ -266,7 +269,7 @@ types:
 
   ApiSectionV2:
     properties:
-      node: navigation.ApiReferenceNode
+      node: navigationV1.ApiReferenceNode
 
   ApiNavigationConfigRoot:
     availability: deprecated
@@ -300,7 +303,7 @@ types:
 
   ChangelogSectionV3:
     properties:
-      node: navigation.ChangelogNode
+      node: navigationV1.ChangelogNode
 
   ChangelogItem:
     properties:

--- a/fern/apis/fdr/definition/docs/v1/write/__package__.yml
+++ b/fern/apis/fdr/definition/docs/v1/write/__package__.yml
@@ -3,7 +3,7 @@
 imports:
   rootCommons: ../../../commons.yml
   commons: ../commons/commons.yml
-  navigation: ../../../navigation/v1/__package__.yml
+  navigationV1: ../../../navigation/v1/__package__.yml
   apiCommonsV1: ../../../api/v1/commons.yml
 
 service:
@@ -87,7 +87,10 @@ types:
       announcement: optional<commons.AnnouncementConfig>
 
       # navigation
-      navigation: NavigationConfig
+      navigation:
+        type: optional<NavigationConfig>
+        availability: deprecated
+      root: optional<navigationV1.RootNode>
       navbarLinks: optional<list<commons.NavbarLink>>
       footerLinks: optional<list<commons.FooterLink>>
 
@@ -277,7 +280,7 @@ types:
 
   ApiSectionV2:
     properties:
-      node: navigation.ApiReferenceNode
+      node: navigationV1.ApiReferenceNode
 
   ApiNavigationConfigRoot:
     availability: deprecated
@@ -331,7 +334,7 @@ types:
 
   ChangelogSectionV3:
     properties:
-      node: navigation.ChangelogNode
+      node: navigationV1.ChangelogNode
 
   ChangelogItem:
     properties:

--- a/fern/apis/fdr/definition/navigation/v1/__package__.yml
+++ b/fern/apis/fdr/definition/navigation/v1/__package__.yml
@@ -321,6 +321,8 @@ types:
       slug: Slug
       icon: optional<string>
       hidden: optional<boolean>
+      authed: optional<boolean>
+      audience: optional<list<commons.AudienceId>>
 
   WithPage:
     properties:

--- a/packages/commons/fdr-utils/src/definition-object-factory.ts
+++ b/packages/commons/fdr-utils/src/definition-object-factory.ts
@@ -21,6 +21,7 @@ export class DefinitionObjectFactory {
                 },
                 navbarLinks: [],
                 navigation: { items: [], landingPage: undefined },
+                root: undefined,
                 title: undefined,
                 defaultLanguage: undefined,
                 announcement: undefined,

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/db/types/DocsDbConfig.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/db/types/DocsDbConfig.ts
@@ -8,7 +8,8 @@ export interface DocsDbConfig {
     title: string | undefined;
     defaultLanguage: FernRegistry.docs.v1.commons.ProgrammingLanguage | undefined;
     announcement: FernRegistry.docs.v1.commons.AnnouncementConfig | undefined;
-    navigation: FernRegistry.docs.v1.db.NavigationConfig;
+    navigation: FernRegistry.docs.v1.db.NavigationConfig | undefined;
+    root: FernRegistry.navigation.v1.RootNode | undefined;
     navbarLinks: FernRegistry.docs.v1.commons.NavbarLink[] | undefined;
     footerLinks: FernRegistry.docs.v1.commons.FooterLink[] | undefined;
     logoHeight: FernRegistry.docs.v1.read.Height | undefined;

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/read/types/DocsConfig.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/read/types/DocsConfig.ts
@@ -8,7 +8,8 @@ export interface DocsConfig {
     title: string | undefined;
     defaultLanguage: FernRegistry.docs.v1.commons.ProgrammingLanguage | undefined;
     announcement: FernRegistry.docs.v1.commons.AnnouncementConfig | undefined;
-    navigation: FernRegistry.docs.v1.read.NavigationConfig;
+    navigation: FernRegistry.docs.v1.read.NavigationConfig | undefined;
+    root: FernRegistry.navigation.v1.RootNode | undefined;
     navbarLinks: FernRegistry.docs.v1.commons.NavbarLink[] | undefined;
     footerLinks: FernRegistry.docs.v1.commons.FooterLink[] | undefined;
     logoHeight: FernRegistry.docs.v1.read.Height | undefined;

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/write/client/Client.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/write/client/Client.ts
@@ -100,47 +100,10 @@ export class Write {
      *                 },
      *                 navigation: {
      *                     tabs: [{
-     *                             title: "string",
-     *                             items: [{
-     *                                     "key": "value"
-     *                                 }],
-     *                             skipUrlSlug: {
-     *                                 "key": "value"
-     *                             },
-     *                             icon: {
-     *                                 "key": "value"
-     *                             },
-     *                             hidden: {
-     *                                 "key": "value"
-     *                             },
-     *                             urlSlugOverride: {
-     *                                 "key": "value"
-     *                             },
-     *                             fullSlug: {
-     *                                 "key": "value"
-     *                             }
+     *                             "key": "value"
      *                         }],
      *                     tabsV2: [{
-     *                             type: "group",
-     *                             title: "string",
-     *                             items: [{
-     *                                     "key": "value"
-     *                                 }],
-     *                             skipUrlSlug: {
-     *                                 "key": "value"
-     *                             },
-     *                             icon: {
-     *                                 "key": "value"
-     *                             },
-     *                             hidden: {
-     *                                 "key": "value"
-     *                             },
-     *                             urlSlugOverride: {
-     *                                 "key": "value"
-     *                             },
-     *                             fullSlug: {
-     *                                 "key": "value"
-     *                             }
+     *                             "key": "value"
      *                         }],
      *                     landingPage: {
      *                         id: FernRegistry.PageId("string"),
@@ -157,6 +120,68 @@ export class Write {
      *                         fullSlug: {
      *                             "key": "value"
      *                         }
+     *                     }
+     *                 },
+     *                 root: {
+     *                     type: "root",
+     *                     version: "v1",
+     *                     child: {
+     *                         type: "versioned",
+     *                         children: [{
+     *                                 type: "version",
+     *                                 default: true,
+     *                                 versionId: FernRegistry.VersionId("string"),
+     *                                 child: {
+     *                                     type: "tabbed",
+     *                                     children: [{
+     *                                             "key": "value"
+     *                                         }],
+     *                                     id: FernRegistry.navigation.v1.NodeId("string")
+     *                                 },
+     *                                 availability: {
+     *                                     "key": "value"
+     *                                 },
+     *                                 landingPage: {
+     *                                     "key": "value"
+     *                                 },
+     *                                 title: "string",
+     *                                 slug: FernRegistry.navigation.v1.Slug("string"),
+     *                                 icon: {
+     *                                     "key": "value"
+     *                                 },
+     *                                 hidden: {
+     *                                     "key": "value"
+     *                                 },
+     *                                 authed: {
+     *                                     "key": "value"
+     *                                 },
+     *                                 audience: {
+     *                                     "key": "value"
+     *                                 },
+     *                                 id: FernRegistry.navigation.v1.NodeId("string"),
+     *                                 pointsTo: {
+     *                                     "key": "value"
+     *                                 }
+     *                             }],
+     *                         id: FernRegistry.navigation.v1.NodeId("string")
+     *                     },
+     *                     title: "string",
+     *                     slug: FernRegistry.navigation.v1.Slug("string"),
+     *                     icon: {
+     *                         "key": "value"
+     *                     },
+     *                     hidden: {
+     *                         "key": "value"
+     *                     },
+     *                     authed: {
+     *                         "key": "value"
+     *                     },
+     *                     audience: {
+     *                         "key": "value"
+     *                     },
+     *                     id: FernRegistry.navigation.v1.NodeId("string"),
+     *                     pointsTo: {
+     *                         "key": "value"
      *                     }
      *                 },
      *                 navbarLinks: [{

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/write/client/requests/RegisterDocsRequest.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/write/client/requests/RegisterDocsRequest.ts
@@ -22,47 +22,10 @@ import * as FernRegistry from "../../../../../../../../index";
  *                 },
  *                 navigation: {
  *                     tabs: [{
- *                             title: "string",
- *                             items: [{
- *                                     "key": "value"
- *                                 }],
- *                             skipUrlSlug: {
- *                                 "key": "value"
- *                             },
- *                             icon: {
- *                                 "key": "value"
- *                             },
- *                             hidden: {
- *                                 "key": "value"
- *                             },
- *                             urlSlugOverride: {
- *                                 "key": "value"
- *                             },
- *                             fullSlug: {
- *                                 "key": "value"
- *                             }
+ *                             "key": "value"
  *                         }],
  *                     tabsV2: [{
- *                             type: "group",
- *                             title: "string",
- *                             items: [{
- *                                     "key": "value"
- *                                 }],
- *                             skipUrlSlug: {
- *                                 "key": "value"
- *                             },
- *                             icon: {
- *                                 "key": "value"
- *                             },
- *                             hidden: {
- *                                 "key": "value"
- *                             },
- *                             urlSlugOverride: {
- *                                 "key": "value"
- *                             },
- *                             fullSlug: {
- *                                 "key": "value"
- *                             }
+ *                             "key": "value"
  *                         }],
  *                     landingPage: {
  *                         id: FernRegistry.PageId("string"),
@@ -79,6 +42,68 @@ import * as FernRegistry from "../../../../../../../../index";
  *                         fullSlug: {
  *                             "key": "value"
  *                         }
+ *                     }
+ *                 },
+ *                 root: {
+ *                     type: "root",
+ *                     version: "v1",
+ *                     child: {
+ *                         type: "versioned",
+ *                         children: [{
+ *                                 type: "version",
+ *                                 default: true,
+ *                                 versionId: FernRegistry.VersionId("string"),
+ *                                 child: {
+ *                                     type: "tabbed",
+ *                                     children: [{
+ *                                             "key": "value"
+ *                                         }],
+ *                                     id: FernRegistry.navigation.v1.NodeId("string")
+ *                                 },
+ *                                 availability: {
+ *                                     "key": "value"
+ *                                 },
+ *                                 landingPage: {
+ *                                     "key": "value"
+ *                                 },
+ *                                 title: "string",
+ *                                 slug: FernRegistry.navigation.v1.Slug("string"),
+ *                                 icon: {
+ *                                     "key": "value"
+ *                                 },
+ *                                 hidden: {
+ *                                     "key": "value"
+ *                                 },
+ *                                 authed: {
+ *                                     "key": "value"
+ *                                 },
+ *                                 audience: {
+ *                                     "key": "value"
+ *                                 },
+ *                                 id: FernRegistry.navigation.v1.NodeId("string"),
+ *                                 pointsTo: {
+ *                                     "key": "value"
+ *                                 }
+ *                             }],
+ *                         id: FernRegistry.navigation.v1.NodeId("string")
+ *                     },
+ *                     title: "string",
+ *                     slug: FernRegistry.navigation.v1.Slug("string"),
+ *                     icon: {
+ *                         "key": "value"
+ *                     },
+ *                     hidden: {
+ *                         "key": "value"
+ *                     },
+ *                     authed: {
+ *                         "key": "value"
+ *                     },
+ *                     audience: {
+ *                         "key": "value"
+ *                     },
+ *                     id: FernRegistry.navigation.v1.NodeId("string"),
+ *                     pointsTo: {
+ *                         "key": "value"
  *                     }
  *                 },
  *                 navbarLinks: [{

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/write/types/DocsConfig.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/write/types/DocsConfig.ts
@@ -8,7 +8,8 @@ export interface DocsConfig {
     title: string | undefined;
     defaultLanguage: FernRegistry.docs.v1.commons.ProgrammingLanguage | undefined;
     announcement: FernRegistry.docs.v1.commons.AnnouncementConfig | undefined;
-    navigation: FernRegistry.docs.v1.write.NavigationConfig;
+    navigation: FernRegistry.docs.v1.write.NavigationConfig | undefined;
+    root: FernRegistry.navigation.v1.RootNode | undefined;
     navbarLinks: FernRegistry.docs.v1.commons.NavbarLink[] | undefined;
     footerLinks: FernRegistry.docs.v1.commons.FooterLink[] | undefined;
     logoHeight: FernRegistry.docs.v1.write.Height | undefined;

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v2/resources/write/client/Client.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v2/resources/write/client/Client.ts
@@ -202,47 +202,10 @@ export class Write {
      *                 },
      *                 navigation: {
      *                     tabs: [{
-     *                             title: "string",
-     *                             items: [{
-     *                                     "key": "value"
-     *                                 }],
-     *                             skipUrlSlug: {
-     *                                 "key": "value"
-     *                             },
-     *                             icon: {
-     *                                 "key": "value"
-     *                             },
-     *                             hidden: {
-     *                                 "key": "value"
-     *                             },
-     *                             urlSlugOverride: {
-     *                                 "key": "value"
-     *                             },
-     *                             fullSlug: {
-     *                                 "key": "value"
-     *                             }
+     *                             "key": "value"
      *                         }],
      *                     tabsV2: [{
-     *                             type: "group",
-     *                             title: "string",
-     *                             items: [{
-     *                                     "key": "value"
-     *                                 }],
-     *                             skipUrlSlug: {
-     *                                 "key": "value"
-     *                             },
-     *                             icon: {
-     *                                 "key": "value"
-     *                             },
-     *                             hidden: {
-     *                                 "key": "value"
-     *                             },
-     *                             urlSlugOverride: {
-     *                                 "key": "value"
-     *                             },
-     *                             fullSlug: {
-     *                                 "key": "value"
-     *                             }
+     *                             "key": "value"
      *                         }],
      *                     landingPage: {
      *                         id: FernRegistry.PageId("string"),
@@ -259,6 +222,68 @@ export class Write {
      *                         fullSlug: {
      *                             "key": "value"
      *                         }
+     *                     }
+     *                 },
+     *                 root: {
+     *                     type: "root",
+     *                     version: "v1",
+     *                     child: {
+     *                         type: "versioned",
+     *                         children: [{
+     *                                 type: "version",
+     *                                 default: true,
+     *                                 versionId: FernRegistry.VersionId("string"),
+     *                                 child: {
+     *                                     type: "tabbed",
+     *                                     children: [{
+     *                                             "key": "value"
+     *                                         }],
+     *                                     id: FernRegistry.navigation.v1.NodeId("string")
+     *                                 },
+     *                                 availability: {
+     *                                     "key": "value"
+     *                                 },
+     *                                 landingPage: {
+     *                                     "key": "value"
+     *                                 },
+     *                                 title: "string",
+     *                                 slug: FernRegistry.navigation.v1.Slug("string"),
+     *                                 icon: {
+     *                                     "key": "value"
+     *                                 },
+     *                                 hidden: {
+     *                                     "key": "value"
+     *                                 },
+     *                                 authed: {
+     *                                     "key": "value"
+     *                                 },
+     *                                 audience: {
+     *                                     "key": "value"
+     *                                 },
+     *                                 id: FernRegistry.navigation.v1.NodeId("string"),
+     *                                 pointsTo: {
+     *                                     "key": "value"
+     *                                 }
+     *                             }],
+     *                         id: FernRegistry.navigation.v1.NodeId("string")
+     *                     },
+     *                     title: "string",
+     *                     slug: FernRegistry.navigation.v1.Slug("string"),
+     *                     icon: {
+     *                         "key": "value"
+     *                     },
+     *                     hidden: {
+     *                         "key": "value"
+     *                     },
+     *                     authed: {
+     *                         "key": "value"
+     *                     },
+     *                     audience: {
+     *                         "key": "value"
+     *                     },
+     *                     id: FernRegistry.navigation.v1.NodeId("string"),
+     *                     pointsTo: {
+     *                         "key": "value"
      *                     }
      *                 },
      *                 navbarLinks: [{

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v2/resources/write/client/requests/RegisterDocsRequest.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v2/resources/write/client/requests/RegisterDocsRequest.ts
@@ -22,47 +22,10 @@ import * as FernRegistry from "../../../../../../../../index";
  *                 },
  *                 navigation: {
  *                     tabs: [{
- *                             title: "string",
- *                             items: [{
- *                                     "key": "value"
- *                                 }],
- *                             skipUrlSlug: {
- *                                 "key": "value"
- *                             },
- *                             icon: {
- *                                 "key": "value"
- *                             },
- *                             hidden: {
- *                                 "key": "value"
- *                             },
- *                             urlSlugOverride: {
- *                                 "key": "value"
- *                             },
- *                             fullSlug: {
- *                                 "key": "value"
- *                             }
+ *                             "key": "value"
  *                         }],
  *                     tabsV2: [{
- *                             type: "group",
- *                             title: "string",
- *                             items: [{
- *                                     "key": "value"
- *                                 }],
- *                             skipUrlSlug: {
- *                                 "key": "value"
- *                             },
- *                             icon: {
- *                                 "key": "value"
- *                             },
- *                             hidden: {
- *                                 "key": "value"
- *                             },
- *                             urlSlugOverride: {
- *                                 "key": "value"
- *                             },
- *                             fullSlug: {
- *                                 "key": "value"
- *                             }
+ *                             "key": "value"
  *                         }],
  *                     landingPage: {
  *                         id: FernRegistry.PageId("string"),
@@ -79,6 +42,68 @@ import * as FernRegistry from "../../../../../../../../index";
  *                         fullSlug: {
  *                             "key": "value"
  *                         }
+ *                     }
+ *                 },
+ *                 root: {
+ *                     type: "root",
+ *                     version: "v1",
+ *                     child: {
+ *                         type: "versioned",
+ *                         children: [{
+ *                                 type: "version",
+ *                                 default: true,
+ *                                 versionId: FernRegistry.VersionId("string"),
+ *                                 child: {
+ *                                     type: "tabbed",
+ *                                     children: [{
+ *                                             "key": "value"
+ *                                         }],
+ *                                     id: FernRegistry.navigation.v1.NodeId("string")
+ *                                 },
+ *                                 availability: {
+ *                                     "key": "value"
+ *                                 },
+ *                                 landingPage: {
+ *                                     "key": "value"
+ *                                 },
+ *                                 title: "string",
+ *                                 slug: FernRegistry.navigation.v1.Slug("string"),
+ *                                 icon: {
+ *                                     "key": "value"
+ *                                 },
+ *                                 hidden: {
+ *                                     "key": "value"
+ *                                 },
+ *                                 authed: {
+ *                                     "key": "value"
+ *                                 },
+ *                                 audience: {
+ *                                     "key": "value"
+ *                                 },
+ *                                 id: FernRegistry.navigation.v1.NodeId("string"),
+ *                                 pointsTo: {
+ *                                     "key": "value"
+ *                                 }
+ *                             }],
+ *                         id: FernRegistry.navigation.v1.NodeId("string")
+ *                     },
+ *                     title: "string",
+ *                     slug: FernRegistry.navigation.v1.Slug("string"),
+ *                     icon: {
+ *                         "key": "value"
+ *                     },
+ *                     hidden: {
+ *                         "key": "value"
+ *                     },
+ *                     authed: {
+ *                         "key": "value"
+ *                     },
+ *                     audience: {
+ *                         "key": "value"
+ *                     },
+ *                     id: FernRegistry.navigation.v1.NodeId("string"),
+ *                     pointsTo: {
+ *                         "key": "value"
  *                     }
  *                 },
  *                 navbarLinks: [{

--- a/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/v1/types/WithNodeMetadata.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/v1/types/WithNodeMetadata.ts
@@ -9,4 +9,6 @@ export interface WithNodeMetadata extends FernRegistry.navigation.v1.WithNodeId 
     slug: FernRegistry.navigation.v1.Slug;
     icon: string | undefined;
     hidden: boolean | undefined;
+    authed: boolean | undefined;
+    audience: FernRegistry.AudienceId[] | undefined;
 }

--- a/packages/fdr-sdk/src/converters/db/convertDocsDefinitionToDb.ts
+++ b/packages/fdr-sdk/src/converters/db/convertDocsDefinitionToDb.ts
@@ -37,7 +37,9 @@ export function convertDocsDefinitionToDb({
     writeShape: DocsV1Write.DocsDefinition;
     files: Record<DocsV1Write.FilePath, S3FileInfo>;
 }): ConvertedDocsDefinition {
-    const navigationConfig: DocsV1Db.NavigationConfig = transformNavigationConfigForDb(writeShape.config.navigation);
+    const navigationConfig: DocsV1Db.NavigationConfig | undefined = writeShape.config.navigation
+        ? transformNavigationConfigForDb(writeShape.config.navigation)
+        : undefined;
     const transformedFiles: Record<DocsV1Write.FileId, DocsV1Db.DbFileInfoV2> = {};
     Object.entries(files).forEach(([, s3FileInfo]) => {
         transformedFiles[s3FileInfo.presignedUrl.fileId] =
@@ -79,10 +81,11 @@ export function convertDocsDefinitionToDb({
 
     return {
         type: "v3",
-        referencedApis: getReferencedApiDefinitionIds(navigationConfig),
+        referencedApis: navigationConfig != null ? getReferencedApiDefinitionIds(navigationConfig) : [],
         files: transformedFiles,
         config: {
             navigation: navigationConfig,
+            root: writeShape.config.root,
             logo,
             logoV2,
             logoHeight: writeShape.config.logoHeight,

--- a/packages/fdr-sdk/src/converters/read/convertDbDocsConfigToRead.ts
+++ b/packages/fdr-sdk/src/converters/read/convertDbDocsConfigToRead.ts
@@ -7,7 +7,8 @@ import { DEFAULT_DARK_MODE_ACCENT_PRIMARY, DEFAULT_LIGHT_MODE_ACCENT_PRIMARY } f
 
 export function convertDbDocsConfigToRead({ dbShape }: { dbShape: DocsV1Db.DocsDbConfig }): DocsV1Read.DocsConfig {
     return {
-        navigation: transformNavigationConfigToRead(dbShape.navigation),
+        navigation: dbShape.navigation != null ? transformNavigationConfigToRead(dbShape.navigation) : undefined,
+        root: dbShape.root,
         logoHeight: dbShape.logoHeight,
         logoHref: dbShape.logoHref,
         colorsV3: dbShape.colorsV3 ?? getColorsV3(dbShape),

--- a/packages/fdr-sdk/src/navigation/migrators/v1ToV2.ts
+++ b/packages/fdr-sdk/src/navigation/migrators/v1ToV2.ts
@@ -30,8 +30,8 @@ export class FernNavigationV1ToLatest {
             canonicalSlug: undefined,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
-            audience: undefined,
+            authed: node.authed,
+            audience: node.audience,
         };
 
         return latest;
@@ -98,10 +98,10 @@ export class FernNavigationV1ToLatest {
             canonicalSlug: undefined,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             id: FernNavigation.NodeId(node.id),
             pointsTo: node.pointsTo ? FernNavigation.Slug(node.pointsTo) : undefined,
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };
@@ -122,11 +122,11 @@ export class FernNavigationV1ToLatest {
             canonicalSlug,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             id: FernNavigation.NodeId(node.id),
             pageId: FernNavigation.PageId(node.pageId),
             noindex: node.noindex,
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };
@@ -161,10 +161,10 @@ export class FernNavigationV1ToLatest {
             canonicalSlug: undefined,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             id: FernNavigation.NodeId(node.id),
             pointsTo: node.pointsTo ? FernNavigation.Slug(node.pointsTo) : undefined,
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };
@@ -256,7 +256,7 @@ export class FernNavigationV1ToLatest {
             canonicalSlug: undefined,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             pointsTo: node.pointsTo ? FernNavigation.Slug(node.pointsTo) : undefined,
             default: node.default,
             productId: FernNavigation.ProductId(node.productId),
@@ -265,7 +265,7 @@ export class FernNavigationV1ToLatest {
                 versioned: (value) => this.versioned(value, [...parents, node]),
             }),
             subtitle: node.subtitle,
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };
@@ -317,10 +317,10 @@ export class FernNavigationV1ToLatest {
             canonicalSlug,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             pageId: FernNavigation.PageId(node.pageId),
             noindex: node.noindex,
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };
@@ -347,12 +347,12 @@ export class FernNavigationV1ToLatest {
             canonicalSlug,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             pointsTo: node.pointsTo ? FernNavigation.Slug(node.pointsTo) : undefined,
             collapsed: node.collapsed,
             overviewPageId,
             noindex: node.noindex,
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };
@@ -383,14 +383,14 @@ export class FernNavigationV1ToLatest {
             canonicalSlug,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             id: FernNavigation.NodeId(node.id),
             overviewPageId,
             noindex: node.noindex,
             apiDefinitionId: node.apiDefinitionId,
             availability: this.#availability(node.availability),
             pointsTo: node.pointsTo ? FernNavigation.Slug(node.pointsTo) : undefined,
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };
@@ -417,10 +417,10 @@ export class FernNavigationV1ToLatest {
             canonicalSlug,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             overviewPageId,
             noindex: node.noindex,
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };
@@ -438,9 +438,9 @@ export class FernNavigationV1ToLatest {
             canonicalSlug: undefined,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             year: node.year,
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };
@@ -458,9 +458,9 @@ export class FernNavigationV1ToLatest {
             canonicalSlug: undefined,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             month: node.month,
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };
@@ -482,11 +482,11 @@ export class FernNavigationV1ToLatest {
             canonicalSlug,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             date: node.date,
             pageId: FernNavigation.PageId(node.pageId),
             noindex: node.noindex,
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };
@@ -513,14 +513,14 @@ export class FernNavigationV1ToLatest {
             canonicalSlug,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             pointsTo: node.pointsTo ? FernNavigation.Slug(node.pointsTo) : undefined,
             playground: node.playground,
             overviewPageId,
             noindex: node.noindex,
             apiDefinitionId: node.apiDefinitionId,
             availability: this.#availability(node.availability),
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };
@@ -545,14 +545,14 @@ export class FernNavigationV1ToLatest {
             canonicalSlug,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             playground: node.playground,
             apiDefinitionId: node.apiDefinitionId,
             availability: this.#availability(node.availability),
             method: node.method,
             endpointId: node.endpointId,
             isResponseStream: node.isResponseStream,
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };
@@ -590,12 +590,12 @@ export class FernNavigationV1ToLatest {
             canonicalSlug,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             playground: node.playground,
             apiDefinitionId: node.apiDefinitionId,
             availability: this.#availability(node.availability),
             webSocketId: node.webSocketId,
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };
@@ -620,12 +620,12 @@ export class FernNavigationV1ToLatest {
             canonicalSlug,
             icon: node.icon,
             hidden: node.hidden,
-            authed: undefined,
+            authed: node.authed,
             apiDefinitionId: node.apiDefinitionId,
             availability: this.#availability(node.availability),
             method: node.method,
             webhookId: node.webhookId,
-            audience: undefined,
+            audience: node.audience,
         };
         return latest;
     };

--- a/packages/fdr-sdk/src/navigation/versions/v1/converters/ApiReferenceNavigationConverter.ts
+++ b/packages/fdr-sdk/src/navigation/versions/v1/converters/ApiReferenceNavigationConverter.ts
@@ -105,6 +105,8 @@ export class ApiReferenceNavigationConverter {
                 availability: undefined,
                 pointsTo,
                 playground: undefined,
+                authed: undefined,
+                audience: undefined,
             };
         });
     }
@@ -140,6 +142,8 @@ export class ApiReferenceNavigationConverter {
                 availability: FernNavigation.V1.convertAvailability(endpoint.availability),
                 isResponseStream: endpoint.response?.type.type === "stream",
                 playground: undefined,
+                authed: undefined,
+                audience: undefined,
             };
         });
     }
@@ -160,6 +164,8 @@ export class ApiReferenceNavigationConverter {
             apiDefinitionId: this.apiDefinitionId,
             availability: FernNavigation.V1.convertAvailability(webSocket.availability),
             playground: undefined,
+            authed: undefined,
+            audience: undefined,
         }));
     }
 
@@ -179,6 +185,8 @@ export class ApiReferenceNavigationConverter {
             method: webhook.method,
             apiDefinitionId: this.apiDefinitionId,
             availability: undefined,
+            authed: undefined,
+            audience: undefined,
         }));
     }
 
@@ -257,6 +265,8 @@ export class ApiReferenceNavigationConverter {
                     apiDefinitionId: this.apiDefinitionId,
                     pointsTo,
                     playground: undefined,
+                    authed: undefined,
+                    audience: undefined,
                 };
             });
             if (child != null) {
@@ -326,6 +336,8 @@ export class ApiReferenceNavigationConverter {
                                 slug: parentSlug.apply(page).get(),
                                 icon: page.icon,
                                 hidden: page.hidden,
+                                authed: undefined,
+                                audience: undefined,
                             };
                         }),
                     );
@@ -396,6 +408,8 @@ export class ApiReferenceNavigationConverter {
                             apiDefinitionId: this.apiDefinitionId,
                             pointsTo: FernNavigation.V1.followRedirects(convertedItems),
                             playground: undefined,
+                            authed: undefined,
+                            audience: undefined,
                         });
                     });
                 },

--- a/packages/fdr-sdk/src/navigation/versions/v1/converters/ChangelogConverter.ts
+++ b/packages/fdr-sdk/src/navigation/versions/v1/converters/ChangelogConverter.ts
@@ -51,6 +51,8 @@ export class ChangelogNavigationConverter {
                 icon: changelog.icon,
                 hidden: changelog.hidden,
                 children: this.convertYear(changelog.items, slug),
+                authed: undefined,
+                audience: undefined,
             };
         });
     }
@@ -87,6 +89,8 @@ export class ChangelogNavigationConverter {
                         icon: undefined,
                         hidden: undefined,
                         children: this.groupByMonth(entries, slug),
+                        authed: undefined,
+                        audience: undefined,
                     };
                 }),
             ),
@@ -117,6 +121,8 @@ export class ChangelogNavigationConverter {
                     icon: undefined,
                     hidden: undefined,
                     children: entries,
+                    authed: undefined,
+                    audience: undefined,
                 })),
             ),
             "month",
@@ -142,6 +148,8 @@ export class ChangelogNavigationConverter {
                 slug: parentSlug.append(date.format("YYYY/M/D")).get(),
                 icon: undefined,
                 hidden: undefined,
+                authed: undefined,
+                audience: undefined,
             };
         });
     }

--- a/packages/fdr-sdk/src/navigation/versions/v1/converters/NavigationConfigConverter.ts
+++ b/packages/fdr-sdk/src/navigation/versions/v1/converters/NavigationConfigConverter.ts
@@ -76,6 +76,8 @@ export class NavigationConfigConverter {
                 hidden: false,
                 icon: undefined,
                 pointsTo,
+                authed: undefined,
+                audience: undefined,
             };
 
             // tag all children of hidden nodes as hidden
@@ -116,6 +118,8 @@ export class NavigationConfigConverter {
                         availability: FernNavigation.V1.convertAvailability(version.availability),
                         pointsTo,
                         landingPage: child.landingPage,
+                        authed: undefined,
+                        audience: undefined,
                     };
                 });
             });
@@ -156,6 +160,8 @@ export class NavigationConfigConverter {
                                     hidden: tab.hidden,
                                     child,
                                     pointsTo,
+                                    authed: undefined,
+                                    audience: undefined,
                                 };
                             });
                         } else if (tab.type === "link") {
@@ -209,8 +215,12 @@ export class NavigationConfigConverter {
                         icon: unversioned.landingPage.icon,
                         hidden: unversioned.landingPage.hidden,
                         noindex: this.noindexMap[pageId],
+                        authed: undefined,
+                        audience: undefined,
                     };
                 }),
+                authed: undefined,
+                audience: undefined,
             };
         });
     }
@@ -265,6 +275,8 @@ export class NavigationConfigConverter {
                         icon: page.icon,
                         hidden: page.hidden,
                         noindex: this.noindexMap[pageId],
+                        authed: undefined,
+                        audience: undefined,
                     };
                 }),
             link: (link) =>
@@ -302,6 +314,8 @@ export class NavigationConfigConverter {
                         slug: slug.get(),
                         children,
                         pointsTo,
+                        authed: undefined,
+                        audience: undefined,
                     };
                 }),
             api: (apiSection) => {

--- a/packages/fdr-sdk/src/navigation/versions/v1/converters/toRootNode.ts
+++ b/packages/fdr-sdk/src/navigation/versions/v1/converters/toRootNode.ts
@@ -30,17 +30,47 @@ export function toRootNode(
             fullSlugMap[FernNavigation.V1.PageId(pageId)] = fullSlug;
         }
     });
-    return NavigationConfigConverter.convert(
-        response.definition.config.title,
-        response.definition.config.navigation,
-        fullSlugMap,
-        noindexMap,
-        hackReorderApis(response.definition.apis, response.baseUrl.domain),
-        response.baseUrl.basePath,
-        isLexicographicSortEnabled(response.baseUrl.domain),
-        disableEndpointPairs,
-        paginated,
-    );
+
+    if (response.definition.config.root) {
+        return response.definition.config.root;
+    } else if (response.definition.config.navigation) {
+        return NavigationConfigConverter.convert(
+            response.definition.config.title,
+            response.definition.config.navigation,
+            fullSlugMap,
+            noindexMap,
+            hackReorderApis(response.definition.apis, response.baseUrl.domain),
+            response.baseUrl.basePath,
+            isLexicographicSortEnabled(response.baseUrl.domain),
+            disableEndpointPairs,
+            paginated,
+        );
+    } else {
+        // eslint-disable-next-line no-console
+        console.error("No root node found");
+        return {
+            type: "root",
+            version: "v1",
+            child: {
+                type: "unversioned",
+                id: FernNavigation.V1.NodeId("root-unversioned"),
+                child: {
+                    type: "sidebarRoot",
+                    id: FernNavigation.V1.NodeId("root-sidebar"),
+                    children: [],
+                },
+                landingPage: undefined,
+            },
+            title: response.definition.config.title ?? "",
+            slug: FernNavigation.V1.Slug(""),
+            icon: undefined,
+            hidden: undefined,
+            authed: undefined,
+            audience: undefined,
+            id: FernNavigation.V1.NodeId("root"),
+            pointsTo: undefined,
+        };
+    }
 }
 
 function isLexicographicSortEnabled(domain: string): boolean {

--- a/servers/fdr/src/__test__/local/services/docs.test.ts
+++ b/servers/fdr/src/__test__/local/services/docs.test.ts
@@ -11,6 +11,7 @@ export const WRITE_DOCS_REGISTER_DEFINITION: DocsV1Write.DocsDefinition = {
             items: [],
             landingPage: undefined,
         },
+        root: undefined,
         typography: {
             headingsFont: {
                 name: "Syne",

--- a/servers/fdr/src/__test__/local/services/docsCache.test.ts
+++ b/servers/fdr/src/__test__/local/services/docsCache.test.ts
@@ -9,6 +9,7 @@ export const WRITE_DOCS_REGISTER_DEFINITION: DocsV1Write.DocsDefinition = {
             items: [],
             landingPage: undefined,
         },
+        root: undefined,
         title: undefined,
         defaultLanguage: undefined,
         announcement: undefined,

--- a/servers/fdr/src/__test__/local/services/snippets.test.ts
+++ b/servers/fdr/src/__test__/local/services/snippets.test.ts
@@ -117,6 +117,7 @@ it("get snippets", async () => {
                         },
                     ],
                 },
+                root: undefined,
                 typography: {
                     headingsFont: {
                         name: "Syne",
@@ -279,6 +280,7 @@ it("get Go snippets", async () => {
                     ],
                     landingPage: undefined,
                 },
+                root: undefined,
                 typography: {
                     headingsFont: {
                         name: "Syne",
@@ -438,6 +440,7 @@ it("get Ruby snippets", async () => {
                     ],
                     landingPage: undefined,
                 },
+                root: undefined,
                 typography: {
                     headingsFont: {
                         name: "Syne",

--- a/servers/fdr/src/__test__/local/services/snippetsByEndpointId.test.ts
+++ b/servers/fdr/src/__test__/local/services/snippetsByEndpointId.test.ts
@@ -111,6 +111,7 @@ it("Load snippets by endpoint id", async () => {
                         } satisfies DocsV1Write.NavigationItem,
                     ],
                 },
+                root: undefined,
                 title: undefined,
                 defaultLanguage: undefined,
                 announcement: undefined,

--- a/servers/fdr/src/__test__/unit-tests/generate-algolia-search-records/testGenerateAlgoliaSearchRecordsForDocs.test.ts
+++ b/servers/fdr/src/__test__/unit-tests/generate-algolia-search-records/testGenerateAlgoliaSearchRecordsForDocs.test.ts
@@ -86,6 +86,10 @@ describe("generateAlgoliaSearchRecordsForDocs", () => {
                 const navigationConfig = docsDefinition.config.navigation;
                 const generator = new AlgoliaSearchRecordGeneratorV2({ docsDefinition, apiDefinitionsById });
 
+                if (navigationConfig == null) {
+                    throw new Error("Navigation config is required for this test");
+                }
+
                 visitDbNavigationConfig(navigationConfig, {
                     versioned: (config) => {
                         config.versions.forEach((v) => {
@@ -150,6 +154,7 @@ describe("generateIndexSegmentsForDefinition", () => {
                             },
                         ],
                     },
+                    root: undefined,
                     title: undefined,
                     defaultLanguage: undefined,
                     announcement: undefined,

--- a/servers/fdr/src/api/generated/api/resources/docs/resources/v1/resources/db/types/DocsDbConfig.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/docs/resources/v1/resources/db/types/DocsDbConfig.d.ts
@@ -6,7 +6,8 @@ export interface DocsDbConfig {
     title: string | undefined;
     defaultLanguage: FernRegistry.docs.v1.commons.ProgrammingLanguage | undefined;
     announcement: FernRegistry.docs.v1.commons.AnnouncementConfig | undefined;
-    navigation: FernRegistry.docs.v1.db.NavigationConfig;
+    navigation: FernRegistry.docs.v1.db.NavigationConfig | undefined;
+    root: FernRegistry.navigation.v1.RootNode | undefined;
     navbarLinks: FernRegistry.docs.v1.commons.NavbarLink[] | undefined;
     footerLinks: FernRegistry.docs.v1.commons.FooterLink[] | undefined;
     logoHeight: FernRegistry.docs.v1.read.Height | undefined;

--- a/servers/fdr/src/api/generated/api/resources/docs/resources/v1/resources/read/types/DocsConfig.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/docs/resources/v1/resources/read/types/DocsConfig.d.ts
@@ -6,7 +6,8 @@ export interface DocsConfig {
     title: string | undefined;
     defaultLanguage: FernRegistry.docs.v1.commons.ProgrammingLanguage | undefined;
     announcement: FernRegistry.docs.v1.commons.AnnouncementConfig | undefined;
-    navigation: FernRegistry.docs.v1.read.NavigationConfig;
+    navigation: FernRegistry.docs.v1.read.NavigationConfig | undefined;
+    root: FernRegistry.navigation.v1.RootNode | undefined;
     navbarLinks: FernRegistry.docs.v1.commons.NavbarLink[] | undefined;
     footerLinks: FernRegistry.docs.v1.commons.FooterLink[] | undefined;
     logoHeight: FernRegistry.docs.v1.read.Height | undefined;

--- a/servers/fdr/src/api/generated/api/resources/docs/resources/v1/resources/write/types/DocsConfig.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/docs/resources/v1/resources/write/types/DocsConfig.d.ts
@@ -6,7 +6,8 @@ export interface DocsConfig {
     title: string | undefined;
     defaultLanguage: FernRegistry.docs.v1.commons.ProgrammingLanguage | undefined;
     announcement: FernRegistry.docs.v1.commons.AnnouncementConfig | undefined;
-    navigation: FernRegistry.docs.v1.write.NavigationConfig;
+    navigation: FernRegistry.docs.v1.write.NavigationConfig | undefined;
+    root: FernRegistry.navigation.v1.RootNode | undefined;
     navbarLinks: FernRegistry.docs.v1.commons.NavbarLink[] | undefined;
     footerLinks: FernRegistry.docs.v1.commons.FooterLink[] | undefined;
     logoHeight: FernRegistry.docs.v1.write.Height | undefined;

--- a/servers/fdr/src/api/generated/api/resources/navigation/resources/v1/types/WithNodeMetadata.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/navigation/resources/v1/types/WithNodeMetadata.d.ts
@@ -7,4 +7,6 @@ export interface WithNodeMetadata extends FernRegistry.navigation.v1.WithNodeId 
     slug: FernRegistry.navigation.v1.Slug;
     icon: string | undefined;
     hidden: boolean | undefined;
+    authed: boolean | undefined;
+    audience: FernRegistry.AudienceId[] | undefined;
 }

--- a/servers/fdr/src/controllers/docs/v1/getDocsReadService.ts
+++ b/servers/fdr/src/controllers/docs/v1/getDocsReadService.ts
@@ -211,7 +211,7 @@ function getSearchInfoFromDocs({
     docsDbDefinition: DocsV1Db.DocsDefinitionDb;
     app: FdrApplication;
 }): Algolia.SearchInfo {
-    if (indexSegmentIds == null) {
+    if (indexSegmentIds == null || docsDbDefinition.config.navigation == null) {
         return { type: "legacyMultiAlgoliaIndex", algoliaIndex };
     }
     return visitDbNavigationConfig<Algolia.SearchInfo>(docsDbDefinition.config.navigation, {

--- a/servers/fdr/src/healthchecks/checkRedis.ts
+++ b/servers/fdr/src/healthchecks/checkRedis.ts
@@ -20,6 +20,7 @@ const HEALTHCHECK_DOCS_RESPONSE: CachedDocsResponse = {
                     items: [],
                     landingPage: undefined,
                 },
+                root: undefined,
                 title: undefined,
                 defaultLanguage: undefined,
                 announcement: undefined,

--- a/servers/fdr/src/services/algolia-index-segment-manager/AlgoliaIndexSegmentManagerService.ts
+++ b/servers/fdr/src/services/algolia-index-segment-manager/AlgoliaIndexSegmentManagerService.ts
@@ -64,6 +64,14 @@ export class AlgoliaIndexSegmentManagerServiceImpl implements AlgoliaIndexSegmen
     }): GenerateNewIndexSegmentsResult {
         const navigationConfig = dbDocsDefinition.config.navigation;
 
+        // TODO: handle root
+        if (navigationConfig == null) {
+            return {
+                type: "versioned",
+                configSegmentTuples: [],
+            };
+        }
+
         return visitDbNavigationConfig<GenerateNewIndexSegmentsResult>(navigationConfig, {
             versioned: (config) => {
                 const configSegmentTuples = config.versions.map((v) => {


### PR DESCRIPTION
This PR updates the v1 registry endpoint to accept NavigationV1 types, and plumbs through authed + audiences on those types.