### PR TITLE
fix: update points-to property because it's not always set

### DIFF
--- a/packages/fdr-sdk/src/navigation/utils/toRootNode.ts
+++ b/packages/fdr-sdk/src/navigation/utils/toRootNode.ts
@@ -1,5 +1,6 @@
 import { DocsV2Read, FernNavigation } from "../..";
 import { FernNavigationV1ToLatest } from "../migrators/v1ToV2";
+import { mutableUpdatePointsTo } from "./updatePointsTo";
 
 export function toRootNode(
     docs: DocsV2Read.LoadDocsForUrlResponse,
@@ -7,5 +8,8 @@ export function toRootNode(
     paginated?: boolean,
 ): FernNavigation.RootNode {
     const v1 = FernNavigation.V1.toRootNode(docs, disableEndpointPairs, paginated);
-    return FernNavigationV1ToLatest.create().root(v1);
+    const latest = FernNavigationV1ToLatest.create().root(v1);
+    // update all `pointsTo`
+    mutableUpdatePointsTo(latest);
+    return latest;
 }


### PR DESCRIPTION
This change guarantees that `pointsTo` is always set. (The CLI does not set the pointsTo field.)