### PR TITLE
fix: sdk generation for fiddle not working

### DIFF
--- a/fern/apis/fdr/generators.yml
+++ b/fern/apis/fdr/generators.yml
@@ -157,7 +157,7 @@ groups:
       - fiddle
     generators:
       - name: fernapi/fern-java-sdk
-        version: 0.10.1
+        version: 0.10.0
         output:
           location: maven
           url: maven.buildwithfern.com

--- a/packages/ui/fern-dashboard/src/lib/utils.ts
+++ b/packages/ui/fern-dashboard/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/packages/ui/fern-dashboard/src/lib/utils.ts
+++ b/packages/ui/fern-dashboard/src/lib/utils.ts
@@ -1,6 +1,0 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}


### PR DESCRIPTION
This PR fixes the failing CI for the fiddle SDK generation. 