### PR TITLE
fix(snippets): actually return api definition ids

### DIFF
--- a/servers/fdr/src/db/snippets/SnippetTemplate.ts
+++ b/servers/fdr/src/db/snippets/SnippetTemplate.ts
@@ -177,7 +177,7 @@ export class SnippetTemplateDaoImpl implements SnippetTemplateDao {
             return null;
         }
         return {
-            apiDefinitionId: undefined,
+            apiDefinitionId: FdrAPI.ApiDefinitionId(snippetTemplate.apiDefinitionId),
             additionalTemplates: undefined,
             endpointId: {
                 path: FdrAPI.EndpointPathLiteral(snippetTemplate.endpointPath),


### PR DESCRIPTION
Setting `undefined` for a property that should not be set 