### PR TITLE
fix(docs): update how we parse for asides

### DIFF
--- a/packages/ui/app/src/resolver/resolveMarkdownPage.ts
+++ b/packages/ui/app/src/resolver/resolveMarkdownPage.ts
@@ -113,7 +113,9 @@ export async function resolveMarkdownPageWithoutApiRefs({
 
     let hasAside = false;
     // this is a hack to force the layout to reference for pages that contain an <Aside>
-    if (markdown.includes("<Aside>")) {
+    
+    const parsing = typeof content === "string" ? "" : content.code;
+    if (parsing.includes("ReferenceLayoutAside")) {
         frontmatter.layout = "reference";
         hasAside = true;
     }

--- a/packages/ui/app/src/resolver/resolveMarkdownPage.ts
+++ b/packages/ui/app/src/resolver/resolveMarkdownPage.ts
@@ -113,7 +113,7 @@ export async function resolveMarkdownPageWithoutApiRefs({
 
     let hasAside = false;
     // this is a hack to force the layout to reference for pages that contain an <Aside>
-    
+
     const parsing = typeof content === "string" ? "" : content.code;
     if (parsing.includes("ReferenceLayoutAside")) {
         frontmatter.layout = "reference";


### PR DESCRIPTION
This PR updates the indicator we search for to render a page with an `<Aside>`.

Properly rendering a page with an `<Aside>` within code but no actual `<Aside>
![Screenshot 2024-10-31 at 1 13 35 PM](https://github.com/user-attachments/assets/d4662c9c-1447-435f-90dc-0d254f8c8db8)

Properly rendering a page with an actual `<Aside>`
![Screenshot 2024-10-31 at 1 13 22 PM](https://github.com/user-attachments/assets/78a33bd2-14d8-4495-9450-e9db88e19eac)


