### PR TITLE
chore(docs): update mobile playground header

### DIFF
--- a/packages/ui/app/src/playground/PlaygroundDrawer.tsx
+++ b/packages/ui/app/src/playground/PlaygroundDrawer.tsx
@@ -88,7 +88,7 @@ export const PlaygroundDrawer = memo((): ReactElement | null => {
     const setFormState = useSetAtom(usePlaygroundFormStateAtom(selectionState?.id ?? NodeId("")));
 
     const renderMobileHeader = () => (
-        <div className="grid h-10 grid-cols-2 gap-2 px-4">
+        <div className="flex w-full justify-between h-10 px-4">
             <div className="flex items-center">
                 <span className="inline-flex items-center gap-2 text-sm font-semibold">
                     <span className="t-accent">API Playground</span>


### PR DESCRIPTION
This PR updates the API Playground header styling for mobile. 

Before: 
![Screenshot 2024-10-16 at 10 22 01 AM](https://github.com/user-attachments/assets/706e96ae-9381-4f14-94f8-bfabc76a2792)

(Ignore the error - this is due to the testing environment and is not related to the styling)
After:
![Screenshot 2024-10-16 at 10 22 50 AM](https://github.com/user-attachments/assets/7554e789-4494-4670-b07c-759e42cd8d15)
