### PR TITLE
fix: rewrite 404 in middleware

### DIFF
--- a/packages/ui/app/src/analytics/posthog.ts
+++ b/packages/ui/app/src/analytics/posthog.ts
@@ -54,6 +54,9 @@ function ifCustomer(posthog: PostHog, run: (hog: PostHogWithCustomer) => void): 
 
 export async function initializePosthog(api_host: string, customerConfig?: DocsV1Read.PostHogConfig): Promise<void> {
     const apiKey = process.env.NEXT_PUBLIC_POSTHOG_API_KEY?.trim() ?? "";
+    /**
+     * TODO: refactor this to use the posthog react provider
+     */
     const posthog = (await import("posthog-js")).default;
 
     if (posthog.__loaded) {

--- a/packages/ui/app/src/index.ts
+++ b/packages/ui/app/src/index.ts
@@ -1,3 +1,4 @@
+export { capturePosthogEvent } from "./analytics/posthog";
 export { type CustomerAnalytics } from "./analytics/types";
 export type { DocsProps } from "./atoms";
 export * from "./docs/DocsPage";

--- a/packages/ui/docs-bundle/src/pages/404.tsx
+++ b/packages/ui/docs-bundle/src/pages/404.tsx
@@ -1,10 +1,15 @@
 import Error from "next/error";
-import { ReactElement } from "react";
+import { ReactElement, useEffect } from "react";
+import { capturePosthogEvent } from "../../../app/src/analytics/posthog";
 
 /**
  * This is required for Next.js to generate `_next/static/chunks/pages/404.js`
  * Which helps prevent a client-side error to be thrown when navigating to a non-existent page
  */
 export default function Page(): ReactElement {
+    useEffect(() => {
+        capturePosthogEvent("not_found");
+    });
+
     return <Error statusCode={404} />;
 }

--- a/packages/ui/docs-bundle/src/pages/404.tsx
+++ b/packages/ui/docs-bundle/src/pages/404.tsx
@@ -1,6 +1,6 @@
+import { capturePosthogEvent } from "@fern-ui/ui";
 import Error from "next/error";
 import { ReactElement, useEffect } from "react";
-import { capturePosthogEvent } from "../../../app/src/analytics/posthog";
 
 /**
  * This is required for Next.js to generate `_next/static/chunks/pages/404.js`

--- a/packages/ui/docs-bundle/src/server/extractNextDataPathname.ts
+++ b/packages/ui/docs-bundle/src/server/extractNextDataPathname.ts
@@ -7,6 +7,12 @@
  * In both cases, we want to extract `/learn/home`
  */
 export function extractNextDataPathname(pathname: string): string {
+    if (pathname.includes("/404.json")) {
+        return "/404";
+    } else if (pathname.includes("/_error.json")) {
+        return "/_error";
+    }
+
     return (
         removeIndex(
             pathname.match(/\/_next\/data\/.*\/_next\/data\/[^/]*(\/.*)\.json.json/)?.[1] ??


### PR DESCRIPTION
Addendum to https://github.com/fern-api/fern-platform/pull/1663 fix, which doesn't work because the middleware is not correctly matching and rewriting on /404.json when the project contains an additional basepath.