### PR TITLE
fix: docs loader cache doesnt index staging domains

### DIFF
--- a/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
+++ b/packages/ui/docs-bundle/src/server/auth/getAuthState.ts
@@ -1,6 +1,7 @@
 import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import { AuthEdgeConfig, FernUser } from "@fern-ui/fern-docs-auth";
 import { PreviewUrlAuth, getAuthEdgeConfig, getPreviewUrlAuthConfig } from "@fern-ui/fern-docs-edge-config";
+import { withoutStaging } from "@fern-ui/fern-docs-utils";
 import { removeTrailingSlash } from "next/dist/shared/lib/router/utils/remove-trailing-slash";
 import urlJoin from "url-join";
 import { safeVerifyFernJWTConfig } from "./FernJWT";
@@ -149,7 +150,7 @@ export async function getAuthState(
     setFernToken?: (token: string) => void,
 ): Promise<AuthState & DomainAndHost> {
     authConfig ??= await getAuthEdgeConfig(domain);
-    const orgMetadata = await getOrgMetadataForDomain(domain);
+    const orgMetadata = await getOrgMetadataForDomain(withoutStaging(domain));
 
     const authState = await getAuthStateInternal({
         host,


### PR DESCRIPTION
## Short description of the changes made
To test authed previews on staging, we need to make sure we strip `.staging` when looking up against the cache. 

## What was the motivation & context behind this PR?
Testing authed preview URLs. 

## How has this PR been tested?
WIll be tested after merging to main.
