### PR TITLE
feat: support raw markdown

### DIFF
--- a/packages/ui/docs-bundle/src/middleware.ts
+++ b/packages/ui/docs-bundle/src/middleware.ts
@@ -8,6 +8,7 @@ import { withPathname } from "./server/withPathname";
 
 const API_FERN_DOCS_PATTERN = /^(?!\/api\/fern-docs\/).*(\/api\/fern-docs\/)/;
 const CHANGELOG_PATTERN = /\.(rss|atom)$/;
+const MARKDOWN_PATTERN = /\.(md|mdx)$/;
 
 export const middleware: NextMiddleware = async (request) => {
     let pathname = extractNextDataPathname(removeTrailingSlash(request.nextUrl.pathname));
@@ -71,8 +72,23 @@ export const middleware: NextMiddleware = async (request) => {
     const changelogFormat = pathname.match(CHANGELOG_PATTERN)?.[1];
     if (changelogFormat != null) {
         pathname = pathname.replace(new RegExp(`.${changelogFormat}$`), "");
+        if (pathname === "/index") {
+            pathname = "/";
+        }
         const url = new URL("/api/fern-docs/changelog", request.nextUrl.origin);
         url.searchParams.set("format", changelogFormat);
+        url.searchParams.set("path", pathname);
+        return NextResponse.rewrite(String(url));
+    }
+
+    const markdownExtension = pathname.match(MARKDOWN_PATTERN)?.[1];
+    if (markdownExtension != null) {
+        pathname = pathname.replace(new RegExp(`.${markdownExtension}$`), "");
+        if (pathname === "/index") {
+            pathname = "/";
+        }
+        const url = new URL("/api/fern-docs/markdown", request.nextUrl.origin);
+        url.searchParams.set("format", markdownExtension);
         url.searchParams.set("path", pathname);
         return NextResponse.rewrite(String(url));
     }

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/markdown.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/markdown.ts
@@ -7,8 +7,6 @@ import { getFrontmatter } from "@fern-ui/fern-docs-mdx";
 import { COOKIE_FERN_TOKEN } from "@fern-ui/fern-docs-utils";
 import { NextApiRequest, NextApiResponse } from "next";
 
-export const revalidate = 60;
-
 function getStringParam(req: NextApiRequest, param: string): string | undefined {
     const value = req.query[param];
     return typeof value === "string" ? value : undefined;
@@ -77,7 +75,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     res.status(200)
         .setHeader("Content-Type", `text/${extension === "mdx" ? "mdx" : "markdown"}`)
-        .setHeader("X-Robots-Tag", "noindex");
+        .setHeader("X-Robots-Tag", "noindex")
+        // cannot guarantee that the content won't change, so we only cache for 60 seconds
+        .setHeader("Cache-Control", "s-maxage=60");
 
     if (node.node.canonicalSlug !== node.node.slug) {
         res.setHeader(

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/markdown.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/markdown.ts
@@ -1,0 +1,90 @@
+import { DocsLoader } from "@/server/DocsLoader";
+import { removeLeadingSlash } from "@/server/removeLeadingSlash";
+import { getDocsDomainNode, getHostNode } from "@/server/xfernhost/node";
+import { FernNavigation } from "@fern-api/fdr-sdk";
+import { withDefaultProtocol } from "@fern-api/ui-core-utils";
+import { getFrontmatter } from "@fern-ui/fern-docs-mdx";
+import { COOKIE_FERN_TOKEN } from "@fern-ui/fern-docs-utils";
+import { NextApiRequest, NextApiResponse } from "next";
+
+export const revalidate = 60;
+
+function getStringParam(req: NextApiRequest, param: string): string | undefined {
+    const value = req.query[param];
+    return typeof value === "string" ? value : undefined;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<unknown> {
+    const path = getStringParam(req, "path");
+    const format = getStringParam(req, "format");
+
+    if (path == null || format == null) {
+        return res.status(400).end();
+    }
+
+    if (req.method === "OPTIONS") {
+        return res.status(200).setHeader("X-Robots-Tag", "noindex").setHeader("Allow", "OPTIONS, GET").end();
+    }
+
+    if (req.method !== "GET") {
+        return res.status(405).end();
+    }
+
+    const domain = getDocsDomainNode(req);
+    const host = getHostNode(req) ?? domain;
+    const fern_token = req.cookies[COOKIE_FERN_TOKEN];
+    const loader = DocsLoader.for(domain, host, fern_token);
+
+    const root = await loader.root();
+    if (!root) {
+        return res.status(404).end();
+    }
+
+    const node = FernNavigation.utils.findNode(root, FernNavigation.Slug(removeLeadingSlash(path)));
+
+    if (node.type !== "found") {
+        return res.status(404).end();
+    }
+
+    if (!FernNavigation.hasMarkdown(node.node)) {
+        return res.status(404).end();
+    }
+
+    const pageId = FernNavigation.getPageId(node.node);
+
+    if (!pageId) {
+        return res.status(404).end();
+    }
+
+    const extension = pageId.endsWith(".mdx") ? "mdx" : "md";
+
+    if (format !== extension) {
+        return res.status(404).end();
+    }
+
+    const pages = await loader.pages();
+
+    const page = pages[pageId];
+
+    if (!page) {
+        return res.status(404).end();
+    }
+
+    const { data: frontmatter, content } = getFrontmatter(page.markdown);
+
+    // TODO: parse the first h1 as the title
+    const title = frontmatter.title ?? node.node.title;
+
+    res.status(200)
+        .setHeader("Content-Type", `text/${extension === "mdx" ? "mdx" : "markdown"}`)
+        .setHeader("X-Robots-Tag", "noindex");
+
+    if (node.node.canonicalSlug !== node.node.slug) {
+        res.setHeader(
+            "Link",
+            `<${String(new URL(`/${node.node.canonicalSlug}.${extension}`, withDefaultProtocol(host)))}>; rel="canonical"`,
+        );
+    }
+
+    return res.send(`# ${title}\n\n${content}`);
+}

--- a/packages/ui/docs-bundle/src/server/removeLeadingSlash.ts
+++ b/packages/ui/docs-bundle/src/server/removeLeadingSlash.ts
@@ -1,0 +1,3 @@
+export function removeLeadingSlash(path: string): string {
+    return path.startsWith("/") ? path.slice(1) : path;
+}


### PR DESCRIPTION
Allow appending `.md` or `.mdx` at the end of any markdown page (the extension depends on the format of the original markdown file) to view the markdown content.

- strips away the frontmatter, but append the title to the top using `#`
- caches for 60 seconds
