### PR TITLE
fix: instantiate fdr client with `NEXT_PUBLIC_FDR_ORIGIN`

### DIFF
--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/org/org-for-url.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/org/org-for-url.ts
@@ -17,7 +17,7 @@ export default async function handler(req: NextRequest): Promise<NextResponse<Do
     }
 
     try {
-        const docsLoader = DocsLoader.create(domain);
+        const docsLoader = DocsLoader.create(domain).withEnvironment(process.env.NEXT_PUBLIC_FDR_ORIGIN);
         const metadata = await docsLoader.getMetadata();
 
         if (metadata) {


### PR DESCRIPTION
## Short description of the changes made
`app-dev` was defaulting to hitting prod

## What was the motivation & context behind this PR?
allows us to do end-to-end testing of the endpoint on dev

## How has this PR been tested?
will test on dev
