### PR TITLE
fix: don't mark parent edges as authed=true if it contains children that are authed=false

### DIFF
--- a/packages/fdr-sdk/src/navigation/utils/pruneNavigationTree.ts
+++ b/packages/fdr-sdk/src/navigation/utils/pruneNavigationTree.ts
@@ -53,28 +53,11 @@ export class Pruner<ROOT extends FernNavigation.NavigationNode> {
         if (this.tree == null) {
             return this;
         }
-
-        const unauthedParents = new Set<FernNavigation.NodeId>();
-
-        // step 1. mark authed nodes based on the predicate
         FernNavigation.traverseBF(this.tree, (node, parents) => {
             if (FernNavigation.hasMetadata(node)) {
                 node.authed = predicate(node, parents) ? true : undefined;
-                if (!node.authed) {
-                    parents.forEach((p) => unauthedParents.add(p.id));
-                }
             }
         });
-
-        // step 2. remove the authed flag only from EDGE nodes that are parents of unauthed nodes
-        // for example, a version node is authed and contains children that are unauthed, then the version node should not be authed
-        // because then the version node would be pruned away, even though it has children that can be viewed.
-        FernNavigation.traverseBF(this.tree, (node) => {
-            if (FernNavigation.hasMetadata(node) && !FernNavigation.isPage(node) && unauthedParents.has(node.id)) {
-                node.authed = undefined;
-            }
-        });
-
         return this;
     }
 

--- a/packages/fdr-sdk/src/navigation/utils/pruneNavigationTree.ts
+++ b/packages/fdr-sdk/src/navigation/utils/pruneNavigationTree.ts
@@ -53,11 +53,28 @@ export class Pruner<ROOT extends FernNavigation.NavigationNode> {
         if (this.tree == null) {
             return this;
         }
+
+        const unauthedParents = new Set<FernNavigation.NodeId>();
+
+        // step 1. mark authed nodes based on the predicate
         FernNavigation.traverseBF(this.tree, (node, parents) => {
             if (FernNavigation.hasMetadata(node)) {
                 node.authed = predicate(node, parents) ? true : undefined;
+                if (!node.authed) {
+                    parents.forEach((p) => unauthedParents.add(p.id));
+                }
             }
         });
+
+        // step 2. remove the authed flag only from EDGE nodes that are parents of unauthed nodes
+        // for example, a version node is authed and contains children that are unauthed, then the version node should not be authed
+        // because then the version node would be pruned away, even though it has children that can be viewed.
+        FernNavigation.traverseBF(this.tree, (node) => {
+            if (FernNavigation.hasMetadata(node) && !FernNavigation.isPage(node) && unauthedParents.has(node.id)) {
+                node.authed = undefined;
+            }
+        });
+
         return this;
     }
 

--- a/packages/fdr-sdk/src/navigation/versions/latest/NavigationNodeWithRedirect.ts
+++ b/packages/fdr-sdk/src/navigation/versions/latest/NavigationNodeWithRedirect.ts
@@ -1,29 +1,12 @@
-import type { Exact, MarkRequired } from "ts-essentials";
-import type {
-    ApiPackageNode,
-    ApiReferenceNode,
-    ProductNode,
-    RootNode,
-    SectionNode,
-    TabNode,
-    VersionNode,
-    WithRedirect,
-} from ".";
+import type { Slug, WithRedirect } from ".";
 import type { NavigationNode } from "./NavigationNode";
 
 /**
  * Navigation nodes that can have a redirect
  */
-export type NavigationNodeWithPointsTo =
-    | RootNode
-    | ProductNode
-    | VersionNode
-    | TabNode
-    | SectionNode
-    | ApiReferenceNode
-    | ApiPackageNode;
+export type NavigationNodeWithPointsTo = Extract<NavigationNode, WithRedirect>;
 
-export function hasPointsTo(node: NavigationNode): node is NavigationNodeWithRedirect {
+export function hasPointsTo(node: NavigationNode): node is NavigationNodeWithPointsTo {
     return (
         node.type === "root" ||
         node.type === "product" ||
@@ -38,10 +21,8 @@ export function hasPointsTo(node: NavigationNode): node is NavigationNodeWithRed
 /**
  * Navigation nodes that extend WithRedirect
  */
-export type NavigationNodeWithRedirect = Exact<NavigationNodeWithPointsTo, Extract<NavigationNode, WithRedirect>> &
-    MarkRequired<WithRedirect, "pointsTo">;
 
-export function hasRedirect(node: NavigationNode): node is NavigationNodeWithRedirect {
+export function hasRedirect(node: NavigationNode): node is NavigationNodeWithPointsTo & { pointsTo: Slug } {
     if (!hasPointsTo(node)) {
         return false;
     }

--- a/packages/fdr-sdk/src/utils/traversers/prunetree.ts
+++ b/packages/fdr-sdk/src/utils/traversers/prunetree.ts
@@ -34,6 +34,7 @@ export function prunetree<NODE, ROOT extends NODE = NODE, PARENT extends NODE = 
 
     const deleted = new Set<POINTER>();
 
+    // nodes is a stack of nodes in reverse order (the root node is the last element, and the "deepest" leaf node is the first element)
     const nodes: [NODE, readonly PARENT[]][] = [];
 
     bfs(

--- a/packages/ui/docs-bundle/src/server/withInitialProps.ts
+++ b/packages/ui/docs-bundle/src/server/withInitialProps.ts
@@ -116,6 +116,11 @@ export async function withInitialProps({
 
     // if the current node requires authentication and the user is not authenticated, redirect to the auth page
     if (found.node.authed && !authState.authed) {
+        // if the page can be considered an edge node when it's unauthed, then we'll follow the redirect
+        if (FernNavigation.hasRedirect(found.node)) {
+            return withRedirect(found.node.pointsTo);
+        }
+
         // TODO: there's currently no way to express a 401 or 403 in Next.js so we'll redirect to 404.
         // ideally this is handled in the middleware, and this should be a 500 error.
         if (authState.authorizationUrl == null) {


### PR DESCRIPTION
This fixes an edge case where, lets say, you have a few version nodes, which contains unauthed children, or you have orphaned children that are visible to "everyone".