### PR TITLE
fix: strip out nulls in url encoded curl

### DIFF
--- a/packages/fdr-sdk/src/api-definition/snippets/curl.test.ts
+++ b/packages/fdr-sdk/src/api-definition/snippets/curl.test.ts
@@ -1,4 +1,4 @@
-import { convertToCurl } from "./curl";
+import { convertToCurl, getUrlQueriesGetString } from "./curl";
 
 describe("curl", () => {
     it("generates basic GET request", () => {
@@ -263,5 +263,20 @@ describe("curl", () => {
                --data-urlencode sort="date desc""
         `,
         );
+    });
+
+    it("does not include nulls in urlencoded parameters", () => {
+        expect(getUrlQueriesGetString({ a: null, b: "b" })).toMatchInlineSnapshot(`
+          [
+            "-d b=b",
+          ]
+        `);
+
+        expect(getUrlQueriesGetString({ a: ["b1", null, "b2"] })).toMatchInlineSnapshot(`
+          [
+            "-d "a[]"=b1",
+            "-d "a[]"=b2",
+          ]
+        `);
     });
 });

--- a/packages/fdr-sdk/src/api-definition/snippets/curl.ts
+++ b/packages/fdr-sdk/src/api-definition/snippets/curl.ts
@@ -1,4 +1,4 @@
-import { isPlainObject, unknownToString } from "@fern-api/ui-core-utils";
+import { isNonNullish, isPlainObject, unknownToString } from "@fern-api/ui-core-utils";
 import { compact } from "es-toolkit/array";
 import { UnreachableCaseError } from "ts-essentials";
 import {
@@ -46,7 +46,7 @@ function getBasicAuthString(basicAuth: { username: string; password: string }): 
     return [`-u "${basicAuth.username}:${basicAuth.password}"`];
 }
 
-function getUrlQueriesGetString(searchParams: Record<string, unknown>): string[] {
+export function getUrlQueriesGetString(searchParams: Record<string, unknown>): string[] {
     return toUrlEncoded(searchParams).map(
         ([key, value]) =>
             `${requiresUrlEncode(value) ? "--data-urlencode" : "-d"} ${key.includes("[") ? `"${key}"` : key}=${value.includes(" ") ? `"${value}"` : value}`,
@@ -196,8 +196,13 @@ function unsafeStringifyHttpRequestExampleToCurl(
 function toUrlEncoded(urlQueries: Record<string, unknown>): Array<[string, string]> {
     return Object.entries(urlQueries).flatMap(([key, value]): [string, string][] => {
         if (Array.isArray(value)) {
-            return value.map((v) => [`${key}[]`, unknownToString(v)]);
+            return value.filter(isNonNullish).map((v) => [`${key}[]`, unknownToString(v)]);
         }
+
+        if (value == null) {
+            return [];
+        }
+
         return [[key, unknownToString(value)]];
     });
 }


### PR DESCRIPTION
fixes the following issue:

<img width="533" alt="Screenshot 2024-11-06 at 3 15 27 PM" src="https://github.com/user-attachments/assets/aa9e4725-ce0f-4d57-bd11-99ade7fb8aac">
