### PR TITLE
fix: take last 25 websocket records

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "packageManager": "pnpm@9.4.0",
   "engines": {
     "node": ">=18.18.0",
-    "pnpm": "9.4.0"
+    "pnpm": "^9.4.0"
   },
   "nextBundleAnalysis": {
     "buildOutputDirectory": "packages/ui/docs-bundle/.next",

--- a/packages/ui/app/src/playground/PlaygroundDrawer.tsx
+++ b/packages/ui/app/src/playground/PlaygroundDrawer.tsx
@@ -88,7 +88,7 @@ export const PlaygroundDrawer = memo((): ReactElement | null => {
     const setFormState = useSetAtom(usePlaygroundFormStateAtom(selectionState?.id ?? NodeId("")));
 
     const renderMobileHeader = () => (
-        <div className="grid h-10 grid-cols-2 gap-2 px-4">
+        <div className="flex w-full justify-between h-10 px-4">
             <div className="flex items-center">
                 <span className="inline-flex items-center gap-2 text-sm font-semibold">
                     <span className="t-accent">API Playground</span>

--- a/packages/ui/app/src/playground/PlaygroundWebSocketSessionForm.tsx
+++ b/packages/ui/app/src/playground/PlaygroundWebSocketSessionForm.tsx
@@ -130,7 +130,8 @@ export const PlaygroundWebSocketSessionForm: FC<PlaygroundWebSocketSessionFormPr
                         </div>
                     </div>
                     <FernScrollArea rootClassName="flex-1 rounded-b-[inherit]">
-                        <WebSocketMessages messages={messages} />
+                        {/* TODO(rohin): Implement Pagination here */}
+                        <WebSocketMessages messages={messages.slice(-25)} />
                     </FernScrollArea>
                 </FernCard>
             </div>


### PR DESCRIPTION
## Short description of the changes made

- Takes only last 25 websocket records when showing messages.
- This is a temporary measure until proper pagination can be added.
- Furthermore, rendering of messages can be made much better since there are a lot of components being re-rendered.

## What was the motivation & context behind this PR?

- Customer performance issue

## How has this PR been tested?


https://github.com/user-attachments/assets/34f2f23e-e9f8-4c25-a4bb-afa4c427d981


