### PR TITLE
chore(docs): changelog mobile friendly

### DIFF
--- a/packages/ui/app/src/changelog/index.scss
+++ b/packages/ui/app/src/changelog/index.scss
@@ -3,7 +3,7 @@
         @apply flex justify-between px-4 md:px-6 lg:px-8;
 
         > main {
-            @apply mx-auto max-w-screen-lg break-words;
+            @apply mx-auto max-w-screen-lg w-full break-words;
         }
     }
 


### PR DESCRIPTION
This is a styling fix to make the changelog mobile-friendly 


![Screenshot 2024-10-16 at 9 49 28 AM](https://github.com/user-attachments/assets/40facb6c-01ad-4ac4-9610-02085dc4882c)

![Screenshot 2024-10-16 at 9 48 13 AM](https://github.com/user-attachments/assets/13e800ef-06d6-4291-bf17-b875e9c29ace)
