### PR TITLE
chore: template resolver compiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
           WORKOS_API_KEY: ${{ secrets.WORKOS_API_KEY }}
           WORKOS_CLIENT_ID: ${{ secrets.WORKOS_CLIENT_ID }}
 
+      - name: Compile Template Resolver
+        run: pnpm --filter=@fern-api/template-resolver compile:cjs
+
       - name: Check dependencies
         run: pnpm depcheck
 

--- a/packages/template-resolver/src/ResolutionUtilities.ts
+++ b/packages/template-resolver/src/ResolutionUtilities.ts
@@ -1,4 +1,4 @@
-import { APIV1Read } from "@fern-api/fdr-sdk/client/types";
+import { APIV1Read } from "@fern-api/fdr-sdk";
 
 export class ObjectFlattener {
     private flattenedObjects: Map<APIV1Read.TypeId, APIV1Read.ObjectProperty[]> = new Map<

--- a/packages/template-resolver/src/SnippetTemplateResolver.ts
+++ b/packages/template-resolver/src/SnippetTemplateResolver.ts
@@ -1,5 +1,5 @@
 import type { FdrClient } from "@fern-api/fdr-sdk";
-import { APIV1Read, FdrAPI } from "@fern-api/fdr-sdk/client/types";
+import { APIV1Read, FdrAPI } from "@fern-api/fdr-sdk";
 import { ObjectFlattener } from "./ResolutionUtilities";
 import { UnionMatcher } from "./UnionResolver";
 import { accessByPathNonNull } from "./accessByPath";

--- a/packages/template-resolver/src/UnionResolver.ts
+++ b/packages/template-resolver/src/UnionResolver.ts
@@ -1,4 +1,4 @@
-import type { APIV1Read, FdrAPI } from "@fern-api/fdr-sdk/client/types";
+import type { APIV1Read, FdrAPI } from "@fern-api/fdr-sdk";
 import { ObjectFlattener } from "./ResolutionUtilities";
 import { accessByPathNonNull } from "./accessByPath";
 import { isPlainObject } from "./isPlainObject";

--- a/packages/template-resolver/src/__test__/unit-tests/assets/imdbApiDefinition.ts
+++ b/packages/template-resolver/src/__test__/unit-tests/assets/imdbApiDefinition.ts
@@ -1,4 +1,4 @@
-import { APIV1Read, FdrAPI } from "@fern-api/fdr-sdk/client/types";
+import { APIV1Read, FdrAPI } from "@fern-api/fdr-sdk";
 
 export const IMDB_API_DEFINITION: APIV1Read.ApiDefinition = {
     id: FdrAPI.ApiDefinitionId("api_imdb"),


### PR DESCRIPTION
## Short description of the changes made
Template resolver is used for our Snippets SDK and was failing to compile

## What was the motivation & context behind this PR?
This adds compile checking to CI + fixes bugs

## How has this PR been tested?
Compile step added to CI/Cd
