### PR TITLE
fix: correctly delete logout cookie

### DIFF
--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/logout.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/auth/logout.ts
@@ -1,3 +1,4 @@
+import { withDeleteCookie } from "@/server/auth/with-secure-cookie";
 import { revokeSessionForToken } from "@/server/auth/workos-session";
 import { safeUrl } from "@/server/safeUrl";
 import { getDocsDomainEdge, getHostEdge } from "@/server/xfernhost/edge";
@@ -30,8 +31,8 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
         logoutUrl ?? safeUrl(req.nextUrl.searchParams.get("state")) ?? safeUrl(withDefaultProtocol(getHostEdge(req)));
 
     const res = redirectLocation ? NextResponse.redirect(redirectLocation) : NextResponse.next();
-    res.cookies.delete(COOKIE_FERN_TOKEN);
-    res.cookies.delete(COOKIE_ACCESS_TOKEN);
-    res.cookies.delete(COOKIE_REFRESH_TOKEN);
+    res.cookies.delete(withDeleteCookie(COOKIE_FERN_TOKEN, withDefaultProtocol(getHostEdge(req))));
+    res.cookies.delete(withDeleteCookie(COOKIE_ACCESS_TOKEN, withDefaultProtocol(getHostEdge(req))));
+    res.cookies.delete(withDeleteCookie(COOKIE_REFRESH_TOKEN, withDefaultProtocol(getHostEdge(req))));
     return res;
 }

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/preview.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/preview.ts
@@ -1,3 +1,4 @@
+import { withDeleteCookie, withSecureCookie } from "@/server/auth/with-secure-cookie";
 import { notFoundResponse, redirectResponse } from "@/server/serverResponse";
 import { COOKIE_FERN_DOCS_PREVIEW } from "@fern-ui/fern-docs-utils";
 import { NextRequest, NextResponse } from "next/server";
@@ -13,25 +14,19 @@ export default async function GET(req: NextRequest): Promise<NextResponse> {
     const clear = req.nextUrl.searchParams.get("clear");
     if (typeof host === "string") {
         const res = redirectResponse(req.nextUrl.origin);
-        res.cookies.set(COOKIE_FERN_DOCS_PREVIEW, host, {
-            httpOnly: true,
-            secure: false,
-            sameSite: "lax",
-            path: "/",
-        });
+        res.cookies.set(COOKIE_FERN_DOCS_PREVIEW, host, withSecureCookie(req.nextUrl.origin));
         return res;
     } else if (typeof site === "string") {
         const res = redirectResponse(req.nextUrl.origin);
-        res.cookies.set(COOKIE_FERN_DOCS_PREVIEW, `${site}.docs.buildwithfern.com`, {
-            httpOnly: true,
-            secure: false,
-            sameSite: "lax",
-            path: "/",
-        });
+        res.cookies.set(
+            COOKIE_FERN_DOCS_PREVIEW,
+            `${site}.docs.buildwithfern.com`,
+            withSecureCookie(req.nextUrl.origin),
+        );
         return res;
     } else if (clear === "true") {
         const res = redirectResponse(req.nextUrl.origin);
-        res.cookies.delete(COOKIE_FERN_DOCS_PREVIEW);
+        res.cookies.delete(withDeleteCookie(COOKIE_FERN_DOCS_PREVIEW, req.nextUrl.origin));
         return res;
     }
 

--- a/packages/ui/docs-bundle/src/server/auth/with-secure-cookie.ts
+++ b/packages/ui/docs-bundle/src/server/auth/with-secure-cookie.ts
@@ -19,3 +19,15 @@ export function withSecureCookie(targetUrl: string, opts?: Partial<ResponseCooki
         domain: url.hostname,
     };
 }
+
+export function withDeleteCookie(name: string, targetUrl: string): Omit<ResponseCookie, "value" | "expires"> {
+    const url = new URL(targetUrl);
+    return {
+        name,
+        path: "/",
+        sameSite: "lax" as const,
+        secure: url.protocol === "https:",
+        httpOnly: true,
+        domain: url.hostname,
+    };
+}

--- a/packages/ui/docs-bundle/src/server/xfernhost/edge.ts
+++ b/packages/ui/docs-bundle/src/server/xfernhost/edge.ts
@@ -28,13 +28,6 @@ export function getDocsDomainEdge(req: NextRequest): string {
 
 // use this for testing auth-based redirects on development and preview environments
 export function getHostEdge(req: NextRequest): string {
-    if (
-        process.env.NODE_ENV === "development" ||
-        (process.env.VERCEL_ENV === "preview" && req.cookies.has(COOKIE_FERN_DOCS_PREVIEW)) ||
-        process.env.VERCEL_ENV === "development"
-    ) {
-        return req.headers.get("host") ?? req.nextUrl.host;
-    }
     // if x-fern-host is set, assume it's proxied:
     return req.headers.get(HEADER_X_FERN_HOST) ?? req.headers.get("host") ?? req.nextUrl.host;
 }

--- a/packages/ui/docs-bundle/src/server/xfernhost/edge.ts
+++ b/packages/ui/docs-bundle/src/server/xfernhost/edge.ts
@@ -33,7 +33,8 @@ export function getHostEdge(req: NextRequest): string {
         (process.env.VERCEL_ENV === "preview" && req.cookies.has(COOKIE_FERN_DOCS_PREVIEW)) ||
         process.env.VERCEL_ENV === "development"
     ) {
-        return req.nextUrl.host;
+        return req.headers.get("host") ?? req.nextUrl.host;
     }
-    return getDocsDomainEdge(req);
+    // if x-fern-host is set, assume it's proxied:
+    return req.headers.get(HEADER_X_FERN_HOST) ?? req.headers.get("host") ?? req.nextUrl.host;
 }

--- a/packages/ui/docs-bundle/src/server/xfernhost/node.ts
+++ b/packages/ui/docs-bundle/src/server/xfernhost/node.ts
@@ -45,17 +45,23 @@ export function getHostNodeStatic(): string | undefined {
     return undefined;
 }
 
-export function getHostNode(req: { url?: string; headers?: IncomingHttpHeaders }): string | undefined {
-    let host = req.headers?.host;
-    if (host == null && req.url != null) {
-        try {
-            host = new URL(req.url, withDefaultProtocol(getHostNodeStatic())).host;
-        } catch (_e) {
-            // do nothing
-        }
+function getHostFromUrl(url: string | undefined): string | undefined {
+    if (url == null) {
+        return undefined;
     }
 
-    const xFernHost = req.headers?.[HEADER_X_FERN_HOST];
+    try {
+        return new URL(url, withDefaultProtocol(getHostNodeStatic())).host;
+    } catch (_e) {
+        return undefined;
+    }
+}
 
-    return typeof xFernHost === "string" ? xFernHost : host ?? getHostNodeStatic();
+export function getHostNode(req: { url?: string; headers?: IncomingHttpHeaders }): string | undefined {
+    const host = req.headers?.host;
+
+    const xFernHostHeader = req.headers?.[HEADER_X_FERN_HOST];
+    const xFernHost = typeof xFernHostHeader === "string" ? xFernHostHeader : undefined;
+
+    return xFernHost ?? host ?? getHostFromUrl(req.url) ?? getHostNodeStatic();
 }

--- a/packages/ui/docs-bundle/src/server/xfernhost/node.ts
+++ b/packages/ui/docs-bundle/src/server/xfernhost/node.ts
@@ -1,5 +1,6 @@
 import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import { COOKIE_FERN_DOCS_PREVIEW, HEADER_X_FERN_HOST } from "@fern-ui/fern-docs-utils";
+import type { IncomingHttpHeaders } from "http";
 import type { NextApiRequest } from "next";
 import { getNextPublicDocsDomain } from "./dev";
 import { cleanHost } from "./util";
@@ -44,14 +45,17 @@ export function getHostNodeStatic(): string | undefined {
     return undefined;
 }
 
-export function getHostNode(req: { url?: string }): string | undefined {
-    if (req.url != null) {
+export function getHostNode(req: { url?: string; headers?: IncomingHttpHeaders }): string | undefined {
+    let host = req.headers?.host;
+    if (host == null && req.url != null) {
         try {
-            return new URL(req.url, withDefaultProtocol(getHostNodeStatic())).host;
+            host = new URL(req.url, withDefaultProtocol(getHostNodeStatic())).host;
         } catch (_e) {
             // do nothing
         }
     }
 
-    return getHostNodeStatic();
+    const xFernHost = req.headers?.[HEADER_X_FERN_HOST];
+
+    return typeof xFernHost === "string" ? xFernHost : host ?? getHostNodeStatic();
 }


### PR DESCRIPTION
1) fern_token cookie isn't being deleted upon logout because we're not setting its `domain` and `path` values.
2) this pr fixes how the `getHostNode` and `getHostEdge` works:

- when the user is loading docs from `docs.domain.com`, the host should be `docs.domain.com`
- when the user is loading docs from `buildwithfern.com/learn` the host should be `buildwithfern.com` (even though it's actually proxied to app.buildwithfern.com)
- when the user is loading docs from a preview or staging url, such as `x.docs.staging.buildwithfern.com`, the host should be `x.docs.staging.buildwithfern.com`
- when the user is loading docs via a PR preview link, the host is still `xxx.vercel.app` because the `__fern_preview_host` cookie should be ignore.

This is done via
1. check if x-fern-host header exists. If so, use it (because this indicates that the url is proxied)
2. default to `host` header, or the URL host, if it exists (which is typically the origin interacting with vercel)