### PR TITLE
fix: error example dropdown issues

### DIFF
--- a/packages/ui/app/src/api-reference/endpoints/CodeExampleClientDropdown.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/CodeExampleClientDropdown.tsx
@@ -1,51 +1,41 @@
 import { FernButton, FernDropdown, RemoteFontAwesomeIcon } from "@fern-ui/components";
 import { NavArrowDown } from "iconoir-react";
-import type { CodeExample, CodeExampleGroup } from "../examples/code-example";
+import { getIconForClient, getLanguageDisplayName } from "../examples/code-example";
 
 export declare namespace CodeExampleClientDropdown {
     export interface Props {
-        clients: CodeExampleGroup[];
-        selectedClient: CodeExample;
-        onClickClient: (example: CodeExample) => void;
+        languages: string[];
+        value: string;
+        onValueChange: (language: string) => void;
     }
 }
 
 export const CodeExampleClientDropdown: React.FC<CodeExampleClientDropdown.Props> = ({
-    clients,
-    selectedClient,
-    onClickClient,
+    languages,
+    value,
+    onValueChange,
 }) => {
-    const selectedClientGroup = clients.find((client) => client.language === selectedClient.language);
+    const options = languages.map((language) => ({
+        type: "value" as const,
+        label: getLanguageDisplayName(language),
+        value: language,
+        className: "group/option",
+        icon: (
+            <RemoteFontAwesomeIcon
+                className="size-icon-sm bg-intent-default group-data-[highlighted]/option:bg-accent-contrast"
+                icon={getIconForClient(language)}
+            />
+        ),
+    }));
+
+    const selectedOption = options.find((option) => option.value === value);
     return (
         <div className="flex justify-end">
-            <FernDropdown
-                value={selectedClient.language}
-                options={clients.map((client) => ({
-                    type: "value",
-                    label: client.languageDisplayName,
-                    value: client.language,
-                    className: "group/option",
-                    icon: (
-                        <RemoteFontAwesomeIcon
-                            className="size-icon-sm bg-intent-default group-data-[highlighted]/option:bg-accent-contrast"
-                            icon={client.icon}
-                        />
-                    ),
-                }))}
-                onValueChange={(value) => {
-                    const client = clients.find((client) => client.language === value);
-                    if (client?.examples[0] != null) {
-                        onClickClient(
-                            client.examples.find((example) => example.exampleIndex === selectedClient.exampleIndex) ??
-                                client.examples[0],
-                        );
-                    }
-                }}
-            >
+            <FernDropdown value={value} options={options} onValueChange={onValueChange}>
                 <FernButton
-                    icon={<RemoteFontAwesomeIcon className="bg-accent size-4" icon={selectedClientGroup?.icon} />}
+                    icon={<RemoteFontAwesomeIcon className="bg-accent size-4" icon={getIconForClient(value)} />}
                     rightIcon={<NavArrowDown className="!size-icon" />}
-                    text={selectedClientGroup?.languageDisplayName ?? selectedClient.language}
+                    text={selectedOption?.label ?? getLanguageDisplayName(value)}
                     size="small"
                     variant="outlined"
                     mono={true}

--- a/packages/ui/app/src/api-reference/endpoints/EndpointContentCodeSnippets.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointContentCodeSnippets.tsx
@@ -255,24 +255,6 @@ const UnmemoizedEndpointContentCodeSnippets: React.FC<EndpointContentCodeSnippet
 
 export const EndpointContentCodeSnippets = memo(UnmemoizedEndpointContentCodeSnippets);
 
-// function applyExampleIndex(name: string | undefined, exampleIndex?: number) {
-//     return exampleIndex ? `${name} Example ${exampleIndex}` : name;
-// }
-
-// function renderErrorTitle(errorName: string | undefined, statusCode: number, exampleIndex?: number) {
-//     return renderResponseTitle(
-//         applyExampleIndex(errorName, exampleIndex) ?? ApiDefinition.getMessageForStatus(statusCode),
-//         statusCode,
-//     );
-// }
-
-// function renderExampleTitle(statusCode: number, method?: APIV1Read.HttpMethod, exampleIndex?: number) {
-//     return renderResponseTitle(
-//         applyExampleIndex(ApiDefinition.getMessageForStatus(statusCode, method), exampleIndex) ?? "Response",
-//         statusCode,
-//     );
-// }
-
 function renderResponseTitle(title: string, statusCode: number) {
     return (
         <span className="inline-flex items-center gap-2">

--- a/packages/ui/app/src/api-reference/endpoints/EndpointContentCodeSnippets.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointContentCodeSnippets.tsx
@@ -1,10 +1,11 @@
 import * as ApiDefinition from "@fern-api/fdr-sdk/api-definition";
-import type { APIV1Read } from "@fern-api/fdr-sdk/client/types";
 import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import { EMPTY_ARRAY, EMPTY_OBJECT, visitDiscriminatedUnion } from "@fern-api/ui-core-utils";
-import { FernButton, FernButtonGroup, FernScrollArea } from "@fern-ui/components";
+import { FernScrollArea } from "@fern-ui/components";
 import { useResizeObserver } from "@fern-ui/react-commons";
-import { ReactNode, memo, useMemo, useRef } from "react";
+import { sortBy } from "es-toolkit";
+import { RESET } from "jotai/utils";
+import { ReactNode, SetStateAction, memo, useCallback, useMemo, useRef } from "react";
 import { FernErrorTag } from "../../components/FernErrorBoundary";
 import { StatusCodeTag, statusCodeToIntent } from "../../components/StatusCodeTag";
 import { PlaygroundButton } from "../../playground/PlaygroundButton";
@@ -13,16 +14,17 @@ import { AudioExample } from "../examples/AudioExample";
 import { CodeSnippetExample, JsonCodeSnippetExample } from "../examples/CodeSnippetExample";
 import { JsonPropertyPath } from "../examples/JsonPropertyPath";
 import { TitledExample } from "../examples/TitledExample";
-import type { CodeExample, CodeExampleGroup } from "../examples/code-example";
+import type { CodeExample } from "../examples/code-example";
 import { lineNumberOf } from "../examples/utils";
 import {
-    ExampleIndex,
-    ExamplesByClientAndTitleAndStatusCode,
+    ExamplesByKeyAndStatusCode,
+    ExamplesByStatusCode,
     SelectedExampleKey,
     StatusCode,
 } from "../types/EndpointContent";
 import { WebSocketMessages } from "../web-socket/WebSocketMessages";
 import { CodeExampleClientDropdown } from "./CodeExampleClientDropdown";
+import { EndpointExampleSegmentedControl } from "./EndpointExampleSegmentedControl";
 import { EndpointUrlWithOverflow } from "./EndpointUrlWithOverflow";
 import { ErrorExampleSelect } from "./ErrorExampleSelect";
 
@@ -30,12 +32,12 @@ export declare namespace EndpointContentCodeSnippets {
     export interface Props {
         node: FernNavigation.EndpointNode;
         endpoint: ApiDefinition.EndpointDefinition;
-        examplesByClientAndTitleAndStatusCode: ExamplesByClientAndTitleAndStatusCode | undefined;
-        selectedExampleKey: SelectedExampleKey | undefined;
-        setSelectedExampleKey: (exampleKey: SelectedExampleKey | undefined) => void;
-        clients: CodeExampleGroup[];
-        selectedClient: CodeExample;
-        onClickClient: (example: CodeExample) => void;
+        languages: string[];
+        examplesByKeyAndStatusCode: ExamplesByKeyAndStatusCode;
+        examplesByStatusCode: ExamplesByStatusCode;
+        selectedExample: CodeExample | undefined;
+        selectedLanguage: string;
+        setSelectedExampleKey: (exampleKey: SetStateAction<SelectedExampleKey> | typeof RESET) => void;
         requestCodeSnippet: string;
         requestCurlJson: unknown;
         hoveredRequestPropertyPath: JsonPropertyPath | undefined;
@@ -43,7 +45,6 @@ export declare namespace EndpointContentCodeSnippets {
         showErrors: boolean;
         errors: ApiDefinition.ErrorResponse[] | undefined;
         selectedError: ApiDefinition.ErrorResponse | undefined;
-        setSelectedError: (error: ApiDefinition.ErrorResponse | undefined) => void;
         measureHeight: (height: number) => void;
     }
 }
@@ -51,20 +52,17 @@ export declare namespace EndpointContentCodeSnippets {
 const UnmemoizedEndpointContentCodeSnippets: React.FC<EndpointContentCodeSnippets.Props> = ({
     node,
     endpoint,
-    examplesByClientAndTitleAndStatusCode,
-    selectedExampleKey,
+    examplesByKeyAndStatusCode,
+    examplesByStatusCode,
+    selectedExample,
+    selectedLanguage,
     setSelectedExampleKey,
-    clients,
-    selectedClient,
-    onClickClient,
+    languages,
     requestCodeSnippet,
     requestCurlJson,
     hoveredRequestPropertyPath = EMPTY_ARRAY,
     hoveredResponsePropertyPath = EMPTY_ARRAY,
     showErrors,
-    errors = EMPTY_ARRAY,
-    selectedError,
-    setSelectedError,
     measureHeight,
 }) => {
     const ref = useRef<HTMLDivElement>(null);
@@ -74,123 +72,83 @@ const UnmemoizedEndpointContentCodeSnippets: React.FC<EndpointContentCodeSnippet
             measureHeight(entry.contentRect.height);
         }
     });
-    const handleSelectErrorAndExample = (error: ApiDefinition.ErrorResponse | undefined) => {
-        setSelectedError(error);
-    };
 
-    const handleSelectExample = (statusCode: StatusCode, exampleIndex: ExampleIndex) => {
-        setSelectedExampleKey([selectedClient.language, selectedExampleKey?.[1], statusCode, exampleIndex]);
-    };
-
-    const getExampleId = useMemo(
-        () => (example: CodeExample | undefined, errorName: string | undefined, exampleIndex: number | undefined) =>
-            example?.exampleCall.responseBody != null
-                ? visitDiscriminatedUnion(example.exampleCall.responseBody)._visit<ReactNode>({
-                      json: () =>
-                          example.globalError || errorName
-                              ? renderErrorTitle(errorName, example.exampleCall.responseStatusCode, exampleIndex)
-                              : renderExampleTitle(
-                                    example.exampleCall.responseStatusCode,
-                                    endpoint.method,
-                                    exampleIndex,
-                                ),
-                      filename: () =>
-                          example.globalError || errorName
-                              ? renderErrorTitle(errorName, example.exampleCall.responseStatusCode, exampleIndex)
-                              : renderExampleTitle(
-                                    example.exampleCall.responseStatusCode,
-                                    endpoint.method,
-                                    exampleIndex,
-                                ),
-                      stream: () => "Streamed Response",
-                      sse: () => "Server-Sent Events",
-                      _other: () => "Response",
-                  })
-                : "Response",
-        [endpoint],
+    const handleSelectExample = useCallback(
+        (statusCode: StatusCode, responseIndex: number) => {
+            setSelectedExampleKey((prev) => ({ ...prev, statusCode, responseIndex }));
+        },
+        [setSelectedExampleKey],
     );
 
-    const selectedExample = useMemo(() => {
-        if (selectedExampleKey == null) {
-            return undefined;
-        }
-        const [language, title, statusCode, exampleIndex] = selectedExampleKey;
-        if (language == null || title == null || statusCode == null || exampleIndex == null) {
-            return undefined;
-        }
-        return examplesByClientAndTitleAndStatusCode?.[language]?.[title]?.[statusCode]?.[exampleIndex];
-    }, [selectedExampleKey, examplesByClientAndTitleAndStatusCode]);
-
-    const errorSelector = showErrors ? (
-        <ErrorExampleSelect
-            errors={errors}
-            selectedError={selectedError}
-            setSelectedErrorAndExample={handleSelectErrorAndExample}
-            selectedExampleKey={selectedExampleKey}
-            setSelectedExampleKey={handleSelectExample}
-            examplesByStatusCode={
-                examplesByClientAndTitleAndStatusCode?.[selectedClient.language]?.[selectedExampleKey?.[1] ?? ""]
+    const getExampleId = useCallback(
+        (example: CodeExample | undefined) => {
+            switch (example?.exampleCall.responseBody?.type) {
+                case "json":
+                case "filename": {
+                    const title =
+                        example.exampleCall.name ??
+                        ApiDefinition.getMessageForStatus(example.exampleCall.responseStatusCode, endpoint.method) ??
+                        "Response";
+                    return renderResponseTitle(title, example.exampleCall.responseStatusCode);
+                }
+                case "stream":
+                    return "Streamed Response";
+                case "sse":
+                    return "Server-Sent Events";
+                default:
+                    return "Response";
             }
-            getExampleId={getExampleId}
-        />
-    ) : (
-        <span className="text-sm t-muted">
-            {getExampleId(selectedExample, selectedError?.examples?.[0]?.name, undefined)}
-        </span>
+        },
+        [endpoint.method],
     );
+
+    const errorSelector =
+        showErrors && Object.keys(examplesByStatusCode).length > 1 ? (
+            <ErrorExampleSelect
+                examplesByStatusCode={examplesByStatusCode}
+                selectedExample={selectedExample}
+                setSelectedExampleKey={handleSelectExample}
+                getExampleId={getExampleId}
+            />
+        ) : (
+            <span className="text-sm t-muted line-clamp-1">{getExampleId(selectedExample)}</span>
+        );
 
     const [baseUrl, environmentId] = usePlaygroundBaseUrl(endpoint);
 
-    const filteredClientExamples = useMemo(() => {
-        const examples = examplesByClientAndTitleAndStatusCode?.[selectedClient.language];
-        if (examples == null) {
-            return [];
-        }
-        return Object.values(examples).flatMap((examplesByStatusCode) => {
-            const statusCode = selectedExample?.exampleCall.responseStatusCode;
-            if (statusCode == null || statusCode >= 400) {
-                return [];
-            }
-            return examplesByStatusCode[statusCode]?.filter((e) => !e.globalError) ?? [];
-        });
-    }, [examplesByClientAndTitleAndStatusCode, selectedClient.language, selectedExample]);
+    const segmentedControlExamples = useMemo(() => {
+        return Object.entries(examplesByKeyAndStatusCode)
+            .map(([exampleKey, examples]) => {
+                const examplesSorted = sortBy(Object.values(examples).flat(), [
+                    (example) => example.exampleCall.responseStatusCode,
+                ]);
+                return { exampleKey, examples: examplesSorted };
+            })
+            .filter(
+                ({ examples }) =>
+                    examples.length > 0 &&
+                    (examples.some((example) => example.exampleCall.responseStatusCode < 400) ||
+                        examples[0]?.name != null),
+            );
+    }, [examplesByKeyAndStatusCode]);
 
+    // note: .fern-endpoint-code-snippets is used to detect clicks outside of the code snippets
+    // this is used to clear the selected error when the user clicks outside of the error
     return (
         <div className="fern-endpoint-code-snippets" ref={ref}>
-            {/* TODO: Replace this with a proper segmented control component */}
-            {filteredClientExamples != null && filteredClientExamples.length > 1 && (
-                <FernButtonGroup className="min-w-0 shrink">
-                    {filteredClientExamples.map(
-                        (example) =>
-                            example && (
-                                <FernButton
-                                    key={example.key}
-                                    rounded={true}
-                                    onClick={() => {
-                                        onClickClient(example);
-                                        const foundExampleIndex = examplesByClientAndTitleAndStatusCode?.[
-                                            example.language
-                                        ]?.[example.key]?.[example.exampleCall.responseStatusCode ?? 0]?.findIndex(
-                                            (e) => e?.key === example.key,
-                                        );
-                                        setSelectedExampleKey([
-                                            example.language,
-                                            example.key,
-                                            example.exampleCall.responseStatusCode,
-                                            foundExampleIndex && foundExampleIndex >= 0 ? foundExampleIndex : 0,
-                                        ]);
-                                    }}
-                                    className="min-w-0 shrink truncate"
-                                    mono
-                                    size="small"
-                                    variant={example === selectedClient ? "outlined" : "minimal"}
-                                    intent={example === selectedClient ? "primary" : "none"}
-                                >
-                                    {example.name}
-                                </FernButton>
-                            ),
-                    )}
-                </FernButtonGroup>
+            {segmentedControlExamples.length > 1 && (
+                <EndpointExampleSegmentedControl
+                    segmentedControlExamples={segmentedControlExamples}
+                    selectedExample={selectedExample}
+                    onSelectExample={(exampleKey) => {
+                        setSelectedExampleKey((prev) => {
+                            if (prev.exampleKey === exampleKey) {
+                                return prev;
+                            }
+                            return { ...prev, exampleKey };
+                        });
+                    }}
+                />
             )}
             <CodeSnippetExample
                 title={
@@ -209,28 +167,25 @@ const UnmemoizedEndpointContentCodeSnippets: React.FC<EndpointContentCodeSnippet
                         {node != null && (
                             <PlaygroundButton
                                 state={node}
-                                // example={selectedClient.exampleCall}
+                                // example={selectedExample?.exampleCall}
                             />
                         )}
-                        {
-                            // filteredClientsByStatusCode != null && filteredClientsByStatusCode.length > 1 ? (
-                            clients.length > 1 ? (
-                                <CodeExampleClientDropdown
-                                    clients={clients}
-                                    onClickClient={onClickClient}
-                                    selectedClient={selectedClient}
-                                />
-                            ) : undefined
-                        }
+                        {languages.length > 1 && (
+                            <CodeExampleClientDropdown
+                                languages={languages}
+                                value={selectedLanguage}
+                                onValueChange={(language) => {
+                                    setSelectedExampleKey((prev) => ({ ...prev, language }));
+                                }}
+                            />
+                        )}
                     </>
                 }
                 code={resolveEnvironmentUrlInCodeSnippet(endpoint, requestCodeSnippet, baseUrl)}
-                language={selectedClient.language}
-                hoveredPropertyPath={selectedClient.language === "curl" ? hoveredRequestPropertyPath : undefined}
+                language={selectedLanguage}
+                hoveredPropertyPath={selectedLanguage === "curl" ? hoveredRequestPropertyPath : undefined}
                 json={requestCurlJson}
-                jsonStartLine={
-                    selectedClient.language === "curl" ? lineNumberOf(requestCodeSnippet, "-d '{") : undefined
-                }
+                jsonStartLine={selectedLanguage === "curl" ? lineNumberOf(requestCodeSnippet, "-d '{") : undefined}
             />
             {selectedExample != null && selectedExample.exampleCall.responseStatusCode >= 400 && (
                 <JsonCodeSnippetExample
@@ -300,23 +255,23 @@ const UnmemoizedEndpointContentCodeSnippets: React.FC<EndpointContentCodeSnippet
 
 export const EndpointContentCodeSnippets = memo(UnmemoizedEndpointContentCodeSnippets);
 
-function applyExampleIndex(name: string | undefined, exampleIndex?: number) {
-    return exampleIndex ? `${name} Example ${exampleIndex}` : name;
-}
+// function applyExampleIndex(name: string | undefined, exampleIndex?: number) {
+//     return exampleIndex ? `${name} Example ${exampleIndex}` : name;
+// }
 
-function renderErrorTitle(errorName: string | undefined, statusCode: number, exampleIndex?: number) {
-    return renderResponseTitle(
-        applyExampleIndex(errorName, exampleIndex) ?? ApiDefinition.getMessageForStatus(statusCode),
-        statusCode,
-    );
-}
+// function renderErrorTitle(errorName: string | undefined, statusCode: number, exampleIndex?: number) {
+//     return renderResponseTitle(
+//         applyExampleIndex(errorName, exampleIndex) ?? ApiDefinition.getMessageForStatus(statusCode),
+//         statusCode,
+//     );
+// }
 
-function renderExampleTitle(statusCode: number, method?: APIV1Read.HttpMethod, exampleIndex?: number) {
-    return renderResponseTitle(
-        applyExampleIndex(ApiDefinition.getMessageForStatus(statusCode, method), exampleIndex) ?? "Response",
-        statusCode,
-    );
-}
+// function renderExampleTitle(statusCode: number, method?: APIV1Read.HttpMethod, exampleIndex?: number) {
+//     return renderResponseTitle(
+//         applyExampleIndex(ApiDefinition.getMessageForStatus(statusCode, method), exampleIndex) ?? "Response",
+//         statusCode,
+//     );
+// }
 
 function renderResponseTitle(title: string, statusCode: number) {
     return (

--- a/packages/ui/app/src/api-reference/endpoints/EndpointExampleSegmentedControl.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointExampleSegmentedControl.tsx
@@ -1,0 +1,44 @@
+import { FernButton, FernButtonGroup } from "@fern-ui/components";
+import { ReactElement } from "react";
+import { CodeExample } from "../examples/code-example";
+
+export function EndpointExampleSegmentedControl({
+    segmentedControlExamples,
+    selectedExample,
+    onSelectExample,
+}: {
+    segmentedControlExamples: {
+        exampleKey: string;
+        examples: CodeExample[];
+    }[];
+    selectedExample: CodeExample | undefined;
+    onSelectExample: (exampleKey: string) => void;
+}): ReactElement {
+    // TODO: Replace this with a proper segmented control component
+    return (
+        <FernButtonGroup className="min-w-0 shrink">
+            {segmentedControlExamples.map(({ exampleKey, examples }) => {
+                const exampleIndex = examples[0]?.exampleIndex ?? 0;
+                return (
+                    <FernButton
+                        key={exampleKey}
+                        rounded={true}
+                        onClick={() => {
+                            onSelectExample(exampleKey);
+                        }}
+                        className="min-w-0 shrink truncate"
+                        mono
+                        size="small"
+                        variant={exampleKey === selectedExample?.exampleKey ? "outlined" : "minimal"}
+                        intent={exampleKey === selectedExample?.exampleKey ? "primary" : "none"}
+                    >
+                        {(exampleKey === selectedExample?.exampleKey ? selectedExample?.name : undefined) ??
+                            examples[0]?.name ??
+                            examples[0]?.exampleCall.name ??
+                            `Example ${exampleIndex + 1}`}
+                    </FernButton>
+                );
+            })}
+        </FernButtonGroup>
+    );
+}

--- a/packages/ui/app/src/api-reference/endpoints/example-groups.ts
+++ b/packages/ui/app/src/api-reference/endpoints/example-groups.ts
@@ -1,0 +1,222 @@
+import { ApiDefinition } from "@fern-api/fdr-sdk";
+import { isNonNullish } from "@fern-api/ui-core-utils";
+import { isEqual } from "es-toolkit";
+import { sortBy } from "es-toolkit/array";
+import { CodeExample } from "../examples/code-example";
+import {
+    ExamplesByKeyAndStatusCode,
+    ExamplesByLanguageKeyAndStatusCode,
+    ExamplesByStatusCode,
+    SelectedExampleKey,
+} from "../types/EndpointContent";
+
+/**
+ * Group examples by language, title, and status code.
+ *
+ * @param endpoint - The endpoint to group examples for.
+ * @returns An object where the keys are the language, exampleId, and statusCode, and the value is an array of code examples.
+ */
+export function groupExamplesByLanguageKeyAndStatusCode(
+    endpoint: ApiDefinition.EndpointDefinition,
+): ExamplesByLanguageKeyAndStatusCode {
+    const toRet: ExamplesByLanguageKeyAndStatusCode = {};
+
+    function addCodeExample(
+        key: { language: string; exampleKey: string; statusCode: number },
+        codeExample: CodeExample,
+    ): void {
+        const existing = (((toRet[key.language] ??= {})[key.exampleKey] ??= {})[key.statusCode] ??= []);
+        if (existing.some((e) => isEqual(e.exampleCall.responseBody, codeExample.exampleCall.responseBody))) {
+            return;
+        }
+        existing.push(codeExample);
+    }
+
+    endpoint.examples?.forEach((example, i) => {
+        if (example.snippets == null) {
+            return;
+        }
+
+        Object.entries(example.snippets).forEach(([language, snippets]) => {
+            snippets.forEach((snippet, j) => {
+                const statusCode = example.responseStatusCode;
+
+                const exampleKey = snippet.code;
+
+                const codeExample: CodeExample = {
+                    key: `${language}-${i},${j}`,
+                    exampleIndex: i,
+                    snippetIndex: j,
+                    exampleKey,
+                    language,
+                    name: snippet.name ?? example.name,
+                    code: snippet.code,
+                    install: snippet.install,
+                    exampleCall: example,
+                };
+                addCodeExample({ language, exampleKey, statusCode }, codeExample);
+
+                endpoint.errors?.forEach((error, k) => {
+                    error.examples?.forEach((errorExample, l) => {
+                        const codeExample: CodeExample = {
+                            key: `${language}-${i},${j},${k},${l}`,
+                            exampleIndex: i,
+                            snippetIndex: j,
+                            exampleKey,
+                            language,
+                            name: snippet.name ?? example.name,
+                            code: snippet.code,
+                            install: snippet.install,
+                            // HACK: this is a bit of a hack to append the global error to every example
+                            exampleCall: {
+                                ...example,
+                                responseStatusCode: error.statusCode,
+                                responseBody: errorExample.responseBody,
+                                name: errorExample.name ?? error.name,
+                            },
+                            globalError: true,
+                        };
+                        addCodeExample({ language, exampleKey, statusCode: error.statusCode }, codeExample);
+                    });
+                });
+            });
+        });
+    });
+
+    return toRet;
+}
+
+/**
+ * Get the available languages for a given endpoint.
+ *
+ * @param examples - The examples to get the available languages for.
+ * @param defaultLanguage - The default language to promote to the top of the list.
+ * @returns The available languages for the given endpoint in the order they should be displayed.
+ */
+export function getAvailableLanguages(examples: ExamplesByLanguageKeyAndStatusCode, defaultLanguage: string): string[] {
+    return sortBy(
+        Object.keys(examples).map((l) => ({ language: l })),
+        [
+            // promote the default language to the top of the list, otherwise promote curl
+            (l) => (examples[defaultLanguage] != null ? l.language !== defaultLanguage : l.language !== "curl"),
+            // sort the rest alphabetically
+            (l) => l.language,
+        ],
+    ).map((l) => l.language);
+}
+
+interface SelectExampleToRenderResponse {
+    selectedExampleKey: SelectedExampleKey;
+    selectedExample: CodeExample | undefined;
+    examplesByStatusCode: ExamplesByStatusCode;
+    examplesByKeyAndStatusCode: ExamplesByKeyAndStatusCode;
+}
+
+/**
+ * Select the example to render for a given key.
+ *
+ * @param examplesByLanguageKeyAndStatusCode - The examples to select the example to render for.
+ * @param key - The key to select the example to render for.
+ * @param defaultLanguage - The default language to use if the selected language is not found.
+ * @returns The selected example to render + additional metadata about the selected example.
+ */
+export function selectExampleToRender(
+    examplesByLanguageKeyAndStatusCode: ExamplesByLanguageKeyAndStatusCode,
+    key: SelectedExampleKey,
+    defaultLanguage: string,
+): SelectExampleToRenderResponse {
+    const { language, exampleKey, statusCode, responseIndex } = key;
+
+    // prefer the selected language, otherwise pick the first available language
+    const examplesByKeyAndStatusCode =
+        examplesByLanguageKeyAndStatusCode[language] ??
+        examplesByLanguageKeyAndStatusCode[
+            getAvailableLanguages(examplesByLanguageKeyAndStatusCode, defaultLanguage)[0] ?? ""
+        ] ??
+        {};
+
+    // prefer the selected exampleId, otherwise pick the first available exampleId
+    const examplesByStatusCode =
+        examplesByKeyAndStatusCode[exampleKey ?? ""] ??
+        examplesByKeyAndStatusCode[Object.keys(examplesByKeyAndStatusCode)[0] ?? ""] ??
+        {};
+
+    // if the status code is defined and there are examples for it, we attempt to use the example at the given index. Otherwise, fall back to the first example in that list.
+    // this is the most specific example we can find
+    let selectedExample = examplesByStatusCode[statusCode ?? ""]?.[responseIndex ?? 0];
+
+    // if the status code is not found, we should attempt to find a different example that has the same status code
+    if (statusCode != null) {
+        selectedExample ??= Object.values(examplesByKeyAndStatusCode).find((examplesByStatusCode) => {
+            const examples = examplesByStatusCode[statusCode];
+            return examples != null && examples.length > 0;
+        })?.[statusCode]?.[0];
+    }
+
+    // as a fallback, we attempt to use the first example under the current exampleId.
+    // the exampleIndex is no longer relevant here, since we're using a fallback, so just return the first found example.
+    selectedExample ??= Object.keys(examplesByStatusCode)
+        .sort()
+        .map((statusCode) => examplesByStatusCode[statusCode])
+        .filter(isNonNullish)
+        .find((examples) => examples.length > 0)?.[0];
+
+    // if all else fails, lets return the first example that can be found under the selected language
+    selectedExample ??= Object.values(examplesByKeyAndStatusCode)
+        .flatMap((examples) => Object.values(examples))
+        .flat()[0];
+
+    // if that fails, then the current language has no examples, so we'll choose the first language
+    selectedExample ??= Object.values(
+        examplesByLanguageKeyAndStatusCode[
+            getAvailableLanguages(examplesByLanguageKeyAndStatusCode, defaultLanguage)[0] ?? ""
+        ] ?? {},
+    )
+        .flatMap((examples) => Object.values(examples))
+        .flat()[0];
+
+    // reverse lookup the selected example to get the actual key, examplesByStatusCode, and examplesByKeyAndStatusCode
+    const reverseLookup =
+        selectedExample != null
+            ? reverseLookupSelectedExample(examplesByLanguageKeyAndStatusCode, selectedExample)
+            : undefined;
+
+    return {
+        selectedExampleKey: reverseLookup?.key ?? key,
+        selectedExample,
+        examplesByStatusCode: reverseLookup?.examplesByStatusCode ?? examplesByStatusCode,
+        examplesByKeyAndStatusCode: reverseLookup?.examplesByKeyAndStatusCode ?? examplesByKeyAndStatusCode,
+    };
+}
+
+/**
+ * Reverse lookup the selected example to get the key, examplesByStatusCode, and examplesByKeyAndStatusCode.
+ *
+ * @param examplesByLanguageKeyAndStatusCode - The examples to reverse lookup.
+ * @param selectedExample - The example to reverse lookup.
+ * @returns The key, examplesByStatusCode, and examplesByKeyAndStatusCode for the selected example.
+ */
+export function reverseLookupSelectedExample(
+    examplesByLanguageKeyAndStatusCode: ExamplesByLanguageKeyAndStatusCode,
+    selectedExample: CodeExample,
+): {
+    key: SelectedExampleKey;
+    examplesByStatusCode: ExamplesByStatusCode;
+    examplesByKeyAndStatusCode: ExamplesByKeyAndStatusCode;
+} {
+    const examplesByKeyAndStatusCode = examplesByLanguageKeyAndStatusCode[selectedExample.language] ?? {};
+    const examplesByStatusCode = examplesByKeyAndStatusCode[selectedExample.exampleKey] ?? {};
+    const statusCode = String(selectedExample.exampleCall.responseStatusCode);
+    const examples = examplesByStatusCode[statusCode] ?? [];
+    const index = examples.findIndex((e) => e.key === selectedExample.key);
+    return {
+        key: {
+            language: selectedExample.language,
+            exampleKey: selectedExample.exampleKey,
+            statusCode,
+            responseIndex: index,
+        },
+        examplesByStatusCode,
+        examplesByKeyAndStatusCode,
+    };
+}

--- a/packages/ui/app/src/api-reference/endpoints/useExampleSelection.ts
+++ b/packages/ui/app/src/api-reference/endpoints/useExampleSelection.ts
@@ -3,7 +3,7 @@ import { SetStateAction, atom, useAtom, useAtomValue } from "jotai";
 import { RESET, atomWithDefault } from "jotai/utils";
 import { useMemo } from "react";
 import { useCallbackOne, useMemoOne } from "use-memo-one";
-import { DEFAULT_LANGUAGE_ATOM, FERN_LANGUAGE_ATOM } from "../../atoms";
+import { DEFAULT_LANGUAGE_ATOM, FERN_LANGUAGE_ATOM, useAtomEffect } from "../../atoms";
 import { CodeExample } from "../examples/code-example";
 import {
     getAvailableLanguages,
@@ -84,6 +84,22 @@ export function useExampleSelection(
                 },
             );
         }, [getInitialExampleKey]),
+    );
+
+    // when the language changes, we'd want to update the selected example key to the new language
+    useAtomEffect(
+        useCallbackOne(
+            (get) => {
+                setSelectedExampleKey((prev) => {
+                    const language = get(FERN_LANGUAGE_ATOM) ?? get(DEFAULT_LANGUAGE_ATOM);
+                    if (prev.language !== language) {
+                        return { ...prev, language };
+                    }
+                    return prev;
+                });
+            },
+            [setSelectedExampleKey],
+        ),
     );
 
     const defaultLanguage = useAtomValue(DEFAULT_LANGUAGE_ATOM);

--- a/packages/ui/app/src/api-reference/endpoints/useExampleSelection.ts
+++ b/packages/ui/app/src/api-reference/endpoints/useExampleSelection.ts
@@ -1,0 +1,110 @@
+import { EndpointDefinition } from "@fern-api/fdr-sdk/api-definition";
+import { SetStateAction, atom, useAtom, useAtomValue } from "jotai";
+import { RESET, atomWithDefault } from "jotai/utils";
+import { useMemo } from "react";
+import { useCallbackOne, useMemoOne } from "use-memo-one";
+import { DEFAULT_LANGUAGE_ATOM, FERN_LANGUAGE_ATOM } from "../../atoms";
+import { CodeExample } from "../examples/code-example";
+import {
+    getAvailableLanguages,
+    groupExamplesByLanguageKeyAndStatusCode,
+    selectExampleToRender,
+} from "../examples/example-groups";
+import { ExamplesByKeyAndStatusCode, ExamplesByStatusCode, SelectedExampleKey } from "../types/EndpointContent";
+
+export function useExampleSelection(
+    endpoint: EndpointDefinition,
+    initialExampleId?: string,
+): {
+    selectedExample: CodeExample | undefined;
+    examplesByStatusCode: ExamplesByStatusCode;
+    examplesByKeyAndStatusCode: ExamplesByKeyAndStatusCode;
+    selectedExampleKey: SelectedExampleKey;
+    defaultLanguage: string;
+    availableLanguages: string[];
+    setSelectedExampleKey: (update: typeof RESET | SetStateAction<SelectedExampleKey>) => void;
+} {
+    const examplesByLanguageKeyAndStatusCode = useMemo(
+        () => groupExamplesByLanguageKeyAndStatusCode(endpoint),
+        [endpoint],
+    );
+
+    const getInitialExampleKey = useCallbackOne(
+        (language: string): SelectedExampleKey => {
+            if (initialExampleId == null) {
+                return {
+                    language,
+                    exampleKey: undefined,
+                    statusCode: undefined,
+                    responseIndex: undefined,
+                };
+            }
+            const allExamples = Object.values(examplesByLanguageKeyAndStatusCode[language] ?? {})
+                .flatMap((e) => Object.values(e))
+                .flat();
+
+            const example = allExamples.find(
+                (e) => e.name === initialExampleId || e.exampleCall.name === initialExampleId,
+            );
+            if (example == null) {
+                return {
+                    language,
+                    exampleKey: undefined,
+                    statusCode: undefined,
+                    responseIndex: undefined,
+                };
+            }
+
+            return {
+                language,
+                exampleKey: example.exampleKey,
+                statusCode: String(example.exampleCall.responseStatusCode),
+                responseIndex: undefined,
+            };
+        },
+        [examplesByLanguageKeyAndStatusCode, initialExampleId],
+    );
+
+    // We use a string here with the intention that this can be used in a query param to deeplink to a particular example
+    const [internalSelectedExampleKey, setSelectedExampleKey] = useAtom(
+        useMemoOne(() => {
+            const internalAtom = atomWithDefault<SelectedExampleKey>((get) => {
+                return getInitialExampleKey(get(FERN_LANGUAGE_ATOM) ?? get(DEFAULT_LANGUAGE_ATOM));
+            });
+
+            return atom(
+                (get) => get(internalAtom),
+                (get, set, update: SetStateAction<SelectedExampleKey> | typeof RESET) => {
+                    const prev = get(internalAtom);
+                    const next = typeof update === "function" ? update(prev) : update;
+                    if (next !== RESET) {
+                        set(FERN_LANGUAGE_ATOM, next.language);
+                    }
+                    set(internalAtom, next);
+                },
+            );
+        }, [getInitialExampleKey]),
+    );
+
+    const defaultLanguage = useAtomValue(DEFAULT_LANGUAGE_ATOM);
+
+    const availableLanguages = useMemo(
+        () => getAvailableLanguages(examplesByLanguageKeyAndStatusCode, defaultLanguage),
+        [examplesByLanguageKeyAndStatusCode, defaultLanguage],
+    );
+
+    const { selectedExample, examplesByStatusCode, examplesByKeyAndStatusCode, selectedExampleKey } = useMemo(
+        () => selectExampleToRender(examplesByLanguageKeyAndStatusCode, internalSelectedExampleKey, defaultLanguage),
+        [defaultLanguage, examplesByLanguageKeyAndStatusCode, internalSelectedExampleKey],
+    );
+
+    return {
+        selectedExample,
+        examplesByStatusCode,
+        examplesByKeyAndStatusCode,
+        selectedExampleKey,
+        defaultLanguage,
+        availableLanguages,
+        setSelectedExampleKey,
+    };
+}

--- a/packages/ui/app/src/api-reference/examples/code-example.ts
+++ b/packages/ui/app/src/api-reference/examples/code-example.ts
@@ -23,66 +23,6 @@ export interface CodeExampleGroup {
     examples: CodeExample[];
 }
 
-// // key is the language
-// export function generateCodeExamples(
-//     examples: ApiDefinition.ExampleEndpointCall[] | undefined,
-//     grpc: boolean = false,
-// ): CodeExampleGroup[] {
-//     const codeExamples = new Map<string, CodeExample[]>();
-//     examples?.forEach((example, i) => {
-//         if (example.snippets == null) {
-//             return;
-//         }
-//         Object.values(example.snippets).forEach((snippets) => {
-//             snippets.forEach((snippet, j) => {
-//                 if (!grpc || snippet.language !== "curl") {
-//                     codeExamples.set(snippet.language, [
-//                         ...(codeExamples.get(snippet.language) ?? []),
-//                         {
-//                             key: `${snippet.language}-${i}/${j}`,
-//                             exampleIndex: i,
-//                             language: snippet.language,
-//                             name: snippet.name ?? example.name ?? `Example ${i + 1}`,
-//                             code: snippet.code,
-//                             // hast: snippet.hast,
-//                             install: snippet.install,
-//                             exampleCall: example,
-//                         },
-//                     ]);
-//                 }
-//             });
-//         });
-//     });
-
-//     // always keep curl at the top
-//     const curlExamples = codeExamples.get("curl");
-//     codeExamples.delete("curl");
-
-//     // TODO: remove after pinecone examples
-//     const examplesByLanguage = grpc
-//         ? []
-//         : [
-//               {
-//                   language: "curl",
-//                   languageDisplayName: "cURL",
-//                   icon: getIconForClient("curl"),
-//                   examples: [...(curlExamples ?? [])],
-//               },
-//           ];
-
-//     return examplesByLanguage.concat([
-//         ...sortBy(
-//             Array.from(codeExamples.entries()).map(([language, examples]) => ({
-//                 language,
-//                 languageDisplayName: getLanguageDisplayName(language),
-//                 icon: getIconForClient(language),
-//                 examples,
-//             })),
-//             ["language"],
-//         ),
-//     ]);
-// }
-
 export function getIconForClient(language: string): string {
     switch (language) {
         case "curl":
@@ -135,26 +75,3 @@ export function getLanguageDisplayName(language: string): string {
             return titleCase(language);
     }
 }
-
-// export interface CodeExampleClientCurl {
-//     id: "curl";
-//     name: string;
-// }
-
-// export interface PythonCodeExample {
-//     id: "python" | "python-async";
-//     name: string;
-//     language: string;
-//     example: string;
-// }
-
-// export interface TypescriptCodeExample {
-//     id: "typescript";
-//     name: string;
-//     language: string;
-//     example: string;
-// }
-
-// export type CodeExampleClient = CodeExampleClientCurl | PythonCodeExample | TypescriptCodeExample;
-
-// export type CodeExampleClientId = CodeExampleClient["id"];

--- a/packages/ui/app/src/api-reference/examples/example-groups.ts
+++ b/packages/ui/app/src/api-reference/examples/example-groups.ts
@@ -2,13 +2,13 @@ import { ApiDefinition } from "@fern-api/fdr-sdk";
 import { isNonNullish } from "@fern-api/ui-core-utils";
 import { isEqual } from "es-toolkit";
 import { sortBy } from "es-toolkit/array";
-import { CodeExample } from "../examples/code-example";
 import {
     ExamplesByKeyAndStatusCode,
     ExamplesByLanguageKeyAndStatusCode,
     ExamplesByStatusCode,
     SelectedExampleKey,
 } from "../types/EndpointContent";
+import { CodeExample } from "./code-example";
 
 /**
  * Group examples by language, title, and status code.

--- a/packages/ui/app/src/api-reference/types/EndpointContent.tsx
+++ b/packages/ui/app/src/api-reference/types/EndpointContent.tsx
@@ -1,14 +1,31 @@
 import { CodeExample } from "../examples/code-example";
 
 export type Language = string;
-export type ExampleId = string;
-export type StatusCode = number;
-export type ExampleIndex = number;
+export type StatusCode = string;
+export type ExampleKey = string;
 
 export type ExamplesByStatusCode = Record<StatusCode, CodeExample[]>;
-export type ExamplesByTitleAndStatusCode = Record<ExampleId, Record<StatusCode, CodeExample[]>>;
-export type ExamplesByClientAndTitleAndStatusCode = Record<
-    Language,
-    Record<ExampleId, Record<StatusCode, CodeExample[]>>
->;
-export type SelectedExampleKey = [Language, ExampleId | undefined, StatusCode | undefined, ExampleIndex | undefined];
+export type ExamplesByKeyAndStatusCode = Record<ExampleKey, ExamplesByStatusCode>;
+export type ExamplesByLanguageKeyAndStatusCode = Record<Language, ExamplesByKeyAndStatusCode>;
+
+/**
+ * This is a compound key that is used to index into ExamplesByLanguageKeyAndStatusCode.
+ */
+export type SelectedExampleKey = {
+    /**
+     * language of the example i.e. "typescript" or "curl"
+     */
+    language: Language;
+    /**
+     * join of exampleIndex and snippetIndex
+     */
+    exampleKey: ExampleKey | undefined;
+    /**
+     * status code of the example (as a string) i.e. "200"
+     */
+    statusCode: StatusCode | undefined;
+    /**
+     * index of the example in the values of ExamplesByStatusCode
+     */
+    responseIndex: number | undefined;
+};

--- a/packages/ui/app/src/atoms/lang.ts
+++ b/packages/ui/app/src/atoms/lang.ts
@@ -1,3 +1,4 @@
+import { ApiDefinition } from "@fern-api/fdr-sdk";
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { DOCS_ATOM } from "./docs";
@@ -8,8 +9,16 @@ const INTERNAL_FERN_LANGUAGE_ATOM = atomWithStorage<string | undefined>("fern-la
 INTERNAL_FERN_LANGUAGE_ATOM.debugLabel = "INTERNAL_FERN_LANGUAGE_ATOM";
 
 export const FERN_LANGUAGE_ATOM = atom(
-    (get) => get(INTERNAL_FERN_LANGUAGE_ATOM) ?? get(DOCS_ATOM).defaultLang,
+    (get) => {
+        const lang = get(INTERNAL_FERN_LANGUAGE_ATOM);
+        if (lang == null) {
+            return undefined;
+        }
+        return ApiDefinition.cleanLanguage(lang);
+    },
     (_get, set, update: string) => {
         set(INTERNAL_FERN_LANGUAGE_ATOM, update);
     },
 );
+
+export const DEFAULT_LANGUAGE_ATOM = atom<string>((get) => ApiDefinition.cleanLanguage(get(DOCS_ATOM).defaultLang));

--- a/packages/ui/app/src/mdx/components/client-libraries/ClientLibraries.tsx
+++ b/packages/ui/app/src/mdx/components/client-libraries/ClientLibraries.tsx
@@ -1,9 +1,10 @@
 import { FernSdk } from "@fern-ui/components";
-import { useAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import { ComponentProps, FC } from "react";
-import { FERN_LANGUAGE_ATOM } from "../../../atoms";
+import { DEFAULT_LANGUAGE_ATOM, FERN_LANGUAGE_ATOM } from "../../../atoms";
 
 export const ClientLibraries: FC<Pick<ComponentProps<typeof FernSdk>, "sdks">> = ({ sdks }) => {
     const [selectedLanguage, setSelectedLanguage] = useAtom(FERN_LANGUAGE_ATOM);
-    return <FernSdk sdks={sdks} language={selectedLanguage} onChange={setSelectedLanguage} />;
+    const defaultLanguage = useAtomValue(DEFAULT_LANGUAGE_ATOM);
+    return <FernSdk sdks={sdks} language={selectedLanguage ?? defaultLanguage} onChange={setSelectedLanguage} />;
 };

--- a/packages/ui/app/src/mdx/components/snippets/EndpointRequestSnippet.tsx
+++ b/packages/ui/app/src/mdx/components/snippets/EndpointRequestSnippet.tsx
@@ -1,14 +1,14 @@
 import type * as ApiDefinition from "@fern-api/fdr-sdk/api-definition";
 import { EMPTY_OBJECT } from "@fern-api/ui-core-utils";
-import { ReactElement, useMemo } from "react";
+import { ReactElement } from "react";
 import { CodeExampleClientDropdown } from "../../../api-reference/endpoints/CodeExampleClientDropdown";
 import { EndpointUrlWithOverflow } from "../../../api-reference/endpoints/EndpointUrlWithOverflow";
+import { useExampleSelection } from "../../../api-reference/endpoints/useExampleSelection";
 import { CodeSnippetExample } from "../../../api-reference/examples/CodeSnippetExample";
-import { generateCodeExamples } from "../../../api-reference/examples/code-example";
 import { usePlaygroundBaseUrl } from "../../../playground/utils/select-environment";
 import { RequestSnippet } from "./types";
 import { useFindEndpoint } from "./useFindEndpoint";
-import { extractEndpointPathAndMethod, useSelectedClient } from "./utils";
+import { extractEndpointPathAndMethod } from "./utils";
 
 export const EndpointRequestSnippet: React.FC<React.PropsWithChildren<RequestSnippet.Props>> = ({
     endpoint: endpointLocator,
@@ -44,11 +44,14 @@ export function EndpointRequestSnippetInternal({
     endpoint: ApiDefinition.EndpointDefinition;
     example: string | undefined;
 }): ReactElement | null {
-    const clients = useMemo(() => generateCodeExamples(endpoint.examples), [endpoint.examples]);
-    const [selectedClient, setSelectedClient] = useSelectedClient(clients, example);
+    const { selectedExample, selectedExampleKey, availableLanguages, setSelectedExampleKey } = useExampleSelection(
+        endpoint,
+        example,
+    );
+
     const [baseUrl, selectedEnvironmentId] = usePlaygroundBaseUrl(endpoint);
 
-    if (selectedClient == null) {
+    if (selectedExample == null) {
         return null;
     }
 
@@ -66,19 +69,19 @@ export function EndpointRequestSnippetInternal({
                 }
                 actions={
                     <>
-                        {clients.length > 1 && (
+                        {availableLanguages.length > 1 && (
                             <CodeExampleClientDropdown
-                                clients={clients}
-                                onClickClient={setSelectedClient}
-                                selectedClient={selectedClient}
+                                languages={availableLanguages}
+                                onValueChange={(language) => setSelectedExampleKey((prev) => ({ ...prev, language }))}
+                                value={selectedExampleKey.language}
                             />
                         )}
                         {/* TODO: Restore this button */}
                         {/* <ApiReferenceButton slug={endpoint.slug} /> */}
                     </>
                 }
-                code={selectedClient.code}
-                language={selectedClient.language}
+                code={selectedExample.code}
+                language={selectedExampleKey.language}
                 json={EMPTY_OBJECT}
                 scrollAreaStyle={{ maxHeight: "500px" }}
             />

--- a/packages/ui/app/src/mdx/components/snippets/EndpointResponseSnippet.tsx
+++ b/packages/ui/app/src/mdx/components/snippets/EndpointResponseSnippet.tsx
@@ -1,9 +1,9 @@
-import { useMemo } from "react";
+import { EndpointDefinition, HttpMethod } from "@fern-api/fdr-sdk/api-definition";
+import { useExampleSelection } from "../../../api-reference/endpoints/useExampleSelection";
 import { CodeSnippetExample } from "../../../api-reference/examples/CodeSnippetExample";
-import { generateCodeExamples } from "../../../api-reference/examples/code-example";
 import { RequestSnippet } from "./types";
 import { useFindEndpoint } from "./useFindEndpoint";
-import { extractEndpointPathAndMethod, useSelectedClient } from "./utils";
+import { extractEndpointPathAndMethod } from "./utils";
 
 export const EndpointResponseSnippet: React.FC<React.PropsWithChildren<RequestSnippet.Props>> = ({
     endpoint: endpointLocator,
@@ -18,21 +18,34 @@ export const EndpointResponseSnippet: React.FC<React.PropsWithChildren<RequestSn
     return <EndpointResponseSnippetInternal method={method} path={path} example={example} />;
 };
 
-const EndpointResponseSnippetInternal: React.FC<React.PropsWithChildren<RequestSnippet.InternalProps>> = ({
+function EndpointResponseSnippetInternal({
     path,
     method,
     example,
-}) => {
+}: {
+    path: string;
+    method: HttpMethod;
+    example: string | undefined;
+}) {
     const endpoint = useFindEndpoint(method, path);
-
-    const clients = useMemo(() => generateCodeExamples(endpoint?.examples ?? []), [endpoint?.examples]);
-    const [selectedClient] = useSelectedClient(clients, example);
 
     if (endpoint == null) {
         return null;
     }
 
-    const responseJson = selectedClient?.exampleCall.responseBody?.value;
+    return <EndpointResponseSnippetRenderer endpoint={endpoint} example={example} />;
+}
+
+function EndpointResponseSnippetRenderer({
+    endpoint,
+    example,
+}: {
+    endpoint: EndpointDefinition;
+    example: string | undefined;
+}) {
+    const { selectedExample } = useExampleSelection(endpoint, example);
+
+    const responseJson = selectedExample?.exampleCall.responseBody?.value;
 
     if (responseJson == null) {
         return null;
@@ -52,4 +65,4 @@ const EndpointResponseSnippetInternal: React.FC<React.PropsWithChildren<RequestS
             />
         </div>
     );
-};
+}

--- a/packages/ui/app/src/mdx/components/snippets/utils.tsx
+++ b/packages/ui/app/src/mdx/components/snippets/utils.tsx
@@ -1,26 +1,4 @@
 import { APIV1Read } from "@fern-api/fdr-sdk/client/types";
-import { useAtom } from "jotai";
-import { useCallback } from "react";
-import { CodeExample, CodeExampleGroup } from "../../../api-reference/examples/code-example";
-import { FERN_LANGUAGE_ATOM } from "../../../atoms";
-
-export function useSelectedClient(
-    clients: CodeExampleGroup[],
-    exampleName: string | undefined,
-): [CodeExample | undefined, (nextClient: CodeExample) => void] {
-    const [selectedLanguage, setSelectedLanguage] = useAtom(FERN_LANGUAGE_ATOM);
-    const client = clients.find((c) => c.language === selectedLanguage) ?? clients[0];
-    const selectedClient = exampleName ? client?.examples.find((e) => e.name === exampleName) : client?.examples[0];
-
-    const handleClickClient = useCallback(
-        (nextClient: CodeExample) => {
-            setSelectedLanguage(nextClient.language);
-        },
-        [setSelectedLanguage],
-    );
-
-    return [selectedClient, handleClickClient];
-}
 
 export function extractEndpointPathAndMethod(endpoint: string): [APIV1Read.HttpMethod | undefined, string | undefined] {
     const [maybeMethod, path] = endpoint.split(" ");


### PR DESCRIPTION
- rewrote the logic that generates the complex input shape for code snippets
- key by request code, and dedupe by response json
- added plenty of redundancies in "selecting" the code example, so that it should never fail to resolve a request/response shape despite external influences (i.e. local storage, which was previously causing examples to disappear)
- clicking outside of the errors block will deselect the error snippet on the right
- slightly improved the rendering of the select dropdown