### PR TITLE
fix: small search papercuts

### DIFF
--- a/packages/ui/app/src/playground/PlaygroundWebSocket.tsx
+++ b/packages/ui/app/src/playground/PlaygroundWebSocket.tsx
@@ -134,6 +134,7 @@ export const PlaygroundWebSocket: FC<PlaygroundWebSocketProps> = ({ context }): 
         formState.headers,
         pushMessage,
         activeSessionMessageCount,
+        websocketMessageLimit,
     ]);
 
     const handleSendMessage = useCallback(

--- a/packages/ui/app/src/search/SearchHits.tsx
+++ b/packages/ui/app/src/search/SearchHits.tsx
@@ -28,7 +28,7 @@ const ExpandButton: React.FC<{ expanded: boolean; setExpanded: (expanded: boolea
     expanded,
     setExpanded,
 }) => (
-    <div className="justify-end">
+    <div className="flex justify-end pt-2">
         <FernButton
             className="text-left"
             variant="minimal"
@@ -50,10 +50,9 @@ const SearchSection: React.FC<{
     hoveredSearchHitId: string | null;
     setHoveredSearchHitId: (id: string) => void;
 }> = ({ title, hits, expanded, setExpanded, refs, hoveredSearchHitId, setHoveredSearchHitId }) => (
-    <div className="pb-4">
+    <div className="pb-2">
         <div className="flex justify-between items-center">
             <div className="text-normal font-semibold pl-0.5">{title}</div>
-            {hits.length > SEARCH_HITS_PER_SECTION && <ExpandButton expanded={expanded} setExpanded={setExpanded} />}
         </div>
         <Separator orientation="horizontal" decorative className="my-2 bg-accent" />
         {expandHits(expanded, hits).map((hit) => (
@@ -69,6 +68,7 @@ const SearchSection: React.FC<{
                 onMouseEnter={() => setHoveredSearchHitId(hit.objectID)}
             />
         ))}
+        {hits.length > SEARCH_HITS_PER_SECTION && <ExpandButton expanded={expanded} setExpanded={setExpanded} />}
     </div>
 );
 

--- a/packages/ui/app/src/search/content/EndpointRecordV4.tsx
+++ b/packages/ui/app/src/search/content/EndpointRecordV4.tsx
@@ -66,14 +66,6 @@ export const EndpointRecordV4: React.FC<EndpointRecordV4.Props> = ({ hit, isHove
                             )}
                     </div>
                 </div>
-                <div
-                    className={cn("text-sm tracking-wide", {
-                        "t-muted": !isHovered,
-                        "t-accent-aaa": isHovered,
-                    })}
-                >
-                    Endpoint
-                </div>
             </div>
             {
                 <div className="flex items-center justify-between">

--- a/packages/ui/app/src/search/content/FieldRecordV1.tsx
+++ b/packages/ui/app/src/search/content/FieldRecordV1.tsx
@@ -70,14 +70,6 @@ export const FieldRecordV1: React.FC<FieldRecordV1.Props> = ({ hit, isHovered })
                             )}
                     </div>
                 </div>
-                <div
-                    className={cn("text-sm tracking-wide", {
-                        "t-muted": !isHovered,
-                        "t-accent-aaa": isHovered,
-                    })}
-                >
-                    Field
-                </div>
             </div>
             <span
                 className={cn("line-clamp-1 text-start text-xs", {

--- a/packages/ui/app/src/search/content/MarkdownSectionRecordV1.tsx
+++ b/packages/ui/app/src/search/content/MarkdownSectionRecordV1.tsx
@@ -24,14 +24,6 @@ export const MarkdownSectionRecordV1: React.FC<MarkdownSectionRecordV1.Props> = 
                 >
                     {hit.title}
                 </span>
-                <div
-                    className={cn("text-sm tracking-wide", {
-                        "t-muted": !isHovered,
-                        "t-accent-aaa": isHovered,
-                    })}
-                >
-                    Section
-                </div>
             </div>
             {hit.content && (
                 <div className="flex items-center justify-between">

--- a/packages/ui/app/src/search/content/PageRecordV4.tsx
+++ b/packages/ui/app/src/search/content/PageRecordV4.tsx
@@ -24,14 +24,6 @@ export const PageRecordV4: React.FC<PageRecordV4.Props> = ({ hit, isHovered }) =
                 >
                     {hit.title}
                 </span>
-                <div
-                    className={cn("text-sm tracking-wide", {
-                        "t-muted": !isHovered,
-                        "t-accent-aaa": isHovered,
-                    })}
-                >
-                    Page
-                </div>
             </div>
             {hit.description && (
                 <div className="flex items-center justify-between">


### PR DESCRIPTION
## Short description of the changes made

* removes block labels
* moves expand button to bottom right

## What was the motivation & context behind this PR?

* unblock go-lives

## How has this PR been tested?


<img width="774" alt="Screenshot 2024-10-28 at 4 41 53 PM" src="https://github.com/user-attachments/assets/a5b5eb2b-2cbe-4edc-a610-ef8c01aa597b">
