### PR TITLE
feat(docs): add id to search

### DIFF
--- a/packages/ui/app/src/header/Header.tsx
+++ b/packages/ui/app/src/header/Header.tsx
@@ -117,6 +117,7 @@ const UnmemoizedHeader = forwardRef<HTMLDivElement, PropsWithChildren<Header.Pro
                             rounded={true}
                             size="large"
                             className="max-sm:hidden"
+                            id="fern-search-button"
                         />
                     )}
 

--- a/packages/ui/app/src/sidebar/SidebarSearchBar.tsx
+++ b/packages/ui/app/src/sidebar/SidebarSearchBar.tsx
@@ -20,6 +20,7 @@ export const SidebarSearchBar: React.FC<SidebarSearchBar.Props> = memo(function 
 
     return (
         <button
+            id="fern-search-bar"
             onClick={openSearchDialog}
             className={cn("fern-search-bar", className)}
             disabled={!searchService.isAvailable}


### PR DESCRIPTION
This PR adds an id to Fern's searchbar so it is easier to integrate with Inkeep
