### PR TITLE
chore(docs): error text align

### DIFF
--- a/packages/ui/app/src/api-reference/endpoints/EndpointError.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointError.tsx
@@ -57,7 +57,7 @@ export const EndpointError = memo<EndpointError.Props>(function EndpointErrorUnm
         >
             <div className="flex items-baseline space-x-2">
                 <div className="rounded-lg bg-tag-danger px-2 py-1 text-xs text-intent-danger">{error.statusCode}</div>
-                <div className="t-muted text-xs">{error.name}</div>
+                <div className="t-muted text-xs text-left">{error.name}</div>
                 {availability != null && <EndpointAvailabilityTag availability={availability} minimal={true} />}
             </div>
 


### PR DESCRIPTION
This PR aligns the error description to the left to avoid the centering bug reported by @abvthecity 


![Screenshot 2024-10-16 at 9 32 43 AM](https://github.com/user-attachments/assets/ad72488c-7eec-4458-9f7d-895657463f86)
