### PR TITLE
fix: how authed edge nodes and redirects are computed

### DIFF
--- a/packages/fdr-sdk/src/navigation/utils/findNode.ts
+++ b/packages/fdr-sdk/src/navigation/utils/findNode.ts
@@ -80,6 +80,7 @@ export function findNode(root: FernNavigation.RootNode, slug: FernNavigation.Slu
     const apiReference =
         found.parents.find(isApiReferenceNode) ?? (found.node.type === "apiReference" ? found.node : undefined);
 
+    // if the node is visible (becaues it's a page), return it as "found"
     if (FernNavigation.isPage(found.node)) {
         const parentsAndNode = [...found.parents, found.node];
         const tabbedNodeIndex = parentsAndNode.findIndex((node) => node === tabbedNode);
@@ -124,13 +125,11 @@ export function findNode(root: FernNavigation.RootNode, slug: FernNavigation.Slu
         return { type: "redirect", redirect: root.pointsTo };
     }
 
-    const redirect = FernNavigation.hasRedirect(found.node)
-        ? found.node.pointsTo
-        : currentVersion?.pointsTo ?? root.pointsTo;
-
-    if (redirect == null || redirect === slug) {
-        return { type: "notFound", redirect: undefined, authed: found.node.authed };
+    // if the node has a redirect, return it
+    if (FernNavigation.hasRedirect(found.node) && found.node.pointsTo != null) {
+        return { type: "redirect", redirect: found.node.pointsTo };
     }
 
-    return { type: "redirect", redirect };
+    // if the node does not have a redirect, return a 404
+    return { type: "notFound", redirect: currentVersion?.pointsTo ?? root.pointsTo, authed: found.node.authed };
 }

--- a/packages/ui/docs-bundle/src/server/withRbac.ts
+++ b/packages/ui/docs-bundle/src/server/withRbac.ts
@@ -3,7 +3,6 @@ import {
     NavigationNodeParent,
     Pruner,
     hasMetadata,
-    isPage,
     type NavigationNode,
     type RootNode,
 } from "@fern-api/fdr-sdk/navigation";
@@ -50,13 +49,15 @@ export function withBasicTokenAnonymousCheck(
             return Gate.ALLOW;
         }
 
-        if (
-            hasMetadata(node) &&
-            !isPage(node as NavigationNode) &&
-            withBasicTokenAnonymous(auth, addLeadingSlash(node.slug)) === Gate.DENY
-        ) {
-            return Gate.DENY;
-        }
+        // Note: this was causing random edge nodes to show "authed=true"
+        // TODO: decide if we should keep this or remove it
+        // if (
+        //     hasMetadata(node) &&
+        //     !isPage(node as NavigationNode) &&
+        //     withBasicTokenAnonymous(auth, addLeadingSlash(node.slug)) === Gate.DENY
+        // ) {
+        //     return Gate.DENY;
+        // }
 
         const predicate = rbacViewGate([], false);
         return predicate(node as NavigationNode, parents);


### PR DESCRIPTION
Fixes two issues:
1. edge nodes are set as "authed=true" even though they're not:
<img width="344" alt="Screenshot 2024-11-04 at 7 37 50 PM" src="https://github.com/user-attachments/assets/6a4b7ca3-2982-4af0-b45c-d933f82da0bf">


2. fixes how fdr-sdk treats the final redirect fallback (it should treat the fallback redirect as a "notFound" so that it can be properly handled by the auth check)