### PR TITLE
fix: set global dispatcher timeout to 5s 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2785,6 +2785,9 @@ importers:
       semver:
         specifier: ^7.6.2
         version: 7.6.2
+      undici:
+        specifier: ^6.20.1
+        version: 6.20.1
       url-join:
         specifier: 5.0.0
         version: 5.0.0
@@ -15334,6 +15337,10 @@ packages:
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  undici@6.20.1:
+    resolution: {integrity: sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==}
+    engines: {node: '>=18.17'}
 
   unherit@3.0.1:
     resolution: {integrity: sha512-akOOQ/Yln8a2sgcLj4U0Jmx0R5jpIg2IUyRrWOzmEbjBtGzBdHtSeFKgoEcoH4KYIG/Pb8GQ/BwtYm0GCq1Sqg==}
@@ -33354,6 +33361,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.19.8: {}
+
+  undici@6.20.1: {}
 
   unherit@3.0.1: {}
 

--- a/servers/fdr/package.json
+++ b/servers/fdr/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.335.0",
     "@aws-sdk/s3-request-presigner": "^3.574.0",
-    "@fern-ui/fern-docs-search-server": "workspace:*",
     "@fern-api/fdr-sdk": "workspace:*",
     "@fern-api/github": "workspace:*",
     "@fern-api/template-resolver": "workspace:*",
@@ -20,6 +19,7 @@
     "@fern-api/venus-api-sdk": "^0.10.1-5-ged06d22",
     "@fern-fern/fern-docs-sdk": "0.0.5",
     "@fern-fern/revalidation-sdk": "0.0.9",
+    "@fern-ui/fern-docs-search-server": "workspace:*",
     "@prisma/client": "5.13.0",
     "@sentry/cli": "^2.31.0",
     "@sentry/node": "^7.112.2",
@@ -44,6 +44,7 @@
     "path-resolver": "*",
     "redis": "^4.6.13",
     "semver": "^7.6.2",
+    "undici": "^6.20.1",
     "url-join": "5.0.0",
     "uuid": "^9.0.0",
     "winston": "^3.10.0"

--- a/servers/fdr/src/controllers/docs/v2/getDocsWriteV2Service.ts
+++ b/servers/fdr/src/controllers/docs/v2/getDocsWriteV2Service.ts
@@ -178,9 +178,17 @@ export function getDocsWriteV2Service(app: FdrApplication): DocsV2WriteService {
                 const warmEndpointCachePromises = apiDefinitions.flatMap((apiDefinition) => {
                     return Object.entries(apiDefinition.subpackages).flatMap(([id, subpackage]) => {
                         return subpackage.endpoints.map(async (endpoint) => {
-                            return await fetch(
-                                `https://${docsRegistrationInfo.fernUrl.getFullUrl()}/api/fern-docs/api-definition/${apiDefinition.id}/endpoint/${endpoint.originalEndpointId}`,
-                            );
+                            try {
+                                return await fetch(
+                                    `https://${docsRegistrationInfo.fernUrl.getFullUrl()}/api/fern-docs/api-definition/${apiDefinition.id}/endpoint/${endpoint.originalEndpointId}`,
+                                );
+                            } catch (e) {
+                                app.logger.error(
+                                    `Error while trying to warm endpoint cache for ${docsRegistrationInfo.fernUrl}`,
+                                    e,
+                                );
+                                throw e;
+                            }
                         });
                     });
                 });

--- a/servers/fdr/src/server.ts
+++ b/servers/fdr/src/server.ts
@@ -3,6 +3,7 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 import compression from "compression";
 import cors from "cors";
 import express from "express";
+import { Agent, setGlobalDispatcher } from "undici";
 import { register } from "./api";
 import { FdrApplication, getConfig } from "./app";
 import { registerBackgroundTasks } from "./background";
@@ -57,6 +58,8 @@ expressApp.use(Sentry.Handlers.tracingHandler());
 
 expressApp.use(cors());
 expressApp.use(compression());
+
+setGlobalDispatcher(new Agent({ connect: { timeout: 5_000 } }));
 
 const app = new FdrApplication(config);
 


### PR DESCRIPTION
## Short description of the changes made

* Sets global dispatcher timeout to 5s.
* Adds a log line to give the reason for failure if it is not that.

## What was the motivation & context behind this PR?

* Consistent failures when trying to deploy from fdr-dev

## How has this PR been tested?

* To be tested
