### PR TITLE
fix: print full error stack in message where fetch is failing

### DIFF
--- a/servers/fdr/src/controllers/docs/v2/getDocsWriteV2Service.ts
+++ b/servers/fdr/src/controllers/docs/v2/getDocsWriteV2Service.ts
@@ -182,10 +182,9 @@ export function getDocsWriteV2Service(app: FdrApplication): DocsV2WriteService {
                                 return await fetch(
                                     `https://${docsRegistrationInfo.fernUrl.getFullUrl()}/api/fern-docs/api-definition/${apiDefinition.id}/endpoint/${endpoint.originalEndpointId}`,
                                 );
-                            } catch (e) {
+                            } catch (e: Error | unknown) {
                                 app.logger.error(
-                                    `Error while trying to warm endpoint cache for ${docsRegistrationInfo.fernUrl}`,
-                                    e,
+                                    `Error while trying to warm endpoint cache for ${JSON.stringify(docsRegistrationInfo.fernUrl)} ${e instanceof Error ? e.stack : ""}`,
                                 );
                                 throw e;
                             }


### PR DESCRIPTION
Improves telemetry for failing fetch so that we can understand what is going on a bit better