### PR TITLE
fix: basepath regression

### DIFF
--- a/packages/ui/app/src/api-reference/endpoints/EndpointUrl.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointUrl.tsx
@@ -125,7 +125,7 @@ export const EndpointUrl = React.forwardRef<HTMLDivElement, PropsWithChildren<En
                                             />
                                         </span>
                                     )}
-                                    {!showEnvironment && environmentBasepath && (
+                                    {!showEnvironment && environmentBasepath && environmentBasepath !== "/" && (
                                         <span className="t-muted">{environmentBasepath}</span>
                                     )}
                                     {pathParts}


### PR DESCRIPTION
regression introduced in https://github.com/fern-api/fern-platform/pull/1818 was adding an additional `/` to the beginning of each endpoint