### PR TITLE
chore(docs): remove process.env from mdx bundler components

### DIFF
--- a/packages/ui/app/src/mdx/bundlers/mdx-bundler.ts
+++ b/packages/ui/app/src/mdx/bundlers/mdx-bundler.ts
@@ -121,6 +121,17 @@ export async function serializeMdx(
 
             esbuildOptions: (o) => {
                 o.minify = disableMinify ? false : true;
+
+                // Create a restricted define object that excludes process.env
+                const restrictedDefine = {
+                    "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
+                };
+
+                o.define = restrictedDefine;
+
+                // Prevent direct process access
+                o.inject = o.inject?.filter((path) => !path.includes("process"));
+
                 return o;
             },
         });


### PR DESCRIPTION
## Short description of the changes made
reduce what is available in `process.env` when bundling custom mdx components

## What was the motivation & context behind this PR?
security

## How has this PR been tested?
will be tested via staging links
