### PR TITLE
feat: enable api key injection from within JWT

### DIFF
--- a/packages/ui/fern-docs-auth/src/types.ts
+++ b/packages/ui/fern-docs-auth/src/types.ts
@@ -9,6 +9,7 @@ export const FernUserSchema = z.object({
             "The roles of the token (can be a string or an array of strings) which limits what content users can access",
         )
         .optional(),
+    api_key: z.string().optional().describe("For API Playground key injection"),
 });
 
 export type FernUser = z.infer<typeof FernUserSchema>;


### PR DESCRIPTION
Adds a `fern.api_key` claim for injecting api keys into the api playground.