### PR TITLE
fix: filter out authed pages from collector

### DIFF
--- a/packages/fdr-sdk/src/__test__/fixtures.test.ts
+++ b/packages/fdr-sdk/src/__test__/fixtures.test.ts
@@ -52,7 +52,7 @@ function testNavigationConfigConverter(fixtureName: string): void {
                 `output/${fixtureName}/slugs.json`,
             );
 
-            expect(JSON.stringify(collector.pageSlugs, undefined, 2)).toMatchFileSnapshot(
+            expect(JSON.stringify(collector.staticPageSlugs, undefined, 2)).toMatchFileSnapshot(
                 `output/${fixtureName}/slugs-pages.json`,
             );
 

--- a/packages/fdr-sdk/src/__test__/testGetAllUrlsFromDocsConfig.ts
+++ b/packages/fdr-sdk/src/__test__/testGetAllUrlsFromDocsConfig.ts
@@ -5,7 +5,7 @@ import { NodeCollector } from "../navigation/NodeCollector";
 export function testGetAllUrlsFromDocsConfig(root: FernNavigation.RootNode, domain: string): void {
     it("gets all urls from docs config", async () => {
         const collector = NodeCollector.collect(root);
-        const urls = collector.pageSlugs.map((slug) => urljoin(domain, slug));
+        const urls = collector.staticPageSlugs.map((slug) => urljoin(domain, slug));
         expect(urls).toMatchSnapshot();
     });
 }

--- a/packages/fdr-sdk/src/navigation/NodeCollector.ts
+++ b/packages/fdr-sdk/src/navigation/NodeCollector.ts
@@ -156,21 +156,22 @@ export class NodeCollector {
     /**
      * Returns a list of slugs for all pages in the navigation tree.
      *
-     * This includes hidden pages and noindex pages, and is intended for revalidation purposes.
+     * This includes hidden pages and noindex pages, but not authed pages, and is intended for revalidation purposes.
      *
      * @returns {string[]} A list of slugs for all canonical pages in the navigation tree.
      */
-    #getPageSlugs = once((): string[] => {
+    #getStaticPageSlugs = once((): string[] => {
         return Array.from(
             new Set(
                 [...this.slugToNode.values()]
                     .filter(({ node }) => FernNavigation.isPage(node))
+                    .filter(({ node }) => !node.authed)
                     .map(({ node }) => node.slug),
             ),
         );
     });
-    get pageSlugs(): string[] {
-        return this.#getPageSlugs();
+    get staticPageSlugs(): string[] {
+        return this.#getStaticPageSlugs();
     }
 
     /**

--- a/packages/healthchecks/src/rules/all-pages-load/rule.ts
+++ b/packages/healthchecks/src/rules/all-pages-load/rule.ts
@@ -18,7 +18,7 @@ export class AllPagesLoadRule implements Rule {
         }
         const node = FernNavigation.utils.toRootNode(getDocsForUrlResponse.body);
         const collector = FernNavigation.NodeCollector.collect(node);
-        const urls = collector.pageSlugs.map((slug) => `${getDocsForUrlResponse.body.baseUrl.domain}/${slug}`);
+        const urls = collector.staticPageSlugs.map((slug) => `${getDocsForUrlResponse.body.baseUrl.domain}/${slug}`);
 
         const responses = await Promise.all(
             urls.map(async (url) => {

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v3.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v3.ts
@@ -33,8 +33,8 @@ const handler: NextApiHandler = async (
     const domain = getDocsDomainNode(req);
     const host = getHostNode(req) ?? domain;
 
-    // never proivde a token here because revalidation should only be done on public routes (for now)
-    const loader = DocsLoader.for(domain, host, undefined);
+    // never provide a token here because revalidation should only be done on public routes (for now)
+    const loader = DocsLoader.for(domain, host);
 
     const root = await loader.root();
 
@@ -48,7 +48,7 @@ const handler: NextApiHandler = async (
     }
 
     const revalidate = new Revalidator(res, domain);
-    const slugs = NodeCollector.collect(root).pageSlugs;
+    const slugs = NodeCollector.collect(root).staticPageSlugs;
 
     try {
         const cache = DocsKVCache.getInstance(domain);

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v4.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v4.ts
@@ -42,8 +42,8 @@ const handler: NextApiHandler = async (
     const domain = getDocsDomainNode(req);
     const host = getHostNode(req) ?? domain;
 
-    // never proivde a token here because revalidation should only be done on public routes (for now)
-    const loader = DocsLoader.for(domain, host, undefined);
+    // never provide a token here because revalidation should only be done on public routes (for now)
+    const loader = DocsLoader.for(domain, host);
     const root = await loader.root();
 
     if (!root) {
@@ -53,7 +53,7 @@ const handler: NextApiHandler = async (
         return res.status(loader.error?.error === "UnauthorizedError" ? 200 : 404).json({ total: 0, results: [] });
     }
 
-    const slugs = NodeCollector.collect(root).pageSlugs;
+    const slugs = NodeCollector.collect(root).staticPageSlugs;
     const revalidate = new Revalidator(res, domain);
 
     if (offset === 0) {

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/sitemap.xml.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/sitemap.xml.ts
@@ -1,9 +1,9 @@
 import { DocsLoader } from "@/server/DocsLoader";
 import { conformTrailingSlash } from "@/server/trailingSlash";
+import { withPrunedNavigation } from "@/server/withPrunedNavigation";
 import { getDocsDomainEdge, getHostEdge } from "@/server/xfernhost/edge";
 import { NodeCollector } from "@fern-api/fdr-sdk/navigation";
 import { withDefaultProtocol } from "@fern-api/ui-core-utils";
-import { COOKIE_FERN_TOKEN } from "@fern-ui/fern-docs-utils";
 import { NextRequest, NextResponse } from "next/server";
 import urljoin from "url-join";
 
@@ -17,9 +17,8 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
     const domain = getDocsDomainEdge(req);
     const host = getHostEdge(req);
 
-    // load the root node
-    const fernToken = req.cookies.get(COOKIE_FERN_TOKEN)?.value;
-    const root = await DocsLoader.for(domain, host, fernToken).root();
+    // load the root node, and prune it— sitemap should only include public routes
+    const root = withPrunedNavigation(await DocsLoader.for(domain, host).root(), { authed: false });
 
     // collect all indexable page slugs
     const slugs = NodeCollector.collect(root).indexablePageSlugs;


### PR DESCRIPTION
**Problem**: authed pages were being needlessly revalidated

**Why this regressed**: the predicate used for filtering out authed pages was recently changed to setting `authed: true`, and so it wasn't filtered out from the revalidation logic.

**What is the impact**: revalidation will make `HEAD` requests to the redirect target, which for authed pages tend to be the customer's servers. This results in a DDoS on their servers.

**Solution**: filtering out `authed: true` pages from the node collector