### PR TITLE
fix(fdr): increase connection limit to support parallel writes

### DIFF
--- a/servers/fdr/.env.dev
+++ b/servers/fdr/.env.dev
@@ -1,1 +1,1 @@
-DATABASE_URL="postgresql://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/fdr?schema=public"
+DATABASE_URL="postgresql://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/fdr?schema=public&connection_limit=4"

--- a/servers/fdr/.env.prod
+++ b/servers/fdr/.env.prod
@@ -1,1 +1,1 @@
-DATABASE_URL="postgresql://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/fdr?schema=public"
+DATABASE_URL="postgresql://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/fdr?schema=public&connection_limit=6"


### PR DESCRIPTION
## Short description of the changes made
Allows the prisma client to add a connection up to 6 on prod and 4 on dev (current default is 3). 

## What was the motivation & context behind this PR?
There are certain db queries that are failing because there are no connections that free up in ~10 seconds. 

## How has this PR been tested?
Will test on dev. 
