### PR TITLE
chore(generator-cli): remove `union-utils` from sdk generation

### DIFF
--- a/fern/apis/generator-cli/generators.yml
+++ b/fern/apis/generator-cli/generators.yml
@@ -33,8 +33,6 @@ groups:
           package-name: "fern-fern-generator-cli-sdk"
         config:
           package_name: "generatorcli"
-          pydantic_config:
-            include_union_utils: true
 
       - name: fernapi/fern-go-sdk
         version: 0.22.0


### PR DESCRIPTION
Union utils is broken on the latest python generator.
