### PR TITLE
fix(docs): force-toc fixes

### DIFF
--- a/packages/ui/app/src/mdx/components/accordion/AccordionGroup.tsx
+++ b/packages/ui/app/src/mdx/components/accordion/AccordionGroup.tsx
@@ -8,8 +8,14 @@ import { ANCHOR_ATOM } from "../../../atoms";
 export interface AccordionItemProps {
     title: string;
     id: string;
-    toc?: boolean;
+    toc?: TocObject;
     children: ReactNode;
+}
+
+interface TocObject {
+    type: string;
+    value: string;
+    data: object;
 }
 
 export interface AccordionGroupProps {

--- a/packages/ui/app/src/mdx/plugins/makeToc.ts
+++ b/packages/ui/app/src/mdx/plugins/makeToc.ts
@@ -113,7 +113,6 @@ export function makeToc(tree: Root, isTocDefaultEnabled = false): TableOfContent
                 const items = JSON.parse(itemsAttr.value.value) as AccordionItemProps[];
                 items.forEach((item) => {
                     const isTocEnabled = getBooleanValue(item.toc?.value) ?? isParentTocEnabled;
-                    console.log(isTocEnabled);
                     if (item.title.trim().length === 0 || !isTocEnabled) {
                         return;
                     }

--- a/packages/ui/app/src/mdx/plugins/makeToc.ts
+++ b/packages/ui/app/src/mdx/plugins/makeToc.ts
@@ -20,7 +20,7 @@ export function makeToc(tree: Root, isTocDefaultEnabled = false): TableOfContent
 
     const visitor: Visitor = (node) => {
         // if the node is a <Steps toc={false}>, skip traversing its children
-        if (isMdxJsxFlowElement(node) && node.name === "Steps") {
+        if (isMdxJsxFlowElement(node) && node.name === "StepGroup") {
             const isTocEnabled =
                 getBooleanValue(
                     node.attributes.find((attr) => isMdxJsxAttribute(attr) && attr.name === "toc")?.value,
@@ -87,7 +87,7 @@ export function makeToc(tree: Root, isTocDefaultEnabled = false): TableOfContent
             try {
                 const items = JSON.parse(itemsAttr.value.value) as AccordionItemProps[];
                 items.forEach((item) => {
-                    const isTocEnabled = item.toc ?? isParentTocEnabled;
+                    const isTocEnabled = getBooleanValue(item.toc?.value) ?? isParentTocEnabled;
                     if (item.title.trim().length === 0 || !isTocEnabled) {
                         return;
                     }
@@ -112,7 +112,8 @@ export function makeToc(tree: Root, isTocDefaultEnabled = false): TableOfContent
             try {
                 const items = JSON.parse(itemsAttr.value.value) as AccordionItemProps[];
                 items.forEach((item) => {
-                    const isTocEnabled = item.toc ?? isParentTocEnabled;
+                    const isTocEnabled = getBooleanValue(item.toc?.value) ?? isParentTocEnabled;
+                    console.log(isTocEnabled);
                     if (item.title.trim().length === 0 || !isTocEnabled) {
                         return;
                     }


### PR DESCRIPTION
This PR fixes the `force-toc` functionality for `<Steps>` as well as `toc={false}` for `<Accordion>`

![Screenshot 2024-10-22 at 9 54 46 AM](https://github.com/user-attachments/assets/1e2a41c9-73b0-4160-bec8-053a6c933b6b)
