### PR TITLE
fix: append host to query params on isr in the middleware

### DIFF
--- a/packages/ui/docs-bundle/src/pages/static/[domain]/[[...slug]].tsx
+++ b/packages/ui/docs-bundle/src/pages/static/[domain]/[[...slug]].tsx
@@ -5,14 +5,19 @@ import { getHostNodeStatic } from "@/server/xfernhost/node";
 import { FernNavigation } from "@fern-api/fdr-sdk";
 import { DocsPage } from "@fern-ui/ui";
 import { GetStaticPaths, GetStaticProps } from "next";
+import type { ParsedUrlQuery } from "querystring";
 import { ComponentProps } from "react";
 
 export default DocsPage;
 
 export const getStaticProps: GetStaticProps<ComponentProps<typeof DocsPage>> = async (context) => {
     const { params = {} } = context;
-    const domain = params.domain as string;
-    const host = getHostNodeStatic() ?? domain;
+    const domain = getDomain(params);
+    if (typeof domain !== "string") {
+        return { notFound: true };
+    }
+
+    const host = getHost(params) ?? getHostNodeStatic() ?? domain;
     const slug = FernNavigation.slugjoin(params.slug);
 
     const props = await withSSGProps(getDocsPageProps(domain, host, slug));
@@ -25,3 +30,11 @@ export const getStaticProps: GetStaticProps<ComponentProps<typeof DocsPage>> = a
 export const getStaticPaths: GetStaticPaths = () => {
     return { paths: [], fallback: "blocking" };
 };
+
+function getHost(params: ParsedUrlQuery): string | undefined {
+    return typeof params.host === "string" ? params.host : undefined;
+}
+
+function getDomain(params: ParsedUrlQuery): string | undefined {
+    return typeof params.domain === "string" ? params.domain : undefined;
+}

--- a/packages/ui/docs-bundle/src/server/withPathname.ts
+++ b/packages/ui/docs-bundle/src/server/withPathname.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
 
-export function withPathname(request: NextRequest, pathname: string): string {
-    return `${request.nextUrl.origin}${pathname}${request.nextUrl.search}`;
+export function withPathname(request: NextRequest, pathname: string, search?: string): string {
+    return `${request.nextUrl.origin}${pathname}${search ?? request.nextUrl.search}`;
 }


### PR DESCRIPTION
In ISR, the getStaticProps function doesn't have access to the node request that made it, so it's not possible to get the `req.headers.host` from it. Here, we'll use query parameters to inject the current `host` into the params.

This will stabilize the login/logout urls generated in the app-staging.buildwithfern.com environment.