### PR TITLE
fix: render min max values

### DIFF
--- a/packages/ui/app/src/playground/WithLabel.tsx
+++ b/packages/ui/app/src/playground/WithLabel.tsx
@@ -8,10 +8,10 @@ import {
 import { FernButton, FernTooltip } from "@fern-ui/components";
 import cn from "clsx";
 import { HelpCircle, Xmark } from "iconoir-react";
-import { FC, PropsWithChildren } from "react";
+import { FC, PropsWithChildren, ReactNode } from "react";
 import { EndpointAvailabilityTag } from "../api-reference/endpoints/EndpointAvailabilityTag";
 import { Markdown } from "../mdx/Markdown";
-import { renderTypeShorthand } from "../type-shorthand";
+import { renderTypeShorthandRoot } from "../type-shorthand";
 import { shouldRenderInline } from "./utils";
 
 interface WithLabelProps {
@@ -48,7 +48,7 @@ export const WithLabel: FC<PropsWithChildren<WithLabelProps>> = ({
             isRequired={!unwrapped.isOptional}
             isList={unwrapped.shape.type === "list"}
             isBoolean={unwrapped.shape.type === "primitive" && unwrapped.shape.value.type === "boolean"}
-            typeShorthand={renderTypeShorthand(unwrapped.shape, undefined, types)}
+            typeShorthand={renderTypeShorthandRoot(unwrapped.shape, types)}
         >
             {children}
         </WithLabelInternal>
@@ -62,7 +62,7 @@ interface WithLabelInternalProps extends WithAvailability, WithDescription {
     onRemove: () => void;
     renderInline?: boolean;
     isRequired: boolean;
-    typeShorthand: string;
+    typeShorthand: ReactNode;
     isList?: boolean;
     isBoolean?: boolean;
 }
@@ -100,7 +100,6 @@ export const WithLabelInternal: FC<PropsWithChildren<WithLabelInternalProps>> = 
 
                     {availability != null && <EndpointAvailabilityTag availability={availability} minimal={true} />}
                     <span className="whitespace-nowrap text-xs">
-                        {isRequired && <span className="t-danger">required </span>}
                         <span className="t-muted">{typeShorthand}</span>
                     </span>
 

--- a/packages/ui/app/src/playground/form/PlaygroundTypeReferenceForm.tsx
+++ b/packages/ui/app/src/playground/form/PlaygroundTypeReferenceForm.tsx
@@ -102,6 +102,11 @@ export const PlaygroundTypeReferenceForm = memo<PlaygroundTypeReferenceFormProps
                                 onValueChange={onChange}
                                 disabled={disabled}
                                 placeholder={string.default}
+                                defaultValue={string.default}
+                                maxLength={string.maxLength}
+                                minLength={string.minLength}
+                                // TODO: add validation UX feedback
+                                pattern={string.regex}
                             />
                         )}
                     </WithLabel>
@@ -148,7 +153,7 @@ export const PlaygroundTypeReferenceForm = memo<PlaygroundTypeReferenceFormProps
                         />
                     </WithLabel>
                 ),
-                long: () => (
+                long: (long) => (
                     <WithLabel property={property} value={value} onRemove={onRemove} types={types} htmlFor={id}>
                         <FernNumericInput
                             id={id}
@@ -157,6 +162,9 @@ export const PlaygroundTypeReferenceForm = memo<PlaygroundTypeReferenceFormProps
                             onValueChange={onChange}
                             disallowFloat={true}
                             disabled={disabled}
+                            defaultValue={long.default}
+                            max={long.maximum}
+                            min={long.minimum}
                         />
                     </WithLabel>
                 ),

--- a/packages/ui/components/src/FernInput.scss
+++ b/packages/ui/components/src/FernInput.scss
@@ -45,7 +45,7 @@
         @apply h-full rounded-none border-default;
     }
 
-    .fern-numeric-input-group:focus-within .fern-numeric-input-step {
+    .fern-numeric-input-group:focus-within .fern-numeric-input-step:not(:disabled) {
         @apply ring-accent hover:bg-tag-primary t-accent hover:t-accent border-primary;
     }
 

--- a/packages/ui/components/src/FernInput.tsx
+++ b/packages/ui/components/src/FernInput.tsx
@@ -21,6 +21,10 @@ export const FernInput = forwardRef<HTMLInputElement, FernInputProps>(function F
                 className={cn("fern-input", inputClassName)}
                 value={value}
                 onChange={(e) => {
+                    if (props.maxLength != null && e.target.value.length > props.maxLength) {
+                        return;
+                    }
+
                     onChange?.(e);
                     onValueChange?.(e.target.value);
                 }}

--- a/packages/ui/components/src/FernNumericInput.tsx
+++ b/packages/ui/components/src/FernNumericInput.tsx
@@ -105,6 +105,7 @@ export const FernNumericInput = forwardRef<HTMLInputElement, FernNumericInputPro
                     }}
                     onMouseLeave={handleClearInterval}
                     tabIndex={-1}
+                    disabled={props.disabled || (props.min != null && value != null && value <= toNumber(props.min))}
                 />
             )}
             <input
@@ -131,8 +132,13 @@ export const FernNumericInput = forwardRef<HTMLInputElement, FernNumericInputPro
                     }}
                     onMouseLeave={handleClearInterval}
                     tabIndex={-1}
+                    disabled={props.disabled || (props.max != null && value != null && value >= toNumber(props.max))}
                 />
             )}
         </div>
     );
 });
+
+function toNumber(value: string | number): number {
+    return typeof value === "string" ? parseFloat(value) : value;
+}


### PR DESCRIPTION
The API Playground labels look awful but keeping it as is until we find time to refactor it.

<img width="549" alt="Screenshot 2024-11-12 at 6 52 00 PM" src="https://github.com/user-attachments/assets/f1c3fa76-31e3-4622-8c51-0880258fa905">

<img width="714" alt="Screenshot 2024-11-12 at 7 02 19 PM" src="https://github.com/user-attachments/assets/723ef017-d7c5-4161-960e-16b87b3c7f0d">
