### PR TITLE
fix: reduce aggressive mdx sanitization

### DIFF
--- a/packages/ui/app/src/components/FernErrorBoundary.tsx
+++ b/packages/ui/app/src/components/FernErrorBoundary.tsx
@@ -39,23 +39,23 @@ export function FernErrorTag({
 }): ReactElement | null {
     const isLocalPreview = useIsLocalPreview();
     useEffect(() => {
-        // TODO: sentry
-        // eslint-disable-next-line no-console
-        console.error(
-            errorDescription ??
-                "An unknown UI error occurred. This could be a critical user-facing error that should be investigated.",
-            error,
-        );
+        if (error) {
+            // TODO: sentry
+            // eslint-disable-next-line no-console
+            console.error(
+                errorDescription ??
+                    "An unknown UI error occurred. This could be a critical user-facing error that should be investigated.",
+                error,
+            );
+        }
     }, [component, error, errorDescription]);
 
+    if (fallback != null) {
+        return <>{fallback}</>;
+    }
+
     // if local preview, always show the error tag for markdown errors
-    const showMarkdownError = isLocalPreview && component === "MdxErrorBoundary";
-
-    if (showError || showMarkdownError) {
-        if (fallback != null) {
-            return <>{fallback}</>;
-        }
-
+    if (showError || isLocalPreview) {
         return (
             <div className={clsx(className ?? "my-4")}>
                 <span className="t-danger inline-flex items-center gap-2 rounded-full bg-tag-danger px-2">

--- a/packages/ui/app/src/mdx/bundlers/mdx-bundler.ts
+++ b/packages/ui/app/src/mdx/bundlers/mdx-bundler.ts
@@ -133,7 +133,7 @@ export async function serializeMdx(
         }
 
         // TODO: this is doing duplicate work; figure out how to combine it with the compiler above.
-        const { jsxElements } = toTree(content);
+        const { jsxElements } = toTree(content, { sanitize: false });
 
         return {
             engine: "mdx-bundler",

--- a/packages/ui/app/src/mdx/bundlers/next-mdx-remote.ts
+++ b/packages/ui/app/src/mdx/bundlers/next-mdx-remote.ts
@@ -111,7 +111,7 @@ export async function serializeMdx(
         });
 
         // TODO: this is doing duplicate work; figure out how to combine it with the compiler above.
-        const { jsxElements } = toTree(content);
+        const { jsxElements } = toTree(content, { sanitize: false });
 
         return {
             engine: "next-mdx-remote",

--- a/packages/ui/app/src/mdx/components/index.tsx
+++ b/packages/ui/app/src/mdx/components/index.tsx
@@ -2,7 +2,7 @@ import { RemoteFontAwesomeIcon } from "@fern-ui/components";
 import type { MDXComponents } from "mdx/types";
 import dynamic from "next/dynamic";
 import { ComponentProps, PropsWithChildren, ReactElement } from "react";
-import { FernErrorBoundaryProps, FernErrorTag } from "../../components/FernErrorBoundary";
+import { FernErrorBoundary, FernErrorBoundaryProps, FernErrorTag } from "../../components/FernErrorBoundary";
 import { AccordionGroup } from "./accordion";
 import { Audience } from "./audience";
 import { Availability } from "./availability";
@@ -87,8 +87,8 @@ const INTERNAL_COMPONENTS = {
     ReferenceLayoutAside,
 
     // error boundary
-    MdxErrorBoundary: (props: PropsWithChildren<Pick<FernErrorBoundaryProps, "error" | "fallback">>): ReactElement => (
-        <FernErrorTag component="MdxErrorBoundary" {...props} />
+    FernErrorBoundary: (props: PropsWithChildren<Pick<FernErrorBoundaryProps, "error" | "fallback">>): ReactElement => (
+        <FernErrorBoundary {...props} />
     ),
 };
 

--- a/packages/ui/fern-docs-mdx/src/__test__/__snapshots__/landing-page.mdx
+++ b/packages/ui/fern-docs-mdx/src/__test__/__snapshots__/landing-page.mdx
@@ -1,0 +1,208 @@
+<style>
+  {`
+
+    /*Custom Styles*/
+    .rm-Header {
+      position: sticky;
+      top: 0;
+      --Header-background: none;
+    }
+
+    #enterprise .container {
+      margin-bottom: 0;
+    }
+    .rm-Flyout {
+      background: #fbfbfb;
+    }
+
+  `}
+</style>
+
+export const LandingPageCard = ({ href, title, imgSrc, description }) => (
+  <div className="rounded-lg bg-[#F5F4F2] dark:bg-[#0F0F0F] px-6 py-5 hover:bg-[#E9E6DE] dark:hover:bg-[#292929] md:p-8">
+    <a href={href} target="_self" className="flex h-full flex-col justify-between">
+      <div className="mb-5 flex flex-col justify-between gap-5">
+        <h2 className="lg:min-h-20 [@media(min-width:1181px)]:min-h-0">{title}</h2>
+        <img src={imgSrc} alt={title} />
+        <p className="p-lg">{description}</p>
+      </div>
+      <div className="mt-2 text-sm text-[#2D4CB9] dark:text-[#4C6EE6] md:mt-0 md:self-end">
+        {"GET STARTED"}
+        <div className="ml-2 inline-block group-hover:no-underline">
+          <svg
+            width="12"
+            height="11"
+            viewBox="0 0 12 11"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{ transform: "rotate(-90deg)" }}
+          >
+            <path
+              d="M6 10.75L0.75 5.31686L1.74907 4.27907L5.2556 8.00291L5.2556 0.25L6.7444 0.25L6.7444 8.00291L10.2509 4.27907L11.25 5.31686L6 10.75Z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </div>
+      </div>
+    </a>
+  </div>
+);
+
+export const EndpointLink = ({ href, title }) => (
+  <a
+    href={href}
+    className="group flex cursor-pointer flex-row text-sm !font-normal text-[#2D4CB9] dark:text-[#4C6EE6]"
+    rel="noreferrer"
+    target="_self"
+  >
+    {title}
+    <span className="duration-400 flex items-center transition-all ease-in-out group-hover:pl-1 group-hover:pr-2">
+      <div className="ml-2 inline-block text-sm !text-[#2D4CB9] group-hover:no-underline">
+        <svg
+          width="12"
+          height="11"
+          viewBox="0 0 12 11"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          style={{ transform: "rotate(-90deg)" }}
+        >
+          <path
+            d="M6 10.75L0.75 5.31686L1.74907 4.27907L5.2556 8.00291L5.2556 0.25L6.7444 0.25L6.7444 8.00291L10.2509 4.27907L11.25 5.31686L6 10.75Z"
+            fill="currentColor"
+          ></path>
+        </svg>
+      </div>
+    </span>
+  </a>
+);
+
+export const cards = [
+  {
+    href: "/docs",
+    imgSrc: "https://fern-image-hosting.s3.amazonaws.com/cohere/8da77c9-Frame_138972.png",
+    title: "Guides and concepts",
+    description: "Understand how to use our API on a deeper level. Train and customize the model to work for you.",
+  },
+  {
+    href: "/reference/about",
+    imgSrc: "https://fern-image-hosting.s3.amazonaws.com/cohere/8ff146a-Group_138977.png",
+    title: "API reference",
+    description: "Integrate natural language processing and generation into your products with a few lines of code.",
+  },
+  {
+    href: "/release-notes",
+    imgSrc: "https://fern-image-hosting.s3.amazonaws.com/cohere/d51d176-Group_138977_1.png",
+    title: "Release notes",
+    description: "Keep up with the latest releases and platform updates from Cohere.",
+  },
+  {
+    href: "/page/cookbooks",
+    imgSrc: "https://fern-image-hosting.s3.amazonaws.com/cohere/7fca92c-Group_138977_2.png",
+    title: "Cookbooks",
+    description: "A collection of resources to help developers get up and running with Cohere.",
+  },
+];
+
+export const endpoints = [
+  {
+    href: "/reference/chat",
+    title: "/CHAT",
+  },
+  {
+    href: "/reference/embed",
+    title: "/EMBED",
+  },
+  {
+    href: "/reference/rerank",
+    title: "/RERANK",
+  },
+  {
+    href: "/reference/classify",
+    title: "/CLASSIFY",
+  },
+];
+
+<div className="m-auto max-w-[1195px] flex-grow overflow-y-auto px-8 pt-10 md:p-10 md:pb-14">
+  <div className="flex flex-col gap-5 md:!grid md:grid-cols-2 md:gap-10 md:pb-7 lg:!grid-cols-3 lg:gap-x-8 lg:gap-y-10 lg:pb-16">
+    {cards.map((card) => (
+          <LandingPageCard
+            key={card.href}
+            href={card.href}
+            imgSrc={card.imgSrc}
+            title={card.title}
+            description={card.description}
+          />
+        ))}
+
+    <div className="col-span-2">
+      <div className="mb-8 flex flex-col gap-9 px-6 py-5 md:!flex-row md:items-end md:gap-16 md:p-8 lg:gap-10">
+        <div className="md:w-1/2">
+          <h2 className="mb-8 mt-4 md:mt-0">
+            Endpoints
+          </h2>
+
+          <p className="p-lg w-full">
+            Our endpoints offer different ways to interact with our models and offer additional value on top of them
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-5 md:w-1/2 md:gap-10 lg:w-1/3 lg:gap-8">
+          {endpoints.map((endpoint) => (
+                      <EndpointLink key={endpoint.href} {...endpoint} />
+                    ))}
+        </div>
+      </div>
+
+      <div
+        className="group hidden rounded-lg bg-cover bg-no-repeat p-6 md:!block md:h-[190px] lg:h-[230px]"
+        style={{
+          backgroundImage: "url('https://fern-image-hosting.s3.amazonaws.com/cohere/55d9cde-InfoCards.png')",
+        }}
+      >
+        <a href="https://cohere.com/llmu" target="_blank" className="flex h-full w-full flex-col items-center justify-between !text-white md:!flex-row">
+          <div className="flex h-full w-[420px] flex-col items-start justify-between">
+            <div className="flex flex-row items-start">
+              <img src="https://fern-image-hosting.s3.amazonaws.com/cohere/9d0694c-Symbol.svg" alt="" className="h-7 w-7 lg:h-10 lg:w-10" />
+
+              <h2 className="!my-0 ml-5">
+                LLM University
+              </h2>
+            </div>
+
+            <p className="p-lg !text-white md:w-[260px] lg:w-[400px]">
+              Join our learning hub to master Enterprise AI with expert-led courses and step-by-step guides
+            </p>
+          </div>
+
+          <div className="flex h-full md:w-1/2">
+            <img src="https://fern-image-hosting.s3.amazonaws.com/cohere/64d7b4f-Group_138975.png" alt="" className="'duration-400 group-hover:pr-2' flex items-center object-contain transition-all ease-in-out group-hover:pl-1" />
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <div
+    className="block h-full w-full rounded-lg bg-cover bg-no-repeat p-6 md:hidden"
+    style={{
+      backgroundImage: "url('https://fern-image-hosting.s3.amazonaws.com/cohere/ddd53ed-Mask_group.png')",
+    }}
+  >
+    <a href="https://cohere.com/llmu" target="_blank" className="flex h-full w-full flex-col justify-between !text-white md:!flex-row">
+      <div className="flex h-full flex-col justify-between">
+        <div className="flex flex-row">
+          <img src="https://fern-image-hosting.s3.amazonaws.com/cohere/9d0694c-Symbol.svg" alt="" className="h-7 w-7 lg:h-10 lg:w-10" />
+
+          <h2 className="h3 mb-28 ml-5 mt-0">
+            LLM University
+          </h2>
+        </div>
+
+        <p className="p-lg !text-white">
+          New to NLP? Learn about Natural Language processing and Large Language Models through our structured
+          curriculum.
+        </p>
+      </div>
+    </a>
+  </div>
+</div>

--- a/packages/ui/fern-docs-mdx/src/__test__/fixtures/landing-page.mdx
+++ b/packages/ui/fern-docs-mdx/src/__test__/fixtures/landing-page.mdx
@@ -1,0 +1,220 @@
+---
+layout: custom
+no-image-zoom: true
+description: >-
+  Cohere's API documentation helps developers easily integrate natural language
+  processing and generation into their products.
+---
+
+<style>
+  {`
+
+  /*Custom Styles*/
+  .rm-Header {
+    position: sticky;
+    top: 0;
+    --Header-background: none;
+  }
+
+  #enterprise .container {
+    margin-bottom: 0;
+  }
+  .rm-Flyout {
+    background: #fbfbfb;
+  }
+
+`}
+</style>
+
+export const LandingPageCard = ({ href, title, imgSrc, description }) => (
+  <div className="rounded-lg bg-[#F5F4F2] dark:bg-[#0F0F0F] px-6 py-5 hover:bg-[#E9E6DE] dark:hover:bg-[#292929] md:p-8">
+    <a href={href} target="_self" className="flex h-full flex-col justify-between">
+      <div className="mb-5 flex flex-col justify-between gap-5">
+        <h2 className="lg:min-h-20 [@media(min-width:1181px)]:min-h-0">{title}</h2>
+        <img src={imgSrc} alt={title} />
+        <p className="p-lg">{description}</p>
+      </div>
+      <div className="mt-2 text-sm text-[#2D4CB9] dark:text-[#4C6EE6] md:mt-0 md:self-end">
+        {"GET STARTED"}
+        <div className="ml-2 inline-block group-hover:no-underline">
+          <svg
+            width="12"
+            height="11"
+            viewBox="0 0 12 11"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{ transform: "rotate(-90deg)" }}
+          >
+            <path
+              d="M6 10.75L0.75 5.31686L1.74907 4.27907L5.2556 8.00291L5.2556 0.25L6.7444 0.25L6.7444 8.00291L10.2509 4.27907L11.25 5.31686L6 10.75Z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </div>
+      </div>
+    </a>
+  </div>
+);
+
+export const EndpointLink = ({ href, title }) => (
+  <a
+    href={href}
+    className="group flex cursor-pointer flex-row text-sm !font-normal text-[#2D4CB9] dark:text-[#4C6EE6]"
+    rel="noreferrer"
+    target="_self"
+  >
+    {title}
+    <span className="duration-400 flex items-center transition-all ease-in-out group-hover:pl-1 group-hover:pr-2">
+      <div className="ml-2 inline-block text-sm !text-[#2D4CB9] group-hover:no-underline">
+        <svg
+          width="12"
+          height="11"
+          viewBox="0 0 12 11"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          style={{ transform: "rotate(-90deg)" }}
+        >
+          <path
+            d="M6 10.75L0.75 5.31686L1.74907 4.27907L5.2556 8.00291L5.2556 0.25L6.7444 0.25L6.7444 8.00291L10.2509 4.27907L11.25 5.31686L6 10.75Z"
+            fill="currentColor"
+          ></path>
+        </svg>
+      </div>
+    </span>
+  </a>
+);
+
+export const cards = [
+  {
+    href: "/docs",
+    imgSrc: "https://fern-image-hosting.s3.amazonaws.com/cohere/8da77c9-Frame_138972.png",
+    title: "Guides and concepts",
+    description: "Understand how to use our API on a deeper level. Train and customize the model to work for you.",
+  },
+  {
+    href: "/reference/about",
+    imgSrc: "https://fern-image-hosting.s3.amazonaws.com/cohere/8ff146a-Group_138977.png",
+    title: "API reference",
+    description: "Integrate natural language processing and generation into your products with a few lines of code.",
+  },
+  {
+    href: "/release-notes",
+    imgSrc: "https://fern-image-hosting.s3.amazonaws.com/cohere/d51d176-Group_138977_1.png",
+    title: "Release notes",
+    description: "Keep up with the latest releases and platform updates from Cohere.",
+  },
+  {
+    href: "/page/cookbooks",
+    imgSrc: "https://fern-image-hosting.s3.amazonaws.com/cohere/7fca92c-Group_138977_2.png",
+    title: "Cookbooks",
+    description: "A collection of resources to help developers get up and running with Cohere.",
+  },
+];
+
+export const endpoints = [
+  {
+    href: "/reference/chat",
+    title: "/CHAT",
+  },
+  {
+    href: "/reference/embed",
+    title: "/EMBED",
+  },
+  {
+    href: "/reference/rerank",
+    title: "/RERANK",
+  },
+  {
+    href: "/reference/classify",
+    title: "/CLASSIFY",
+  },
+];
+
+<div className="m-auto max-w-[1195px] flex-grow overflow-y-auto px-8 pt-10 md:p-10 md:pb-14">
+  <div className="flex flex-col gap-5 md:!grid md:grid-cols-2 md:gap-10 md:pb-7 lg:!grid-cols-3 lg:gap-x-8 lg:gap-y-10 lg:pb-16">
+    {cards.map((card) => (
+      <LandingPageCard
+        key={card.href}
+        href={card.href}
+        imgSrc={card.imgSrc}
+        title={card.title}
+        description={card.description}
+      />
+    ))}
+    <div className="col-span-2">
+      <div className="mb-8 flex flex-col gap-9 px-6 py-5 md:!flex-row md:items-end md:gap-16 md:p-8 lg:gap-10">
+        <div className="md:w-1/2">
+          <h2 className="mb-8 mt-4 md:mt-0">Endpoints</h2>
+          <p className="p-lg w-full">
+            Our endpoints offer different ways to interact with our models and offer additional value on top of them
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-5 md:w-1/2 md:gap-10 lg:w-1/3 lg:gap-8">
+          {endpoints.map((endpoint) => (
+            <EndpointLink key={endpoint.href} {...endpoint} />
+          ))}
+        </div>
+      </div>
+      <div
+        className="group hidden rounded-lg bg-cover bg-no-repeat p-6 md:!block md:h-[190px] lg:h-[230px]"
+        style={{
+          backgroundImage: "url('https://fern-image-hosting.s3.amazonaws.com/cohere/55d9cde-InfoCards.png')",
+        }}
+      >
+        <a
+          href="https://cohere.com/llmu"
+          target="_blank"
+          className="flex h-full w-full flex-col items-center justify-between !text-white md:!flex-row"
+        >
+          <div className="flex h-full w-[420px] flex-col items-start justify-between">
+            <div className="flex flex-row items-start">
+              <img
+                src="https://fern-image-hosting.s3.amazonaws.com/cohere/9d0694c-Symbol.svg"
+                alt=""
+                className="h-7 w-7 lg:h-10 lg:w-10"
+              />
+              <h2 className="!my-0 ml-5">LLM University</h2>
+            </div>
+            <p className="p-lg !text-white md:w-[260px] lg:w-[400px]">
+              Join our learning hub to master Enterprise AI with expert-led courses and step-by-step guides
+            </p>
+          </div>
+          <div className="flex h-full md:w-1/2">
+            <img
+              src="https://fern-image-hosting.s3.amazonaws.com/cohere/64d7b4f-Group_138975.png"
+              alt=""
+              className="'duration-400 group-hover:pr-2' flex items-center object-contain transition-all ease-in-out group-hover:pl-1"
+            />
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+  <div
+    className="block h-full w-full rounded-lg bg-cover bg-no-repeat p-6 md:hidden"
+    style={{
+      backgroundImage: "url('https://fern-image-hosting.s3.amazonaws.com/cohere/ddd53ed-Mask_group.png')",
+    }}
+  >
+    <a
+      href="https://cohere.com/llmu"
+      target="_blank"
+      className="flex h-full w-full flex-col justify-between !text-white md:!flex-row"
+    >
+      <div className="flex h-full flex-col justify-between">
+        <div className="flex flex-row">
+          <img
+            src="https://fern-image-hosting.s3.amazonaws.com/cohere/9d0694c-Symbol.svg"
+            alt=""
+            className="h-7 w-7 lg:h-10 lg:w-10"
+          />
+          <h2 className="h3 mb-28 ml-5 mt-0">LLM University</h2>
+        </div>
+        <p className="p-lg !text-white">
+          New to NLP? Learn about Natural Language processing and Large Language Models through our structured
+          curriculum.
+        </p>
+      </div>
+    </a>
+  </div>
+</div>

--- a/packages/ui/fern-docs-mdx/src/__test__/sanitize-fixtures.test.ts
+++ b/packages/ui/fern-docs-mdx/src/__test__/sanitize-fixtures.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync, readdirSync } from "fs";
+import path from "path";
+import { getFrontmatter } from "../frontmatter.js";
+import { mdastToMarkdown, toTree } from "../parse.js";
+
+describe("Sanitize fixtures", () => {
+    const fixtures = readdirSync(path.join(__dirname, "fixtures"));
+
+    for (const fixture of fixtures) {
+        it(`Snapshot: ${fixture}`, () => {
+            const fixturePath = path.join(__dirname, "fixtures", fixture);
+            const fixtureContents = readFileSync(fixturePath, "utf-8");
+            const input = getFrontmatter(fixtureContents).content;
+            const output = mdastToMarkdown(toTree(input).mdast);
+            expect(output).toMatchFileSnapshot(path.join(__dirname, "__snapshots__", fixture));
+        });
+    }
+});

--- a/packages/ui/fern-docs-mdx/src/plugins/__test__/remark-sanitize-acorn.test.ts
+++ b/packages/ui/fern-docs-mdx/src/plugins/__test__/remark-sanitize-acorn.test.ts
@@ -1,11 +1,7 @@
 import { mdastToMarkdown, toTree } from "../../parse.js";
-import { sanitizeMdxExpression } from "../../sanitize/sanitize-mdx-expression.js";
-import { remarkSanitizeAcorn } from "../remark-sanitize-acorn.js";
 
 function sanitizeAcorns(content: string, allowedIdentifiers: string[] = []) {
-    const tree = toTree(sanitizeMdxExpression(content));
-    remarkSanitizeAcorn({ allowedIdentifiers })(tree.mdast);
-    return mdastToMarkdown(tree.mdast);
+    return mdastToMarkdown(toTree(content, { allowedIdentifiers }).mdast);
 }
 
 describe("remarkSanitizeAcorn", () => {

--- a/packages/ui/fern-docs-mdx/src/plugins/rehype-acorn-error-boundary.ts
+++ b/packages/ui/fern-docs-mdx/src/plugins/rehype-acorn-error-boundary.ts
@@ -5,7 +5,7 @@ import { toAttribute } from "../utils.js";
 /**
  * This is an additional safeguard to ensure that any acorn expressions that are not valid does not throw an error in the final output.
  *
- * Requirement: `MdxErrorBoundary` is globally available with `fallback` string property
+ * Requirement: `FernErrorBoundary` is globally available with `fallback` string property
  */
 export function rehypeAcornErrorBoundary(): (tree: Root) => void {
     return (root) => {
@@ -16,7 +16,7 @@ export function rehypeAcornErrorBoundary(): (tree: Root) => void {
             if (node.type === "mdxFlowExpression" || node.type === "mdxTextExpression") {
                 parent.children[index] = {
                     type: "mdxJsxFlowElement",
-                    name: "MdxErrorBoundary",
+                    name: "FernErrorBoundary",
                     children: [node],
                     attributes: [toAttribute("fallback", `{${node.value}}`)],
                 };


### PR DESCRIPTION
rehype-sanitize-acorns is over-sanitizing markdown

```
export const cards = ["test"];

cards.map(elem => <div>{elem}</div>);
```

was getting sanitized because `elem` was getting matched.