### PR TITLE
chore: plumb roles through root node for consumption with generating roles in search records

### DIFF
--- a/fern/apis/fdr/definition/navigation/latest/__package__.yml
+++ b/fern/apis/fdr/definition/navigation/latest/__package__.yml
@@ -138,6 +138,7 @@ types:
       type: literal<"root">
       version: literal<"v2">
       child: RootChild
+      roles: optional<list<commons.RoleId>>
 
   ProductNode:
     extends:

--- a/fern/apis/fdr/definition/navigation/v1/__package__.yml
+++ b/fern/apis/fdr/definition/navigation/v1/__package__.yml
@@ -138,6 +138,7 @@ types:
       type: literal<"root">
       version: literal<"v1">
       child: RootChild
+      roles: optional<list<commons.RoleId>>
 
   ProductNode:
     extends:

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/write/client/Client.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/write/client/Client.ts
@@ -168,6 +168,9 @@ export class Write {
      *                             }],
      *                         id: FernRegistry.navigation.v1.NodeId("string")
      *                     },
+     *                     roles: [{
+     *                             "key": "value"
+     *                         }],
      *                     title: "string",
      *                     slug: FernRegistry.navigation.v1.Slug("string"),
      *                     icon: {

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/write/client/requests/RegisterDocsRequest.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/write/client/requests/RegisterDocsRequest.ts
@@ -90,6 +90,9 @@ import * as FernRegistry from "../../../../../../../../index";
  *                             }],
  *                         id: FernRegistry.navigation.v1.NodeId("string")
  *                     },
+ *                     roles: [{
+ *                             "key": "value"
+ *                         }],
  *                     title: "string",
  *                     slug: FernRegistry.navigation.v1.Slug("string"),
  *                     icon: {

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v2/resources/write/client/Client.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v2/resources/write/client/Client.ts
@@ -270,6 +270,9 @@ export class Write {
      *                             }],
      *                         id: FernRegistry.navigation.v1.NodeId("string")
      *                     },
+     *                     roles: [{
+     *                             "key": "value"
+     *                         }],
      *                     title: "string",
      *                     slug: FernRegistry.navigation.v1.Slug("string"),
      *                     icon: {

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v2/resources/write/client/requests/RegisterDocsRequest.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v2/resources/write/client/requests/RegisterDocsRequest.ts
@@ -90,6 +90,9 @@ import * as FernRegistry from "../../../../../../../../index";
  *                             }],
  *                         id: FernRegistry.navigation.v1.NodeId("string")
  *                     },
+ *                     roles: [{
+ *                             "key": "value"
+ *                         }],
  *                     title: "string",
  *                     slug: FernRegistry.navigation.v1.Slug("string"),
  *                     icon: {

--- a/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/latest/types/RootNode.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/latest/types/RootNode.ts
@@ -10,4 +10,5 @@ export interface RootNode
     type: "root";
     version: "v2";
     child: FernRegistry.navigation.latest.RootChild;
+    roles: FernRegistry.RoleId[] | undefined;
 }

--- a/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/v1/types/RootNode.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/v1/types/RootNode.ts
@@ -8,4 +8,5 @@ export interface RootNode extends FernRegistry.navigation.v1.WithNodeMetadata, F
     type: "root";
     version: "v1";
     child: FernRegistry.navigation.v1.RootChild;
+    roles: FernRegistry.RoleId[] | undefined;
 }

--- a/packages/fdr-sdk/src/navigation/migrators/v1ToV2.ts
+++ b/packages/fdr-sdk/src/navigation/migrators/v1ToV2.ts
@@ -33,6 +33,7 @@ export class FernNavigationV1ToLatest {
             authed: node.authed,
             viewers: node.viewers,
             orphaned: node.orphaned,
+            roles: node.roles,
         };
 
         return latest;

--- a/packages/fdr-sdk/src/navigation/versions/v1/converters/NavigationConfigConverter.ts
+++ b/packages/fdr-sdk/src/navigation/versions/v1/converters/NavigationConfigConverter.ts
@@ -79,6 +79,7 @@ export class NavigationConfigConverter {
                 authed: undefined,
                 viewers: undefined,
                 orphaned: undefined,
+                roles: undefined,
             };
 
             // tag all children of hidden nodes as hidden

--- a/packages/fdr-sdk/src/navigation/versions/v1/converters/toRootNode.ts
+++ b/packages/fdr-sdk/src/navigation/versions/v1/converters/toRootNode.ts
@@ -70,6 +70,7 @@ export function toRootNode(
             orphaned: undefined,
             id: FernNavigation.V1.NodeId("root"),
             pointsTo: undefined,
+            roles: undefined,
         };
     }
 }

--- a/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
+++ b/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
@@ -87,6 +87,7 @@ export async function getAuthStateInternal({
     if (!authConfig) {
         if (previewAuthConfig != null) {
             if (previewAuthConfig.type === "workos") {
+                const state = urlJoin(removeTrailingSlash(withDefaultProtocol(host)), pathname ?? "");
                 const session = fernToken != null ? await getSessionFromToken(fernToken) : undefined;
                 const workosUserInfo = await toSessionUserInfo(session);
                 if (workosUserInfo.user) {
@@ -107,6 +108,7 @@ export async function getAuthStateInternal({
                 const authorizationUrl = getWorkosSSOAuthorizationUrl({
                     redirectUri,
                     organization: previewAuthConfig.org,
+                    state,
                 });
 
                 return { authed: false, ok: false, authorizationUrl, partner: "workos" };

--- a/servers/fdr/src/api/generated/api/resources/navigation/resources/latest/types/RootNode.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/navigation/resources/latest/types/RootNode.d.ts
@@ -6,4 +6,5 @@ export interface RootNode extends FernRegistry.navigation.latest.WithNodeMetadat
     type: "root";
     version: "v2";
     child: FernRegistry.navigation.latest.RootChild;
+    roles: FernRegistry.RoleId[] | undefined;
 }

--- a/servers/fdr/src/api/generated/api/resources/navigation/resources/v1/types/RootNode.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/navigation/resources/v1/types/RootNode.d.ts
@@ -6,4 +6,5 @@ export interface RootNode extends FernRegistry.navigation.v1.WithNodeMetadata, F
     type: "root";
     version: "v1";
     child: FernRegistry.navigation.v1.RootChild;
+    roles: FernRegistry.RoleId[] | undefined;
 }


### PR DESCRIPTION
## Short description of the changes made

* plumbs through an optional roles property to give the full set of roles available for use in docs
* dependency for encoding permissions
* optional for now, to not create a breaking change with back-compat (can potentially think about making required in future)

## What was the motivation & context behind this PR?

* show how we can segment algolia search records based on RBAC

## How has this PR been tested?

* to be tested in toy app for search v3
