### PR TITLE
fix: authed previews works

### DIFF
--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/org/org-for-url.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/org/org-for-url.ts
@@ -1,4 +1,4 @@
-import { getOrgMetadataForDomain } from "@/server/auth/meta";
+import { getOrgMetadataForDomain } from "@/server/auth/metadata-for-url";
 import { getDocsDomainEdge } from "@/server/xfernhost/edge";
 import { NextRequest, NextResponse } from "next/server";
 

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/org/org-for-url.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/org/org-for-url.ts
@@ -1,12 +1,12 @@
+import { getOrgMetadataForDomain } from "@/server/auth/meta";
 import { getDocsDomainEdge } from "@/server/xfernhost/edge";
-import { DocsLoader } from "@fern-ui/fern-docs-server";
 import { NextRequest, NextResponse } from "next/server";
 
 export const runtime = "edge";
 
 export interface DocsMetadata {
-    orgId: string | undefined;
-    isPreviewUrl: boolean | undefined;
+    orgId: string;
+    isPreviewUrl: boolean;
 }
 
 export default async function handler(req: NextRequest): Promise<NextResponse<DocsMetadata>> {
@@ -16,16 +16,11 @@ export default async function handler(req: NextRequest): Promise<NextResponse<Do
         return new NextResponse(JSON.stringify({ error: "Invalid domain" }), { status: 400 });
     }
 
-    try {
-        const docsLoader = DocsLoader.create(domain).withEnvironment(process.env.NEXT_PUBLIC_FDR_ORIGIN);
-        const metadata = await docsLoader.getMetadata();
+    const metadata = await getOrgMetadataForDomain(domain);
 
-        if (metadata) {
-            return new NextResponse(JSON.stringify(metadata), { status: 200 });
-        } else {
-            return new NextResponse(JSON.stringify({ error: "Org not found" }), { status: 404 });
-        }
-    } catch (error) {
-        return new NextResponse(JSON.stringify({ error: "Internal server error" }), { status: 500 });
+    if (metadata) {
+        return new NextResponse(JSON.stringify(metadata), { status: 200 });
+    } else {
+        return new NextResponse(JSON.stringify({ error: "Org not found" }), { status: 404 });
     }
 }

--- a/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
+++ b/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
@@ -4,6 +4,7 @@ import { PreviewUrlAuth, getAuthEdgeConfig, getPreviewUrlAuthConfig } from "@fer
 import { removeTrailingSlash } from "next/dist/shared/lib/router/utils/remove-trailing-slash";
 import urlJoin from "url-join";
 import { safeVerifyFernJWTConfig } from "./FernJWT";
+import { getOrgMetadataForDomain } from "./metadata-for-url";
 import { getOryAuthorizationUrl } from "./ory";
 import { getReturnToQueryParam } from "./return-to";
 import { getWebflowAuthorizationUrl } from "./webflow";
@@ -107,7 +108,8 @@ export async function getAuthStateInternal({
                     redirectUri,
                     organization: previewAuthConfig.org,
                 });
-                return { authed: false, ok: true, authorizationUrl, partner: "workos" };
+
+                return { authed: false, ok: false, authorizationUrl, partner: "workos" };
             }
         }
         return { authed: false, ok: true, authorizationUrl: undefined, partner: undefined };
@@ -182,7 +184,7 @@ export async function getAuthState(
     setFernToken?: (token: string) => void,
 ): Promise<AuthState & DomainAndHost> {
     authConfig ??= await getAuthEdgeConfig(domain);
-    const previewAuthConfig = await getPreviewUrlAuthConfig(domain);
+    const orgMetadata = await getOrgMetadataForDomain(domain);
 
     const authState = await getAuthStateInternal({
         host,
@@ -190,7 +192,7 @@ export async function getAuthState(
         pathname,
         authConfig,
         setFernToken,
-        previewAuthConfig,
+        previewAuthConfig: orgMetadata != null ? await getPreviewUrlAuthConfig(orgMetadata) : undefined,
     });
 
     return { ...authState, domain, host };

--- a/packages/ui/docs-bundle/src/server/auth/metadata-for-url.ts
+++ b/packages/ui/docs-bundle/src/server/auth/metadata-for-url.ts
@@ -1,0 +1,20 @@
+import { DocsLoader } from "@fern-ui/fern-docs-server";
+
+export interface OrgMetadata {
+    orgId: string;
+    isPreviewUrl: boolean;
+}
+
+export async function getOrgMetadataForDomain(domain: string): Promise<OrgMetadata | undefined> {
+    if (!domain || typeof domain !== "string") {
+        return undefined;
+    }
+
+    try {
+        const docsLoader = DocsLoader.create(domain).withEnvironment(process.env.NEXT_PUBLIC_FDR_ORIGIN);
+        const metadata = await docsLoader.getMetadata();
+        return metadata ?? undefined;
+    } catch (error) {
+        return undefined;
+    }
+}

--- a/packages/ui/fern-docs-edge-config/src/getPreviewUrlAuthConfig.ts
+++ b/packages/ui/fern-docs-edge-config/src/getPreviewUrlAuthConfig.ts
@@ -17,15 +17,17 @@ const PreviewUrlAuthConfigSchema = z.record(PreviewUrlAuthSchema);
 
 type PreviewUrlAuthConfig = z.infer<typeof PreviewUrlAuthConfigSchema>;
 
-export async function getPreviewUrlAuthConfig(currentDomain: string): Promise<PreviewUrlAuth | undefined> {
-    const previewDomain = isPreviewDomain(currentDomain);
-    const org = extractOrgFromPreview(currentDomain);
-    if (!previewDomain || !org) {
+export interface Metadata {
+    isPreviewUrl: boolean;
+    orgId: string;
+}
+
+export async function getPreviewUrlAuthConfig(metadata: Metadata): Promise<PreviewUrlAuth | undefined> {
+    if (!metadata.isPreviewUrl) {
         return undefined;
     }
-
     const config = await get<PreviewUrlAuthConfig>("authed-previews");
-    return config?.[org];
+    return config?.[metadata.orgId];
 }
 
 export function isPreviewDomain(domain: string): boolean {

--- a/packages/ui/fern-docs-server/src/DocsLoader.ts
+++ b/packages/ui/fern-docs-server/src/DocsLoader.ts
@@ -2,8 +2,8 @@ import { FdrAPI, FdrClient } from "@fern-api/fdr-sdk";
 import { DocsDomainKVCache } from "./DocsKVCache";
 
 export interface DocsMetadata {
-    orgId: string | undefined;
-    isPreviewUrl: boolean | undefined;
+    orgId: string;
+    isPreviewUrl: boolean;
 }
 
 export class DocsLoader {
@@ -47,7 +47,10 @@ export class DocsLoader {
 
     #getClient = () => new FdrClient({ environment: this.environment });
     #loadMetadataForUrl = async (): Promise<FdrAPI.docs.v2.read.DocsUrlMetadata | undefined> => {
-        const response = await this.#getClient().docs.v2.read.getDocsUrlMetadata({ url: FdrAPI.Url(this.domain) });
+        const response = await this.#getClient().docs.v2.read.getDocsUrlMetadata(
+            { url: FdrAPI.Url(this.domain) },
+            { timeoutInSeconds: 180 },
+        );
         if (!response.ok) {
             return undefined;
         }

--- a/packages/ui/fern-docs-server/src/DocsLoader.ts
+++ b/packages/ui/fern-docs-server/src/DocsLoader.ts
@@ -49,7 +49,7 @@ export class DocsLoader {
     #loadMetadataForUrl = async (): Promise<FdrAPI.docs.v2.read.DocsUrlMetadata | undefined> => {
         const response = await this.#getClient().docs.v2.read.getDocsUrlMetadata(
             { url: FdrAPI.Url(this.domain) },
-            { timeoutInSeconds: 180 },
+            { timeoutInSeconds: 3 },
         );
         if (!response.ok) {
             return undefined;


### PR DESCRIPTION
## Short description of the changes made
Tests authed previews using local dev: 
1) stop using regex to figure out if a preview URL and instead use KV
2) add a timeout when loading from raw FDR

## What was the motivation & context behind this PR?
Making sure docs previews are behind auth if configured

## How has this PR been tested?
Tested locally
