### PR TITLE
fix: make sure endpoints are cached in nextjs route on register

### DIFF
--- a/servers/fdr/src/__test__/mock.ts
+++ b/servers/fdr/src/__test__/mock.ts
@@ -25,7 +25,7 @@ export class MockAlgoliaService implements AlgoliaService {
 
     async generateSearchRecords(_: {
         docsDefinition: DocsV1Db.DocsDefinitionDb;
-        apiDefinitionsById: Map<string, APIV1Db.DbApiDefinition>;
+        apiDefinitionsById: Record<string, APIV1Db.DbApiDefinition>;
         configSegmentTuples: ConfigSegmentTuple[];
     }): Promise<AlgoliaSearchRecord[]> {
         return [];

--- a/servers/fdr/src/__test__/unit-tests/generate-algolia-search-records/testGenerateAlgoliaSearchRecordsForDocs.test.ts
+++ b/servers/fdr/src/__test__/unit-tests/generate-algolia-search-records/testGenerateAlgoliaSearchRecordsForDocs.test.ts
@@ -78,7 +78,7 @@ describe("generateAlgoliaSearchRecordsForDocs", () => {
                         return [id, convertAPIDefinitionToDb(apiDef, id, EMPTY_SNIPPET_HOLDER)] as const;
                     });
 
-                    return new Map(apiIdDefinitionTuples);
+                    return Object.fromEntries(apiIdDefinitionTuples);
                 };
 
                 const apiDefinitionsById = preloadApiDefinitions();

--- a/servers/fdr/src/services/algolia/AlgoliaSearchRecordGenerator.ts
+++ b/servers/fdr/src/services/algolia/AlgoliaSearchRecordGenerator.ts
@@ -22,7 +22,7 @@ import type { AlgoliaSearchRecord, IndexSegment } from "./types";
 
 interface AlgoliaSearchRecordGeneratorConfig {
     docsDefinition: DocsV1Db.DocsDefinitionDb;
-    apiDefinitionsById: Map<string, APIV1Db.DbApiDefinition>;
+    apiDefinitionsById: Record<string, APIV1Db.DbApiDefinition>;
 }
 
 export class AlgoliaSearchRecordGenerator {
@@ -140,7 +140,7 @@ export class AlgoliaSearchRecordGenerator {
             const records: AlgoliaSearchRecord[] = [];
             const api = item;
             const apiId = api.api;
-            const apiDef = this.config.apiDefinitionsById.get(apiId);
+            const apiDef = this.config.apiDefinitionsById[apiId];
             if (apiDef != null) {
                 records.push(
                     ...this.generateAlgoliaSearchRecordsForApiDefinition(
@@ -232,7 +232,7 @@ export class AlgoliaSearchRecordGenerator {
         root: FernNavigation.V1.ApiReferenceNode,
         context: NavigationContext,
     ): AlgoliaSearchRecord[] {
-        const api = this.config.apiDefinitionsById.get(root.apiDefinitionId);
+        const api = this.config.apiDefinitionsById[root.apiDefinitionId];
         if (api == null) {
             LOGGER.error("Failed to find API definition for API reference node. id=", root.apiDefinitionId);
         }

--- a/servers/fdr/src/services/algolia/AlgoliaSearchRecordGeneratorV2.ts
+++ b/servers/fdr/src/services/algolia/AlgoliaSearchRecordGeneratorV2.ts
@@ -54,7 +54,7 @@ export class AlgoliaSearchRecordGeneratorV2 extends AlgoliaSearchRecordGenerator
         const records: AlgoliaSearchRecord[] = [];
         const api = item;
         const apiId = api.api;
-        const apiDef = this.config.apiDefinitionsById.get(apiId);
+        const apiDef = this.config.apiDefinitionsById[apiId];
         if (apiDef != null) {
             records.push(
                 ...this.generateAlgoliaSearchRecordsForApiDefinition(
@@ -444,7 +444,7 @@ export class AlgoliaSearchRecordGeneratorV2 extends AlgoliaSearchRecordGenerator
         root: FernNavigation.V1.ApiReferenceNode,
         context: NavigationContext,
     ): AlgoliaSearchRecord[] {
-        const api = this.config.apiDefinitionsById.get(root.apiDefinitionId);
+        const api = this.config.apiDefinitionsById[root.apiDefinitionId];
         if (api == null) {
             LOGGER.error("Failed to find API definition for API reference node. id=", root.apiDefinitionId);
         }

--- a/servers/fdr/src/services/algolia/AlgoliaService.ts
+++ b/servers/fdr/src/services/algolia/AlgoliaService.ts
@@ -11,7 +11,7 @@ export interface AlgoliaService {
     generateSearchRecords(params: {
         url: string;
         docsDefinition: DocsV1Db.DocsDefinitionDb;
-        apiDefinitionsById: Map<string, APIV1Db.DbApiDefinition>;
+        apiDefinitionsById: Record<string, APIV1Db.DbApiDefinition>;
         configSegmentTuples: ConfigSegmentTuple[];
     }): Promise<AlgoliaSearchRecord[]>;
 
@@ -48,7 +48,7 @@ export class AlgoliaServiceImpl implements AlgoliaService {
     }: {
         url: string;
         docsDefinition: DocsV1Db.DocsDefinitionDb;
-        apiDefinitionsById: Map<string, APIV1Db.DbApiDefinition>;
+        apiDefinitionsById: Record<string, APIV1Db.DbApiDefinition>;
         configSegmentTuples: ConfigSegmentTuple[];
     }) {
         return configSegmentTuples.flatMap(([config, indexSegment]) => {


### PR DESCRIPTION
## Short description of the changes made
Cache endpoints in the `fern-docs/api-definition` route. 

## What was the motivation & context behind this PR?
Make loading playground faster.

## How has this PR been tested?
Will test on dev
