### PR TITLE
fix: header fields in the api playground, and resetting user-entered token

### DIFF
--- a/packages/ui/app/src/playground/auth/PlaygroundAuthorizationFormCard.tsx
+++ b/packages/ui/app/src/playground/auth/PlaygroundAuthorizationFormCard.tsx
@@ -3,7 +3,7 @@ import { FernButton, FernCollapse } from "@fern-ui/components";
 import { useBooleanState } from "@fern-ui/react-commons";
 import { useSetAtom } from "jotai/react";
 import { ReactElement } from "react";
-import { PLAYGROUND_AUTH_STATE_BEARER_TOKEN_ATOM } from "../../atoms";
+import { PLAYGROUND_AUTH_STATE_BEARER_TOKEN_ATOM, PLAYGROUND_AUTH_STATE_OAUTH_ATOM } from "../../atoms";
 import { useApiKeyInjectionConfig } from "../../services/useApiKeyInjectionConfig";
 import { PlaygroundAuthorizationForm } from "./PlaygroundAuthorizationForm";
 import { PlaygroundCardTriggerApiKeyInjected } from "./PlaygroundCardTriggerApiKeyInjected";
@@ -18,12 +18,14 @@ export function PlaygroundAuthorizationFormCard({
     disabled,
 }: PlaygroundAuthorizationFormCardProps): ReactElement | null {
     const setBearerAuth = useSetAtom(PLAYGROUND_AUTH_STATE_BEARER_TOKEN_ATOM);
+    const setOAuth = useSetAtom(PLAYGROUND_AUTH_STATE_OAUTH_ATOM);
     const isOpen = useBooleanState(false);
     const apiKeyInjection = useApiKeyInjectionConfig();
     const apiKey = apiKeyInjection.enabled && apiKeyInjection.authenticated ? apiKeyInjection.access_token : null;
 
     const handleResetBearerAuth = () => {
         setBearerAuth({ token: apiKey ?? "" });
+        setOAuth((prev) => ({ ...prev, userSuppliedAccessToken: "" }));
     };
 
     return (

--- a/packages/ui/app/src/playground/auth/PlaygroundCardTriggerApiKeyInjected.tsx
+++ b/packages/ui/app/src/playground/auth/PlaygroundCardTriggerApiKeyInjected.tsx
@@ -63,7 +63,7 @@ export function PlaygroundCardTriggerApiKeyInjected({
         }
     };
 
-    if (apiKey != null) {
+    if (apiKey != null && apiKey.trim().length > 0) {
         return (
             <FernCard className="rounded-xl p-4 shadow-sm mb-3" title="Login to send a real request">
                 <FernButton

--- a/packages/ui/app/src/playground/endpoint/PlaygroundEndpointForm.tsx
+++ b/packages/ui/app/src/playground/endpoint/PlaygroundEndpointForm.tsx
@@ -107,7 +107,7 @@ export const PlaygroundEndpointForm: FC<PlaygroundEndpointFormProps> = ({
                         properties={headers}
                         extraProperties={undefined}
                         onChange={setHeaders}
-                        value={headers}
+                        value={formState?.headers}
                         types={types}
                     />
                 </PlaygroundEndpointFormSection>


### PR DESCRIPTION
- header fields in the api playground passed in the wrong "value" field, which made it impossible to type and update the header state
- if the injected api key is `""`, don't treat it as "logged in"
- when clicking "reset", reset not only the bearer token but also the user-entered bearer token