### PR TITLE
fix: globally increase prisma timeout to 15s

### DIFF
--- a/servers/fdr/src/__test__/local/setupMockFdr.ts
+++ b/servers/fdr/src/__test__/local/setupMockFdr.ts
@@ -54,6 +54,10 @@ export async function setup({ provide }: { provide: (key: string, value: any) =>
 
 export const prisma = new PrismaClient({
     log: ["query", "info", "warn", "error"],
+    transactionOptions: {
+        timeout: 15000,
+        maxWait: 15000,
+    },
 });
 
 function sleep(ms: number) {

--- a/servers/fdr/src/app/FdrApplication.ts
+++ b/servers/fdr/src/app/FdrApplication.ts
@@ -63,6 +63,10 @@ export class FdrApplication {
         });
         const prisma = new PrismaClient({
             log: ["info", "warn", "error"],
+            transactionOptions: {
+                timeout: 15000,
+                maxWait: 15000,
+            },
         });
 
         this.services = {


### PR DESCRIPTION
## Short description of the changes made

- increases global timeout on prisma to 15s

## What was the motivation & context behind this PR?

- prisma timeouts for large docs generation

## How has this PR been tested?

- to be tested with fdr
