### PR TITLE
Rohin/encoding permissions

### DIFF
--- a/fern/apis/fdr/definition/navigation/latest/__package__.yml
+++ b/fern/apis/fdr/definition/navigation/latest/__package__.yml
@@ -138,6 +138,7 @@ types:
       type: literal<"root">
       version: literal<"v2">
       child: RootChild
+      roles: optional<list<commons.RoleId>>
 
   ProductNode:
     extends:

--- a/fern/apis/fdr/definition/navigation/v1/__package__.yml
+++ b/fern/apis/fdr/definition/navigation/v1/__package__.yml
@@ -138,6 +138,7 @@ types:
       type: literal<"root">
       version: literal<"v1">
       child: RootChild
+      roles: optional<list<commons.RoleId>>
 
   ProductNode:
     extends:

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/write/client/Client.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/write/client/Client.ts
@@ -168,6 +168,9 @@ export class Write {
      *                             }],
      *                         id: FernRegistry.navigation.v1.NodeId("string")
      *                     },
+     *                     roles: [{
+     *                             "key": "value"
+     *                         }],
      *                     title: "string",
      *                     slug: FernRegistry.navigation.v1.Slug("string"),
      *                     icon: {

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/write/client/requests/RegisterDocsRequest.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v1/resources/write/client/requests/RegisterDocsRequest.ts
@@ -90,6 +90,9 @@ import * as FernRegistry from "../../../../../../../../index";
  *                             }],
  *                         id: FernRegistry.navigation.v1.NodeId("string")
  *                     },
+ *                     roles: [{
+ *                             "key": "value"
+ *                         }],
  *                     title: "string",
  *                     slug: FernRegistry.navigation.v1.Slug("string"),
  *                     icon: {

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v2/resources/write/client/Client.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v2/resources/write/client/Client.ts
@@ -270,6 +270,9 @@ export class Write {
      *                             }],
      *                         id: FernRegistry.navigation.v1.NodeId("string")
      *                     },
+     *                     roles: [{
+     *                             "key": "value"
+     *                         }],
      *                     title: "string",
      *                     slug: FernRegistry.navigation.v1.Slug("string"),
      *                     icon: {

--- a/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v2/resources/write/client/requests/RegisterDocsRequest.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/docs/resources/v2/resources/write/client/requests/RegisterDocsRequest.ts
@@ -90,6 +90,9 @@ import * as FernRegistry from "../../../../../../../../index";
  *                             }],
  *                         id: FernRegistry.navigation.v1.NodeId("string")
  *                     },
+ *                     roles: [{
+ *                             "key": "value"
+ *                         }],
  *                     title: "string",
  *                     slug: FernRegistry.navigation.v1.Slug("string"),
  *                     icon: {

--- a/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/latest/types/RootNode.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/latest/types/RootNode.ts
@@ -10,4 +10,5 @@ export interface RootNode
     type: "root";
     version: "v2";
     child: FernRegistry.navigation.latest.RootChild;
+    roles: FernRegistry.RoleId[] | undefined;
 }

--- a/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/v1/types/RootNode.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/v1/types/RootNode.ts
@@ -8,4 +8,5 @@ export interface RootNode extends FernRegistry.navigation.v1.WithNodeMetadata, F
     type: "root";
     version: "v1";
     child: FernRegistry.navigation.v1.RootChild;
+    roles: FernRegistry.RoleId[] | undefined;
 }

--- a/packages/fdr-sdk/src/navigation/migrators/v1ToV2.ts
+++ b/packages/fdr-sdk/src/navigation/migrators/v1ToV2.ts
@@ -33,6 +33,7 @@ export class FernNavigationV1ToLatest {
             authed: node.authed,
             viewers: node.viewers,
             orphaned: node.orphaned,
+            roles: node.roles,
         };
 
         return latest;

--- a/packages/fdr-sdk/src/navigation/versions/v1/converters/NavigationConfigConverter.ts
+++ b/packages/fdr-sdk/src/navigation/versions/v1/converters/NavigationConfigConverter.ts
@@ -79,6 +79,7 @@ export class NavigationConfigConverter {
                 authed: undefined,
                 viewers: undefined,
                 orphaned: undefined,
+                roles: undefined,
             };
 
             // tag all children of hidden nodes as hidden

--- a/packages/fdr-sdk/src/navigation/versions/v1/converters/toRootNode.ts
+++ b/packages/fdr-sdk/src/navigation/versions/v1/converters/toRootNode.ts
@@ -70,6 +70,7 @@ export function toRootNode(
             orphaned: undefined,
             id: FernNavigation.V1.NodeId("root"),
             pointsTo: undefined,
+            roles: undefined,
         };
     }
 }

--- a/packages/ui/fern-docs-search-server/package.json
+++ b/packages/ui/fern-docs-search-server/package.json
@@ -45,6 +45,7 @@
     "@fern-api/ui-core-utils": "workspace:*",
     "@fern-ui/fern-docs-mdx": "workspace:*",
     "@fern-ui/fern-docs-utils": "workspace:*",
+    "@vercel/kv": "^2.0.0",
     "algoliasearch": "^5.10.2",
     "date-fns": "^2.30.0",
     "es-toolkit": "^1.24.0",

--- a/packages/ui/fern-docs-search-server/src/algolia/__test__/generation.test.ts
+++ b/packages/ui/fern-docs-search-server/src/algolia/__test__/generation.test.ts
@@ -45,13 +45,13 @@ for (const fixtureName of [
 ]) {
     // eslint-disable-next-line vitest/valid-title
     describe(fixtureName, () => {
-        it("should work", () => {
+        it("should work", async () => {
             const fixture = readFixture(fixtureName);
             const root = FernNavigation.utils.toRootNode(fixture);
             const apis = FernNavigation.utils.toApis(fixture);
             const pages = FernNavigation.utils.toPages(fixture);
 
-            const records = createAlgoliaRecords({
+            const records = await createAlgoliaRecords({
                 root,
                 domain: "test.com",
                 org_id: "test",

--- a/packages/ui/fern-docs-search-server/src/algolia/__test__/hume.test.ts
+++ b/packages/ui/fern-docs-search-server/src/algolia/__test__/hume.test.ts
@@ -3,11 +3,11 @@ import { createAlgoliaRecords } from "../records/create-algolia-records";
 import { readFixture, readFixtureToRootNode } from "./test-utils";
 
 describe("hume", () => {
-    it("should work", () => {
+    it("should work", async () => {
         const [fixture, snapshotFilepath] = readFixture("hume");
         const { root, apis, pages } = readFixtureToRootNode(fixture);
 
-        const records = createAlgoliaRecords({
+        const records = await createAlgoliaRecords({
             root,
             domain: "dev.hume.ai",
             org_id: "hume",

--- a/packages/ui/fern-docs-search-server/src/algolia/get-search-api-key.ts
+++ b/packages/ui/fern-docs-search-server/src/algolia/get-search-api-key.ts
@@ -19,9 +19,14 @@ interface GetSearchApiKeyOptions {
     domain: string;
 
     /**
-     * Roles of the user
+     * All roles
      */
     roles: string[];
+
+    /**
+     * Roles of the user
+     */
+    userRoles: string[];
 
     /**
      * Whether the user is authed or anonymous
@@ -38,6 +43,7 @@ export function getSearchApiKey({
     parentApiKey,
     domain,
     roles,
+    userRoles,
     authed,
     expiresInSeconds,
     searchIndex,
@@ -45,7 +51,7 @@ export function getSearchApiKey({
     return generateSecuredApiKey({
         parentApiKey,
         restrictions: {
-            filters: createSearchFilters({ domain, roles, authed }) + " AND NOT type:navigation",
+            filters: createSearchFilters({ domain, roles, userRoles, authed }) + " AND NOT type:navigation",
             validUntil: Math.floor(Date.now() / 1_000) + expiresInSeconds,
             restrictIndices: [searchIndex],
         },

--- a/packages/ui/fern-docs-search-server/src/algolia/roles/__test__/create-search-filters.test.ts
+++ b/packages/ui/fern-docs-search-server/src/algolia/roles/__test__/create-search-filters.test.ts
@@ -4,29 +4,50 @@ const TEST_DOMAIN = "buildwithfern.com";
 
 describe("create-search-filters", () => {
     it("should create filters for unauthed users", () => {
-        expect(createSearchFilters({ domain: TEST_DOMAIN, roles: [], authed: false })).toBe(
+        expect(createSearchFilters({ domain: TEST_DOMAIN, roles: [], userRoles: [], authed: false })).toBe(
             `domain:${TEST_DOMAIN} AND authed:false`,
         );
-        expect(createSearchFilters({ domain: TEST_DOMAIN, roles: ["a", "b", "c"], authed: false })).toBe(
+        expect(createSearchFilters({ domain: TEST_DOMAIN, roles: ["a", "b", "c"], userRoles: [], authed: false })).toBe(
             `domain:${TEST_DOMAIN} AND authed:false`,
         );
     });
 
     it("should include the everyone role in all permutations", () => {
         expect(
-            createSearchFilters({ domain: TEST_DOMAIN, roles: ["a", "b", "c"], authed: true }),
+            createSearchFilters({
+                domain: TEST_DOMAIN,
+                roles: ["a", "b", "c"],
+                userRoles: ["a", "b", "c"],
+                authed: true,
+            }),
         ).toMatchInlineSnapshot(
-            '"domain:buildwithfern.com AND (visible_by:role/everyone OR visible_by:role/a OR visible_by:role/a/b OR visible_by:role/a/b/c OR visible_by:role/a/c OR visible_by:role/b OR visible_by:role/b/c OR visible_by:role/c)"',
+            '"domain:buildwithfern.com AND (visible_by:0 OR visible_by:1 OR visible_by:2 OR visible_by:3 OR visible_by:4 OR visible_by:5 OR visible_by:6 OR visible_by:7)"',
         );
 
         expect(
-            createSearchFilters({ domain: TEST_DOMAIN, roles: ["c", "b", "a"], authed: true }),
+            createSearchFilters({
+                domain: TEST_DOMAIN,
+                roles: ["c", "b", "a"],
+                userRoles: ["a", "b", "c"],
+                authed: true,
+            }),
         ).toMatchInlineSnapshot(
-            '"domain:buildwithfern.com AND (visible_by:role/everyone OR visible_by:role/a OR visible_by:role/a/b OR visible_by:role/a/b/c OR visible_by:role/a/c OR visible_by:role/b OR visible_by:role/b/c OR visible_by:role/c)"',
+            '"domain:buildwithfern.com AND (visible_by:0 OR visible_by:1 OR visible_by:2 OR visible_by:3 OR visible_by:4 OR visible_by:5 OR visible_by:6 OR visible_by:7)"',
         );
 
-        expect(createSearchFilters({ domain: TEST_DOMAIN, roles: [], authed: true })).toMatchInlineSnapshot(
-            '"domain:buildwithfern.com AND (visible_by:role/everyone)"',
+        expect(
+            createSearchFilters({
+                domain: TEST_DOMAIN,
+                roles: ["a", "b", "c"],
+                userRoles: ["a", "b"],
+                authed: true,
+            }),
+        ).toMatchInlineSnapshot(
+            '"domain:buildwithfern.com AND (visible_by:0 OR visible_by:1 OR visible_by:2 OR visible_by:3)"',
         );
+
+        expect(
+            createSearchFilters({ domain: TEST_DOMAIN, roles: [], userRoles: [], authed: true }),
+        ).toMatchInlineSnapshot('"domain:buildwithfern.com AND (visible_by:0)"');
     });
 });

--- a/packages/ui/fern-docs-search-server/src/algolia/roles/__test__/role-utils.test.ts
+++ b/packages/ui/fern-docs-search-server/src/algolia/roles/__test__/role-utils.test.ts
@@ -3,25 +3,57 @@ import { createPermutations, flipAndOrToOrAnd, modifyRolesForEveryone } from "..
 
 describe("flipAndOrToOrAnd", () => {
     it("should return []", () => {
-        expect(flipAndOrToOrAnd([])).toEqual([]);
+        expect(flipAndOrToOrAnd([], new Map())).toEqual([]);
     });
 
     it("should return [a]", () => {
-        expect(flipAndOrToOrAnd([["a"]])).toEqual([["a"]]);
-        expect(flipAndOrToOrAnd([["a", "a"]])).toEqual([["a"]]);
-        expect(flipAndOrToOrAnd([["a"], ["a"], ["a"]])).toEqual([["a"]]);
+        expect(flipAndOrToOrAnd([["a"]], new Map([["a", 0]]))).toEqual([["a"]]);
+        expect(flipAndOrToOrAnd([["a", "a"]], new Map([["a", 0]]))).toEqual([["a"]]);
+        expect(flipAndOrToOrAnd([["a"], ["a"], ["a"]], new Map([["a", 0]]))).toEqual([["a"]]);
     });
 
     it("should return [a&b]", () => {
-        expect(flipAndOrToOrAnd([["a"], ["b"]])).toEqual([["a", "b"]]);
+        expect(
+            flipAndOrToOrAnd(
+                [["a"], ["b"]],
+                new Map([
+                    ["a", 0],
+                    ["b", 1],
+                ]),
+            ),
+        ).toEqual([["a", "b"]]);
     });
 
     it("should return [a&e, a&f]", () => {
-        expect(flipAndOrToOrAnd([["a"], ["e", "f"]])).toEqual([
+        expect(
+            flipAndOrToOrAnd(
+                [["a"], ["e", "f"]],
+                new Map([
+                    ["a", 0],
+                    ["b", 1],
+                    ["c", 2],
+                    ["d", 3],
+                    ["e", 4],
+                    ["f", 5],
+                ]),
+            ),
+        ).toEqual([
             ["a", "e"],
             ["a", "f"],
         ]);
-        expect(flipAndOrToOrAnd([["e", "f"], ["a"]])).toEqual([
+        expect(
+            flipAndOrToOrAnd(
+                [["e", "f"], ["a"]],
+                new Map([
+                    ["a", 0],
+                    ["b", 1],
+                    ["c", 2],
+                    ["d", 3],
+                    ["e", 4],
+                    ["f", 5],
+                ]),
+            ),
+        ).toEqual([
             ["a", "e"],
             ["a", "f"],
         ]);
@@ -29,29 +61,53 @@ describe("flipAndOrToOrAnd", () => {
 
     it("should return [a&c, b&d, b&c, b&d]", () => {
         expect(
-            flipAndOrToOrAnd([
-                ["a", "b"],
-                ["c", "d"],
-            ]),
+            flipAndOrToOrAnd(
+                [
+                    ["a", "b"],
+                    ["c", "d"],
+                ],
+                new Map([
+                    ["a", 0],
+                    ["b", 1],
+                    ["c", 2],
+                    ["d", 3],
+                ]),
+            ),
         ).toEqual([
-            ["a", "c"],
-            ["a", "d"],
-            ["b", "c"],
             ["b", "d"],
+            ["a", "c"],
+            ["b", "c"],
+            ["a", "d"],
         ]);
     });
 
     it("should skip redundant combinations", () => {
-        expect(flipAndOrToOrAnd([["a", "b"], ["c"], ["b"]])).toEqual([["b", "c"]]);
+        expect(
+            flipAndOrToOrAnd(
+                [["a", "b"], ["c"], ["b"]],
+                new Map([
+                    ["a", 0],
+                    ["b", 1],
+                    ["c", 2],
+                ]),
+            ),
+        ).toEqual([["b", "c"]]);
     });
 
     it("should return [a&b, a&c, b&c] (skipping a&b&c)", () => {
         expect(
-            flipAndOrToOrAnd([
-                ["a", "b"],
-                ["a", "c"],
-                ["b", "c"],
-            ]),
+            flipAndOrToOrAnd(
+                [
+                    ["a", "b"],
+                    ["a", "c"],
+                    ["b", "c"],
+                ],
+                new Map([
+                    ["a", 0],
+                    ["b", 1],
+                    ["c", 2],
+                ]),
+            ),
         ).toEqual([
             ["a", "b"],
             ["a", "c"],
@@ -60,33 +116,51 @@ describe("flipAndOrToOrAnd", () => {
     });
 
     it("skip all other optional subsets", () => {
-        expect(flipAndOrToOrAnd([[], ["a"], [], ["b", "c", "d"], ["c"], ["a", "b"]])).toEqual([["a", "c"]]);
+        expect(
+            flipAndOrToOrAnd(
+                [[], ["a"], [], ["b", "c", "d"], ["c"], ["a", "b"]],
+                new Map([
+                    ["a", 0],
+                    ["b", 1],
+                    ["c", 2],
+                ]),
+            ),
+        ).toEqual([["a", "c"]]);
     });
 });
 
 describe("createPermutations", () => {
     it("should return []", () => {
-        expect(createPermutations([])).toEqual([]);
+        expect(createPermutations([], new Map())).toEqual([]);
     });
 
     it("should return [a]", () => {
-        expect(createPermutations(["a"])).toEqual([["a"]]);
+        expect(createPermutations(["a"], new Map([["a", 0]]))).toEqual([["a"]]);
     });
 
     it("should return [a, b, a&b]", () => {
-        expect(createPermutations(["a", "b"])).toEqual([["a"], ["a", "b"], ["b"]]);
+        expect(
+            createPermutations(
+                ["a", "b"],
+                new Map([
+                    ["a", 0],
+                    ["b", 1],
+                ]),
+            ),
+        ).toEqual([["a"], ["b"], ["a", "b"]]);
     });
 
     it("should return [a, b, a&b, c, a&c, b&c, a&b&c]", () => {
-        expect(createPermutations(["a", "b", "c"])).toEqual([
-            ["a"],
-            ["a", "b"],
-            ["a", "b", "c"],
-            ["a", "c"],
-            ["b"],
-            ["b", "c"],
-            ["c"],
-        ]);
+        expect(
+            createPermutations(
+                ["a", "b", "c"],
+                new Map([
+                    ["a", 0],
+                    ["b", 1],
+                    ["c", 2],
+                ]),
+            ),
+        ).toEqual([["a"], ["b"], ["a", "b"], ["c"], ["a", "c"], ["b", "c"], ["a", "b", "c"]]);
     });
 });
 

--- a/packages/ui/fern-docs-search-server/src/algolia/roles/create-role-facet.ts
+++ b/packages/ui/fern-docs-search-server/src/algolia/roles/create-role-facet.ts
@@ -1,3 +1,5 @@
+import { EVERYONE_ROLE } from "@fern-ui/fern-docs-utils";
+
 /**
  * Create a facet for the given roles.
  *
@@ -7,10 +9,20 @@
  * a -> role/a
  * [a, b] -> role/a/b
  */
-export function createRoleFacet(roles: string[]): string {
-    return `role/${roles
-        .sort()
-        // ensure that the role is encoded such that it can be used in a filter safely
-        .map((role) => encodeURIComponent(role))
-        .join("/")}`;
+export function createRoleFacet(roles: string[], roleIndexes: Map<string, number>): string {
+    // return `role/${roles
+    // .sort()
+    // // ensure that the role is encoded such that it can be used in a filter safely
+    // .map((role) => encodeURIComponent(role))
+    // .join("/")}`;
+    if (roles[0] === EVERYONE_ROLE) {
+        return "0";
+    }
+    return `${roles.reduce((acc, role) => {
+        const roleIdx = roleIndexes.get(role);
+        if (roleIdx != null) {
+            return acc | (1 << roleIdx);
+        }
+        return acc;
+    }, 0)}`;
 }

--- a/packages/ui/fern-docs-search-server/src/algolia/roles/create-roles-indexes.ts
+++ b/packages/ui/fern-docs-search-server/src/algolia/roles/create-roles-indexes.ts
@@ -1,0 +1,5 @@
+export function createRoleIndexes(roles: string[]): Map<string, number> {
+    const roleIndexes = new Map<string, number>();
+    roles.forEach((role, idx) => roleIndexes.set(role, idx));
+    return roleIndexes;
+}

--- a/packages/ui/fern-docs-search-server/src/algolia/roles/create-search-filters.ts
+++ b/packages/ui/fern-docs-search-server/src/algolia/roles/create-search-filters.ts
@@ -1,5 +1,6 @@
 import { EVERYONE_ROLE } from "@fern-ui/fern-docs-utils";
 import { createRoleFacet } from "./create-role-facet";
+import { createRoleIndexes } from "./create-roles-indexes";
 import { createPermutations } from "./role-utils";
 
 interface CreateSearchFiltersOpts {
@@ -13,6 +14,13 @@ interface CreateSearchFiltersOpts {
     roles: string[];
 
     /**
+     * roles are ignored if the user is unauthed
+     * but if they are authed, we automatically include the "everyone" role, and then generate all permutations of the provided roles
+     * "everyone" does not have to be included explicitly in the permutations.
+     */
+    userRoles: string[];
+
+    /**
      * If false, filters out any content that is only visible to unauthed users
      */
     authed: boolean;
@@ -21,21 +29,25 @@ interface CreateSearchFiltersOpts {
 const VISIBLE_BY_FACET = "visible_by";
 const AUTHED_FACET = "authed";
 
-export function createSearchFilters({ domain, roles, authed }: CreateSearchFiltersOpts): string {
+export function createSearchFilters({ domain, roles, userRoles, authed }: CreateSearchFiltersOpts): string {
     if (!authed) {
         // if the user is unauthed, we only want to show content where authed=false
         return `domain:${domain} AND ${AUTHED_FACET}:false`;
     }
+
+    // To encode correctly, we can construct an index map, for fast access on role processing
+    const roleIndexes = createRoleIndexes(roles);
 
     // if the user is authed, we can show both content where authed=false AND authed=true
     // In algolia, you cannot create a OR statements across multiple facets, so we must include the "everyone" role in all the filter combinations
     // for example, all records that do not require auth must include the visible_by:role/everyone facet.
     // therefore, all filter combinations must include visible_by:role/everyone as well as any additional role filters.
     const roleFilters = [
-        `${VISIBLE_BY_FACET}:${createRoleFacet([EVERYONE_ROLE])}`,
-        ...createPermutations(roles.filter((r) => r !== EVERYONE_ROLE)).map(
-            (perms) => `${VISIBLE_BY_FACET}:${createRoleFacet(perms)}`,
-        ),
+        `${VISIBLE_BY_FACET}:${createRoleFacet([EVERYONE_ROLE], roleIndexes)}`,
+        ...createPermutations(
+            userRoles.filter((r) => r !== EVERYONE_ROLE),
+            roleIndexes,
+        ).map((perms) => `${VISIBLE_BY_FACET}:${createRoleFacet(perms, roleIndexes)}`),
     ];
 
     return `domain:${domain} AND (${roleFilters.join(" OR ")})`;

--- a/packages/ui/fern-docs-search-server/src/algolia/roles/role-utils.ts
+++ b/packages/ui/fern-docs-search-server/src/algolia/roles/role-utils.ts
@@ -20,7 +20,7 @@ import { createRoleFacet } from "./create-role-facet";
  * @param roles is a 2d list of roles, where the outer array represents AND and the inner array represents OR
  * @returns a 2d list of roles where the outer array represents OR and the inner array represents AND
  */
-export function flipAndOrToOrAnd(andOrRoles: string[][]): string[][] {
+export function flipAndOrToOrAnd(andOrRoles: string[][], roleIndexes: Map<string, number>): string[][] {
     if (andOrRoles.length === 0) {
         return [];
     }
@@ -33,7 +33,7 @@ export function flipAndOrToOrAnd(andOrRoles: string[][]): string[][] {
 
     // if a combination is a subset of another, remove the larger one, e.g. [[a, b], [a]] -> [[a]]
     // this is because the larger one is redundant
-    return sortBy(removeSubsets(uniqueCombinations), [createRoleFacet]);
+    return sortBy(removeSubsets(uniqueCombinations), [(role) => createRoleFacet(role, roleIndexes)]);
 }
 
 function combine<T>(arrays: T[][]): T[][] {
@@ -68,7 +68,7 @@ function removeSubsets(arrays: string[][]): string[][] {
 // [a, b] -> [a, b, a|b]
 // [b, a] -> [a, b, a|b]
 // [a, c, b] -> [a, b, c, a|b, a|c, b|c, a|b|c]
-export function createPermutations(roles: string[]): string[][] {
+export function createPermutations(roles: string[], roleIndexes: Map<string, number>): string[][] {
     if (roles.length === 0) {
         return [];
     }
@@ -86,7 +86,10 @@ export function createPermutations(roles: string[]): string[][] {
         });
     }
 
-    return sortBy(uniqBy(result, createRoleFacet), [createRoleFacet]);
+    return sortBy(
+        uniqBy(result, (role) => createRoleFacet(role, roleIndexes)),
+        [(role) => createRoleFacet(role, roleIndexes)],
+    );
 }
 
 function getPermutations(arr: string[], k: number): string[][] {

--- a/packages/ui/fern-docs-search-server/src/tasks/algolia-indexer-task.ts
+++ b/packages/ui/fern-docs-search-server/src/tasks/algolia-indexer-task.ts
@@ -65,7 +65,14 @@ export async function algoliaIndexerTask(payload: AlgoliaIndexerPayload): Promis
     const { org_id, root, pages, apis, domain } = await loadDocsWithUrl(payload);
 
     // create new records (this is the target state of the index)
-    const targetRecords = createAlgoliaRecords({ root, domain, org_id, pages, apis, authed: payload.authed ?? false });
+    const targetRecords = await createAlgoliaRecords({
+        root,
+        domain,
+        org_id,
+        pages,
+        apis,
+        authed: payload.authed ?? false,
+    });
 
     // browse the existing records (what is currently in the index)
     const existingObjectIDs = (await browseAllObjectsForDomain(algolia, domain, payload.indexName, ["objectID"]))

--- a/packages/ui/fern-docs-search-ui/package.json
+++ b/packages/ui/fern-docs-search-ui/package.json
@@ -29,6 +29,7 @@
     "@date-fns/tz": "^1.1.2",
     "@fern-ui/fern-docs-search-server": "workspace:*",
     "@fern-ui/fern-http-method-tag": "workspace:*",
+    "@vercel/kv": "^2.0.0",
     "ai": "^3.4.33",
     "algoliasearch": "^5.10.2",
     "cmdk": "^1.0.4",

--- a/packages/ui/fern-docs-search-ui/src/app/api/anthropic/route.ts
+++ b/packages/ui/fern-docs-search-ui/src/app/api/anthropic/route.ts
@@ -57,7 +57,7 @@ export async function POST(request: Request): Promise<Response> {
                 }),
                 async execute({ query }) {
                     const client = algoliasearch(algoliaAppId(), algoliaWriteApiKey());
-                    const filters = createSearchFilters({ domain, roles: [], authed: false });
+                    const filters = createSearchFilters({ domain, roles: [], userRoles: [], authed: false });
                     const { hits } = await client.browse<AlgoliaRecord>({
                         indexName: "fern-docs-search",
                         browseParams: { query, filters },

--- a/packages/ui/fern-docs-search-ui/src/app/api/search-key/route.ts
+++ b/packages/ui/fern-docs-search-ui/src/app/api/search-key/route.ts
@@ -1,5 +1,6 @@
 import { algoliaSearchApikey } from "@/server/env-variables";
 import { withSearchApiKey } from "@/server/with-search-api-key";
+import { kv } from "@vercel/kv";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -7,10 +8,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     if (!domain) {
         return NextResponse.json({ error: "Domain is required" }, { status: 400 });
     }
+
     const apiKey = withSearchApiKey({
         searchApiKey: algoliaSearchApikey(),
         domain,
-        roles: [],
+        roles: (await kv.get(domain)) ?? [],
+        userRoles: ["employee"],
         authed: false,
     });
 

--- a/packages/ui/fern-docs-search-ui/src/app/api/search-key/route.ts
+++ b/packages/ui/fern-docs-search-ui/src/app/api/search-key/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         searchApiKey: algoliaSearchApikey(),
         domain,
         roles: (await kv.get(domain)) ?? [],
-        userRoles: ["employee"],
+        userRoles: [],
         authed: false,
     });
 

--- a/packages/ui/fern-docs-search-ui/src/server/with-search-api-key.ts
+++ b/packages/ui/fern-docs-search-ui/src/server/with-search-api-key.ts
@@ -4,14 +4,16 @@ interface WithSearchApiKeyOptions {
     searchApiKey: string;
     domain: string;
     roles: string[];
+    userRoles: string[];
     authed: boolean;
 }
 
-export function withSearchApiKey({ searchApiKey, domain, roles, authed }: WithSearchApiKeyOptions): string {
+export function withSearchApiKey({ searchApiKey, domain, roles, userRoles, authed }: WithSearchApiKeyOptions): string {
     return getSearchApiKey({
         parentApiKey: searchApiKey,
         domain,
         roles,
+        userRoles,
         authed,
         expiresInSeconds: 60 * 60 * 24,
         searchIndex: "fern-docs-search",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2296,6 +2296,9 @@ importers:
       '@fern-ui/fern-docs-utils':
         specifier: workspace:*
         version: link:../fern-docs-utils
+      '@vercel/kv':
+        specifier: ^2.0.0
+        version: 2.0.0
       algoliasearch:
         specifier: ^5.10.2
         version: 5.10.2
@@ -2375,6 +2378,9 @@ importers:
       '@fern-ui/fern-http-method-tag':
         specifier: workspace:*
         version: link:../fern-http-method-tag
+      '@vercel/kv':
+        specifier: ^2.0.0
+        version: 2.0.0
       ai:
         specifier: ^3.4.33
         version: 3.4.33(react@18.3.1)(sswr@2.1.0(svelte@5.1.12))(svelte@5.1.12)(vue@3.5.12(typescript@5.4.3))(zod@3.23.8)

--- a/servers/fdr/src/api/generated/api/resources/navigation/resources/latest/types/RootNode.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/navigation/resources/latest/types/RootNode.d.ts
@@ -6,4 +6,5 @@ export interface RootNode extends FernRegistry.navigation.latest.WithNodeMetadat
     type: "root";
     version: "v2";
     child: FernRegistry.navigation.latest.RootChild;
+    roles: FernRegistry.RoleId[] | undefined;
 }

--- a/servers/fdr/src/api/generated/api/resources/navigation/resources/v1/types/RootNode.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/navigation/resources/v1/types/RootNode.d.ts
@@ -6,4 +6,5 @@ export interface RootNode extends FernRegistry.navigation.v1.WithNodeMetadata, F
     type: "root";
     version: "v1";
     child: FernRegistry.navigation.v1.RootChild;
+    roles: FernRegistry.RoleId[] | undefined;
 }


### PR DESCRIPTION
## Short description of the changes made

* adds encoding to the permissions so that there is a terse representation of the permissions that go into the algolia records, to save space

## What was the motivation & context behind this PR?

* permissions could potentially explode and fail to generate proper algolia records

## How has this PR been tested?

* unit test and with demo search ui