### PR TITLE
fix: ping-pong behavior of use callback which messes with deferred state

### DIFF
--- a/packages/ui/app/src/playground/endpoint/PlaygroundEndpointAliasForm.tsx
+++ b/packages/ui/app/src/playground/endpoint/PlaygroundEndpointAliasForm.tsx
@@ -1,0 +1,37 @@
+import * as ApiDefinition from "@fern-api/fdr-sdk/api-definition";
+import { unwrapReference } from "@fern-api/fdr-sdk/api-definition";
+import { ReactElement, useMemo } from "react";
+import { PlaygroundObjectForm } from "../form/PlaygroundObjectForm";
+import { PlaygroundTypeReferenceForm } from "../form/PlaygroundTypeReferenceForm";
+import { PlaygroundEndpointFormSection } from "./PlaygroundEndpointFormSection";
+
+interface PlaygroundEndpointAliasFormProps {
+    alias: ApiDefinition.HttpRequestBodyShape.Alias;
+    types: Record<ApiDefinition.TypeId, ApiDefinition.TypeDefinition>;
+    ignoreHeaders: boolean;
+    setBodyJson: (value: unknown) => void;
+    value: unknown;
+}
+
+export function PlaygroundEndpointAliasForm({
+    alias,
+    types,
+    ignoreHeaders,
+    setBodyJson,
+    value,
+}: PlaygroundEndpointAliasFormProps): ReactElement {
+    const { shape, isOptional } = useMemo(() => unwrapReference(alias.value, types), [alias.value, types]);
+
+    if (shape.type === "object" && !isOptional) {
+        return (
+            <PlaygroundEndpointFormSection ignoreHeaders={ignoreHeaders} title="Body Parameters">
+                <PlaygroundObjectForm id="body" shape={shape} onChange={setBodyJson} value={value} types={types} />
+            </PlaygroundEndpointFormSection>
+        );
+    }
+    return (
+        <PlaygroundEndpointFormSection ignoreHeaders={ignoreHeaders} title={isOptional ? "Optional Body" : "Body"}>
+            <PlaygroundTypeReferenceForm id="body" shape={shape} onChange={setBodyJson} value={value} types={types} />
+        </PlaygroundEndpointFormSection>
+    );
+}

--- a/packages/ui/app/src/playground/endpoint/PlaygroundEndpointForm.tsx
+++ b/packages/ui/app/src/playground/endpoint/PlaygroundEndpointForm.tsx
@@ -1,11 +1,11 @@
 import type { EndpointContext } from "@fern-api/fdr-sdk/api-definition";
-import { unwrapObjectType, unwrapReference } from "@fern-api/fdr-sdk/api-definition";
 import { EMPTY_ARRAY, visitDiscriminatedUnion } from "@fern-api/ui-core-utils";
 import { Dispatch, FC, SetStateAction, useCallback, useMemo } from "react";
 import { PlaygroundFileUploadForm } from "../form/PlaygroundFileUploadForm";
+import { PlaygroundObjectForm } from "../form/PlaygroundObjectForm";
 import { PlaygroundObjectPropertiesForm } from "../form/PlaygroundObjectPropertyForm";
-import { PlaygroundTypeReferenceForm } from "../form/PlaygroundTypeReferenceForm";
 import { PlaygroundEndpointRequestFormState, PlaygroundFormStateBody } from "../types";
+import { PlaygroundEndpointAliasForm } from "./PlaygroundEndpointAliasForm";
 import { PlaygroundEndpointFormSection } from "./PlaygroundEndpointFormSection";
 import { PlaygroundEndpointMultipartForm } from "./PlaygroundEndpointMultipartForm";
 
@@ -169,13 +169,11 @@ export const PlaygroundEndpointForm: FC<PlaygroundEndpointFormProps> = ({
                         </PlaygroundEndpointFormSection>
                     ),
                     object: (value) => {
-                        const unwrappedObjectType = unwrapObjectType(value, types);
                         return (
                             <PlaygroundEndpointFormSection ignoreHeaders={ignoreHeaders} title="Body Parameters">
-                                <PlaygroundObjectPropertiesForm
+                                <PlaygroundObjectForm
                                     id="body"
-                                    properties={unwrappedObjectType.properties}
-                                    extraProperties={unwrappedObjectType.extraProperties}
+                                    shape={value}
                                     onChange={setBodyJson}
                                     value={formState?.body?.value}
                                     types={types}
@@ -184,36 +182,14 @@ export const PlaygroundEndpointForm: FC<PlaygroundEndpointFormProps> = ({
                         );
                     },
                     alias: (alias) => {
-                        const { shape, isOptional } = unwrapReference(alias.value, types);
-
-                        if (shape.type === "object" && !isOptional) {
-                            const unwrappedObjectType = unwrapObjectType(shape, types);
-                            return (
-                                <PlaygroundEndpointFormSection ignoreHeaders={ignoreHeaders} title="Body Parameters">
-                                    <PlaygroundObjectPropertiesForm
-                                        id="body"
-                                        properties={unwrappedObjectType.properties}
-                                        extraProperties={unwrappedObjectType.extraProperties}
-                                        onChange={setBodyJson}
-                                        value={formState?.body?.value}
-                                        types={types}
-                                    />
-                                </PlaygroundEndpointFormSection>
-                            );
-                        }
                         return (
-                            <PlaygroundEndpointFormSection
-                                ignoreHeaders={ignoreHeaders}
-                                title={isOptional ? "Optional Body" : "Body"}
-                            >
-                                <PlaygroundTypeReferenceForm
-                                    id="body"
-                                    shape={shape}
-                                    onChange={setBodyJson}
-                                    value={formState?.body?.value}
-                                    types={types}
-                                />
-                            </PlaygroundEndpointFormSection>
+                            <PlaygroundEndpointAliasForm
+                                alias={alias}
+                                types={types}
+                                ignoreHeaders={ignoreHeaders ?? false}
+                                setBodyJson={setBodyJson}
+                                value={formState?.body?.value}
+                            />
                         );
                     },
                 })}

--- a/packages/ui/app/src/playground/form/PlaygroundAdditionalProperties.tsx
+++ b/packages/ui/app/src/playground/form/PlaygroundAdditionalProperties.tsx
@@ -1,0 +1,129 @@
+// import { Property, TypeIdKey, TypeId } from "@fern-api/fdr-sdk/navigation";
+import * as ApiDefinition from "@fern-api/fdr-sdk/api-definition";
+import clsx from "clsx";
+import { ReactElement, useCallback, useMemo } from "react";
+import { noop } from "ts-essentials";
+import { WithLabel } from "../WithLabel";
+import { castToRecord } from "../utils";
+import { PlaygroundMapForm } from "./PlaygroundMapForm";
+
+const ADDITIONAL_PROPERTIES_KEY_SHAPE = {
+    type: "primitive",
+    value: {
+        type: "string",
+        regex: undefined,
+        minLength: undefined,
+        maxLength: undefined,
+        default: undefined,
+    },
+} as const;
+
+const ADDITIONAL_PROPERTIES_VALUE_SHAPE = {
+    type: "primitive",
+    value: {
+        type: "string",
+        regex: undefined,
+        minLength: undefined,
+        maxLength: undefined,
+        default: undefined,
+    },
+} as const;
+
+// TODO: This is hardcoded for now, but change to dynamic type references, by setting value
+const ADDITIONAL_PROPERTIES_DEFAULT_SHAPE = {
+    type: "alias",
+    value: {
+        type: "optional",
+        shape: {
+            type: "alias",
+            value: {
+                type: "map",
+                keyShape: {
+                    type: "alias",
+                    value: ADDITIONAL_PROPERTIES_KEY_SHAPE,
+                },
+                valueShape: {
+                    type: "alias",
+                    value: ADDITIONAL_PROPERTIES_VALUE_SHAPE,
+                },
+            },
+        },
+        default: undefined,
+    },
+} as const;
+
+interface PlaygroundAdditionalPropertiesProps {
+    onChange: (dispatch: unknown) => void;
+    properties: readonly ApiDefinition.ObjectProperty[];
+    extraProperties: ApiDefinition.TypeReference;
+    value: unknown;
+    types: Record<ApiDefinition.TypeId, ApiDefinition.TypeDefinition>;
+}
+
+export function PlaygroundAdditionalProperties({
+    onChange,
+    properties,
+    // TODO: this should be used:
+    // extraProperties,
+    value,
+    types,
+}: PlaygroundAdditionalPropertiesProps): ReactElement {
+    const additionalProperties = useMemo(() => {
+        // remove property keys from value
+        const valueAsRecord = castToRecord(value);
+
+        const additionalPropertiesOnly: Record<string, unknown> = {};
+
+        Object.keys(valueAsRecord).forEach((key) => {
+            if (!properties.some((p) => p.key === key)) {
+                additionalPropertiesOnly[key] = valueAsRecord[key];
+            }
+        });
+
+        return additionalPropertiesOnly;
+    }, [properties, value]);
+
+    const handleChange = useCallback(
+        (dispatch: unknown) => {
+            onChange((prev: unknown) => {
+                const castedPrev = castToRecord(prev);
+                const newValue = typeof dispatch === "function" ? dispatch(prev) : dispatch;
+
+                // spread in the properties that are not in the extraProperties
+                const obj = { ...newValue };
+                Object.keys(castedPrev).forEach((key) => {
+                    if (properties.find((p) => p.key === key)) {
+                        obj[key] = castedPrev[key];
+                    }
+                });
+                return obj;
+            });
+        },
+        [onChange, properties],
+    );
+
+    return (
+        <div className={clsx("flex-1 shrink min-w-0 mt-8")}>
+            <WithLabel
+                property={{
+                    key: ApiDefinition.PropertyKey("Optional Extra Properties"),
+                    valueShape: ADDITIONAL_PROPERTIES_DEFAULT_SHAPE,
+                    description: undefined,
+                    availability: undefined,
+                }}
+                value={"Optional Extra Properties"}
+                onRemove={noop}
+                types={types}
+            >
+                <PlaygroundMapForm
+                    id="extraProperties"
+                    keyShape={ADDITIONAL_PROPERTIES_KEY_SHAPE}
+                    valueShape={ADDITIONAL_PROPERTIES_VALUE_SHAPE}
+                    onChange={handleChange}
+                    value={additionalProperties}
+                    types={types}
+                />
+            </WithLabel>
+        </div>
+    );
+}

--- a/packages/ui/app/src/playground/form/PlaygroundDescriminatedUnionForm.tsx
+++ b/packages/ui/app/src/playground/form/PlaygroundDescriminatedUnionForm.tsx
@@ -70,7 +70,10 @@ export const PlaygroundDiscriminatedUnionForm = memo<PlaygroundDiscriminatedUnio
         (variant) => variant.discriminantValue === selectedVariantKey,
     );
 
-    const properties = selectedVariant != null ? unwrapObjectType(selectedVariant, types).properties : [];
+    const properties = useMemo(
+        () => (selectedVariant != null ? unwrapObjectType(selectedVariant, types).properties : []),
+        [selectedVariant, types],
+    );
 
     return (
         <div className="w-full">

--- a/packages/ui/app/src/playground/form/PlaygroundMapForm.tsx
+++ b/packages/ui/app/src/playground/form/PlaygroundMapForm.tsx
@@ -1,4 +1,4 @@
-import { TypeDefinition, TypeShapeOrReference, unwrapReference } from "@fern-api/fdr-sdk/api-definition";
+import { TypeDefinition, TypeShapeOrReference } from "@fern-api/fdr-sdk/api-definition";
 import { isPlainObject, unknownToString } from "@fern-api/ui-core-utils";
 import { FernButton } from "@fern-ui/components";
 import { Plus, Xmark } from "iconoir-react";
@@ -71,6 +71,7 @@ export const PlaygroundMapForm = memo<PlaygroundMapFormProps>((props) => {
             return [...oldState.slice(0, idx), nextState, ...oldState.slice(idx + 1)];
         });
     }, []);
+
     const handleRemoveItem = useCallback((idx: number) => {
         setInternalState((oldArray) => [...oldArray.slice(0, idx), ...oldArray.slice(idx + 1)]);
     }, []);
@@ -80,45 +81,18 @@ export const PlaygroundMapForm = memo<PlaygroundMapFormProps>((props) => {
             {internalState.length > 0 && (
                 <ul className="border-default divide-default w-full max-w-full list-none divide-y divide-dashed border-t border-dashed">
                     {internalState.map((item, idx) => (
-                        <li key={idx} className="flex min-h-12 flex-row items-start gap-1 py-2">
-                            {/* <div className="flex min-w-0 shrink items-center justify-between gap-2">
-                                <label className="inline-flex flex-wrap items-baseline">
-                                    <span className="t-muted bg-tag-default min-w-6 rounded-xl p-1 text-center text-xs font-semibold uppercase">
-                                        {idx + 1}
-                                    </span>
-                                </label>
-                            </div> */}
-
-                            <div className="min-w-0 flex-1 shrink">
-                                <span className="t-muted text-xs">{"key"}</span>
-                                <PlaygroundTypeReferenceForm
-                                    id={`${id}[${idx}].key`}
-                                    shape={keyShape}
-                                    value={item.key}
-                                    onChange={(newKey) => handleChangeKey(idx, newKey)}
-                                    types={types}
-                                />
-                            </div>
-                            <div className="min-w-0 flex-1 shrink">
-                                <span className="t-muted text-xs">{"value"}</span>
-                                <PlaygroundTypeReferenceForm
-                                    id={`${id}[${idx}].value`}
-                                    shape={unwrapReference(valueShape, types).shape}
-                                    value={item.value}
-                                    onChange={(newValue) => handleChangeValue(idx, newValue)}
-                                    types={types}
-                                />
-                            </div>
-                            <div>
-                                <FernButton
-                                    icon={<Xmark />}
-                                    onClick={() => handleRemoveItem(idx)}
-                                    variant="minimal"
-                                    size="small"
-                                    className="-ml-1 -mr-3 opacity-50 transition-opacity hover:opacity-100"
-                                />
-                            </div>
-                        </li>
+                        <PlaygroundMapItemForm
+                            key={idx}
+                            idx={idx}
+                            id={id}
+                            keyShape={keyShape}
+                            valueShape={valueShape}
+                            onKeyChange={handleChangeKey}
+                            onValueChange={handleChangeValue}
+                            onRemoveItem={handleRemoveItem}
+                            item={item}
+                            types={types}
+                        />
                     ))}
                     <li className="pt-2">
                         <FernButton
@@ -143,5 +117,85 @@ export const PlaygroundMapForm = memo<PlaygroundMapFormProps>((props) => {
         </>
     );
 });
+
+interface PlaygroundMapItemFormProps {
+    idx: number;
+    id: string;
+    keyShape: TypeShapeOrReference;
+    valueShape: TypeShapeOrReference;
+    onKeyChange: (idx: number, value: unknown) => void;
+    onValueChange: (idx: number, value: unknown) => void;
+    onRemoveItem: (idx: number) => void;
+    item: { key: unknown; value: unknown };
+    types: Record<string, TypeDefinition>;
+}
+
+function PlaygroundMapItemForm({
+    idx,
+    id,
+    keyShape,
+    valueShape,
+    onKeyChange,
+    onValueChange,
+    onRemoveItem,
+    item,
+    types,
+}: PlaygroundMapItemFormProps) {
+    const handleChangeKey = useCallback(
+        (newKey: unknown) => {
+            onKeyChange(idx, newKey);
+        },
+        [onKeyChange, idx],
+    );
+
+    const handleChangeValue = useCallback(
+        (newValue: unknown) => {
+            onValueChange(idx, newValue);
+        },
+        [onValueChange, idx],
+    );
+
+    return (
+        <li key={idx} className="flex min-h-12 flex-row items-start gap-1 py-2">
+            {/* <div className="flex min-w-0 shrink items-center justify-between gap-2">
+                <label className="inline-flex flex-wrap items-baseline">
+                    <span className="t-muted bg-tag-default min-w-6 rounded-xl p-1 text-center text-xs font-semibold uppercase">
+                        {idx + 1}
+                    </span>
+                </label>
+            </div> */}
+
+            <div className="min-w-0 flex-1 shrink">
+                <span className="t-muted text-xs">{"key"}</span>
+                <PlaygroundTypeReferenceForm
+                    id={`${id}[${idx}].key`}
+                    shape={keyShape}
+                    value={item.key}
+                    onChange={handleChangeKey}
+                    types={types}
+                />
+            </div>
+            <div className="min-w-0 flex-1 shrink">
+                <span className="t-muted text-xs">{"value"}</span>
+                <PlaygroundTypeReferenceForm
+                    id={`${id}[${idx}].value`}
+                    shape={valueShape}
+                    value={item.value}
+                    onChange={handleChangeValue}
+                    types={types}
+                />
+            </div>
+            <div>
+                <FernButton
+                    icon={<Xmark />}
+                    onClick={() => onRemoveItem(idx)}
+                    variant="minimal"
+                    size="small"
+                    className="-ml-1 -mr-3 opacity-50 transition-opacity hover:opacity-100"
+                />
+            </div>
+        </li>
+    );
+}
 
 PlaygroundMapForm.displayName = "PlaygroundMapForm";

--- a/packages/ui/app/src/playground/form/PlaygroundObjectForm.tsx
+++ b/packages/ui/app/src/playground/form/PlaygroundObjectForm.tsx
@@ -1,0 +1,27 @@
+import { TypeDefinition, TypeShape, unwrapObjectType } from "@fern-api/fdr-sdk/api-definition";
+import { ReactElement, useMemo } from "react";
+import { PlaygroundObjectPropertiesForm } from "./PlaygroundObjectPropertyForm";
+
+interface PlaygroundObjectFormProps {
+    id: string;
+    shape: TypeShape.Object_;
+    onChange: (value: unknown) => void;
+    value: unknown;
+    indent?: boolean;
+    types: Record<string, TypeDefinition>;
+    disabled?: boolean;
+}
+
+export function PlaygroundObjectForm({ id, shape, onChange, value, types }: PlaygroundObjectFormProps): ReactElement {
+    const { properties, extraProperties } = useMemo(() => unwrapObjectType(shape, types), [shape, types]);
+    return (
+        <PlaygroundObjectPropertiesForm
+            id={id}
+            properties={properties}
+            extraProperties={extraProperties}
+            onChange={onChange}
+            value={value}
+            types={types}
+        />
+    );
+}

--- a/packages/ui/app/src/playground/form/PlaygroundObjectPropertyForm.tsx
+++ b/packages/ui/app/src/playground/form/PlaygroundObjectPropertyForm.tsx
@@ -162,34 +162,30 @@ export const PlaygroundObjectPropertiesForm = memo<PlaygroundObjectPropertiesFor
 
     const onChangeAdditionalObjectProperty = useCallback(
         (newValue: unknown) => {
-            onChange((oldValue: unknown) => {
-                const oldObject = castToRecord(oldValue);
-                const val = castToRecord(newValue);
+            if (JSON.stringify(castToRecord(additionalProperties)) !== JSON.stringify(castToRecord(newValue))) {
+                onChange((oldValue: unknown) => {
+                    const oldObject = castToRecord(oldValue);
 
-                if (newValue === undefined) {
-                    return Object.fromEntries(
-                        Object.entries(oldObject).filter(
-                            ([k]) => !Object.keys(castToRecord(additionalProperties)).includes(k),
-                        ),
-                    );
-                } else {
-                    if (
-                        JSON.stringify(Object.keys(castToRecord(additionalProperties))) !==
-                        JSON.stringify(Object.keys(val))
-                    ) {
-                        setAdditionalProperties(newValue);
-                    }
-
-                    return {
-                        ...Object.fromEntries(
+                    if (newValue === undefined) {
+                        return Object.fromEntries(
                             Object.entries(oldObject).filter(
                                 ([k]) => !Object.keys(castToRecord(additionalProperties)).includes(k),
                             ),
-                        ),
-                        ...newValue,
-                    };
-                }
-            });
+                        );
+                    } else {
+                        setAdditionalProperties(newValue);
+
+                        return {
+                            ...Object.fromEntries(
+                                Object.entries(oldObject).filter(
+                                    ([k]) => !Object.keys(castToRecord(additionalProperties)).includes(k),
+                                ),
+                            ),
+                            ...newValue,
+                        };
+                    }
+                });
+            }
         },
         [onChange, additionalProperties],
     );

--- a/packages/ui/app/src/playground/form/PlaygroundObjectPropertyForm.tsx
+++ b/packages/ui/app/src/playground/form/PlaygroundObjectPropertyForm.tsx
@@ -1,6 +1,5 @@
 import {
     ObjectProperty,
-    PropertyKey,
     TypeDefinition,
     TypeId,
     TypeReference,
@@ -13,59 +12,13 @@ import { PlusCircle } from "iconoir-react";
 import dynamic from "next/dynamic";
 import { FC, memo, useCallback, useEffect, useMemo, useState } from "react";
 import { renderTypeShorthandRoot } from "../../type-shorthand";
-import { WithLabel } from "../WithLabel";
 import { castToRecord, getEmptyValueForType, isExpandable } from "../utils";
-import { PlaygroundMapForm } from "./PlaygroundMapForm";
+import { PlaygroundAdditionalProperties } from "./PlaygroundAdditionalProperties";
 import { PlaygroundTypeReferenceForm } from "./PlaygroundTypeReferenceForm";
 
 const Markdown = dynamic(() => import("../../mdx/Markdown").then(({ Markdown }) => Markdown));
 
 const ADD_ALL_KEY = "__FERN_ADD_ALL__" as const;
-
-const ADDITIONAL_PROPERTIES_KEY_SHAPE = {
-    type: "primitive",
-    value: {
-        type: "string",
-        regex: undefined,
-        minLength: undefined,
-        maxLength: undefined,
-        default: undefined,
-    },
-} as const;
-
-const ADDITIONAL_PROPERTIES_VALUE_SHAPE = {
-    type: "primitive",
-    value: {
-        type: "string",
-        regex: undefined,
-        minLength: undefined,
-        maxLength: undefined,
-        default: undefined,
-    },
-} as const;
-
-// TODO: This is hardcoded for now, but change to dynamic type references, by setting value
-const ADDITIONAL_PROPERTIES_DEFAULT_SHAPE = {
-    type: "alias",
-    value: {
-        type: "optional",
-        shape: {
-            type: "alias",
-            value: {
-                type: "map",
-                keyShape: {
-                    type: "alias",
-                    value: ADDITIONAL_PROPERTIES_KEY_SHAPE,
-                },
-                valueShape: {
-                    type: "alias",
-                    value: ADDITIONAL_PROPERTIES_VALUE_SHAPE,
-                },
-            },
-        },
-        default: undefined,
-    },
-} as const;
 
 interface PlaygroundObjectPropertyFormProps {
     id: string;
@@ -114,7 +67,7 @@ export const PlaygroundObjectPropertyForm: FC<PlaygroundObjectPropertyFormProps>
         <PlaygroundTypeReferenceForm
             id={id}
             property={property}
-            shape={unwrapReference(property.valueShape, types).shape}
+            shape={property.valueShape}
             onChange={handleChange}
             value={value}
             renderAsPanel={true}
@@ -158,43 +111,12 @@ export const PlaygroundObjectPropertiesForm = memo<PlaygroundObjectPropertiesFor
         [onChange],
     );
 
-    const [additionalProperties, setAdditionalProperties] = useState<unknown>({});
-
-    const onChangeAdditionalObjectProperty = useCallback(
-        (newValue: unknown) => {
-            if (JSON.stringify(castToRecord(additionalProperties)) !== JSON.stringify(castToRecord(newValue))) {
-                onChange((oldValue: unknown) => {
-                    const oldObject = castToRecord(oldValue);
-
-                    if (newValue === undefined) {
-                        return Object.fromEntries(
-                            Object.entries(oldObject).filter(
-                                ([k]) => !Object.keys(castToRecord(additionalProperties)).includes(k),
-                            ),
-                        );
-                    } else {
-                        setAdditionalProperties(newValue);
-
-                        return {
-                            ...Object.fromEntries(
-                                Object.entries(oldObject).filter(
-                                    ([k]) => !Object.keys(castToRecord(additionalProperties)).includes(k),
-                                ),
-                            ),
-                            ...newValue,
-                        };
-                    }
-                });
-            }
-        },
-        [onChange, additionalProperties],
-    );
-
     const shownProperties = useMemo(() => {
         return properties.filter((property) =>
             shouldShowProperty(property.valueShape, types, castToRecord(value)[property.key]),
         );
     }, [properties, types, value]);
+
     const hiddenProperties = useMemo(() => {
         return properties.filter(
             (property) => !shouldShowProperty(property.valueShape, types, castToRecord(value)[property.key]),
@@ -227,6 +149,31 @@ export const PlaygroundObjectPropertiesForm = memo<PlaygroundObjectPropertiesFor
         return options;
     }, [hiddenProperties, types]);
 
+    const handleAddAdditionalProperties = useCallback(
+        (key: string) => {
+            if (key === ADD_ALL_KEY) {
+                onChange((oldValue: unknown) => {
+                    const oldObject = castToRecord(oldValue);
+                    return hiddenProperties.reduce((acc, property) => {
+                        const newValue = getEmptyValueForType(unwrapReference(property.valueShape, types).shape, types);
+                        return { ...acc, [property.key]: newValue };
+                    }, oldObject);
+                });
+                return;
+            }
+
+            const property = hiddenProperties.find((p) => p.key === key);
+            if (!property) {
+                return;
+            }
+            onChangeObjectProperty(
+                property.key,
+                getEmptyValueForType(unwrapReference(property.valueShape, types).shape, types) ?? "",
+            );
+        },
+        [hiddenProperties, onChange, onChangeObjectProperty, types],
+    );
+
     return (
         <div
             className={cn("flex-1 shrink min-w-0", {
@@ -254,33 +201,7 @@ export const PlaygroundObjectPropertiesForm = memo<PlaygroundObjectPropertiesFor
             )}
 
             {hiddenProperties.length > 0 && (
-                <FernDropdown
-                    options={hiddenPropertiesOptions}
-                    onValueChange={(key) => {
-                        if (key === ADD_ALL_KEY) {
-                            onChange((oldValue: unknown) => {
-                                const oldObject = castToRecord(oldValue);
-                                return hiddenProperties.reduce((acc, property) => {
-                                    const newValue = getEmptyValueForType(
-                                        unwrapReference(property.valueShape, types).shape,
-                                        types,
-                                    );
-                                    return { ...acc, [property.key]: newValue };
-                                }, oldObject);
-                            });
-                            return;
-                        }
-
-                        const property = hiddenProperties.find((p) => p.key === key);
-                        if (!property) {
-                            return;
-                        }
-                        onChangeObjectProperty(
-                            property.key,
-                            getEmptyValueForType(unwrapReference(property.valueShape, types).shape, types) ?? "",
-                        );
-                    }}
-                >
+                <FernDropdown options={hiddenPropertiesOptions} onValueChange={handleAddAdditionalProperties}>
                     <FernButton
                         text={
                             <span>
@@ -298,33 +219,13 @@ export const PlaygroundObjectPropertiesForm = memo<PlaygroundObjectPropertiesFor
             )}
 
             {extraProperties != null && (
-                <div className={cn("flex-1 shrink min-w-0 mt-8")}>
-                    <WithLabel
-                        property={{
-                            key: PropertyKey("Optional Extra Properties"),
-                            valueShape: ADDITIONAL_PROPERTIES_DEFAULT_SHAPE,
-                            description: undefined,
-                            availability: undefined,
-                        }}
-                        value={"Optional Extra Properties"}
-                        onRemove={() => onChangeAdditionalObjectProperty(undefined)}
-                        types={types}
-                    >
-                        <PlaygroundMapForm
-                            id="extraProperties"
-                            keyShape={ADDITIONAL_PROPERTIES_KEY_SHAPE}
-                            valueShape={ADDITIONAL_PROPERTIES_VALUE_SHAPE}
-                            onChange={onChangeAdditionalObjectProperty}
-                            value={Object.keys(castToRecord(value)).reduce((acc: Record<string, unknown>, key) => {
-                                if (!properties.some((p) => p.key === key)) {
-                                    acc[key] = castToRecord(value)[key];
-                                }
-                                return acc;
-                            }, {})}
-                            types={types}
-                        />
-                    </WithLabel>
-                </div>
+                <PlaygroundAdditionalProperties
+                    onChange={onChange}
+                    properties={properties}
+                    extraProperties={extraProperties}
+                    value={value}
+                    types={types}
+                />
             )}
         </div>
     );

--- a/packages/ui/app/src/playground/form/PlaygroundTypeReferenceForm.tsx
+++ b/packages/ui/app/src/playground/form/PlaygroundTypeReferenceForm.tsx
@@ -2,7 +2,6 @@ import {
     ObjectProperty,
     TypeDefinition,
     TypeShapeOrReference,
-    unwrapObjectType,
     unwrapReference,
 } from "@fern-api/fdr-sdk/api-definition";
 import { visitDiscriminatedUnion } from "@fern-api/ui-core-utils";
@@ -15,7 +14,7 @@ import { PlaygroundElevenLabsVoiceIdForm } from "./PlaygroundElevenLabsVoiceIdFo
 import { PlaygroundEnumForm } from "./PlaygroundEnumForm";
 import { PlaygroundListForm } from "./PlaygroundListForm";
 import { PlaygroundMapForm } from "./PlaygroundMapForm";
-import { PlaygroundObjectPropertiesForm } from "./PlaygroundObjectPropertyForm";
+import { PlaygroundObjectForm } from "./PlaygroundObjectForm";
 import { PlaygroundUniscriminatedUnionForm } from "./PlaygroundUniscriminatedUnionForm";
 
 interface PlaygroundTypeReferenceFormProps {
@@ -41,23 +40,19 @@ export const PlaygroundTypeReferenceForm = memo<PlaygroundTypeReferenceFormProps
         onChange(undefined);
     }, [onChange]);
     return visitDiscriminatedUnion(unwrapReference(shape, types).shape)._visit<ReactElement | null>({
-        object: (object) => {
-            const unwrappedObjectType = unwrapObjectType(object, types);
-            return (
-                <WithLabel property={property} value={value} onRemove={onRemove} types={types}>
-                    <PlaygroundObjectPropertiesForm
-                        properties={unwrappedObjectType.properties}
-                        extraProperties={unwrappedObjectType.extraProperties}
-                        onChange={onChange}
-                        value={value}
-                        indent={indent}
-                        id={id}
-                        types={types}
-                        disabled={disabled}
-                    />
-                </WithLabel>
-            );
-        },
+        object: (object) => (
+            <WithLabel property={property} value={value} onRemove={onRemove} types={types}>
+                <PlaygroundObjectForm
+                    shape={object}
+                    onChange={onChange}
+                    value={value}
+                    indent={indent}
+                    id={id}
+                    types={types}
+                    disabled={disabled}
+                />
+            </WithLabel>
+        ),
         enum: ({ values }) => (
             <WithLabel property={property} value={value} onRemove={onRemove} types={types}>
                 <PlaygroundEnumForm enumValues={values} onChange={onChange} value={value} id={id} disabled={disabled} />


### PR DESCRIPTION
Fixes FER-3440

## Short description of the changes made

* fixes ping pong behavior between dual callbacks that leads to deferred state not picking up the right update during render step

## What was the motivation & context behind this PR?

* Customer regression

## How has this PR been tested?

https://github.com/user-attachments/assets/3316ea70-3004-4d88-9d5a-4adf640bafdf

