### PR TITLE
bump generator cli python generator version

### DIFF
--- a/fern/apis/generator-cli/generators.yml
+++ b/fern/apis/generator-cli/generators.yml
@@ -26,7 +26,7 @@ groups:
           useBrandedStringAliases: true
 
       - name: fernapi/fern-python-sdk
-        version: 2.9.9
+        version: 4.2.8
         output:
           location: pypi
           url: pypi.buildwithfern.com


### PR DESCRIPTION
This brings the generator CLI Python SDK to a version that is Pydantic  v2 compatible