### PR TITLE
found needle in haystack that is overwriting name

### DIFF
--- a/packages/fdr-sdk/src/__test__/output/humanloop/apiDefinitions.json
+++ b/packages/fdr-sdk/src/__test__/output/humanloop/apiDefinitions.json
@@ -31715,7 +31715,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.log({\n    path: \"persona\",\n    prompt: {\n        model: \"gpt-4\",\n        template: [{\n                role: \"system\",\n                content: \"You are {{person}}. Answer questions as this person. Do not break character.\"\n            }]\n    },\n    messages: [{\n            role: \"user\",\n            content: \"What really happened at Roswell?\"\n        }],\n    inputs: {\n        \"person\": \"Trump\"\n    },\n    createdAt: \"2024-07-19T00:29:35.178992\",\n    providerLatency: 6.5931549072265625,\n    outputMessage: {\n        content: \"Well, you know, there is so much secrecy involved in government, folks, it's unbelievable. They don't want to tell you everything. They don't tell me everything! But about Roswell, it’s a very popular question. I know, I just know, that something very, very peculiar happened there. Was it a weather balloon? Maybe. Was it something extraterrestrial? Could be. I'd love to go down and open up all the classified documents, believe me, I would. But they don't let that happen. The Deep State, folks, the Deep State. They’re unbelievable. They want to keep everything a secret. But whatever the truth is, I can tell you this: it’s something big, very very big. Tremendous, in fact.\",\n        role: \"assistant\"\n    },\n    promptTokens: 100,\n    outputTokens: 220,\n    promptCost: 0.00001,\n    outputCost: 0.0002,\n    finishReason: \"stop\"\n});\n",
                   "generated": true
@@ -31767,7 +31766,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.log({\n    path: \"persona\",\n    prompt: {\n        model: \"gpt-4\",\n        template: [{\n                role: \"system\",\n                content: \"You are {{person}}. Answer questions as this person. Do not break character.\"\n            }]\n    },\n    messages: [{\n            role: \"user\",\n            content: \"What really happened at Roswell?\"\n        }],\n    inputs: {\n        \"person\": \"Trump\"\n    },\n    createdAt: \"2024-07-19T00:29:35.178992\",\n    providerLatency: 6.5931549072265625,\n    outputMessage: {\n        content: \"Well, you know, there is so much secrecy involved in government, folks, it's unbelievable. They don't want to tell you everything. They don't tell me everything! But about Roswell, it’s a very popular question. I know, I just know, that something very, very peculiar happened there. Was it a weather balloon? Maybe. Was it something extraterrestrial? Could be. I'd love to go down and open up all the classified documents, believe me, I would. But they don't let that happen. The Deep State, folks, the Deep State. They’re unbelievable. They want to keep everything a secret. But whatever the truth is, I can tell you this: it’s something big, very very big. Tremendous, in fact.\",\n        role: \"assistant\"\n    },\n    promptTokens: 100,\n    outputTokens: 220,\n    promptCost: 0.00001,\n    outputCost: 0.0002,\n    finishReason: \"stop\"\n});\n",
                   "generated": true
@@ -34768,7 +34766,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.update(\"id\", \"log_id\");\n",
                   "generated": true
@@ -34820,7 +34817,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.update(\"id\", \"log_id\");\n",
                   "generated": true
@@ -36701,7 +36697,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.callStream({\n    versionId: \"string\",\n    environment: \"string\",\n    path: \"string\",\n    id: \"string\",\n    messages: [{\n            content: \"string\",\n            name: \"string\",\n            toolCallId: \"string\",\n            role: \"user\",\n            toolCalls: [{\n                    id: \"string\",\n                    type: \"function\",\n                    function: {\n                        name: \"string\",\n                        arguments: undefined\n                    }\n                }]\n        }],\n    toolChoice: \"none\",\n    prompt: {\n        model: \"string\",\n        endpoint: \"complete\",\n        template: \"string\",\n        provider: \"openai\",\n        maxTokens: 1,\n        temperature: 1.1,\n        topP: 1.1,\n        stop: \"string\",\n        presencePenalty: 1.1,\n        frequencyPenalty: 1.1,\n        other: {\n            \"string\": {\n                \"key\": \"value\"\n            }\n        },\n        seed: 1,\n        responseFormat: {\n            type: \"json_object\",\n            jsonSchema: {}\n        },\n        tools: [{\n                name: \"string\",\n                description: \"string\",\n                strict: undefined,\n                parameters: undefined\n            }],\n        linkedTools: [\"string\"],\n        attributes: {\n            \"string\": {\n                \"key\": \"value\"\n            }\n        }\n    },\n    inputs: {\n        \"string\": {\n            \"key\": \"value\"\n        }\n    },\n    source: \"string\",\n    metadata: {\n        \"string\": {\n            \"key\": \"value\"\n        }\n    },\n    startTime: \"2024-01-15T09:30:00Z\",\n    endTime: \"2024-01-15T09:30:00Z\",\n    sourceDatapointId: \"string\",\n    traceParentId: \"string\",\n    batches: [\"string\"],\n    user: \"string\",\n    promptsCallStreamRequestEnvironment: \"string\",\n    save: true,\n    providerApiKeys: {\n        openai: \"string\",\n        ai21: \"string\",\n        mock: \"string\",\n        anthropic: \"string\",\n        bedrock: \"string\",\n        cohere: \"string\",\n        openaiAzure: \"string\",\n        openaiAzureEndpoint: \"string\"\n    },\n    numSamples: 1,\n    returnInputs: true,\n    logprobs: 1,\n    suffix: \"string\"\n});\n",
                   "generated": true
@@ -36755,7 +36750,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.callStream({\n    versionId: \"string\",\n    environment: \"string\",\n    path: \"string\",\n    id: \"string\",\n    messages: [{\n            content: \"string\",\n            name: \"string\",\n            toolCallId: \"string\",\n            role: \"user\",\n            toolCalls: [{\n                    id: \"string\",\n                    type: \"function\",\n                    function: {\n                        name: \"string\",\n                        arguments: undefined\n                    }\n                }]\n        }],\n    toolChoice: \"none\",\n    prompt: {\n        model: \"string\",\n        endpoint: \"complete\",\n        template: \"string\",\n        provider: \"openai\",\n        maxTokens: 1,\n        temperature: 1.1,\n        topP: 1.1,\n        stop: \"string\",\n        presencePenalty: 1.1,\n        frequencyPenalty: 1.1,\n        other: {\n            \"string\": {\n                \"key\": \"value\"\n            }\n        },\n        seed: 1,\n        responseFormat: {\n            type: \"json_object\",\n            jsonSchema: {}\n        },\n        tools: [{\n                name: \"string\",\n                description: \"string\",\n                strict: undefined,\n                parameters: undefined\n            }],\n        linkedTools: [\"string\"],\n        attributes: {\n            \"string\": {\n                \"key\": \"value\"\n            }\n        }\n    },\n    inputs: {\n        \"string\": {\n            \"key\": \"value\"\n        }\n    },\n    source: \"string\",\n    metadata: {\n        \"string\": {\n            \"key\": \"value\"\n        }\n    },\n    startTime: \"2024-01-15T09:30:00Z\",\n    endTime: \"2024-01-15T09:30:00Z\",\n    sourceDatapointId: \"string\",\n    traceParentId: \"string\",\n    batches: [\"string\"],\n    user: \"string\",\n    promptsCallStreamRequestEnvironment: \"string\",\n    save: true,\n    providerApiKeys: {\n        openai: \"string\",\n        ai21: \"string\",\n        mock: \"string\",\n        anthropic: \"string\",\n        bedrock: \"string\",\n        cohere: \"string\",\n        openaiAzure: \"string\",\n        openaiAzureEndpoint: \"string\"\n    },\n    numSamples: 1,\n    returnInputs: true,\n    logprobs: 1,\n    suffix: \"string\"\n});\n",
                   "generated": true
@@ -39276,7 +39270,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.call({\n    path: \"persona\",\n    prompt: {\n        model: \"gpt-4\",\n        template: [{\n                role: \"system\",\n                content: \"You are stockbot. Return latest prices.\"\n            }],\n        tools: [{\n                name: \"get_stock_price\",\n                description: \"Get current stock price\",\n                parameters: {\n                    \"type\": \"object\",\n                    \"properties\": {\n                        \"ticker_symbol\": {\n                            \"type\": \"string\",\n                            \"name\": \"Ticker Symbol\",\n                            \"description\": \"Ticker symbol of the stock\"\n                        }\n                    },\n                    \"required\": []\n                }\n            }]\n    },\n    messages: [{\n            role: \"user\",\n            content: \"latest apple\"\n        }]\n});\n",
                   "generated": true
@@ -39379,7 +39372,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.call({\n    path: \"persona\",\n    prompt: {\n        model: \"gpt-4\",\n        template: [{\n                role: \"system\",\n                content: \"You are {{person}}. Answer any questions as this person. Do not break character.\"\n            }]\n    },\n    messages: [{\n            role: \"user\",\n            content: \"What really happened at Roswell?\"\n        }],\n    inputs: {\n        \"person\": \"Trump\"\n    }\n});\n",
                   "generated": true
@@ -39474,7 +39466,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.call({\n    versionId: \"prv_Wu6zx1lAWJRqOyL8nWuZk\",\n    path: \"persona\",\n    messages: [{\n            role: \"user\",\n            content: \"What really happened at Roswell?\"\n        }],\n    inputs: {\n        \"person\": \"Trump\"\n    }\n});\n",
                   "generated": true
@@ -39528,7 +39519,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.call({\n    path: \"persona\",\n    prompt: {\n        model: \"gpt-4\",\n        template: [{\n                role: \"system\",\n                content: \"You are stockbot. Return latest prices.\"\n            }],\n        tools: [{\n                name: \"get_stock_price\",\n                description: \"Get current stock price\",\n                parameters: {\n                    \"type\": \"object\",\n                    \"properties\": {\n                        \"ticker_symbol\": {\n                            \"type\": \"string\",\n                            \"name\": \"Ticker Symbol\",\n                            \"description\": \"Ticker symbol of the stock\"\n                        }\n                    },\n                    \"required\": []\n                }\n            }]\n    },\n    messages: [{\n            role: \"user\",\n            content: \"latest apple\"\n        }]\n});\n",
                   "generated": true
@@ -41645,7 +41635,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.list({\n    size: 1\n});\n",
                   "generated": true
@@ -41693,7 +41682,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.list({\n    size: 1\n});\n",
                   "generated": true
@@ -42408,7 +42396,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.upsert({\n    path: \"Personal Projects/Coding Assistant\",\n    model: \"gpt-4o\",\n    endpoint: \"chat\",\n    template: [{\n            content: \"You are a helpful coding assistant specialising in {{language}}\",\n            role: \"system\"\n        }],\n    provider: \"openai\",\n    maxTokens: -1,\n    temperature: 0.7,\n    topP: 1,\n    presencePenalty: 0,\n    frequencyPenalty: 0,\n    other: {},\n    tools: [],\n    linkedTools: [],\n    commitMessage: \"Initial commit\"\n});\n",
                   "generated": true
@@ -42459,7 +42446,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.upsert({\n    path: \"Personal Projects/Coding Assistant\",\n    model: \"gpt-4o\",\n    endpoint: \"chat\",\n    template: [{\n            content: \"You are a helpful coding assistant specialising in {{language}}\",\n            role: \"system\"\n        }],\n    provider: \"openai\",\n    maxTokens: -1,\n    temperature: 0.7,\n    topP: 1,\n    presencePenalty: 0,\n    frequencyPenalty: 0,\n    other: {},\n    tools: [],\n    linkedTools: [],\n    commitMessage: \"Initial commit\"\n});\n",
                   "generated": true
@@ -43642,7 +43628,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.get(\"pr_30gco7dx6JDq4200GVOHa\");\n",
                   "generated": true
@@ -43692,7 +43677,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.get(\"pr_30gco7dx6JDq4200GVOHa\");\n",
                   "generated": true
@@ -43910,7 +43894,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.delete(\"pr_30gco7dx6JDq4200GVOHa\");\n",
                   "generated": true
@@ -43957,7 +43940,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.delete(\"pr_30gco7dx6JDq4200GVOHa\");\n",
                   "generated": true
@@ -44246,7 +44228,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.move(\"pr_30gco7dx6JDq4200GVOHa\", {\n    path: \"new directory/new name\"\n});\n",
                   "generated": true
@@ -44297,7 +44278,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.move(\"pr_30gco7dx6JDq4200GVOHa\", {\n    path: \"new directory/new name\"\n});\n",
                   "generated": true
@@ -44625,7 +44605,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.listVersions(\"pr_30gco7dx6JDq4200GVOHa\", {\n    status: \"committed\"\n});\n",
                   "generated": true
@@ -44675,7 +44654,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.listVersions(\"pr_30gco7dx6JDq4200GVOHa\", {\n    status: \"committed\"\n});\n",
                   "generated": true
@@ -44999,7 +44977,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.commit(\"pr_30gco7dx6JDq4200GVOHa\", \"prv_F34aba5f3asp0\", {\n    commitMessage: \"Reiterated point about not discussing sentience\"\n});\n",
                   "generated": true
@@ -45053,7 +45030,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.commit(\"pr_30gco7dx6JDq4200GVOHa\", \"prv_F34aba5f3asp0\", {\n    commitMessage: \"Reiterated point about not discussing sentience\"\n});\n",
                   "generated": true
@@ -45368,7 +45344,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.updateMonitoring(\"pr_30gco7dx6JDq4200GVOHa\", {\n    activate: [{\n            evaluatorVersionId: \"evv_1abc4308abd\"\n        }]\n});\n",
                   "generated": true
@@ -45419,7 +45394,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.updateMonitoring(\"pr_30gco7dx6JDq4200GVOHa\", {\n    activate: [{\n            evaluatorVersionId: \"evv_1abc4308abd\"\n        }]\n});\n",
                   "generated": true
@@ -45963,7 +45937,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.setDeployment(\"id\", \"environment_id\", {\n    versionId: \"version_id\"\n});\n",
                   "generated": true
@@ -46013,7 +45986,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.setDeployment(\"id\", \"environment_id\", {\n    versionId: \"version_id\"\n});\n",
                   "generated": true
@@ -46252,7 +46224,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.removeDeployment(\"id\", \"environment_id\");\n",
                   "generated": true
@@ -46300,7 +46271,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.removeDeployment(\"id\", \"environment_id\");\n",
                   "generated": true
@@ -46570,7 +46540,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.listEnvironments(\"pr_30gco7dx6JDq4200GVOHa\");\n",
                   "generated": true
@@ -46617,7 +46586,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.prompts.listEnvironments(\"pr_30gco7dx6JDq4200GVOHa\");\n",
                   "generated": true
@@ -47321,7 +47289,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.log({\n    path: \"math-tool\",\n    tool: {\n        function: {\n            name: \"multiply\",\n            description: \"Multiply two numbers\",\n            parameters: {\n                \"type\": \"object\",\n                \"properties\": {\n                    \"a\": {\n                        \"type\": \"number\"\n                    },\n                    \"b\": {\n                        \"type\": \"number\"\n                    }\n                },\n                \"required\": [\n                    \"a\",\n                    \"b\"\n                ]\n            }\n        }\n    },\n    inputs: {\n        \"a\": 5,\n        \"b\": 7\n    },\n    output: \"35\"\n});\n",
                   "generated": true
@@ -47373,7 +47340,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.log({\n    path: \"math-tool\",\n    tool: {\n        function: {\n            name: \"multiply\",\n            description: \"Multiply two numbers\",\n            parameters: {\n                \"type\": \"object\",\n                \"properties\": {\n                    \"a\": {\n                        \"type\": \"number\"\n                    },\n                    \"b\": {\n                        \"type\": \"number\"\n                    }\n                },\n                \"required\": [\n                    \"a\",\n                    \"b\"\n                ]\n            }\n        }\n    },\n    inputs: {\n        \"a\": 5,\n        \"b\": 7\n    },\n    output: \"35\"\n});\n",
                   "generated": true
@@ -48738,7 +48704,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.update(\"id\", \"log_id\");\n",
                   "generated": true
@@ -48790,7 +48755,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.update(\"id\", \"log_id\");\n",
                   "generated": true
@@ -49415,7 +49379,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.list({\n    size: 1\n});\n",
                   "generated": true
@@ -49463,7 +49426,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.list({\n    size: 1\n});\n",
                   "generated": true
@@ -49937,7 +49899,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.upsert({\n    path: \"math-tool\",\n    function: {\n        name: \"multiply\",\n        description: \"Multiply two numbers\",\n        parameters: {\n            \"type\": \"object\",\n            \"properties\": {\n                \"a\": {\n                    \"type\": \"number\"\n                },\n                \"b\": {\n                    \"type\": \"number\"\n                }\n            },\n            \"required\": [\n                \"a\",\n                \"b\"\n            ]\n        }\n    },\n    commitMessage: \"Initial commit\"\n});\n",
                   "generated": true
@@ -49986,7 +49947,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.upsert({\n    path: \"math-tool\",\n    function: {\n        name: \"multiply\",\n        description: \"Multiply two numbers\",\n        parameters: {\n            \"type\": \"object\",\n            \"properties\": {\n                \"a\": {\n                    \"type\": \"number\"\n                },\n                \"b\": {\n                    \"type\": \"number\"\n                }\n            },\n            \"required\": [\n                \"a\",\n                \"b\"\n            ]\n        }\n    },\n    commitMessage: \"Initial commit\"\n});\n",
                   "generated": true
@@ -50483,7 +50443,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.get(\"tl_789ghi\");\n",
                   "generated": true
@@ -50533,7 +50492,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.get(\"tl_789ghi\");\n",
                   "generated": true
@@ -50751,7 +50709,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.delete(\"tl_789ghi\");\n",
                   "generated": true
@@ -50798,7 +50755,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.delete(\"tl_789ghi\");\n",
                   "generated": true
@@ -51056,7 +51012,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.move(\"tl_789ghi\", {\n    path: \"new directory/new name\"\n});\n",
                   "generated": true
@@ -51107,7 +51062,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.move(\"tl_789ghi\", {\n    path: \"new directory/new name\"\n});\n",
                   "generated": true
@@ -51404,7 +51358,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.listVersions(\"tl_789ghi\", {\n    status: \"committed\"\n});\n",
                   "generated": true
@@ -51454,7 +51407,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.listVersions(\"tl_789ghi\", {\n    status: \"committed\"\n});\n",
                   "generated": true
@@ -51747,7 +51699,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.commit(\"tl_789ghi\", \"tv_012jkl\", {\n    commitMessage: \"Initial commit\"\n});\n",
                   "generated": true
@@ -51801,7 +51752,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.commit(\"tl_789ghi\", \"tv_012jkl\", {\n    commitMessage: \"Initial commit\"\n});\n",
                   "generated": true
@@ -52085,7 +52035,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.updateMonitoring(\"tl_789ghi\", {\n    activate: [{\n            evaluatorVersionId: \"evv_1abc4308abd\"\n        }]\n});\n",
                   "generated": true
@@ -52136,7 +52085,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.updateMonitoring(\"tl_789ghi\", {\n    activate: [{\n            evaluatorVersionId: \"evv_1abc4308abd\"\n        }]\n});\n",
                   "generated": true
@@ -52612,7 +52560,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.setDeployment(\"tl_789ghi\", \"staging\", {\n    versionId: \"tv_012jkl\"\n});\n",
                   "generated": true
@@ -52662,7 +52609,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.setDeployment(\"tl_789ghi\", \"staging\", {\n    versionId: \"tv_012jkl\"\n});\n",
                   "generated": true
@@ -52902,7 +52848,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.removeDeployment(\"tl_789ghi\", \"staging\");\n",
                   "generated": true
@@ -52950,7 +52895,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.removeDeployment(\"tl_789ghi\", \"staging\");\n",
                   "generated": true
@@ -53189,7 +53133,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.listEnvironments(\"tl_789ghi\");\n",
                   "generated": true
@@ -53236,7 +53179,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.tools.listEnvironments(\"tl_789ghi\");\n",
                   "generated": true
@@ -53541,7 +53483,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.list({\n    size: 1\n});\n",
                   "generated": true
@@ -53589,7 +53530,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.list({\n    size: 1\n});\n",
                   "generated": true
@@ -54047,7 +53987,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.upsert({\n    path: \"test-questions\",\n    datapoints: [{\n            inputs: {\n                \"question\": \"What is the capital of France?\"\n            },\n            target: {\n                \"answer\": \"Paris\"\n            }\n        }, {\n            inputs: {\n                \"question\": \"Who wrote Hamlet?\"\n            },\n            target: {\n                \"answer\": \"William Shakespeare\"\n            }\n        }],\n    action: \"set\",\n    commitMessage: \"Add two new questions and answers\"\n});\n",
                   "generated": true
@@ -54125,7 +54064,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.upsert({\n    path: \"datasets/support-queries\",\n    datapoints: [{\n            messages: [{\n                    role: \"user\",\n                    content: \"How do i manage my organizations API keys?\\n\"\n                }],\n            target: {\n                \"response\": \"Hey, thanks for your questions. Here are steps for how to achieve: 1. Log in to the Humanloop Dashboard \\n\\n2. Click on \\\"Organization Settings.\\\"\\n If you do not see this option, you might need to contact your organization admin to gain the necessary permissions.\\n\\n3. Within the settings or organization settings, select the option labeled \\\"API Keys\\\" on the left. Here you will be able to view and manage your API keys.\\n\\n4. You will see a list of existing API keys. You can perform various actions, such as:\\n     - **Generate New API Key:** Click on the \\\"Generate New Key\\\" button if you need a new API key.\\n     - **Revoke an API Key:** If you need to disable an existing key, find the key in the list and click the \\\"Revoke\\\" or \\\"Delete\\\" button.\\n     - **Copy an API Key:** If you need to use an existing key, you can copy it to your clipboard by clicking the \\\"Copy\\\" button next to the key.\\n\\n5. **Save and Secure API Keys:** Make sure to securely store any new or existing API keys you are using. Treat them like passwords and do not share them publicly.\\n\\nIf you encounter any issues or need further assistance, it might be helpful to engage with an engineer or your IT department to ensure you have the necessary permissions and support.\\n\\nWould you need help with anything else?\"\n            }\n        }, {\n            messages: [{\n                    role: \"user\",\n                    content: \"Hey, can do I use my code evaluator for monitoring my legal-copilot prompt?\"\n                }],\n            target: {\n                \"response\": \"Hey, thanks for your questions. Here are steps for how to achieve: 1. Navigate to your Prompt dashboard. \\n 2. Select the `Monitoring` button on the top right of the Prompt dashboard \\n 3. Within the model select the Version of the Evaluator you want to turn on for monitoring. \\n\\nWould you need help with anything else?\"\n            }\n        }],\n    commitMessage: \"Add two new questions and answers\"\n});\n",
                   "generated": true
@@ -54181,7 +54119,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.upsert({\n    path: \"datasets/support-queries\",\n    datapoints: [{\n            messages: [{\n                    role: \"user\",\n                    content: \"How do i manage my organizations API keys?\\n\"\n                }],\n            target: {\n                \"response\": \"Hey, thanks for your questions. Here are steps for how to achieve: 1. Log in to the Humanloop Dashboard \\n\\n2. Click on \\\"Organization Settings.\\\"\\n If you do not see this option, you might need to contact your organization admin to gain the necessary permissions.\\n\\n3. Within the settings or organization settings, select the option labeled \\\"API Keys\\\" on the left. Here you will be able to view and manage your API keys.\\n\\n4. You will see a list of existing API keys. You can perform various actions, such as:\\n     - **Generate New API Key:** Click on the \\\"Generate New Key\\\" button if you need a new API key.\\n     - **Revoke an API Key:** If you need to disable an existing key, find the key in the list and click the \\\"Revoke\\\" or \\\"Delete\\\" button.\\n     - **Copy an API Key:** If you need to use an existing key, you can copy it to your clipboard by clicking the \\\"Copy\\\" button next to the key.\\n\\n5. **Save and Secure API Keys:** Make sure to securely store any new or existing API keys you are using. Treat them like passwords and do not share them publicly.\\n\\nIf you encounter any issues or need further assistance, it might be helpful to engage with an engineer or your IT department to ensure you have the necessary permissions and support.\\n\\nWould you need help with anything else?\"\n            }\n        }, {\n            messages: [{\n                    role: \"user\",\n                    content: \"Hey, can do I use my code evaluator for monitoring my legal-copilot prompt?\"\n                }],\n            target: {\n                \"response\": \"Hey, thanks for your questions. Here are steps for how to achieve: 1. Navigate to your Prompt dashboard. \\n 2. Select the `Monitoring` button on the top right of the Prompt dashboard \\n 3. Within the model select the Version of the Evaluator you want to turn on for monitoring. \\n\\nWould you need help with anything else?\"\n            }\n        }],\n    commitMessage: \"Add two new questions and answers\"\n});\n",
                   "generated": true
@@ -55139,7 +55076,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.get(\"ds_b0baF1ca7652\", {\n    versionId: \"dsv_6L78pqrdFi2xa\",\n    includeDatapoints: true\n});\n",
                   "generated": true
@@ -55189,7 +55125,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.get(\"ds_b0baF1ca7652\", {\n    versionId: \"dsv_6L78pqrdFi2xa\",\n    includeDatapoints: true\n});\n",
                   "generated": true
@@ -55422,7 +55357,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.delete(\"id\");\n",
                   "generated": true
@@ -55469,7 +55403,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.delete(\"id\");\n",
                   "generated": true
@@ -55752,7 +55685,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.move(\"id\");\n",
                   "generated": true
@@ -55803,7 +55735,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.move(\"id\");\n",
                   "generated": true
@@ -56149,7 +56080,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.listDatapoints(\"ds_b0baF1ca7652\", {\n    size: 1\n});\n",
                   "generated": true
@@ -56199,7 +56129,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.listDatapoints(\"ds_b0baF1ca7652\", {\n    size: 1\n});\n",
                   "generated": true
@@ -56509,7 +56438,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.listVersions(\"ds_b0baF1ca7652\", {\n    status: \"committed\"\n});\n",
                   "generated": true
@@ -56558,7 +56486,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.listVersions(\"ds_b0baF1ca7652\", {\n    status: \"committed\"\n});\n",
                   "generated": true
@@ -56835,7 +56762,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.commit(\"ds_b0baF1ca7652\", \"dsv_6L78pqrdFi2xa\", {\n    commitMessage: \"initial commit\"\n});\n",
                   "generated": true
@@ -56889,7 +56815,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.commit(\"ds_b0baF1ca7652\", \"dsv_6L78pqrdFi2xa\", {\n    commitMessage: \"initial commit\"\n});\n",
                   "generated": true
@@ -57261,7 +57186,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\nimport * as fs from \"fs\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.uploadCsv(fs.createReadStream(\"/path/to/your/file\"), \"id\", {\n    commitMessage: \"commit_message\"\n});\n",
                   "generated": true
@@ -57324,7 +57248,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\nimport * as fs from \"fs\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.uploadCsv(fs.createReadStream(\"/path/to/your/file\"), \"id\", {\n    commitMessage: \"commit_message\"\n});\n",
                   "generated": true
@@ -57658,7 +57581,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.setDeployment(\"ds_b0baF1ca7652\", \"staging\", {\n    versionId: \"dsv_6L78pqrdFi2xa\"\n});\n",
                   "generated": true
@@ -57708,7 +57630,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.setDeployment(\"ds_b0baF1ca7652\", \"staging\", {\n    versionId: \"dsv_6L78pqrdFi2xa\"\n});\n",
                   "generated": true
@@ -57948,7 +57869,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.removeDeployment(\"ds_b0baF1ca7652\", \"staging\");\n",
                   "generated": true
@@ -57996,7 +57916,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.removeDeployment(\"ds_b0baF1ca7652\", \"staging\");\n",
                   "generated": true
@@ -58291,7 +58210,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.listEnvironments(\"id\");\n",
                   "generated": true
@@ -58338,7 +58256,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.datasets.listEnvironments(\"id\");\n",
                   "generated": true
@@ -58649,7 +58566,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.list({\n    size: 1\n});\n",
                   "generated": true
@@ -58697,7 +58613,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.list({\n    size: 1\n});\n",
                   "generated": true
@@ -59059,7 +58974,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.upsert({\n    path: \"Shared Evaluators/Accuracy Evaluator\",\n    spec: {\n        argumentsType: \"target_required\",\n        returnType: \"number\",\n        evaluatorType: \"python\",\n        code: \"def evaluate(answer, target):\\n    return 0.5\"\n    },\n    commitMessage: \"Initial commit\"\n});\n",
                   "generated": true
@@ -59114,7 +59028,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.upsert({\n    path: \"Shared Evaluators/Accuracy Evaluator\",\n    spec: {\n        argumentsType: \"target_required\",\n        returnType: \"number\",\n        evaluatorType: \"python\",\n        code: \"def evaluate(answer, target):\\n    return 0.5\"\n    },\n    commitMessage: \"Initial commit\"\n});\n",
                   "generated": true
@@ -60712,7 +60625,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.get(\"ev_890bcd\");\n",
                   "generated": true
@@ -60762,7 +60674,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.get(\"ev_890bcd\");\n",
                   "generated": true
@@ -60980,7 +60891,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.delete(\"ev_890bcd\");\n",
                   "generated": true
@@ -61027,7 +60937,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.delete(\"ev_890bcd\");\n",
                   "generated": true
@@ -61291,7 +61200,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.move(\"ev_890bcd\", {\n    path: \"new directory/new name\"\n});\n",
                   "generated": true
@@ -61342,7 +61250,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.move(\"ev_890bcd\", {\n    path: \"new directory/new name\"\n});\n",
                   "generated": true
@@ -61643,7 +61550,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.listVersions(\"ev_890bcd\");\n",
                   "generated": true
@@ -61693,7 +61599,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.listVersions(\"ev_890bcd\");\n",
                   "generated": true
@@ -61992,7 +61897,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.commit(\"ev_890bcd\", \"evv_012def\", {\n    commitMessage: \"Initial commit\"\n});\n",
                   "generated": true
@@ -62046,7 +61950,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.commit(\"ev_890bcd\", \"evv_012def\", {\n    commitMessage: \"Initial commit\"\n});\n",
                   "generated": true
@@ -62352,7 +62255,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.setDeployment(\"ev_890bcd\", \"staging\", {\n    versionId: \"evv_012def\"\n});\n",
                   "generated": true
@@ -62402,7 +62304,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.setDeployment(\"ev_890bcd\", \"staging\", {\n    versionId: \"evv_012def\"\n});\n",
                   "generated": true
@@ -62642,7 +62543,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.removeDeployment(\"ev_890bcd\", \"staging\");\n",
                   "generated": true
@@ -62690,7 +62590,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.removeDeployment(\"ev_890bcd\", \"staging\");\n",
                   "generated": true
@@ -62935,7 +62834,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.listEnvironments(\"ev_890bcd\");\n",
                   "generated": true
@@ -62982,7 +62880,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.listEnvironments(\"ev_890bcd\");\n",
                   "generated": true
@@ -63688,7 +63585,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.log({\n    parentId: \"parent_id\"\n});\n",
                   "generated": true
@@ -63742,7 +63638,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluators.log({\n    parentId: \"parent_id\"\n});\n",
                   "generated": true
@@ -65954,7 +65849,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.get(\"id\");\n",
                   "generated": true
@@ -66004,7 +65898,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.get(\"id\");\n",
                   "generated": true
@@ -66221,7 +66114,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.delete(\"id\");\n",
                   "generated": true
@@ -66268,7 +66160,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.delete(\"id\");\n",
                   "generated": true
@@ -66619,7 +66510,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.move(\"id\");\n",
                   "generated": true
@@ -66670,7 +66560,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.move(\"id\");\n",
                   "generated": true
@@ -67086,7 +66975,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.list();\n",
                   "generated": true
@@ -67134,7 +67022,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.list();\n",
                   "generated": true
@@ -67576,7 +67463,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.upsert({\n    attributes: {\n        \"key\": \"value\"\n    }\n});\n",
                   "generated": true
@@ -67629,7 +67515,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.upsert({\n    attributes: {\n        \"key\": \"value\"\n    }\n});\n",
                   "generated": true
@@ -68432,7 +68317,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.log();\n",
                   "generated": true
@@ -68484,7 +68368,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.log();\n",
                   "generated": true
@@ -69622,7 +69505,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.updateLog(\"log_id\", {\n    traceStatus: \"complete\"\n});\n",
                   "generated": true
@@ -69675,7 +69557,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.updateLog(\"log_id\", {\n    traceStatus: \"complete\"\n});\n",
                   "generated": true
@@ -70081,7 +69962,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.listVersions(\"id\");\n",
                   "generated": true
@@ -70131,7 +70011,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.listVersions(\"id\");\n",
                   "generated": true
@@ -70500,7 +70379,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.commit(\"id\", \"version_id\", {\n    commitMessage: \"commit_message\"\n});\n",
                   "generated": true
@@ -70554,7 +70432,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.commit(\"id\", \"version_id\", {\n    commitMessage: \"commit_message\"\n});\n",
                   "generated": true
@@ -70930,7 +70807,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.setDeployment(\"id\", \"environment_id\", {\n    versionId: \"version_id\"\n});\n",
                   "generated": true
@@ -70980,7 +70856,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.setDeployment(\"id\", \"environment_id\", {\n    versionId: \"version_id\"\n});\n",
                   "generated": true
@@ -71219,7 +71094,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.removeDeployment(\"id\", \"environment_id\");\n",
                   "generated": true
@@ -71267,7 +71141,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.removeDeployment(\"id\", \"environment_id\");\n",
                   "generated": true
@@ -71562,7 +71435,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.listEnvironments(\"id\");\n",
                   "generated": true
@@ -71609,7 +71481,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.listEnvironments(\"id\");\n",
                   "generated": true
@@ -71907,7 +71778,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient, Humanloop } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.updateMonitoring(\"id\", {});\n",
                   "generated": true
@@ -71958,7 +71828,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient, Humanloop } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.flows.updateMonitoring(\"id\", {});\n",
                   "generated": true
@@ -72566,7 +72435,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.files.list();\n",
                   "generated": true
@@ -72614,7 +72482,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.files.list();\n",
                   "generated": true
@@ -73053,7 +72920,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.list({\n    fileId: \"pr_30gco7dx6JDq4200GVOHa\",\n    size: 1\n});\n",
                   "generated": true
@@ -73102,7 +72968,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.list({\n    fileId: \"pr_30gco7dx6JDq4200GVOHa\",\n    size: 1\n});\n",
                   "generated": true
@@ -73523,7 +73388,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.create({\n    dataset: {\n        versionId: \"dsv_6L78pqrdFi2xa\"\n    },\n    evaluatees: [{\n            versionId: \"prv_7ZlQREDScH0xkhUwtXruN\",\n            orchestrated: false\n        }],\n    evaluators: [{\n            versionId: \"evv_012def\",\n            orchestrated: false\n        }]\n});\n",
                   "generated": true
@@ -73577,7 +73441,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.create({\n    dataset: {\n        versionId: \"dsv_6L78pqrdFi2xa\"\n    },\n    evaluatees: [{\n            versionId: \"prv_7ZlQREDScH0xkhUwtXruN\",\n            orchestrated: false\n        }],\n    evaluators: [{\n            versionId: \"evv_012def\",\n            orchestrated: false\n        }]\n});\n",
                   "generated": true
@@ -74213,7 +74076,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.get(\"ev_567yza\");\n",
                   "generated": true
@@ -74260,7 +74122,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.get(\"ev_567yza\");\n",
                   "generated": true
@@ -74434,7 +74295,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.delete(\"ev_567yza\");\n",
                   "generated": true
@@ -74481,7 +74341,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.delete(\"ev_567yza\");\n",
                   "generated": true
@@ -74903,7 +74762,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.updateSetup(\"ev_567yza\", {\n    dataset: {\n        versionId: \"dsv_6L78pqrdFi2xa\"\n    },\n    evaluatees: [{\n            versionId: \"prv_7ZlQREDScH0xkhUwtXruN\",\n            orchestrated: false\n        }],\n    evaluators: [{\n            versionId: \"evv_012def\",\n            orchestrated: false\n        }]\n});\n",
                   "generated": true
@@ -74954,7 +74812,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.updateSetup(\"ev_567yza\", {\n    dataset: {\n        versionId: \"dsv_6L78pqrdFi2xa\"\n    },\n    evaluatees: [{\n            versionId: \"prv_7ZlQREDScH0xkhUwtXruN\",\n            orchestrated: false\n        }],\n    evaluators: [{\n            versionId: \"evv_012def\",\n            orchestrated: false\n        }]\n});\n",
                   "generated": true
@@ -75639,7 +75496,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.updateStatus(\"id\", {\n    status: \"pending\"\n});\n",
                   "generated": true
@@ -75692,7 +75548,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.updateStatus(\"id\", {\n    status: \"pending\"\n});\n",
                   "generated": true
@@ -75947,7 +75802,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.getStats(\"id\");\n",
                   "generated": true
@@ -75994,7 +75848,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.getStats(\"id\");\n",
                   "generated": true
@@ -76354,7 +76207,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.getLogs(\"id\");\n",
                   "generated": true
@@ -76404,7 +76256,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.evaluations.getLogs(\"id\");\n",
                   "generated": true
@@ -76851,7 +76702,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.logs.list({\n    fileId: \"file_123abc\",\n    size: 1\n});\n",
                   "generated": true
@@ -76900,7 +76750,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.logs.list({\n    fileId: \"file_123abc\",\n    size: 1\n});\n",
                   "generated": true
@@ -77237,7 +77086,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.logs.delete({\n    id: \"string\"\n});\n",
                   "generated": true
@@ -77284,7 +77132,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.logs.delete({\n    id: \"string\"\n});\n",
                   "generated": true
@@ -77495,7 +77342,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.logs.get(\"prv_Wu6zx1lAWJRqOyL8nWuZk\");\n",
                   "generated": true
@@ -77542,7 +77388,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumanloopClient } from \"humanloop\";\n\nconst client = new HumanloopClient({ apiKey: \"YOUR_API_KEY\" });\nawait client.logs.get(\"prv_Wu6zx1lAWJRqOyL8nWuZk\");\n",
                   "generated": true

--- a/packages/fdr-sdk/src/__test__/output/hume/apiDefinitions.json
+++ b/packages/fdr-sdk/src/__test__/output/hume/apiDefinitions.json
@@ -244,7 +244,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.expressionMeasurement.batch.listJobs();\n",
                   "generated": true
@@ -329,7 +328,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.expressionMeasurement.batch.startInferenceJob({\n    urls: [\"https://hume-tutorials.s3.amazonaws.com/faces.zip\"],\n    notify: true\n});\n",
                   "generated": true
@@ -430,7 +428,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.expressionMeasurement.batch.getJobDetails(\"job_id\");\n",
                   "generated": true
@@ -510,7 +507,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.expressionMeasurement.batch.getJobDetails(\"job_id\");\n",
                   "generated": true
@@ -838,7 +834,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.expressionMeasurement.batch.getJobPredictions(\"job_id\");\n",
                   "generated": true
@@ -922,7 +917,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.expressionMeasurement.batch.getJobArtifacts(\"string\");\n",
                   "generated": true
@@ -1030,7 +1024,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.expressionMeasurement.batch.startInferenceJob({\n    urls: [\"https://hume-tutorials.s3.amazonaws.com/faces.zip\"],\n    notify: true\n});\n",
                   "generated": true
@@ -8066,7 +8059,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.files.listFiles();\n",
                   "generated": true
@@ -8193,7 +8185,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.files.createFiles([{\n        file: {\n            name: \"name\",\n            humeStorage: true,\n            dataType: \"data_type\"\n        }\n    }]);\n",
                   "generated": true
@@ -8315,7 +8306,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\nimport * as fs from \"fs\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.files.uploadFile(fs.createReadStream(\"/path/to/your/file\"), fs.createReadStream(\"/path/to/your/file\"));\n",
                   "generated": true
@@ -8427,7 +8417,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.files.getFile(\"id\");\n",
                   "generated": true
@@ -8498,7 +8487,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.files.deleteFile(\"id\");\n",
                   "generated": true
@@ -8627,7 +8615,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.files.updateFileName(\"id\", {\n    name: \"name\"\n});\n",
                   "generated": true
@@ -8702,7 +8689,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.files.getFilePredictions(\"id\");\n",
                   "generated": true
@@ -8892,7 +8878,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.datasets.listDatasets();\n",
                   "generated": true
@@ -9027,7 +9012,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\nimport * as fs from \"fs\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.datasets.createDataset(fs.createReadStream(\"/path/to/your/file\"), fs.createReadStream(\"/path/to/your/file\"), {\n    name: \"name\"\n});\n",
                   "generated": true
@@ -9134,7 +9118,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.datasets.getDataset(\"id\");\n",
                   "generated": true
@@ -9276,7 +9259,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\nimport * as fs from \"fs\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.datasets.createDatasetVersion(fs.createReadStream(\"/path/to/your/file\"), fs.createReadStream(\"/path/to/your/file\"), \"id\");\n",
                   "generated": true
@@ -9347,7 +9329,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.datasets.deleteDataset(\"id\");\n",
                   "generated": true
@@ -9535,7 +9516,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.datasets.listDatasetVersions(\"id\");\n",
                   "generated": true
@@ -9724,7 +9704,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.datasets.listDatasetFiles(\"id\");\n",
                   "generated": true
@@ -9818,7 +9797,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.datasets.getDatasetVersion(\"id\");\n",
                   "generated": true
@@ -10007,7 +9985,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.datasets.listDatasetVersionFiles(\"id\");\n",
                   "generated": true
@@ -10197,7 +10174,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.models.listModels();\n",
                   "generated": true
@@ -10314,7 +10290,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.models.getModelDetails(\"id\");\n",
                   "generated": true
@@ -10448,7 +10423,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.models.updateModelName(\"id\", {\n    name: \"name\"\n});\n",
                   "generated": true
@@ -10620,7 +10594,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.models.listModelVersions();\n",
                   "generated": true
@@ -10752,7 +10725,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.models.getModelVersion(\"id\");\n",
                   "generated": true
@@ -10879,7 +10851,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.models.updateModelDescription(\"id\", \"string\");\n",
                   "generated": true
@@ -10966,7 +10937,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.jobs.startTrainingJob({\n    customModel: {\n        name: \"name\"\n    },\n    dataset: {\n        id: \"id\"\n    }\n});\n",
                   "generated": true
@@ -11050,7 +11020,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.customModels.jobs.startCustomModelsInferenceJob({\n    customModel: {\n        id: \"id\"\n    }\n});\n",
                   "generated": true
@@ -18774,7 +18743,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.tools.listTools({\n    pageNumber: 0,\n    pageSize: 2\n});\n",
                   "generated": true
@@ -18954,7 +18922,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.tools.createTool({\n    name: \"get_current_weather\",\n    parameters: \"{ \\\"type\\\": \\\"object\\\", \\\"properties\\\": { \\\"location\\\": { \\\"type\\\": \\\"string\\\", \\\"description\\\": \\\"The city and state, e.g. San Francisco, CA\\\" }, \\\"format\\\": { \\\"type\\\": \\\"string\\\", \\\"enum\\\": [\\\"celsius\\\", \\\"fahrenheit\\\"], \\\"description\\\": \\\"The temperature unit to use. Infer this from the users location.\\\" } }, \\\"required\\\": [\\\"location\\\", \\\"format\\\"] }\",\n    versionDescription: \"Fetches current weather and uses celsius or fahrenheit based on location of user.\",\n    description: \"This tool is for getting the current weather.\",\n    fallbackContent: \"Unable to fetch current weather.\"\n});\n",
                   "generated": true
@@ -19112,7 +19079,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.tools.listToolVersions(\"00183a3f-79ba-413d-9f3b-609864268bea\");\n",
                   "generated": true
@@ -19299,7 +19265,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.tools.createToolVersion(\"00183a3f-79ba-413d-9f3b-609864268bea\", {\n    parameters: \"{ \\\"type\\\": \\\"object\\\", \\\"properties\\\": { \\\"location\\\": { \\\"type\\\": \\\"string\\\", \\\"description\\\": \\\"The city and state, e.g. San Francisco, CA\\\" }, \\\"format\\\": { \\\"type\\\": \\\"string\\\", \\\"enum\\\": [\\\"celsius\\\", \\\"fahrenheit\\\", \\\"kelvin\\\"], \\\"description\\\": \\\"The temperature unit to use. Infer this from the users location.\\\" } }, \\\"required\\\": [\\\"location\\\", \\\"format\\\"] }\",\n    versionDescription: \"Fetches current weather and uses celsius, fahrenheit, or kelvin based on location of user.\",\n    fallbackContent: \"Unable to fetch current weather.\",\n    description: \"This tool is for getting the current weather.\"\n});\n",
                   "generated": true
@@ -19366,7 +19331,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.tools.deleteTool(\"00183a3f-79ba-413d-9f3b-609864268bea\");\n",
                   "generated": true
@@ -19461,7 +19425,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.tools.updateToolName(\"00183a3f-79ba-413d-9f3b-609864268bea\", {\n    name: \"get_current_temperature\"\n});\n",
                   "generated": true
@@ -19582,7 +19545,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.tools.getToolVersion(\"00183a3f-79ba-413d-9f3b-609864268bea\", 1);\n",
                   "generated": true
@@ -19671,7 +19633,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.tools.deleteToolVersion(\"00183a3f-79ba-413d-9f3b-609864268bea\", 1);\n",
                   "generated": true
@@ -19826,7 +19787,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.tools.updateToolDescription(\"00183a3f-79ba-413d-9f3b-609864268bea\", 1, {\n    versionDescription: \"Fetches current temperature, precipitation, wind speed, AQI, and other weather conditions. Uses Celsius, Fahrenheit, or kelvin depending on user's region.\"\n});\n",
                   "generated": true
@@ -19960,7 +19920,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.prompts.listPrompts();\n",
                   "generated": true
@@ -20096,7 +20055,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.prompts.createPrompt({\n    name: \"name\",\n    text: \"text\"\n});\n",
                   "generated": true
@@ -20251,7 +20209,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.prompts.listPromptVersions(\"id\");\n",
                   "generated": true
@@ -20394,7 +20351,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.prompts.createPromptVerison(\"id\", {\n    text: \"text\"\n});\n",
                   "generated": true
@@ -20461,7 +20417,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.prompts.deletePrompt(\"id\");\n",
                   "generated": true
@@ -20556,7 +20511,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.prompts.updatePromptName(\"string\", {\n    name: \"string\"\n});\n",
                   "generated": true
@@ -20674,7 +20628,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.prompts.getPromptVersion(\"id\", 1);\n",
                   "generated": true
@@ -20763,7 +20716,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.prompts.deletePromptVersion(\"id\", 1);\n",
                   "generated": true
@@ -20913,7 +20865,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.prompts.updatePromptDescription(\"id\", 1);\n",
                   "generated": true
@@ -21058,7 +21009,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.configs.listConfigs();\n",
                   "generated": true
@@ -21319,7 +21269,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.configs.createConfig({\n    name: \"name\"\n});\n",
                   "generated": true
@@ -21485,7 +21434,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.configs.listConfigVersions(\"id\");\n",
                   "generated": true
@@ -21752,7 +21700,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.configs.createConfigVersion(\"id\");\n",
                   "generated": true
@@ -21819,7 +21766,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.configs.deleteConfig(\"id\");\n",
                   "generated": true
@@ -21914,7 +21860,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.configs.updateConfigName(\"string\", {\n    name: \"string\"\n});\n",
                   "generated": true
@@ -22065,7 +22010,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.configs.getConfigVersion(\"id\", 1);\n",
                   "generated": true
@@ -22154,7 +22098,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.configs.deleteConfigVersion(\"id\", 1);\n",
                   "generated": true
@@ -22337,7 +22280,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.configs.updateConfigDescription(\"id\", 1);\n",
                   "generated": true
@@ -22455,7 +22397,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.chats.listChats();\n",
                   "generated": true
@@ -22602,7 +22543,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.chats.listChatEvents(\"id\");\n",
                   "generated": true
@@ -22715,7 +22655,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.chatGroups.listChatGroups();\n",
                   "generated": true
@@ -22876,7 +22815,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { HumeClient } from \"hume\";\n\nconst hume = new HumeClient({ apiKey: \"YOUR_API_KEY\" });\nawait hume.empathicVoice.chatGroups.listChatGroupEvents(\"id\");\n",
                   "generated": true

--- a/packages/fdr-sdk/src/__test__/output/octoai/apiDefinitions.json
+++ b/packages/fdr-sdk/src/__test__/output/octoai/apiDefinitions.json
@@ -6280,7 +6280,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.assetLibrary.list();\n",
                   "generated": true
@@ -6328,7 +6327,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.assetLibrary.list();\n",
                   "generated": true
@@ -7069,7 +7067,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient, OctoAI } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.assetLibrary.create({\n    assetType: OctoAI.AssetType.File,\n    data: {\n        assetType: \"checkpoint\",\n        dataType: OctoAI.DataType.Fp16,\n        engine: OctoAI.BaseEngine.TextLlama27B,\n        fileFormat: OctoAI.FileFormat.Safetensors\n    },\n    description: \"string\",\n    hfRepo: \"string\",\n    hfTokenSecret: \"string\",\n    isPublic: true,\n    name: \"string\",\n    skipValidation: true,\n    transferApiType: OctoAI.TransferApiType.PresignedUrl,\n    url: \"string\"\n});\n",
                   "generated": true
@@ -7125,7 +7122,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient, OctoAI } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.assetLibrary.create({\n    assetType: OctoAI.AssetType.File,\n    data: {\n        assetType: \"checkpoint\",\n        dataType: OctoAI.DataType.Fp16,\n        engine: OctoAI.BaseEngine.TextLlama27B,\n        fileFormat: OctoAI.FileFormat.Safetensors\n    },\n    description: \"string\",\n    hfRepo: \"string\",\n    hfTokenSecret: \"string\",\n    isPublic: true,\n    name: \"string\",\n    skipValidation: true,\n    transferApiType: OctoAI.TransferApiType.PresignedUrl,\n    url: \"string\"\n});\n",
                   "generated": true
@@ -8662,7 +8658,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.assetLibrary.delete(\"asset_id\");\n",
                   "generated": true
@@ -8709,7 +8704,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.assetLibrary.delete(\"asset_id\");\n",
                   "generated": true
@@ -8945,7 +8939,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.assetLibrary.completeUpload(\"asset_id\");\n",
                   "generated": true
@@ -8996,7 +8989,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.assetLibrary.completeUpload(\"asset_id\");\n",
                   "generated": true
@@ -9298,7 +9290,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient, OctoAI } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.assetLibrary.get(\"string\", {\n    transferApiType: OctoAI.TransferApiType.PresignedUrl\n});\n",
                   "generated": true
@@ -9347,7 +9338,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient, OctoAI } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.assetLibrary.get(\"string\", {\n    transferApiType: OctoAI.TransferApiType.PresignedUrl\n});\n",
                   "generated": true
@@ -9689,7 +9679,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.fineTuning.create({\n    continueOnRejection: true,\n    description: \"string\",\n    details: {\n        tuneType: \"lora_tune\",\n        baseCheckpoint: {},\n        files: [{}],\n        resizeImages: true,\n        seed: 1,\n        steps: 1,\n        triggerWords: [\"string\"]\n    },\n    name: \"string\"\n});\n",
                   "generated": true
@@ -9755,7 +9744,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.fineTuning.create({\n    continueOnRejection: true,\n    description: \"string\",\n    details: {\n        tuneType: \"lora_tune\",\n        baseCheckpoint: {},\n        files: [{}],\n        resizeImages: true,\n        seed: 1,\n        steps: 1,\n        triggerWords: [\"string\"]\n    },\n    name: \"string\"\n});\n",
                   "generated": true
@@ -10634,7 +10622,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.fineTuning.get(\"string\");\n",
                   "generated": true
@@ -10681,7 +10668,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.fineTuning.get(\"string\");\n",
                   "generated": true
@@ -10879,7 +10865,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.fineTuning.delete(\"tune_id\");\n",
                   "generated": true
@@ -10926,7 +10911,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.fineTuning.delete(\"tune_id\");\n",
                   "generated": true
@@ -11157,7 +11141,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.fineTuning.cancel(\"string\");\n",
                   "generated": true
@@ -11204,7 +11187,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.fineTuning.cancel(\"string\");\n",
                   "generated": true
@@ -11500,7 +11482,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.fineTuning.list();\n",
                   "generated": true
@@ -11548,7 +11529,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.fineTuning.list();\n",
                   "generated": true
@@ -11931,7 +11911,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.imageGen.generateSsd({\n    prompt: \"An octopus playing chess, masterpiece, photorealistic\"\n});\n",
                   "generated": true
@@ -11982,7 +11961,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.imageGen.generateSsd({\n    prompt: \"An octopus playing chess, masterpiece, photorealistic\"\n});\n",
                   "generated": true
@@ -13531,7 +13509,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.imageGen.generateControlnetSdxl({\n    prompt: \"An octopus playing chess, masterpiece, photorealistic\"\n});\n",
                   "generated": true
@@ -13582,7 +13559,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.imageGen.generateControlnetSdxl({\n    prompt: \"An octopus playing chess, masterpiece, photorealistic\"\n});\n",
                   "generated": true
@@ -15131,7 +15107,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.imageGen.generateControlnetSd15({\n    prompt: \"An octopus playing chess, masterpiece, photorealistic\"\n});\n",
                   "generated": true
@@ -15182,7 +15157,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.imageGen.generateControlnetSd15({\n    prompt: \"An octopus playing chess, masterpiece, photorealistic\"\n});\n",
                   "generated": true
@@ -16731,7 +16705,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.imageGen.generateSdxl({\n    prompt: \"An octopus playing chess, masterpiece, photorealistic\"\n});\n",
                   "generated": true
@@ -16782,7 +16755,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.imageGen.generateSdxl({\n    prompt: \"An octopus playing chess, masterpiece, photorealistic\"\n});\n",
                   "generated": true
@@ -18331,7 +18303,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.imageGen.generateSd({\n    prompt: \"An octopus playing chess, masterpiece, photorealistic\"\n});\n",
                   "generated": true
@@ -18382,7 +18353,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.imageGen.generateSd({\n    prompt: \"An octopus playing chess, masterpiece, photorealistic\"\n});\n",
                   "generated": true
@@ -20182,7 +20152,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.imageGen.generateSvd({\n    image: \"image\"\n});\n",
                   "generated": true
@@ -20233,7 +20202,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.imageGen.generateSvd({\n    image: \"image\"\n});\n",
                   "generated": true
@@ -21261,7 +21229,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.textGen.createChatCompletion({\n    messages: [{\n            role: \"role\"\n        }],\n    model: \"model\",\n    stream: false\n});\n",
                   "generated": true
@@ -21318,7 +21285,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.textGen.createChatCompletion({\n    messages: [{\n            role: \"role\"\n        }],\n    model: \"model\",\n    stream: false\n});\n",
                   "generated": true
@@ -21374,7 +21340,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.textGen.createChatCompletion({\n    messages: [{\n            role: \"role\"\n        }],\n    model: \"model\",\n    stream: false\n});\n",
                   "generated": true
@@ -23068,7 +23033,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.textGen.createChatCompletion({\n    messages: [{\n            role: \"role\"\n        }],\n    model: \"model\",\n    stream: false\n});\n",
                   "generated": true
@@ -23125,7 +23089,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.textGen.createChatCompletion({\n    messages: [{\n            role: \"role\"\n        }],\n    model: \"model\",\n    stream: false\n});\n",
                   "generated": true
@@ -23181,7 +23144,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.textGen.createChatCompletion({\n    messages: [{\n            role: \"role\"\n        }],\n    model: \"model\",\n    stream: false\n});\n",
                   "generated": true
@@ -24942,7 +24904,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.textGen.createCompletion({\n    model: \"model\",\n    stream: false\n});\n",
                   "generated": true
@@ -24994,7 +24955,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.textGen.createCompletion({\n    model: \"model\",\n    stream: false\n});\n",
                   "generated": true
@@ -25045,7 +25005,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.textGen.createCompletion({\n    model: \"model\",\n    stream: false\n});\n",
                   "generated": true
@@ -26203,7 +26162,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.textGen.createCompletion({\n    model: \"model\",\n    stream: false\n});\n",
                   "generated": true
@@ -26255,7 +26213,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.textGen.createCompletion({\n    model: \"model\",\n    stream: false\n});\n",
                   "generated": true
@@ -26306,7 +26263,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { OctoAIClient } from \"@octoai/sdk\";\n\nconst octoAi = new OctoAIClient({ apiKey: \"YOUR_API_KEY\" });\nawait octoAi.textGen.createCompletion({\n    model: \"model\",\n    stream: false\n});\n",
                   "generated": true

--- a/packages/fdr-sdk/src/__test__/output/polytomic/apiDefinitions.json
+++ b/packages/fdr-sdk/src/__test__/output/polytomic/apiDefinitions.json
@@ -33971,7 +33971,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.list();\n",
                   "generated": true
@@ -34022,7 +34021,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.list();\n",
                   "generated": true
@@ -34070,7 +34068,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.list();\n",
                   "generated": true
@@ -34530,7 +34527,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.create({\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"My Bulk Sync\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -34589,7 +34585,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.create({\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"My Bulk Sync\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -34651,7 +34646,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.create({\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"My Bulk Sync\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -34710,7 +34704,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.create({\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"My Bulk Sync\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -34769,7 +34762,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.create({\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"My Bulk Sync\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -34947,7 +34939,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -35002,7 +34993,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -35054,7 +35044,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -35548,7 +35537,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"My Bulk Sync\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -35609,7 +35597,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"My Bulk Sync\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -35673,7 +35660,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"My Bulk Sync\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -35734,7 +35720,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"My Bulk Sync\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -35795,7 +35780,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"My Bulk Sync\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -35856,7 +35840,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"My Bulk Sync\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -36015,7 +35998,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -36070,7 +36052,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -36122,7 +36103,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -36174,7 +36154,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -36226,7 +36205,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -36402,7 +36380,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -36461,7 +36438,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -36517,7 +36493,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -36573,7 +36548,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -36629,7 +36603,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -36849,7 +36822,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -36903,7 +36875,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -36960,7 +36931,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -37140,7 +37110,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -37193,7 +37162,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -37243,7 +37211,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -37293,7 +37260,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -37482,7 +37448,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    include_fields: true\n});\n",
                   "generated": true
@@ -37534,7 +37499,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    include_fields: true\n});\n",
                   "generated": true
@@ -37589,7 +37553,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    include_fields: true\n});\n",
                   "generated": true
@@ -37641,7 +37604,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    include_fields: true\n});\n",
                   "generated": true
@@ -37693,7 +37655,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    include_fields: true\n});\n",
                   "generated": true
@@ -37879,7 +37840,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.getDestination(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -37929,7 +37889,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.getDestination(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -37982,7 +37941,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.getDestination(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -38032,7 +37990,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.getDestination(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -38082,7 +38039,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.getDestination(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -38232,7 +38188,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.executions.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -38285,7 +38240,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.executions.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -38335,7 +38289,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.executions.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -38500,7 +38453,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.executions.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -38554,7 +38506,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.executions.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -38605,7 +38556,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.executions.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -38792,7 +38742,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -38849,7 +38798,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -38903,7 +38851,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -39110,7 +39057,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.patch(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -39167,7 +39113,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.patch(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -39221,7 +39166,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.patch(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -39275,7 +39219,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.patch(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -39329,7 +39272,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.patch(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -39490,7 +39432,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"Contact\");\n",
                   "generated": true
@@ -39544,7 +39485,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"Contact\");\n",
                   "generated": true
@@ -39595,7 +39535,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"Contact\");\n",
                   "generated": true
@@ -39853,7 +39792,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\", {});\n",
                   "generated": true
@@ -39911,7 +39849,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\", {});\n",
                   "generated": true
@@ -39966,7 +39903,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\", {});\n",
                   "generated": true
@@ -40021,7 +39957,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\", {});\n",
                   "generated": true
@@ -40076,7 +40011,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.bulkSync.schemas.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\", {});\n",
                   "generated": true
@@ -40192,7 +40126,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.getTypes();\n",
                   "generated": true
@@ -40243,7 +40176,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.getTypes();\n",
                   "generated": true
@@ -40291,7 +40223,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.getTypes();\n",
                   "generated": true
@@ -40421,7 +40352,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.list();\n",
                   "generated": true
@@ -40472,7 +40402,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.list();\n",
                   "generated": true
@@ -40520,7 +40449,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.list();\n",
                   "generated": true
@@ -40841,7 +40769,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.create({\n    name: \"My Postgres Connection\",\n    type: \"postgresql\"\n});\n",
                   "generated": true
@@ -40896,7 +40823,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.create({\n    name: \"My Postgres Connection\",\n    type: \"postgresql\"\n});\n",
                   "generated": true
@@ -40954,7 +40880,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.create({\n    name: \"My Postgres Connection\",\n    type: \"postgresql\"\n});\n",
                   "generated": true
@@ -41009,7 +40934,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.create({\n    name: \"My Postgres Connection\",\n    type: \"postgresql\"\n});\n",
                   "generated": true
@@ -41064,7 +40988,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.create({\n    name: \"My Postgres Connection\",\n    type: \"postgresql\"\n});\n",
                   "generated": true
@@ -41119,7 +41042,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.create({\n    name: \"My Postgres Connection\",\n    type: \"postgresql\"\n});\n",
                   "generated": true
@@ -41366,7 +41288,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.connect({\n    name: \"Salesforce Connection\",\n    redirect_url: \"redirect_url\"\n});\n",
                   "generated": true
@@ -41410,7 +41331,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.connect({\n    name: \"Salesforce Connection\",\n    redirect_url: \"redirect_url\"\n});\n",
                   "generated": true
@@ -41451,7 +41371,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.connect({\n    name: \"Salesforce Connection\",\n    redirect_url: \"redirect_url\"\n});\n",
                   "generated": true
@@ -41492,7 +41411,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.connect({\n    name: \"Salesforce Connection\",\n    redirect_url: \"redirect_url\"\n});\n",
                   "generated": true
@@ -41533,7 +41451,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.connect({\n    name: \"Salesforce Connection\",\n    redirect_url: \"redirect_url\"\n});\n",
                   "generated": true
@@ -41690,7 +41607,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -41743,7 +41659,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -41793,7 +41708,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -41843,7 +41757,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -42201,7 +42114,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Postgres Connection\"\n});\n",
                   "generated": true
@@ -42257,7 +42169,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Postgres Connection\"\n});\n",
                   "generated": true
@@ -42316,7 +42227,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Postgres Connection\"\n});\n",
                   "generated": true
@@ -42372,7 +42282,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Postgres Connection\"\n});\n",
                   "generated": true
@@ -42428,7 +42337,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Postgres Connection\"\n});\n",
                   "generated": true
@@ -42484,7 +42392,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Postgres Connection\"\n});\n",
                   "generated": true
@@ -42540,7 +42447,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Postgres Connection\"\n});\n",
                   "generated": true
@@ -42712,7 +42618,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -42767,7 +42672,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -42819,7 +42723,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -42871,7 +42774,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -42923,7 +42825,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -42975,7 +42876,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -43126,7 +43026,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.getParameterValues(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -43179,7 +43078,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.getParameterValues(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -43229,7 +43127,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.getParameterValues(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -43279,7 +43176,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.connections.getParameterValues(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -43503,7 +43399,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -43559,7 +43454,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -43618,7 +43512,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -43674,7 +43567,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -43730,7 +43622,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -43786,7 +43677,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -43970,7 +43860,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getSourceFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -44020,7 +43909,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getSourceFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -44073,7 +43961,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getSourceFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -44123,7 +44010,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getSourceFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -44173,7 +44059,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getSourceFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -44223,7 +44108,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getSourceFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -44443,7 +44327,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getTarget(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -44496,7 +44379,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getTarget(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -44552,7 +44434,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getTarget(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -44605,7 +44486,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getTarget(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -44658,7 +44538,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getTarget(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -44711,7 +44590,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getTarget(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -44944,7 +44822,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getTargetFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    target: \"database.table\",\n    refresh: false\n});\n",
                   "generated": true
@@ -45000,7 +44877,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getTargetFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    target: \"database.table\",\n    refresh: false\n});\n",
                   "generated": true
@@ -45053,7 +44929,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getTargetFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    target: \"database.table\",\n    refresh: false\n});\n",
                   "generated": true
@@ -45106,7 +44981,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getTargetFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    target: \"database.table\",\n    refresh: false\n});\n",
                   "generated": true
@@ -45159,7 +45033,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getTargetFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    target: \"database.table\",\n    refresh: false\n});\n",
                   "generated": true
@@ -45351,7 +45224,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.list();\n",
                   "generated": true
@@ -45402,7 +45274,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.list();\n",
                   "generated": true
@@ -45450,7 +45321,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.list();\n",
                   "generated": true
@@ -45498,7 +45368,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.list();\n",
                   "generated": true
@@ -46016,7 +45885,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.create({\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {},\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -46076,7 +45944,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.create({\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {},\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -46139,7 +46006,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.create({\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {},\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -46199,7 +46065,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.create({\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {},\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -46259,7 +46124,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.create({\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {},\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -46319,7 +46183,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.create({\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {},\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -46433,7 +46296,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getScheduleOptions();\n",
                   "generated": true
@@ -46484,7 +46346,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getScheduleOptions();\n",
                   "generated": true
@@ -46532,7 +46393,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getScheduleOptions();\n",
                   "generated": true
@@ -46761,7 +46621,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -46814,7 +46673,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -46864,7 +46722,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -46914,7 +46771,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -47465,7 +47321,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {},\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -47527,7 +47382,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {},\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -47592,7 +47446,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {},\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -47654,7 +47507,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {},\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -47716,7 +47568,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {},\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -47778,7 +47629,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {},\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -47840,7 +47690,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {},\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -47977,7 +47826,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -48030,7 +47878,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -48080,7 +47927,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -48130,7 +47976,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -48180,7 +48025,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -48356,7 +48200,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -48415,7 +48258,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -48471,7 +48313,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -48527,7 +48368,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -48583,7 +48423,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -48813,7 +48652,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -48867,7 +48705,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -48924,7 +48761,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -48978,7 +48814,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -49032,7 +48867,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -49086,7 +48920,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -49266,7 +49099,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -49319,7 +49151,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -49369,7 +49200,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -49419,7 +49249,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -49560,7 +49389,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.refresh(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -49610,7 +49438,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.refresh(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -49663,7 +49490,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.refresh(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -49713,7 +49539,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.refresh(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -49763,7 +49588,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.refresh(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -49924,7 +49748,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -49974,7 +49797,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -50027,7 +49849,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -50077,7 +49898,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -50127,7 +49947,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -50312,7 +50131,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"public.users\");\n",
                   "generated": true
@@ -50363,7 +50181,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"public.users\");\n",
                   "generated": true
@@ -50417,7 +50234,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"public.users\");\n",
                   "generated": true
@@ -50468,7 +50284,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"public.users\");\n",
                   "generated": true
@@ -50519,7 +50334,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"public.users\");\n",
                   "generated": true
@@ -50716,7 +50530,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.getRecords(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"public.users\");\n",
                   "generated": true
@@ -50767,7 +50580,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.getRecords(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"public.users\");\n",
                   "generated": true
@@ -50821,7 +50633,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.getRecords(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"public.users\");\n",
                   "generated": true
@@ -50872,7 +50683,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.getRecords(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"public.users\");\n",
                   "generated": true
@@ -50923,7 +50733,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.getRecords(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"public.users\");\n",
                   "generated": true
@@ -50974,7 +50783,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.schemas.getRecords(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"public.users\");\n",
                   "generated": true
@@ -51165,7 +50973,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.post(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -51222,7 +51029,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.post(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -51276,7 +51082,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.post(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -51330,7 +51135,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.post(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -51384,7 +51188,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.post(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -51619,7 +51422,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.preview({\n    body: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        name: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -51676,7 +51478,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.preview({\n    body: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        name: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -51736,7 +51537,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.preview({\n    body: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        name: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -51793,7 +51593,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.preview({\n    body: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        name: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -51850,7 +51649,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.preview({\n    body: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        name: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -52000,7 +51798,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.list();\n",
                   "generated": true
@@ -52051,7 +51848,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.list();\n",
                   "generated": true
@@ -52099,7 +51895,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.list();\n",
                   "generated": true
@@ -52334,7 +52129,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.create({\n    body: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        name: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -52391,7 +52185,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.create({\n    body: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        name: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -52451,7 +52244,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.create({\n    body: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        name: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -52508,7 +52300,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.create({\n    body: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        name: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -52565,7 +52356,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.create({\n    body: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        name: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -52790,7 +52580,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -52845,7 +52634,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -52897,7 +52685,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -52949,7 +52736,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -53451,7 +53237,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    async: false,\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -53510,7 +53295,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    async: false,\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -53572,7 +53356,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    async: false,\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -53631,7 +53414,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    async: false,\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -53690,7 +53472,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    async: false,\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -53847,7 +53628,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -53902,7 +53682,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -53954,7 +53733,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -54006,7 +53784,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -54058,7 +53835,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.models.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -54581,7 +54357,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.events.list({\n    organization_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    starting_after: new Date(\"2020-01-01T00:00:00.000Z\"),\n    ending_before: new Date(\"2020-01-01T00:00:00.000Z\")\n});\n",
                   "generated": true
@@ -54635,7 +54410,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.events.list({\n    organization_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    starting_after: new Date(\"2020-01-01T00:00:00.000Z\"),\n    ending_before: new Date(\"2020-01-01T00:00:00.000Z\")\n});\n",
                   "generated": true
@@ -54686,7 +54460,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.events.list({\n    organization_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    starting_after: new Date(\"2020-01-01T00:00:00.000Z\"),\n    ending_before: new Date(\"2020-01-01T00:00:00.000Z\")\n});\n",
                   "generated": true
@@ -54737,7 +54510,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.events.list({\n    organization_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    starting_after: new Date(\"2020-01-01T00:00:00.000Z\"),\n    ending_before: new Date(\"2020-01-01T00:00:00.000Z\")\n});\n",
                   "generated": true
@@ -54833,7 +54605,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.events.getTypes();\n",
                   "generated": true
@@ -54884,7 +54655,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.events.getTypes();\n",
                   "generated": true
@@ -55066,7 +54836,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.jobs.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"createmodel\");\n",
                   "generated": true
@@ -55117,7 +54886,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.jobs.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"createmodel\");\n",
                   "generated": true
@@ -55171,7 +54939,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.jobs.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"createmodel\");\n",
                   "generated": true
@@ -55222,7 +54989,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.jobs.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"createmodel\");\n",
                   "generated": true
@@ -55273,7 +55039,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.jobs.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"createmodel\");\n",
                   "generated": true
@@ -55390,7 +55155,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.identity.get();\n",
                   "generated": true
@@ -55441,7 +55205,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.identity.get();\n",
                   "generated": true
@@ -55489,7 +55252,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.identity.get();\n",
                   "generated": true
@@ -55605,7 +55367,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.list();\n",
                   "generated": true
@@ -55656,7 +55417,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.list();\n",
                   "generated": true
@@ -55704,7 +55464,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.list();\n",
                   "generated": true
@@ -55948,7 +55707,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.create({\n    name: \"My Organization\"\n});\n",
                   "generated": true
@@ -56005,7 +55763,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.create({\n    name: \"My Organization\"\n});\n",
                   "generated": true
@@ -56059,7 +55816,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.create({\n    name: \"My Organization\"\n});\n",
                   "generated": true
@@ -56113,7 +55869,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.create({\n    name: \"My Organization\"\n});\n",
                   "generated": true
@@ -56247,7 +56002,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -56300,7 +56054,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -56350,7 +56103,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -56614,7 +56366,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Organization\"\n});\n",
                   "generated": true
@@ -56673,7 +56424,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Organization\"\n});\n",
                   "generated": true
@@ -56729,7 +56479,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Organization\"\n});\n",
                   "generated": true
@@ -56785,7 +56534,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Organization\"\n});\n",
                   "generated": true
@@ -56910,7 +56658,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -56963,7 +56710,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -57013,7 +56759,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -57063,7 +56808,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.organization.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -57202,7 +56946,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -57255,7 +56998,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -57305,7 +57047,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -57500,7 +57241,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.create(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\"\n});\n",
                   "generated": true
@@ -57559,7 +57299,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.create(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\"\n});\n",
                   "generated": true
@@ -57615,7 +57354,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.create(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\"\n});\n",
                   "generated": true
@@ -57671,7 +57409,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.create(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\"\n});\n",
                   "generated": true
@@ -57838,7 +57575,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -57892,7 +57628,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -57943,7 +57678,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -57994,7 +57728,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -58206,7 +57939,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\"\n});\n",
                   "generated": true
@@ -58266,7 +57998,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\"\n});\n",
                   "generated": true
@@ -58323,7 +58054,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\"\n});\n",
                   "generated": true
@@ -58380,7 +58110,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\"\n});\n",
                   "generated": true
@@ -58547,7 +58276,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -58601,7 +58329,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -58652,7 +58379,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -58703,7 +58429,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -58893,7 +58618,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.createApiKey(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -58949,7 +58673,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.createApiKey(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -59002,7 +58725,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.createApiKey(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -59055,7 +58777,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.users.createApiKey(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -59178,7 +58899,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.list();\n",
                   "generated": true
@@ -59229,7 +58949,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.list();\n",
                   "generated": true
@@ -59277,7 +58996,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.list();\n",
                   "generated": true
@@ -59504,7 +59222,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -59558,7 +59275,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -59615,7 +59331,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -59669,7 +59384,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -59723,7 +59437,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -59777,7 +59490,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -59931,7 +59643,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -59984,7 +59695,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -60034,7 +59744,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -60084,7 +59793,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -60331,7 +60039,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -60387,7 +60094,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -60446,7 +60152,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -60502,7 +60207,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -60558,7 +60262,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -60614,7 +60317,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -60752,7 +60454,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -60805,7 +60506,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -60855,7 +60555,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -60905,7 +60604,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -60955,7 +60653,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.policies.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -61070,7 +60767,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.list();\n",
                   "generated": true
@@ -61121,7 +60817,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.list();\n",
                   "generated": true
@@ -61169,7 +60864,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.list();\n",
                   "generated": true
@@ -61366,7 +61060,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -61420,7 +61113,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -61477,7 +61169,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -61531,7 +61222,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -61585,7 +61275,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -61639,7 +61328,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -61772,7 +61460,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -61825,7 +61512,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -61875,7 +61561,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -62092,7 +61777,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -62148,7 +61832,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -62207,7 +61890,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -62263,7 +61945,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -62319,7 +62000,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -62375,7 +62055,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -62513,7 +62192,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -62566,7 +62244,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -62616,7 +62293,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -62666,7 +62342,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -62716,7 +62391,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.permissions.roles.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -62866,7 +62540,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -62919,7 +62592,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -62969,7 +62641,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -63147,7 +62818,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -63201,7 +62871,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -63252,7 +62921,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -63303,7 +62971,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -63504,7 +63171,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.getLogUrls(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", \"records\");\n",
                   "generated": true
@@ -63556,7 +63222,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.getLogUrls(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", \"records\");\n",
                   "generated": true
@@ -63611,7 +63276,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.getLogUrls(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", \"records\");\n",
                   "generated": true
@@ -63663,7 +63327,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.getLogUrls(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", \"records\");\n",
                   "generated": true
@@ -63715,7 +63378,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.getLogUrls(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", \"records\");\n",
                   "generated": true
@@ -63916,7 +63578,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.getLogs(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", \"records\", \"path/to/file.json\");\n",
                   "generated": true
@@ -63969,7 +63630,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.getLogs(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", \"records\", \"path/to/file.json\");\n",
                   "generated": true
@@ -64025,7 +63685,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.getLogs(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", \"records\", \"path/to/file.json\");\n",
                   "generated": true
@@ -64078,7 +63737,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.getLogs(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", \"records\", \"path/to/file.json\");\n",
                   "generated": true
@@ -64131,7 +63789,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.modelSync.executions.getLogs(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", \"records\", \"path/to/file.json\");\n",
                   "generated": true
@@ -64247,7 +63904,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.list();\n",
                   "generated": true
@@ -64298,7 +63954,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.list();\n",
                   "generated": true
@@ -64346,7 +64001,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.list();\n",
                   "generated": true
@@ -64533,7 +64187,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.create({\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -64591,7 +64244,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.create({\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -64646,7 +64298,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.create({\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -64701,7 +64352,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.create({\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -64835,7 +64485,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -64888,7 +64537,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -64938,7 +64586,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -65145,7 +64792,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -65205,7 +64851,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -65262,7 +64907,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -65319,7 +64963,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -65443,7 +65086,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -65496,7 +65138,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -65546,7 +65187,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -65596,7 +65236,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\" });\nawait polytomic.webhooks.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -74930,7 +74569,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getDestination(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -74980,7 +74618,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getDestination(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -75033,7 +74670,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getDestination(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -75083,7 +74719,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getDestination(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -75133,7 +74768,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getDestination(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -75336,7 +74970,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    include_fields: true\n});\n",
                   "generated": true
@@ -75389,7 +75022,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    include_fields: true\n});\n",
                   "generated": true
@@ -75445,7 +75077,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    include_fields: true\n});\n",
                   "generated": true
@@ -75498,7 +75129,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    include_fields: true\n});\n",
                   "generated": true
@@ -75551,7 +75181,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    include_fields: true\n});\n",
                   "generated": true
@@ -75736,7 +75365,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSourceSchema(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"schema_id\");\n",
                   "generated": true
@@ -75787,7 +75415,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSourceSchema(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"schema_id\");\n",
                   "generated": true
@@ -75841,7 +75468,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSourceSchema(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"schema_id\");\n",
                   "generated": true
@@ -75892,7 +75518,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSourceSchema(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"schema_id\");\n",
                   "generated": true
@@ -75943,7 +75568,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSourceSchema(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"schema_id\");\n",
                   "generated": true
@@ -76104,7 +75728,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSourceStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -76154,7 +75777,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSourceStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -76207,7 +75829,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSourceStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -76257,7 +75878,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSourceStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -76307,7 +75927,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getSourceStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -76442,7 +76061,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.list();\n",
                   "generated": true
@@ -76493,7 +76111,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.list();\n",
                   "generated": true
@@ -76541,7 +76158,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.list();\n",
                   "generated": true
@@ -77001,7 +76617,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.create({\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"name\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -77060,7 +76675,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.create({\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"name\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -77122,7 +76736,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.create({\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"name\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -77181,7 +76794,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.create({\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"name\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -77240,7 +76852,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.create({\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"name\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -77418,7 +77029,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -77473,7 +77083,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -77525,7 +77134,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -77684,7 +77292,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -77739,7 +77346,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -77791,7 +77397,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -77843,7 +77448,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -77895,7 +77499,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh_schemas: true\n});\n",
                   "generated": true
@@ -78389,7 +77992,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"name\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -78450,7 +78052,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"name\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -78514,7 +78115,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"name\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -78575,7 +78175,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"name\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -78636,7 +78235,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"name\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -78697,7 +78295,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient, Polytomic } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    destination_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    name: \"name\",\n    schedule: {\n        frequency: Polytomic.ScheduleFrequency.Manual\n    },\n    source_connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n});\n",
                   "generated": true
@@ -78873,7 +78470,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -78932,7 +78528,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -78988,7 +78583,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -79044,7 +78638,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -79100,7 +78693,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -79320,7 +78912,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.executions.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    resync: false,\n    test: false\n});\n",
                   "generated": true
@@ -79374,7 +78965,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.executions.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    resync: false,\n    test: false\n});\n",
                   "generated": true
@@ -79431,7 +79021,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.executions.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    resync: false,\n    test: false\n});\n",
                   "generated": true
@@ -79611,7 +79200,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -79664,7 +79252,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -79714,7 +79301,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -79764,7 +79350,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -79914,7 +79499,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.executions.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -79967,7 +79551,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.executions.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -80017,7 +79600,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.executions.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -80182,7 +79764,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.executions.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -80236,7 +79817,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.executions.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -80287,7 +79867,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.executions.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -80474,7 +80053,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.schemas.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -80531,7 +80109,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.schemas.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -80585,7 +80162,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.schemas.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -81097,7 +80673,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.schemas.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"Contact\");\n",
                   "generated": true
@@ -81151,7 +80726,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.schemas.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"Contact\");\n",
                   "generated": true
@@ -81202,7 +80776,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.schemas.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"Contact\");\n",
                   "generated": true
@@ -81460,7 +81033,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.schemas.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\", {\n    enabled: true,\n    partition_key: \"email\"\n});\n",
                   "generated": true
@@ -81518,7 +81090,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.schemas.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\", {\n    enabled: true,\n    partition_key: \"email\"\n});\n",
                   "generated": true
@@ -81573,7 +81144,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.schemas.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\", {\n    enabled: true,\n    partition_key: \"email\"\n});\n",
                   "generated": true
@@ -81628,7 +81198,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.schemas.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\", {\n    enabled: true,\n    partition_key: \"email\"\n});\n",
                   "generated": true
@@ -81683,7 +81252,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.bulkSync.schemas.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\", {\n    enabled: true,\n    partition_key: \"email\"\n});\n",
                   "generated": true
@@ -81799,7 +81367,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getTypes();\n",
                   "generated": true
@@ -81850,7 +81417,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getTypes();\n",
                   "generated": true
@@ -81898,7 +81464,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getTypes();\n",
                   "generated": true
@@ -82028,7 +81593,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.list();\n",
                   "generated": true
@@ -82079,7 +81643,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.list();\n",
                   "generated": true
@@ -82127,7 +81690,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.list();\n",
                   "generated": true
@@ -82448,7 +82010,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.create({\n    name: \"My Connection\",\n    redirect_url: \"https://example.com/oauth_redirect\",\n    type: \"s3\",\n    validate: true\n});\n",
                   "generated": true
@@ -82503,7 +82064,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.create({\n    name: \"My Connection\",\n    redirect_url: \"https://example.com/oauth_redirect\",\n    type: \"s3\",\n    validate: true\n});\n",
                   "generated": true
@@ -82561,7 +82121,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.create({\n    name: \"My Connection\",\n    redirect_url: \"https://example.com/oauth_redirect\",\n    type: \"s3\",\n    validate: true\n});\n",
                   "generated": true
@@ -82616,7 +82175,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.create({\n    name: \"My Connection\",\n    redirect_url: \"https://example.com/oauth_redirect\",\n    type: \"s3\",\n    validate: true\n});\n",
                   "generated": true
@@ -82671,7 +82229,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.create({\n    name: \"My Connection\",\n    redirect_url: \"https://example.com/oauth_redirect\",\n    type: \"s3\",\n    validate: true\n});\n",
                   "generated": true
@@ -82726,7 +82283,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.create({\n    name: \"My Connection\",\n    redirect_url: \"https://example.com/oauth_redirect\",\n    type: \"s3\",\n    validate: true\n});\n",
                   "generated": true
@@ -83257,7 +82813,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -83310,7 +82865,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -83360,7 +82914,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -83410,7 +82963,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -83582,7 +83134,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -83637,7 +83188,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -83689,7 +83239,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -83741,7 +83290,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -83793,7 +83341,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -83845,7 +83392,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -84203,7 +83749,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Connection\",\n    reconnect: false,\n    type: \"s3\",\n    validate: true\n});\n",
                   "generated": true
@@ -84259,7 +83804,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Connection\",\n    reconnect: false,\n    type: \"s3\",\n    validate: true\n});\n",
                   "generated": true
@@ -84318,7 +83862,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Connection\",\n    reconnect: false,\n    type: \"s3\",\n    validate: true\n});\n",
                   "generated": true
@@ -84374,7 +83917,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Connection\",\n    reconnect: false,\n    type: \"s3\",\n    validate: true\n});\n",
                   "generated": true
@@ -84430,7 +83972,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Connection\",\n    reconnect: false,\n    type: \"s3\",\n    validate: true\n});\n",
                   "generated": true
@@ -84486,7 +84027,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Connection\",\n    reconnect: false,\n    type: \"s3\",\n    validate: true\n});\n",
                   "generated": true
@@ -84542,7 +84082,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"My Connection\",\n    reconnect: false,\n    type: \"s3\",\n    validate: true\n});\n",
                   "generated": true
@@ -84693,7 +84232,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getParameterValues(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -84746,7 +84284,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getParameterValues(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -84796,7 +84333,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getParameterValues(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -84846,7 +84382,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getParameterValues(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -85028,7 +84563,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -85078,7 +84612,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -85131,7 +84664,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -85181,7 +84713,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -85231,7 +84762,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -85281,7 +84811,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getSource(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -85508,7 +85037,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getSourceFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -85562,7 +85090,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getSourceFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -85619,7 +85146,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getSourceFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -85673,7 +85199,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getSourceFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -85727,7 +85252,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getSourceFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -85781,7 +85305,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getSourceFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -86004,7 +85527,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getTarget(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    type: \"table\",\n    search: \"public.users\"\n});\n",
                   "generated": true
@@ -86057,7 +85579,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getTarget(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    type: \"table\",\n    search: \"public.users\"\n});\n",
                   "generated": true
@@ -86113,7 +85634,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getTarget(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    type: \"table\",\n    search: \"public.users\"\n});\n",
                   "generated": true
@@ -86166,7 +85686,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getTarget(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    type: \"table\",\n    search: \"public.users\"\n});\n",
                   "generated": true
@@ -86219,7 +85738,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getTarget(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    type: \"table\",\n    search: \"public.users\"\n});\n",
                   "generated": true
@@ -86272,7 +85790,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getTarget(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    type: \"table\",\n    search: \"public.users\"\n});\n",
                   "generated": true
@@ -86515,7 +86032,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getTargetFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh: false,\n    target: \"database.table\"\n});\n",
                   "generated": true
@@ -86574,7 +86090,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getTargetFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh: false,\n    target: \"database.table\"\n});\n",
                   "generated": true
@@ -86630,7 +86145,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getTargetFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh: false,\n    target: \"database.table\"\n});\n",
                   "generated": true
@@ -86686,7 +86200,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getTargetFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh: false,\n    target: \"database.table\"\n});\n",
                   "generated": true
@@ -86742,7 +86255,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.connections.getTargetFields(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    refresh: false,\n    target: \"database.table\"\n});\n",
                   "generated": true
@@ -86939,7 +86451,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.schemas.getRecords(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\");\n",
                   "generated": true
@@ -86990,7 +86501,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.schemas.getRecords(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\");\n",
                   "generated": true
@@ -87044,7 +86554,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.schemas.getRecords(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\");\n",
                   "generated": true
@@ -87095,7 +86604,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.schemas.getRecords(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\");\n",
                   "generated": true
@@ -87146,7 +86654,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.schemas.getRecords(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\");\n",
                   "generated": true
@@ -87197,7 +86704,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.schemas.getRecords(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"contact\");\n",
                   "generated": true
@@ -88003,7 +87509,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.list();\n",
                   "generated": true
@@ -88054,7 +87559,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.list();\n",
                   "generated": true
@@ -88102,7 +87606,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.list();\n",
                   "generated": true
@@ -88337,7 +87840,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.create({\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    identifier: \"id\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -88394,7 +87896,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.create({\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    identifier: \"id\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -88454,7 +87955,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.create({\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    identifier: \"id\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -88511,7 +88011,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.create({\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    identifier: \"id\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -88568,7 +88067,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.create({\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    identifier: \"id\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -88793,7 +88291,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -88848,7 +88345,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -88900,7 +88396,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -88952,7 +88447,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -89109,7 +88603,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -89164,7 +88657,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -89216,7 +88708,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -89268,7 +88759,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -89320,7 +88810,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -89822,7 +89311,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    async: false,\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    identifier: \"id\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -89881,7 +89369,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    async: false,\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    identifier: \"id\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -89943,7 +89430,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    async: false,\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    identifier: \"id\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -90002,7 +89488,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    async: false,\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    identifier: \"id\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -90061,7 +89546,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.models.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    async: false,\n    connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    identifier: \"id\",\n    name: \"Users\"\n});\n",
                   "generated": true
@@ -90584,7 +90068,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.events.apiV2GetEvents({\n    organization_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    starting_after: new Date(\"2020-01-01T00:00:00.000Z\"),\n    ending_before: new Date(\"2020-01-01T00:00:00.000Z\")\n});\n",
                   "generated": true
@@ -90638,7 +90121,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.events.apiV2GetEvents({\n    organization_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    starting_after: new Date(\"2020-01-01T00:00:00.000Z\"),\n    ending_before: new Date(\"2020-01-01T00:00:00.000Z\")\n});\n",
                   "generated": true
@@ -90689,7 +90171,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.events.apiV2GetEvents({\n    organization_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    starting_after: new Date(\"2020-01-01T00:00:00.000Z\"),\n    ending_before: new Date(\"2020-01-01T00:00:00.000Z\")\n});\n",
                   "generated": true
@@ -90740,7 +90221,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.events.apiV2GetEvents({\n    organization_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n    starting_after: new Date(\"2020-01-01T00:00:00.000Z\"),\n    ending_before: new Date(\"2020-01-01T00:00:00.000Z\")\n});\n",
                   "generated": true
@@ -90836,7 +90316,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.events.apiV2GetEventTypes();\n",
                   "generated": true
@@ -90887,7 +90366,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.events.apiV2GetEventTypes();\n",
                   "generated": true
@@ -91069,7 +90547,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.jobs.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"createmodel\");\n",
                   "generated": true
@@ -91120,7 +90597,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.jobs.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"createmodel\");\n",
                   "generated": true
@@ -91174,7 +90650,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.jobs.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"createmodel\");\n",
                   "generated": true
@@ -91225,7 +90700,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.jobs.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"createmodel\");\n",
                   "generated": true
@@ -91276,7 +90750,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.jobs.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"createmodel\");\n",
                   "generated": true
@@ -91563,7 +91036,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.list();\n",
                   "generated": true
@@ -91614,7 +91086,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.list();\n",
                   "generated": true
@@ -91662,7 +91133,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.list();\n",
                   "generated": true
@@ -91906,7 +91376,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.create({\n    client_id: \"client_id\",\n    client_secret: \"client_secret\",\n    issuer: \"https://example.com\",\n    name: \"My Organization\",\n    sso_domain: \"example.com\",\n    sso_org_id: \"123456\"\n});\n",
                   "generated": true
@@ -91963,7 +91432,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.create({\n    client_id: \"client_id\",\n    client_secret: \"client_secret\",\n    issuer: \"https://example.com\",\n    name: \"My Organization\",\n    sso_domain: \"example.com\",\n    sso_org_id: \"123456\"\n});\n",
                   "generated": true
@@ -92017,7 +91485,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.create({\n    client_id: \"client_id\",\n    client_secret: \"client_secret\",\n    issuer: \"https://example.com\",\n    name: \"My Organization\",\n    sso_domain: \"example.com\",\n    sso_org_id: \"123456\"\n});\n",
                   "generated": true
@@ -92071,7 +91538,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.create({\n    client_id: \"client_id\",\n    client_secret: \"client_secret\",\n    issuer: \"https://example.com\",\n    name: \"My Organization\",\n    sso_domain: \"example.com\",\n    sso_org_id: \"123456\"\n});\n",
                   "generated": true
@@ -92205,7 +91671,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -92258,7 +91723,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -92308,7 +91772,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -92433,7 +91896,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -92486,7 +91948,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -92536,7 +91997,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -92586,7 +92046,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -92850,7 +92309,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    client_id: \"client_id\",\n    client_secret: \"client_secret\",\n    issuer: \"https://example.com\",\n    name: \"My Organization\",\n    sso_domain: \"example.com\",\n    sso_org_id: \"123456\"\n});\n",
                   "generated": true
@@ -92909,7 +92367,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    client_id: \"client_id\",\n    client_secret: \"client_secret\",\n    issuer: \"https://example.com\",\n    name: \"My Organization\",\n    sso_domain: \"example.com\",\n    sso_org_id: \"123456\"\n});\n",
                   "generated": true
@@ -92965,7 +92422,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    client_id: \"client_id\",\n    client_secret: \"client_secret\",\n    issuer: \"https://example.com\",\n    name: \"My Organization\",\n    sso_domain: \"example.com\",\n    sso_org_id: \"123456\"\n});\n",
                   "generated": true
@@ -93021,7 +92477,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.organization.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    client_id: \"client_id\",\n    client_secret: \"client_secret\",\n    issuer: \"https://example.com\",\n    name: \"My Organization\",\n    sso_domain: \"example.com\",\n    sso_org_id: \"123456\"\n});\n",
                   "generated": true
@@ -93160,7 +92615,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -93213,7 +92667,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -93263,7 +92716,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -93458,7 +92910,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.create(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\",\n    role: \"admin\"\n});\n",
                   "generated": true
@@ -93517,7 +92968,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.create(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\",\n    role: \"admin\"\n});\n",
                   "generated": true
@@ -93573,7 +93023,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.create(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\",\n    role: \"admin\"\n});\n",
                   "generated": true
@@ -93629,7 +93078,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.create(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\",\n    role: \"admin\"\n});\n",
                   "generated": true
@@ -93796,7 +93244,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -93850,7 +93297,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -93901,7 +93347,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -93952,7 +93397,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -94119,7 +93563,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -94173,7 +93616,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -94224,7 +93666,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -94275,7 +93716,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -94487,7 +93927,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\",\n    role: \"admin\"\n});\n",
                   "generated": true
@@ -94547,7 +93986,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\",\n    role: \"admin\"\n});\n",
                   "generated": true
@@ -94604,7 +94042,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\",\n    role: \"admin\"\n});\n",
                   "generated": true
@@ -94661,7 +94098,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    email: \"mail@example.com\",\n    role: \"admin\"\n});\n",
                   "generated": true
@@ -94851,7 +94287,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.createApiKey(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -94907,7 +94342,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.createApiKey(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -94960,7 +94394,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.createApiKey(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -95013,7 +94446,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.users.createApiKey(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    force: true\n});\n",
                   "generated": true
@@ -95136,7 +94568,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.list();\n",
                   "generated": true
@@ -95187,7 +94618,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.list();\n",
                   "generated": true
@@ -95235,7 +94665,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.list();\n",
                   "generated": true
@@ -95462,7 +94891,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.create({\n    name: \"Custom\",\n    policy_actions: [{\n            action: \"read\",\n            role_ids: [\"248df4b7-aa70-47b8-a036-33ac447e668d\"]\n        }]\n});\n",
                   "generated": true
@@ -95516,7 +94944,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.create({\n    name: \"Custom\",\n    policy_actions: [{\n            action: \"read\",\n            role_ids: [\"248df4b7-aa70-47b8-a036-33ac447e668d\"]\n        }]\n});\n",
                   "generated": true
@@ -95573,7 +95000,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.create({\n    name: \"Custom\",\n    policy_actions: [{\n            action: \"read\",\n            role_ids: [\"248df4b7-aa70-47b8-a036-33ac447e668d\"]\n        }]\n});\n",
                   "generated": true
@@ -95627,7 +95053,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.create({\n    name: \"Custom\",\n    policy_actions: [{\n            action: \"read\",\n            role_ids: [\"248df4b7-aa70-47b8-a036-33ac447e668d\"]\n        }]\n});\n",
                   "generated": true
@@ -95681,7 +95106,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.create({\n    name: \"Custom\",\n    policy_actions: [{\n            action: \"read\",\n            role_ids: [\"248df4b7-aa70-47b8-a036-33ac447e668d\"]\n        }]\n});\n",
                   "generated": true
@@ -95735,7 +95159,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.create({\n    name: \"Custom\",\n    policy_actions: [{\n            action: \"read\",\n            role_ids: [\"248df4b7-aa70-47b8-a036-33ac447e668d\"]\n        }]\n});\n",
                   "generated": true
@@ -95889,7 +95312,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -95942,7 +95364,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -95992,7 +95413,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -96042,7 +95462,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -96180,7 +95599,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.delete(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -96233,7 +95651,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.delete(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -96283,7 +95700,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.delete(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -96333,7 +95749,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.delete(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -96383,7 +95798,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.delete(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -96630,7 +96044,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\",\n    policy_actions: [{\n            action: \"read\",\n            role_ids: [\"248df4b7-aa70-47b8-a036-33ac447e668d\"]\n        }]\n});\n",
                   "generated": true
@@ -96686,7 +96099,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\",\n    policy_actions: [{\n            action: \"read\",\n            role_ids: [\"248df4b7-aa70-47b8-a036-33ac447e668d\"]\n        }]\n});\n",
                   "generated": true
@@ -96745,7 +96157,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\",\n    policy_actions: [{\n            action: \"read\",\n            role_ids: [\"248df4b7-aa70-47b8-a036-33ac447e668d\"]\n        }]\n});\n",
                   "generated": true
@@ -96801,7 +96212,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\",\n    policy_actions: [{\n            action: \"read\",\n            role_ids: [\"248df4b7-aa70-47b8-a036-33ac447e668d\"]\n        }]\n});\n",
                   "generated": true
@@ -96857,7 +96267,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\",\n    policy_actions: [{\n            action: \"read\",\n            role_ids: [\"248df4b7-aa70-47b8-a036-33ac447e668d\"]\n        }]\n});\n",
                   "generated": true
@@ -96913,7 +96322,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.policies.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\",\n    policy_actions: [{\n            action: \"read\",\n            role_ids: [\"248df4b7-aa70-47b8-a036-33ac447e668d\"]\n        }]\n});\n",
                   "generated": true
@@ -97028,7 +96436,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.list();\n",
                   "generated": true
@@ -97079,7 +96486,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.list();\n",
                   "generated": true
@@ -97127,7 +96533,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.list();\n",
                   "generated": true
@@ -97324,7 +96729,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -97378,7 +96782,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -97435,7 +96838,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -97489,7 +96891,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -97543,7 +96944,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -97597,7 +96997,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.create({\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -97730,7 +97129,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -97783,7 +97181,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -97833,7 +97230,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -97971,7 +97367,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.delete(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -98024,7 +97419,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.delete(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -98074,7 +97468,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.delete(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -98124,7 +97517,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.delete(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -98174,7 +97566,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.delete(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -98391,7 +97782,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -98447,7 +97837,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -98506,7 +97895,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -98562,7 +97950,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -98618,7 +98005,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -98674,7 +98060,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.permissions.roles.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    name: \"Custom\"\n});\n",
                   "generated": true
@@ -98866,7 +98251,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.list();\n",
                   "generated": true
@@ -98917,7 +98301,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.list();\n",
                   "generated": true
@@ -98965,7 +98348,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.list();\n",
                   "generated": true
@@ -99013,7 +98395,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.list();\n",
                   "generated": true
@@ -99531,7 +98912,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.create({\n    fields: [{\n            source: {\n                field: \"id\",\n                model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n            },\n            target: \"name\"\n        }],\n    filter_logic: \"A and B or C\",\n    identity: {\n        function: \"Equality\",\n        source: {\n            field: \"id\",\n            model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n        },\n        target: \"name\"\n    },\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        frequency: \"daily\"\n    },\n    sync_all_records: false,\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -99591,7 +98971,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.create({\n    fields: [{\n            source: {\n                field: \"id\",\n                model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n            },\n            target: \"name\"\n        }],\n    filter_logic: \"A and B or C\",\n    identity: {\n        function: \"Equality\",\n        source: {\n            field: \"id\",\n            model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n        },\n        target: \"name\"\n    },\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        frequency: \"daily\"\n    },\n    sync_all_records: false,\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -99654,7 +99033,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.create({\n    fields: [{\n            source: {\n                field: \"id\",\n                model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n            },\n            target: \"name\"\n        }],\n    filter_logic: \"A and B or C\",\n    identity: {\n        function: \"Equality\",\n        source: {\n            field: \"id\",\n            model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n        },\n        target: \"name\"\n    },\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        frequency: \"daily\"\n    },\n    sync_all_records: false,\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -99714,7 +99092,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.create({\n    fields: [{\n            source: {\n                field: \"id\",\n                model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n            },\n            target: \"name\"\n        }],\n    filter_logic: \"A and B or C\",\n    identity: {\n        function: \"Equality\",\n        source: {\n            field: \"id\",\n            model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n        },\n        target: \"name\"\n    },\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        frequency: \"daily\"\n    },\n    sync_all_records: false,\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -99774,7 +99151,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.create({\n    fields: [{\n            source: {\n                field: \"id\",\n                model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n            },\n            target: \"name\"\n        }],\n    filter_logic: \"A and B or C\",\n    identity: {\n        function: \"Equality\",\n        source: {\n            field: \"id\",\n            model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n        },\n        target: \"name\"\n    },\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        frequency: \"daily\"\n    },\n    sync_all_records: false,\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -99834,7 +99210,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.create({\n    fields: [{\n            source: {\n                field: \"id\",\n                model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n            },\n            target: \"name\"\n        }],\n    filter_logic: \"A and B or C\",\n    identity: {\n        function: \"Equality\",\n        source: {\n            field: \"id\",\n            model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n        },\n        target: \"name\"\n    },\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        frequency: \"daily\"\n    },\n    sync_all_records: false,\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -99948,7 +99323,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.getScheduleOptions();\n",
                   "generated": true
@@ -99999,7 +99373,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.getScheduleOptions();\n",
                   "generated": true
@@ -100047,7 +99420,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.getScheduleOptions();\n",
                   "generated": true
@@ -100276,7 +99648,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -100329,7 +99700,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -100379,7 +99749,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -100429,7 +99798,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -100566,7 +99934,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -100619,7 +99986,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -100669,7 +100035,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -100719,7 +100084,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -100769,7 +100133,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.remove(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -101320,7 +100683,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    fields: [{\n            source: {\n                field: \"id\",\n                model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n            },\n            target: \"name\"\n        }],\n    filter_logic: \"A and B or C\",\n    identity: {\n        function: \"Equality\",\n        source: {\n            field: \"id\",\n            model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n        },\n        target: \"name\"\n    },\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        frequency: \"daily\"\n    },\n    sync_all_records: false,\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -101382,7 +100744,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    fields: [{\n            source: {\n                field: \"id\",\n                model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n            },\n            target: \"name\"\n        }],\n    filter_logic: \"A and B or C\",\n    identity: {\n        function: \"Equality\",\n        source: {\n            field: \"id\",\n            model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n        },\n        target: \"name\"\n    },\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        frequency: \"daily\"\n    },\n    sync_all_records: false,\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -101447,7 +100808,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    fields: [{\n            source: {\n                field: \"id\",\n                model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n            },\n            target: \"name\"\n        }],\n    filter_logic: \"A and B or C\",\n    identity: {\n        function: \"Equality\",\n        source: {\n            field: \"id\",\n            model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n        },\n        target: \"name\"\n    },\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        frequency: \"daily\"\n    },\n    sync_all_records: false,\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -101509,7 +100869,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    fields: [{\n            source: {\n                field: \"id\",\n                model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n            },\n            target: \"name\"\n        }],\n    filter_logic: \"A and B or C\",\n    identity: {\n        function: \"Equality\",\n        source: {\n            field: \"id\",\n            model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n        },\n        target: \"name\"\n    },\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        frequency: \"daily\"\n    },\n    sync_all_records: false,\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -101571,7 +100930,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    fields: [{\n            source: {\n                field: \"id\",\n                model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n            },\n            target: \"name\"\n        }],\n    filter_logic: \"A and B or C\",\n    identity: {\n        function: \"Equality\",\n        source: {\n            field: \"id\",\n            model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n        },\n        target: \"name\"\n    },\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        frequency: \"daily\"\n    },\n    sync_all_records: false,\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -101633,7 +100991,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    fields: [{\n            source: {\n                field: \"id\",\n                model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n            },\n            target: \"name\"\n        }],\n    filter_logic: \"A and B or C\",\n    identity: {\n        function: \"Equality\",\n        source: {\n            field: \"id\",\n            model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n        },\n        target: \"name\"\n    },\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        frequency: \"daily\"\n    },\n    sync_all_records: false,\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -101695,7 +101052,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    fields: [{\n            source: {\n                field: \"id\",\n                model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n            },\n            target: \"name\"\n        }],\n    filter_logic: \"A and B or C\",\n    identity: {\n        function: \"Equality\",\n        source: {\n            field: \"id\",\n            model_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\"\n        },\n        target: \"name\"\n    },\n    mode: \"create\",\n    name: \"Users Sync\",\n    schedule: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        frequency: \"daily\"\n    },\n    sync_all_records: false,\n    target: {\n        connection_id: \"248df4b7-aa70-47b8-a036-33ac447e668d\",\n        object: \"Users\"\n    }\n});\n",
                   "generated": true
@@ -101871,7 +101227,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -101930,7 +101285,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -101986,7 +101340,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -102042,7 +101395,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -102098,7 +101450,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.activate(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    active: true\n});\n",
                   "generated": true
@@ -102328,7 +101679,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -102382,7 +101732,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -102439,7 +101788,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -102493,7 +101841,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -102547,7 +101894,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -102601,7 +101947,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.start(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {});\n",
                   "generated": true
@@ -102781,7 +102126,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -102834,7 +102178,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -102884,7 +102227,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -102934,7 +102276,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.getStatus(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -103084,7 +102425,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.executions.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -103137,7 +102477,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.executions.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -103187,7 +102526,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.executions.list(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -103365,7 +102703,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.executions.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -103419,7 +102756,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.executions.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -103470,7 +102806,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.executions.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -103521,7 +102856,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.modelSync.executions.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\", \"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -104315,7 +103649,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.list();\n",
                   "generated": true
@@ -104366,7 +103699,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.list();\n",
                   "generated": true
@@ -104414,7 +103746,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.list();\n",
                   "generated": true
@@ -104601,7 +103932,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.create({\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -104659,7 +103989,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.create({\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -104714,7 +104043,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.create({\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -104769,7 +104097,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.create({\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -104903,7 +104230,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -104956,7 +104282,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -105006,7 +104331,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.get(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -105130,7 +104454,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.delete(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -105183,7 +104506,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.delete(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -105233,7 +104555,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.delete(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -105283,7 +104604,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.delete(\"248df4b7-aa70-47b8-a036-33ac447e668d\");\n",
                   "generated": true
@@ -105490,7 +104810,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -105550,7 +104869,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -105607,7 +104925,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true
@@ -105664,7 +104981,6 @@
               ],
               "typescript": [
                 {
-                  "name": "TypeScript SDK",
                   "language": "typescript",
                   "code": "import { PolytomicClient } from \"polytomic\";\n\nconst polytomic = new PolytomicClient({ token: \"YOUR_TOKEN\", xPolytomicVersion: \"YOUR_X_POLYTOMIC_VERSION\" });\nawait polytomic.webhooks.update(\"248df4b7-aa70-47b8-a036-33ac447e668d\", {\n    endpoint: \"https://example.com/webhook\",\n    secret: \"secret\"\n});\n",
                   "generated": true

--- a/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
+++ b/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
@@ -673,7 +673,7 @@ export class ApiDefinitionV1ToLatest {
             codeExamples.typescriptSdk != null
         ) {
             push(jsLang, {
-                name: `${jsLangName} SDK`,
+                name: undefined,
                 language: jsLang,
                 install: codeExamples.typescriptSdk.install,
                 code: codeExamples.typescriptSdk.client,


### PR DESCRIPTION
Fixes FER-3461 FER-3462

## Short description of the changes made

* Does not set name for example snippet for js or ts snippets in FDR. Example generation prefers snippet names, so this aligns with other languages

## What was the motivation & context behind this PR?

* Customer reported bugs

## How has this PR been tested?

* To be tested on staging site (on Mercoa)
