### PR TITLE
fix: make rbac rules more clear and unblock public pages

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -44,6 +44,7 @@ jobs:
         run: pnpm playwright:build
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: buildwithfern
 
       - name: Run Playwright tests
         run: pnpm exec playwright test playwright --workers 6 --reporter json,html

--- a/packages/commons/core-utils/src/withDefaultProtocol.ts
+++ b/packages/commons/core-utils/src/withDefaultProtocol.ts
@@ -5,7 +5,13 @@
  * @param defaultProtocol defaults to "https://"
  * @returns the endpoint, which will always have a protocol
  */
-export function withDefaultProtocol(endpoint: string, defaultProtocol = "https://"): string {
+export function withDefaultProtocol(endpoint: string, defaultProtocol?: string): string;
+export function withDefaultProtocol(endpoint: string | undefined, defaultProtocol?: string): string | undefined;
+export function withDefaultProtocol(endpoint: string | undefined, defaultProtocol = "https://"): string | undefined {
+    if (endpoint == null) {
+        return undefined;
+    }
+
     // matches any protocol scheme at the beginning of the string (e.g., "http://", "https://", "ftp://")
     const protocolRegex = /^[a-z]+:\/\//i;
 

--- a/packages/fdr-sdk/src/__test__/__snapshots__/no-version-no-tabs.test.ts.snap
+++ b/packages/fdr-sdk/src/__test__/__snapshots__/no-version-no-tabs.test.ts.snap
@@ -13,6 +13,7 @@ exports[`no-version-no-tabs > gets all urls from docs config 1`] = `
 
 exports[`no-version-no-tabs > gets navigation root for /docs 1`] = `
 {
+  "authed": undefined,
   "redirect": "docs/api/section-1/page-1",
   "type": "notFound",
 }
@@ -69,6 +70,7 @@ exports[`no-version-no-tabs > gets navigation root for /docs/api/section-2 3`] =
 
 exports[`no-version-no-tabs > gets navigation root for /docs/api/section-3 1`] = `
 {
+  "authed": undefined,
   "redirect": "docs/api/section-1/page-1",
   "type": "notFound",
 }

--- a/packages/fdr-sdk/src/__test__/__snapshots__/no-version-yes-tabs.test.ts.snap
+++ b/packages/fdr-sdk/src/__test__/__snapshots__/no-version-yes-tabs.test.ts.snap
@@ -44,6 +44,7 @@ exports[`no-version-yes-tabs > gets navigation root for /docs/api/page-2 3`] = `
 
 exports[`no-version-yes-tabs > gets navigation root for /docs/api/section-1 1`] = `
 {
+  "authed": undefined,
   "redirect": "docs/api/tab-1/section-1/page-1",
   "type": "notFound",
 }

--- a/packages/fdr-sdk/src/__test__/__snapshots__/octoai.test.ts.snap
+++ b/packages/fdr-sdk/src/__test__/__snapshots__/octoai.test.ts.snap
@@ -136,6 +136,7 @@ exports[`octoai > gets all urls from docs config 1`] = `
 
 exports[`octoai > gets navigation root for /api-reference/asset-library/list 1`] = `
 {
+  "authed": undefined,
   "redirect": "docs/getting-started/quickstart",
   "type": "notFound",
 }
@@ -143,6 +144,7 @@ exports[`octoai > gets navigation root for /api-reference/asset-library/list 1`]
 
 exports[`octoai > gets navigation root for /api-reference/octoai-api/account/get-account 1`] = `
 {
+  "authed": undefined,
   "redirect": "docs/getting-started/quickstart",
   "type": "notFound",
 }
@@ -150,6 +152,7 @@ exports[`octoai > gets navigation root for /api-reference/octoai-api/account/get
 
 exports[`octoai > gets navigation root for /api-reference/octoai-api/authentication 1`] = `
 {
+  "authed": undefined,
   "redirect": "docs/getting-started/quickstart",
   "type": "notFound",
 }
@@ -157,6 +160,7 @@ exports[`octoai > gets navigation root for /api-reference/octoai-api/authenticat
 
 exports[`octoai > gets navigation root for /getting-started 1`] = `
 {
+  "authed": undefined,
   "redirect": "docs/getting-started/quickstart",
   "type": "notFound",
 }
@@ -164,6 +168,7 @@ exports[`octoai > gets navigation root for /getting-started 1`] = `
 
 exports[`octoai > gets navigation root for /getting-started/quickstart 1`] = `
 {
+  "authed": undefined,
   "redirect": "docs/getting-started/quickstart",
   "type": "notFound",
 }

--- a/packages/fdr-sdk/src/__test__/__snapshots__/polytomic.test.ts.snap
+++ b/packages/fdr-sdk/src/__test__/__snapshots__/polytomic.test.ts.snap
@@ -847,6 +847,7 @@ exports[`polytomic > gets all urls from docs config 1`] = `
 
 exports[`polytomic > gets navigation root for /2023-04-25/guides/introduction 1`] = `
 {
+  "authed": undefined,
   "redirect": "2023-04-25/introduction",
   "type": "notFound",
 }
@@ -854,6 +855,7 @@ exports[`polytomic > gets navigation root for /2023-04-25/guides/introduction 1`
 
 exports[`polytomic > gets navigation root for /2023-04-25/not-found 1`] = `
 {
+  "authed": undefined,
   "redirect": "2023-04-25/introduction",
   "type": "notFound",
 }

--- a/packages/fdr-sdk/src/navigation/utils/__test__/followRedirects.test.ts
+++ b/packages/fdr-sdk/src/navigation/utils/__test__/followRedirects.test.ts
@@ -1,0 +1,167 @@
+import { FernNavigation } from "../../..";
+import { followRedirect } from "../followRedirect";
+
+function sectionNode(
+    section: Partial<FernNavigation.SectionNode> & Pick<FernNavigation.SectionNode, "slug">,
+): FernNavigation.SectionNode {
+    return {
+        type: "section",
+        title: "Section",
+        children: [],
+        id: FernNavigation.NodeId("0"),
+        collapsed: undefined,
+        canonicalSlug: undefined,
+        icon: undefined,
+        hidden: undefined,
+        authed: undefined,
+        viewers: undefined,
+        orphaned: undefined,
+        overviewPageId: undefined,
+        noindex: undefined,
+        pointsTo: undefined,
+        ...section,
+    };
+}
+
+function pageNode(
+    page: Partial<FernNavigation.PageNode> & Pick<FernNavigation.PageNode, "slug">,
+): FernNavigation.PageNode {
+    return {
+        type: "page",
+        title: "Page",
+        pageId: FernNavigation.PageId("page.mdx"),
+        id: FernNavigation.NodeId("1"),
+        canonicalSlug: undefined,
+        icon: undefined,
+        hidden: undefined,
+        authed: undefined,
+        viewers: undefined,
+        orphaned: undefined,
+        noindex: undefined,
+        ...page,
+    };
+}
+
+describe("followRedirect", () => {
+    it("should return null if the node is not a page", () => {
+        expect(
+            followRedirect(
+                sectionNode({
+                    id: FernNavigation.NodeId("1"),
+                    slug: FernNavigation.Slug("section"),
+                }),
+            ),
+        ).toBe(undefined);
+    });
+
+    it("should return itself if the node is a page", () => {
+        expect(
+            followRedirect(
+                pageNode({
+                    id: FernNavigation.NodeId("1"),
+                    slug: FernNavigation.Slug("path/to/page"),
+                }),
+            ),
+        ).toBe("path/to/page");
+
+        expect(
+            followRedirect(
+                sectionNode({
+                    slug: FernNavigation.Slug("path/to/section"),
+                    overviewPageId: FernNavigation.PageId("path/to/section/overview.mdx"),
+                }),
+            ),
+        ).toBe("path/to/section");
+    });
+
+    it("should follow redirects", () => {
+        expect(
+            followRedirect(
+                sectionNode({
+                    children: [
+                        pageNode({
+                            id: FernNavigation.NodeId("2"),
+                            slug: FernNavigation.Slug("path/to/page"),
+                        }),
+                    ],
+                    slug: FernNavigation.Slug("section"),
+                }),
+            ),
+        ).toBe("path/to/page");
+
+        expect(
+            followRedirect(
+                sectionNode({
+                    children: [
+                        sectionNode({
+                            slug: FernNavigation.Slug("path/to/section"),
+                        }),
+                        pageNode({
+                            id: FernNavigation.NodeId("3"),
+                            slug: FernNavigation.Slug("path/to/page"),
+                        }),
+                    ],
+                    slug: FernNavigation.Slug("section"),
+                }),
+            ),
+        ).toBe("path/to/page");
+    });
+
+    it("should skip hidden and authed nodes", () => {
+        expect(
+            followRedirect(
+                sectionNode({
+                    id: FernNavigation.NodeId("1"),
+                    type: "section",
+                    title: "Section",
+                    children: [
+                        pageNode({
+                            slug: FernNavigation.Slug("hidden-page"),
+                            hidden: true,
+                        }),
+                        pageNode({
+                            slug: FernNavigation.Slug("authed-page"),
+                            authed: true,
+                        }),
+                        pageNode({
+                            slug: FernNavigation.Slug("path/to/page"),
+                        }),
+                    ],
+                    slug: FernNavigation.Slug("section"),
+                }),
+            ),
+        ).toBe("path/to/page");
+    });
+
+    it("should not follow redirects if the destination is an authed page", () => {
+        expect(
+            followRedirect(
+                sectionNode({
+                    children: [pageNode({ slug: FernNavigation.Slug("path/to/page"), authed: true })],
+                    slug: FernNavigation.Slug("section"),
+                }),
+            ),
+        ).toBe(undefined);
+    });
+
+    it("should follow redirects even if the intermediate node is authed", () => {
+        expect(
+            followRedirect(
+                sectionNode({
+                    children: [
+                        sectionNode({
+                            children: [
+                                pageNode({
+                                    slug: FernNavigation.Slug("path/to/page"),
+                                }),
+                            ],
+                            slug: FernNavigation.Slug("path/to/section"),
+                            authed: true, // <--- this is authed
+                        }),
+                    ],
+                    slug: FernNavigation.Slug("section"),
+                }),
+            ),
+        ).toBe("path/to/page");
+    });
+});

--- a/packages/fdr-sdk/src/navigation/utils/findNode.ts
+++ b/packages/fdr-sdk/src/navigation/utils/findNode.ts
@@ -43,6 +43,7 @@ export declare namespace Node {
     interface NotFound {
         type: "notFound";
         redirect: FernNavigation.Slug | undefined;
+        authed: boolean | undefined;
     }
 }
 
@@ -62,7 +63,7 @@ export function findNode(root: FernNavigation.RootNode, slug: FernNavigation.Slu
             }
         }
 
-        return { type: "notFound", redirect: maybeVersionNode.pointsTo };
+        return { type: "notFound", redirect: maybeVersionNode.pointsTo, authed: maybeVersionNode.authed };
     }
 
     const sidebar = found.parents.find(isSidebarRootNode);
@@ -128,7 +129,7 @@ export function findNode(root: FernNavigation.RootNode, slug: FernNavigation.Slu
         : currentVersion?.pointsTo ?? root.pointsTo;
 
     if (redirect == null || redirect === slug) {
-        return { type: "notFound", redirect: undefined };
+        return { type: "notFound", redirect: undefined, authed: found.node.authed };
     }
 
     return { type: "redirect", redirect };

--- a/packages/ui/app/src/analytics/posthog.ts
+++ b/packages/ui/app/src/analytics/posthog.ts
@@ -53,7 +53,14 @@ function ifCustomer(posthog: PostHog, run: (hog: PostHogWithCustomer) => void): 
 }
 
 export async function initializePosthog(api_host: string, customerConfig?: DocsV1Read.PostHogConfig): Promise<void> {
-    const apiKey = process.env.NEXT_PUBLIC_POSTHOG_API_KEY?.trim() ?? "";
+    const apiKey = process.env.NEXT_PUBLIC_POSTHOG_API_KEY;
+
+    if (apiKey == null) {
+        // eslint-disable-next-line no-console
+        console.warn("Posthog will NOT be initialized.");
+        return;
+    }
+
     /**
      * TODO: refactor this to use the posthog react provider
      */

--- a/packages/ui/app/src/mdx/components/if/If.tsx
+++ b/packages/ui/app/src/mdx/components/if/If.tsx
@@ -30,13 +30,10 @@ export interface IfProps {
 export function If({ not, roles, children }: PropsWithChildren<IfProps>): ReactNode {
     const user = useFernUser();
 
-    if (roles == null || roles.length === 0) {
-        return children;
-    }
-
     const userRoles = user?.roles ?? [];
 
-    const show = roles.some((roles) => userRoles.some((role) => roles.includes(role) || role === EVERYONE_ROLE));
+    const show =
+        roles?.some((roles) => userRoles.some((role) => roles.includes(role) || role === EVERYONE_ROLE)) ?? false;
 
     return not ? !show && children : show && children;
 }

--- a/packages/ui/docs-bundle/src/server/DocsLoader.ts
+++ b/packages/ui/docs-bundle/src/server/DocsLoader.ts
@@ -4,7 +4,7 @@ import type { AuthEdgeConfig } from "@fern-ui/fern-docs-auth";
 import { getAuthEdgeConfig } from "@fern-ui/fern-docs-edge-config";
 import { getAuthState, type AuthState } from "./auth/getAuthState";
 import { loadWithUrl } from "./loadWithUrl";
-import { pruneWithBasicTokenAnonymous, pruneWithBasicTokenAuthed } from "./withRbac";
+import { pruneWithAuthState } from "./withRbac";
 
 interface DocsLoaderFlags {
     isBatchStreamToggleDisabled: boolean;
@@ -104,9 +104,7 @@ export class DocsLoader {
             try {
                 if (authConfig?.type === "basic_token_verification") {
                     // TODO: store this in cache
-                    root = authState.authed
-                        ? pruneWithBasicTokenAuthed(authConfig, root, authState.user.roles)
-                        : pruneWithBasicTokenAnonymous(authConfig, root);
+                    root = pruneWithAuthState(authState, authConfig, root);
                 }
             } catch (e) {
                 // TODO: sentry

--- a/packages/ui/docs-bundle/src/server/__test__/withRbac.test.ts
+++ b/packages/ui/docs-bundle/src/server/__test__/withRbac.test.ts
@@ -1,31 +1,34 @@
 import { NodeId, PageId, RoleId, Slug, Url } from "@fern-api/fdr-sdk/navigation";
-import { getViewerFilters, matchRoles, withBasicTokenAnonymous, withBasicTokenAnonymousCheck } from "../withRbac";
+import { Gate, getViewerFilters, matchRoles, withBasicTokenAnonymous, withBasicTokenAnonymousCheck } from "../withRbac";
 
 describe("withBasicTokenAnonymous", () => {
+    it("should allow the request if no rules are provided", () => {
+        expect(withBasicTokenAnonymous({}, "/public")).toBe(Gate.ALLOW);
+    });
+
     it("should deny the request if the allowlist is empty", () => {
-        expect(withBasicTokenAnonymous({}, "/public")).toBe(true);
-        expect(withBasicTokenAnonymous({ allowlist: [] }, "/public")).toBe(true);
+        expect(withBasicTokenAnonymous({ allowlist: [] }, "/public")).toBe(Gate.DENY);
     });
 
     it("should allow the request to pass through if the path is in the allowlist", () => {
-        expect(withBasicTokenAnonymous({ allowlist: ["/public"] }, "/public")).toBe(false);
+        expect(withBasicTokenAnonymous({ allowlist: ["/public"] }, "/public")).toBe(Gate.ALLOW);
     });
 
     it("should allow the request to pass through if the path matches a regex in the allowlist", () => {
-        expect(withBasicTokenAnonymous({ allowlist: ["/public/(.*)"] }, "/public/123")).toBe(false);
+        expect(withBasicTokenAnonymous({ allowlist: ["/public/(.*)"] }, "/public/123")).toBe(Gate.ALLOW);
     });
 
     it("should allow the request to pass through if the path matches a path expression in the allowlist", () => {
-        expect(withBasicTokenAnonymous({ allowlist: ["/public/:id"] }, "/public/123")).toBe(false);
+        expect(withBasicTokenAnonymous({ allowlist: ["/public/:id"] }, "/public/123")).toBe(Gate.ALLOW);
     });
 
     it("should not allow the request to pass through if the path is not in the allowlist", () => {
-        expect(withBasicTokenAnonymous({ allowlist: ["/public", "/public/:id"] }, "/private")).toBe(true);
-        expect(withBasicTokenAnonymous({ allowlist: ["/public", "/public/:id"] }, "/private/123")).toBe(true);
+        expect(withBasicTokenAnonymous({ allowlist: ["/public", "/public/:id"] }, "/private")).toBe(Gate.DENY);
+        expect(withBasicTokenAnonymous({ allowlist: ["/public", "/public/:id"] }, "/private/123")).toBe(Gate.DENY);
     });
 
     it("shouuld respect denylist before allowlist", () => {
-        expect(withBasicTokenAnonymous({ allowlist: ["/public"], denylist: ["/public"] }, "/public")).toBe(true);
+        expect(withBasicTokenAnonymous({ allowlist: ["/public"], denylist: ["/public"] }, "/public")).toBe(Gate.DENY);
     });
 });
 
@@ -39,29 +42,7 @@ describe("withBasicTokenAnonymousCheck", () => {
                 icon: undefined,
                 id: NodeId("1"),
             }),
-        ).toBe(false);
-    });
-
-    it("should ignore childless non-leaf nodes", () => {
-        expect(
-            withBasicTokenAnonymousCheck({ allowlist: ["/public"] })({
-                type: "section",
-                title: "Public",
-                children: [],
-                id: NodeId("1"),
-                slug: Slug("public"),
-                collapsed: false,
-                canonicalSlug: undefined,
-                icon: undefined,
-                hidden: undefined,
-                authed: undefined,
-                overviewPageId: undefined,
-                noindex: undefined,
-                pointsTo: undefined,
-                viewers: undefined,
-                orphaned: undefined,
-            }),
-        ).toBe(false);
+        ).toBe(Gate.ALLOW);
     });
 
     it("should not prune childless non-leaf nodes that have content", () => {
@@ -83,52 +64,52 @@ describe("withBasicTokenAnonymousCheck", () => {
                 viewers: undefined,
                 orphaned: undefined,
             }),
-        ).toBe(false);
+        ).toBe(Gate.ALLOW);
     });
 });
 
 describe("matchRoles", () => {
     it("should return true if the audience is empty", () => {
-        expect(matchRoles([], [])).toBe(true);
-        expect(matchRoles([], [[], []])).toBe(true);
+        expect(matchRoles(true, [], [])).toBe(Gate.ALLOW);
+        expect(matchRoles(true, [], [[], []])).toBe(Gate.ALLOW);
     });
 
     it("should return false if an audience filter exists", () => {
-        expect(matchRoles([], [["a"]])).toBe(false);
+        expect(matchRoles(true, [], [["a"]])).toBe(Gate.DENY);
     });
 
     it("should return true if the role is everyone", () => {
-        expect(matchRoles([], [["everyone"]])).toBe(true);
+        expect(matchRoles(true, [], [["everyone"]])).toBe(Gate.ALLOW);
     });
 
     it("should return true if the audience matches the filter", () => {
-        expect(matchRoles(["a"], [["a"]])).toBe(true);
+        expect(matchRoles(true, ["a"], [["a"]])).toBe(Gate.ALLOW);
     });
 
     it("should return true if the audience matches any of the filters", () => {
-        expect(matchRoles(["a"], [["b", "a"]])).toBe(true);
+        expect(matchRoles(true, ["a"], [["b", "a"]])).toBe(Gate.ALLOW);
     });
 
     it("should return false if the audience does not match any of the filters", () => {
-        expect(matchRoles(["a"], [["b"]])).toBe(false);
+        expect(matchRoles(true, ["a"], [["b"]])).toBe(Gate.DENY);
     });
 
     it("should return false if the audience does not match all filters across all nodes", () => {
-        expect(matchRoles(["a"], [["a"], ["b"]])).toBe(false);
-        expect(matchRoles(["b"], [["a"], ["a", "b"]])).toBe(false);
+        expect(matchRoles(true, ["a"], [["a"], ["b"]])).toBe(Gate.DENY);
+        expect(matchRoles(true, ["b"], [["a"], ["a", "b"]])).toBe(Gate.DENY);
     });
 
     it("should return true if the audience matches all filters across all nodes", () => {
-        expect(matchRoles(["a"], [["a"], ["a"]])).toBe(true);
-        expect(matchRoles(["a"], [["a"], ["a", "b"]])).toBe(true);
-        expect(matchRoles(["a", "b"], [["a"], ["a", "b"]])).toBe(true);
-        expect(matchRoles(["a", "b"], [["a"], ["b"]])).toBe(true);
+        expect(matchRoles(true, ["a"], [["a"], ["a"]])).toBe(Gate.ALLOW);
+        expect(matchRoles(true, ["a"], [["a"], ["a", "b"]])).toBe(Gate.ALLOW);
+        expect(matchRoles(true, ["a", "b"], [["a"], ["a", "b"]])).toBe(Gate.ALLOW);
+        expect(matchRoles(true, ["a", "b"], [["a"], ["b"]])).toBe(Gate.ALLOW);
     });
 
     it("should return true if the user has more audiences than the filter", () => {
-        expect(matchRoles(["a", "b"], [])).toBe(true);
-        expect(matchRoles(["a", "b"], [[]])).toBe(true);
-        expect(matchRoles(["a", "b"], [["a"]])).toBe(true);
+        expect(matchRoles(true, ["a", "b"], [])).toBe(Gate.ALLOW);
+        expect(matchRoles(true, ["a", "b"], [[]])).toBe(Gate.ALLOW);
+        expect(matchRoles(true, ["a", "b"], [["a"]])).toBe(Gate.ALLOW);
     });
 });
 

--- a/packages/ui/docs-bundle/src/server/__test__/withRbac.test.ts
+++ b/packages/ui/docs-bundle/src/server/__test__/withRbac.test.ts
@@ -33,7 +33,7 @@ describe("withBasicTokenAnonymous", () => {
 });
 
 describe("withBasicTokenAnonymousCheck", () => {
-    it("should never deny external links", () => {
+    it("should allow external links", () => {
         expect(
             withBasicTokenAnonymousCheck({ denylist: ["/(.*)"] })({
                 type: "link",
@@ -45,7 +45,7 @@ describe("withBasicTokenAnonymousCheck", () => {
         ).toBe(Gate.ALLOW);
     });
 
-    it("should not prune childless non-leaf nodes that have content", () => {
+    it("should allow childless non-leaf nodes that have content", () => {
         expect(
             withBasicTokenAnonymousCheck({ allowlist: ["/public"] })({
                 type: "section",
@@ -65,6 +65,28 @@ describe("withBasicTokenAnonymousCheck", () => {
                 orphaned: undefined,
             }),
         ).toBe(Gate.ALLOW);
+    });
+
+    it("should deny childless non-leaf nodes that do not have content", () => {
+        expect(
+            withBasicTokenAnonymousCheck({ denylist: ["/private"] })({
+                type: "section",
+                title: "Private",
+                children: [],
+                id: NodeId("1"),
+                slug: Slug("private"),
+                collapsed: false,
+                canonicalSlug: undefined,
+                icon: undefined,
+                hidden: undefined,
+                authed: undefined,
+                overviewPageId: PageId("1.mdx"),
+                noindex: undefined,
+                pointsTo: undefined,
+                viewers: undefined,
+                orphaned: undefined,
+            }),
+        ).toBe(Gate.DENY);
     });
 });
 

--- a/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
+++ b/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
@@ -70,8 +70,7 @@ export async function getAuthState(
     pathname?: string,
     authConfig?: AuthEdgeConfig,
 ): Promise<AuthState> {
-    // don't fetch auth config in dev (for now)
-    authConfig ??= process.env.NODE_ENV === "development" ? undefined : await getAuthEdgeConfig(domain);
+    authConfig ??= await getAuthEdgeConfig(domain);
 
     // if the auth type is neither sso nor basic_token_verification, allow the request to pass through
     // we're currently assuming that all oauth2 integrations are meant for API Playground. This may change.

--- a/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
+++ b/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
@@ -2,7 +2,6 @@ import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import { AuthEdgeConfig, FernUser } from "@fern-ui/fern-docs-auth";
 import { getAuthEdgeConfig } from "@fern-ui/fern-docs-edge-config";
 import urlJoin from "url-join";
-import { withBasicTokenAnonymous } from "../withRbac";
 import { safeVerifyFernJWTConfig } from "./FernJWT";
 
 export type AuthPartner = "workos" | "ory" | "webflow" | "custom";
@@ -82,21 +81,12 @@ export async function getAuthState(
 
     // check if the request is allowed to pass through without authentication
     if (authConfig.type === "basic_token_verification") {
+        const partner = "custom";
         if (user) {
-            // TODO: right now it's not possible to compare the user's roles with the permissions required for the current pathname
-            // because this function must be run in the middleware handler, which does not have access to the navigation node structure
-            // so today we're assuming that getServerSideProps will return a 404 for specific pages (when it should certainly be a 403)
-            return { domain, host, authed: true, ok: true, user, partner: "custom" };
+            return { domain, host, authed: true, ok: true, user, partner };
         } else {
-            const isAuthRequired = pathname ? withBasicTokenAnonymous(authConfig, pathname) : true;
-            return {
-                domain,
-                host,
-                authed: false,
-                ok: !isAuthRequired,
-                authorizationUrl: getAuthorizationUrl(authConfig, domain, pathname),
-                partner: "custom",
-            };
+            const authorizationUrl = getAuthorizationUrl(authConfig, domain, pathname);
+            return { domain, host, authed: false, ok: true, authorizationUrl, partner };
         }
     }
 

--- a/packages/ui/docs-bundle/src/server/handleLoadDocsError.ts
+++ b/packages/ui/docs-bundle/src/server/handleLoadDocsError.ts
@@ -15,6 +15,6 @@ export async function handleLoadDocsError(
     }
 
     // eslint-disable-next-line no-console
-    console.error(`Failed to load initial props for docs page: https://${xFernHost}/${slug}`);
+    console.error(`Failed to load initial props for docs page: https://${xFernHost}/${slug}`, error.content);
     return { notFound: true };
 }

--- a/packages/ui/docs-bundle/src/server/withInitialProps.ts
+++ b/packages/ui/docs-bundle/src/server/withInitialProps.ts
@@ -93,12 +93,16 @@ export async function withInitialProps({
     // find the node that is currently being viewed
     const found = FernNavigation.utils.findNode(root, slug);
 
+    // this is a special case for when the user is not authenticated, but the not-found status originates from an authed node
+    if (found.type === "notFound" && found.authed && !authState.authed && authState.authorizationUrl != null) {
+        return withRedirect(authState.authorizationUrl);
+    }
+
     if (found.type === "notFound") {
         // TODO: returning "notFound: true" here will render vercel's default 404 page
         // this is better than following redirects, since it will signal a proper 404 status code.
         // however, we should consider rendering a custom 404 page in the future using the customer's branding.
         // see: https://nextjs.org/docs/app/api-reference/file-conventions/not-found
-
         if (featureFlags.is404PageHidden && found.redirect != null) {
             return withRedirect(found.redirect);
         }

--- a/packages/ui/docs-bundle/src/server/withPrunedNavigation.ts
+++ b/packages/ui/docs-bundle/src/server/withPrunedNavigation.ts
@@ -26,7 +26,7 @@ export function pruneNavigationPredicate(
     { visibleNodeIds, authed, discoverable }: WithPrunedSidebarOpts,
 ): boolean {
     // prune authenticated pages (unless the discoverable flag is turned on)
-    if (FernNavigation.hasMetadata(node) && node.authed && !authed && !discoverable) {
+    if (FernNavigation.isPage(node) && node.authed && !authed && !discoverable) {
         return false;
     }
 

--- a/packages/ui/docs-bundle/src/server/withRbac.ts
+++ b/packages/ui/docs-bundle/src/server/withRbac.ts
@@ -12,6 +12,11 @@ import type { AuthEdgeConfigBasicTokenVerification } from "@fern-ui/fern-docs-au
 import { EVERYONE_ROLE, matchPath } from "@fern-ui/fern-docs-utils";
 import { addLeadingSlash } from "./addLeadingSlash";
 
+export enum Gate {
+    ALLOW,
+    DENY,
+}
+
 interface AuthRulesPathName {
     /**
      * List of paths that should be allowed to pass through without authentication
@@ -30,17 +35,17 @@ interface AuthRulesPathName {
 }
 
 /**
- * @returns true if the request should should be marked as authed
+ * @returns true if the request should should be denied
  */
-export function withBasicTokenAnonymous(auth: AuthRulesPathName, pathname: string): boolean {
+export function withBasicTokenAnonymous(auth: AuthRulesPathName, pathname: string): Gate {
     // if there are no auth rules, allow the request to pass through
     if (auth.allowlist == null && auth.denylist == null && auth.anonymous == null) {
-        return false;
+        return Gate.ALLOW;
     }
 
     // if the path is in the denylist, deny the request
     if (auth.denylist?.find((path) => matchPath(path, pathname))) {
-        return true;
+        return Gate.DENY;
     }
 
     // if the path is in the allowlist, allow the request to pass through
@@ -48,11 +53,11 @@ export function withBasicTokenAnonymous(auth: AuthRulesPathName, pathname: strin
         auth.allowlist?.find((path) => matchPath(path, pathname)) ||
         auth.anonymous?.find((path) => matchPath(path, pathname))
     ) {
-        return false;
+        return Gate.ALLOW;
     }
 
     // if the path is not in the allowlist, deny the request
-    return true;
+    return Gate.DENY;
 }
 
 /**
@@ -60,24 +65,29 @@ export function withBasicTokenAnonymous(auth: AuthRulesPathName, pathname: strin
  */
 export function withBasicTokenAnonymousCheck(
     auth: AuthRulesPathName,
-): (node: NavigationNode, parents?: readonly NavigationNodeParent[]) => boolean {
+): (node: NavigationNode, parents?: readonly NavigationNodeParent[]) => Gate {
     return (node, parents = EMPTY_ARRAY) => {
-        if (!rbacViewPredicate([], false)(node, parents)) {
-            return false;
+        if (isPage(node) && withBasicTokenAnonymous(auth, addLeadingSlash(node.slug)) === Gate.ALLOW) {
+            return Gate.ALLOW;
         }
 
-        if (isPage(node)) {
-            return withBasicTokenAnonymous(auth, addLeadingSlash(node.slug));
-        }
-
-        return false;
+        const predicate = rbacViewGate([], false);
+        return predicate(node, parents);
     };
+}
+
+function withDenied<T extends (...args: any[]) => Gate>(predicate: T): (...args: Parameters<T>) => boolean {
+    return (...args) => predicate(...args) === Gate.DENY;
+}
+
+function withAllowed<T extends (...args: any[]) => Gate>(predicate: T): (...args: Parameters<T>) => boolean {
+    return (...args) => predicate(...args) === Gate.ALLOW;
 }
 
 export function pruneWithBasicTokenAnonymous(auth: AuthEdgeConfigBasicTokenVerification, node: RootNode): RootNode {
     const result = Pruner.from(node)
         // mark nodes that are authed
-        .authed(withBasicTokenAnonymousCheck(auth))
+        .authed(withDenied(withBasicTokenAnonymousCheck(auth)))
         .get();
 
     // TODO: handle this more gracefully
@@ -92,20 +102,24 @@ export function pruneWithBasicTokenAnonymous(auth: AuthEdgeConfigBasicTokenVerif
  * @internal
  * @param roles current viewer's roles
  * @param filters rbac filters for the current node
+ * @param authed whether the viewer is authenticated
  * @returns true if the roles matches the filters (i.e. the viewer is allowed to view the node)
  */
-export function matchRoles(roles: string[], filters: string[][]): boolean {
-    if (filters.length === 0 || filters.every((filter) => filter.length === 0)) {
-        return true;
+export function matchRoles(authed: boolean, roles: string[], filters: string[][]): Gate {
+    roles = [EVERYONE_ROLE, ...roles];
+
+    // filters must include "everyone" if the viewer is authenticated
+    if (authed && (filters.length === 0 || filters.every((filter) => filter.length === 0))) {
+        return Gate.ALLOW;
     }
 
-    return filters.every((filter) => filter.some((aud) => roles.includes(aud) || aud === EVERYONE_ROLE));
+    return filters.every((filter) => filter.some((aud) => roles.includes(aud))) ? Gate.ALLOW : Gate.DENY;
 }
 
 export function pruneWithBasicTokenAuthed(auth: AuthRulesPathName, node: RootNode, roles: string[] = []): RootNode {
     const result = Pruner.from(node)
         // apply rbac
-        .keep(rbacViewPredicate(roles, true))
+        .keep(withAllowed(rbacViewGate(roles, true)))
         // hide nodes that are not authed
         .hide((n) => node.hidden || auth.anonymous?.find((path) => matchPath(path, addLeadingSlash(n.slug))) != null)
         // mark all nodes as unauthed since we are currently authenticated
@@ -137,20 +151,22 @@ export function getViewerFilters(...nodes: FernNavigation.WithPermissions[]): st
     );
 }
 
-function rbacViewPredicate(
+function rbacViewGate(
     roles: string[],
     authed: boolean,
-): (node: NavigationNode, parents: readonly NavigationNodeParent[]) => boolean {
+): (node: NavigationNode, parents: readonly NavigationNodeParent[]) => Gate {
     return (node, parents) => {
         if (!hasMetadata(node)) {
-            return true;
+            return Gate.ALLOW;
         }
 
         if (!authed && node.authed) {
-            return false;
+            return Gate.DENY;
         }
 
         const nodes = [...parents, node];
-        return matchRoles(roles, getViewerFilters(...nodes.filter(FernNavigation.hasMetadata)));
+        const filters = getViewerFilters(...nodes.filter(FernNavigation.hasMetadata));
+
+        return matchRoles(authed, roles, filters);
     };
 }

--- a/packages/ui/docs-bundle/src/server/withRbac.ts
+++ b/packages/ui/docs-bundle/src/server/withRbac.ts
@@ -33,6 +33,11 @@ interface AuthRulesPathName {
  * @returns true if the request should should be marked as authed
  */
 export function withBasicTokenAnonymous(auth: AuthRulesPathName, pathname: string): boolean {
+    // if there are no auth rules, allow the request to pass through
+    if (auth.allowlist == null && auth.denylist == null && auth.anonymous == null) {
+        return false;
+    }
+
     // if the path is in the denylist, deny the request
     if (auth.denylist?.find((path) => matchPath(path, pathname))) {
         return true;

--- a/packages/ui/docs-bundle/src/server/xfernhost/node.ts
+++ b/packages/ui/docs-bundle/src/server/xfernhost/node.ts
@@ -1,3 +1,4 @@
+import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import { COOKIE_FERN_DOCS_PREVIEW, HEADER_X_FERN_HOST } from "@fern-ui/fern-docs-utils";
 import type { NextApiRequest } from "next";
 import { getNextPublicDocsDomain } from "./dev";
@@ -46,10 +47,9 @@ export function getHostNodeStatic(): string | undefined {
 export function getHostNode(req: { url?: string }): string | undefined {
     if (req.url != null) {
         try {
-            return new URL(req.url).host;
-        } catch (e) {
-            // eslint-disable-next-line no-console
-            console.error(`Error parsing URL ${req.url}: ${e}`);
+            return new URL(req.url, withDefaultProtocol(getHostNodeStatic())).host;
+        } catch (_e) {
+            // do nothing
         }
     }
 


### PR DESCRIPTION
- Returns ALLOW or DENY instead of true/false
- fixes case where all requests are blocked in the middleware. We're not quite ready for that yet.
https://appbuildwithfern-3uuora74q-buildwithfern.vercel.app/api/fern-docs/preview?host=test-jwt-auth-smokey.docs.buildwithfern.com