### PR TITLE
fix: logout url for sso

### DIFF
--- a/packages/ui/docs-bundle/src/server/auth/workos-session.ts
+++ b/packages/ui/docs-bundle/src/server/auth/workos-session.ts
@@ -25,7 +25,7 @@ async function refreshSession(session: WorkOSSession): Promise<WorkOSSession | u
     }
 }
 
-async function getLogoutUrl(fern_token: string | undefined): Promise<string | undefined> {
+async function revokeSessionForToken(fern_token: string | undefined): Promise<void> {
     if (fern_token == null) {
         return undefined;
     }
@@ -36,7 +36,7 @@ async function getLogoutUrl(fern_token: string | undefined): Promise<string | un
     }
 
     const { sid: sessionId } = decodeJwt<AccessToken>(session.accessToken);
-    return workos().userManagement.getLogoutUrl({ sessionId });
+    return workos().userManagement.revokeSession({ sessionId });
 }
 
 const withJWKS = once(() => createRemoteJWKSet(new URL(workos().userManagement.getJwksUrl(getWorkOSClientId()))));
@@ -86,4 +86,4 @@ async function toSessionUserInfo(session?: WorkOSSession): Promise<WorkOSUserInf
     return { user: null };
 }
 
-export { encryptSession, getLogoutUrl, getSessionFromToken, refreshSession, toSessionUserInfo };
+export { encryptSession, getSessionFromToken, refreshSession, revokeSessionForToken, toSessionUserInfo };


### PR DESCRIPTION
Before: the logoutUrl generated by workos doesn't delete cookies, and it always redirects to buildwithfern.com