### PR TITLE
feat(docs): add edge config for authed previews

### DIFF
--- a/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
+++ b/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
@@ -90,10 +90,11 @@ export async function getAuthStateInternal({
                 const workosUserInfo = await toSessionUserInfo(session);
                 if (workosUserInfo.user) {
                     // TODO: should this be stored in the session itself?
+                    const roles = await getWorkosRbacRoles(previewAuthConfig.org, workosUserInfo.user.email);
                     return {
                         authed: true,
                         ok: true,
-                        user: toFernUser(workosUserInfo),
+                        user: toFernUser(workosUserInfo, roles),
                         partner: "workos",
                     };
                 }

--- a/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
+++ b/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
@@ -1,6 +1,6 @@
 import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import { AuthEdgeConfig, FernUser } from "@fern-ui/fern-docs-auth";
-import { getAuthEdgeConfig } from "@fern-ui/fern-docs-edge-config";
+import { PreviewUrlAuth, getAuthEdgeConfig, getPreviewUrlAuthConfig } from "@fern-ui/fern-docs-edge-config";
 import { removeTrailingSlash } from "next/dist/shared/lib/router/utils/remove-trailing-slash";
 import urlJoin from "url-join";
 import { safeVerifyFernJWTConfig } from "./FernJWT";
@@ -72,16 +72,43 @@ export async function getAuthStateInternal({
     fernToken,
     pathname,
     authConfig,
+    previewAuthConfig,
     setFernToken,
 }: {
     host: string;
     fernToken: string | undefined;
     pathname?: string;
     authConfig?: AuthEdgeConfig;
+    previewAuthConfig?: PreviewUrlAuth;
     setFernToken?: (token: string) => void;
 }): Promise<AuthState> {
     // if the auth type is neither sso nor basic_token_verification, allow the request to pass through
     if (!authConfig) {
+        if (previewAuthConfig != null) {
+            if (previewAuthConfig.type === "workos") {
+                const session = fernToken != null ? await getSessionFromToken(fernToken) : undefined;
+                const workosUserInfo = await toSessionUserInfo(session);
+                if (workosUserInfo.user) {
+                    // TODO: should this be stored in the session itself?
+                    return {
+                        authed: true,
+                        ok: true,
+                        user: toFernUser(workosUserInfo),
+                        partner: "workos",
+                    };
+                }
+
+                const redirectUri = urlJoin(
+                    removeTrailingSlash(withDefaultProtocol(host)),
+                    "/api/fern-docs/auth/sso/callback",
+                );
+                const authorizationUrl = getWorkosSSOAuthorizationUrl({
+                    redirectUri,
+                    organization: previewAuthConfig.org,
+                });
+                return { authed: false, ok: true, authorizationUrl, partner: "workos" };
+            }
+        }
         return { authed: false, ok: true, authorizationUrl: undefined, partner: undefined };
     }
 
@@ -154,6 +181,7 @@ export async function getAuthState(
     setFernToken?: (token: string) => void,
 ): Promise<AuthState & DomainAndHost> {
     authConfig ??= await getAuthEdgeConfig(domain);
+    const previewAuthConfig = await getPreviewUrlAuthConfig(domain);
 
     const authState = await getAuthStateInternal({
         host,
@@ -161,6 +189,7 @@ export async function getAuthState(
         pathname,
         authConfig,
         setFernToken,
+        previewAuthConfig,
     });
 
     return { ...authState, domain, host };

--- a/packages/ui/fern-docs-edge-config/src/__test__/isPreviewDomain.test.ts
+++ b/packages/ui/fern-docs-edge-config/src/__test__/isPreviewDomain.test.ts
@@ -1,0 +1,29 @@
+import { isPreviewDomain } from "../getPreviewUrlAuthConfig";
+
+describe("isPreviewDomain", () => {
+    it("should return true for valid preview domains", () => {
+        const validDomains = [
+            "fern-12345678-1234-1234-1234-123456789012.docs.buildwithfern.com",
+            "acme-abcdef01-2345-6789-abcd-ef0123456789.docs.buildwithfern.com",
+        ];
+
+        validDomains.forEach((domain) => {
+            expect(isPreviewDomain(domain)).toBe(true);
+        });
+    });
+
+    it("should return false for invalid preview domains", () => {
+        const invalidDomains = [
+            "docs.buildwithfern.com",
+            "example.com",
+            "12345678-1234-1234-1234-123456789012.example.com",
+            "12345678-1234-1234-1234-12345678901.docs.buildwithfern.com", // UUID too short
+            "12345678-1234-1234-1234-1234567890123.docs.buildwithfern.com", // UUID too long
+            "12345678-1234-1234-1234-12345678901g.docs.buildwithfern.com", // Invalid character in UUID
+        ];
+
+        invalidDomains.forEach((domain) => {
+            expect(isPreviewDomain(domain)).toBe(false);
+        });
+    });
+});

--- a/packages/ui/fern-docs-edge-config/src/__test__/isPreviewDomain.test.ts
+++ b/packages/ui/fern-docs-edge-config/src/__test__/isPreviewDomain.test.ts
@@ -1,4 +1,4 @@
-import { isPreviewDomain } from "../getPreviewUrlAuthConfig";
+import { extractOrgFromPreview, isPreviewDomain } from "../getPreviewUrlAuthConfig";
 
 describe("isPreviewDomain", () => {
     it("should return true for valid preview domains", () => {
@@ -24,6 +24,35 @@ describe("isPreviewDomain", () => {
 
         invalidDomains.forEach((domain) => {
             expect(isPreviewDomain(domain)).toBe(false);
+        });
+    });
+
+    describe("extractOrgFromPreview", () => {
+        it("should return the organization name for valid preview domains", () => {
+            const validDomains = [
+                { domain: "fern-preview-12345678-1234-1234-1234-123456789012.docs.buildwithfern.com", org: "fern" },
+                { domain: "acme-preview-abcdef01-2345-6789-abcd-ef0123456789.docs.buildwithfern.com", org: "acme" },
+            ];
+
+            validDomains.forEach(({ domain, org }) => {
+                expect(extractOrgFromPreview(domain)).toBe(org);
+            });
+        });
+
+        it("should return undefined for invalid preview domains", () => {
+            const invalidDomains = [
+                "docs.buildwithfern.com",
+                "example.com",
+                "12345678-1234-1234-1234-123456789012.example.com",
+                "12345678-1234-1234-1234-12345678901.docs.buildwithfern.com", // UUID too short
+                "12345678-1234-1234-1234-1234567890123.docs.buildwithfern.com", // UUID too long
+                "12345678-1234-1234-1234-12345678901g.docs.buildwithfern.com", // Invalid character in UUID
+                "fern-12345678-1234-1234-1234-123456789012.docs.buildwithfern.com", // Missing 'preview' keyword
+            ];
+
+            invalidDomains.forEach((domain) => {
+                expect(extractOrgFromPreview(domain)).toBeUndefined();
+            });
         });
     });
 });

--- a/packages/ui/fern-docs-edge-config/src/getPreviewUrlAuthConfig.ts
+++ b/packages/ui/fern-docs-edge-config/src/getPreviewUrlAuthConfig.ts
@@ -11,13 +11,13 @@ const PreviewUrlAuthSchema = z.discriminatedUnion("type", [
     // Add more auth types here as needed
 ]);
 
+export type PreviewUrlAuth = z.infer<typeof PreviewUrlAuthSchema>;
+
 const PreviewUrlAuthConfigSchema = z.record(PreviewUrlAuthSchema);
 
 type PreviewUrlAuthConfig = z.infer<typeof PreviewUrlAuthConfigSchema>;
 
-export async function getPreviewUrlAuthConfig(
-    currentDomain: string,
-): Promise<z.infer<typeof PreviewUrlAuthSchema> | undefined> {
+export async function getPreviewUrlAuthConfig(currentDomain: string): Promise<PreviewUrlAuth | undefined> {
     const previewDomain = isPreviewDomain(currentDomain);
     const org = extractOrgFromPreview(currentDomain);
     if (!previewDomain || !org) {

--- a/packages/ui/fern-docs-edge-config/src/getPreviewUrlAuthConfig.ts
+++ b/packages/ui/fern-docs-edge-config/src/getPreviewUrlAuthConfig.ts
@@ -1,0 +1,33 @@
+import { get } from "@vercel/edge-config";
+import { z } from "zod";
+
+const PasswordAuthSchema = z.object({
+    type: z.literal("password"),
+    password: z.string(),
+});
+
+const PreviewUrlAuthSchema = z.discriminatedUnion("type", [
+    PasswordAuthSchema,
+    // Add more auth types here as needed
+]);
+
+const PreviewUrlAuthConfigSchema = z.record(PreviewUrlAuthSchema);
+
+type PreviewUrlAuthConfig = z.infer<typeof PreviewUrlAuthConfigSchema>;
+
+export async function getPreviewUrlAuthConfig(
+    currentDomain: string,
+): Promise<z.infer<typeof PreviewUrlAuthSchema> | undefined> {
+    const previewDomain = isPreviewDomain(currentDomain);
+    if (!previewDomain) {
+        return undefined;
+    }
+
+    const config = await get<PreviewUrlAuthConfig>("authed-previews");
+    return config?.[currentDomain];
+}
+
+export function isPreviewDomain(domain: string): boolean {
+    const uuidRegex = "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}";
+    return new RegExp(`^.*?${uuidRegex}\\.docs\\.buildwithfern\\.com$`).test(domain);
+}

--- a/packages/ui/fern-docs-edge-config/src/getPreviewUrlAuthConfig.ts
+++ b/packages/ui/fern-docs-edge-config/src/getPreviewUrlAuthConfig.ts
@@ -1,13 +1,13 @@
 import { get } from "@vercel/edge-config";
 import { z } from "zod";
 
-const PasswordAuthSchema = z.object({
-    type: z.literal("password"),
-    password: z.string(),
+const WorkosAuthSchema = z.object({
+    type: z.literal("workos"),
+    org: z.string(),
 });
 
 const PreviewUrlAuthSchema = z.discriminatedUnion("type", [
-    PasswordAuthSchema,
+    WorkosAuthSchema,
     // Add more auth types here as needed
 ]);
 
@@ -19,15 +19,23 @@ export async function getPreviewUrlAuthConfig(
     currentDomain: string,
 ): Promise<z.infer<typeof PreviewUrlAuthSchema> | undefined> {
     const previewDomain = isPreviewDomain(currentDomain);
-    if (!previewDomain) {
+    const org = extractOrgFromPreview(currentDomain);
+    if (!previewDomain || !org) {
         return undefined;
     }
 
     const config = await get<PreviewUrlAuthConfig>("authed-previews");
-    return config?.[currentDomain];
+    return config?.[org];
 }
 
 export function isPreviewDomain(domain: string): boolean {
     const uuidRegex = "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}";
     return new RegExp(`^.*?${uuidRegex}\\.docs\\.buildwithfern\\.com$`).test(domain);
+}
+
+export function extractOrgFromPreview(domain: string): string | undefined {
+    const orgRegex = "^[a-zA-Z0-9-]+";
+    const uuidRegex = "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}";
+    const match = new RegExp(`^(${orgRegex})-preview-${uuidRegex}\\.docs\\.buildwithfern\\.com$`).exec(domain);
+    return match ? match[1] : undefined;
 }

--- a/packages/ui/fern-docs-edge-config/src/index.ts
+++ b/packages/ui/fern-docs-edge-config/src/index.ts
@@ -3,4 +3,5 @@ export * from "./getCustomerAnalytics";
 export * from "./getFeatureFlags";
 export * from "./getInkeepSettings";
 export * from "./getLaunchDarklySettings";
+export * from "./getPreviewUrlAuthConfig";
 export * from "./getSeoDisabled";


### PR DESCRIPTION
## Short description of the changes made
Add edge config for authed previews. 

## What was the motivation & context behind this PR?
Some customers dont want their preview urls to be public.

## How has this PR been tested?
Unit tests for checking if a domain is a "preview" domain
