### PR TITLE
feat: fga-based workos rbac

### DIFF
--- a/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
+++ b/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
@@ -118,12 +118,14 @@ export async function getAuthState(
                 if (setFernToken) {
                     setFernToken(await encryptSession(updatedSession));
                 }
+                // TODO: should this be stored in the session itself?
+                const roles = await getWorkosRbacRoles(authConfig.organization, updatedSession.user.email);
                 return {
                     domain,
                     host,
                     authed: true,
                     ok: true,
-                    user: toFernUser(await toSessionUserInfo(updatedSession)),
+                    user: toFernUser(await toSessionUserInfo(updatedSession), roles),
                     partner: authConfig.partner,
                 };
             }

--- a/packages/ui/docs-bundle/src/server/auth/workos-user-to-fern-user.ts
+++ b/packages/ui/docs-bundle/src/server/auth/workos-user-to-fern-user.ts
@@ -2,9 +2,10 @@ import { FernUser } from "@fern-ui/fern-docs-auth";
 import { compact } from "es-toolkit/array";
 import { NoWorkOSUserInfo, WorkOSUserInfo } from "./interfaces";
 
-export function toFernUser({ user }: WorkOSUserInfo | NoWorkOSUserInfo): FernUser {
+export function toFernUser({ user }: WorkOSUserInfo | NoWorkOSUserInfo, roles?: string[]): FernUser {
     return {
         email: user?.email,
         name: compact([user?.firstName, user?.lastName]).join(" ") || user?.email?.split("@")[0],
+        roles,
     };
 }


### PR DESCRIPTION
This is designed only to work with staging for now. This is a follow up of https://github.com/fern-api/fern-platform/pull/1770 but can be merged before #1770 is merged, since the staging environment (https://rbac.ferndocs.dev) has already been stood up.

Idea behind this is that RBAC is store in WorkOS FGA.