### PR TITLE
chore(doc): update banner styling

### DIFF
--- a/packages/ui/app/src/css/utilities.scss
+++ b/packages/ui/app/src/css/utilities.scss
@@ -60,7 +60,7 @@
     }
 
     .clipped-background {
-        @apply pointer-events-none absolute -z-10 h-full w-full overflow-hidden;
+        @apply pointer-events-none absolute top-0 -z-10 h-full w-full overflow-hidden;
 
         clip-path: inset(0);
     }


### PR DESCRIPTION
This PR has not been tested. 

Resolves an issue reported by Vapi with the banner component:
![Screenshot 2024-10-24 at 11 03 49 PM](https://github.com/user-attachments/assets/a431835f-74cb-4509-b88c-62942ca18e9e)

I added the same styling as custom CSS to Vapi's style sheet to fix:
[style](https://github.com/VapiAI/fern/blob/04614aeae2b95eb576cebe8b6f2eb9850ccb40c4/fern/assets/styles.css#L116-L118)
![Screenshot 2024-10-24 at 11 05 28 PM](https://github.com/user-attachments/assets/68c126b6-7cc0-4f13-9278-310113e999f0)
