### PR TITLE
feat: llms.txt

### DIFF
--- a/packages/ui/docs-bundle/src/middleware.ts
+++ b/packages/ui/docs-bundle/src/middleware.ts
@@ -63,6 +63,17 @@ export const middleware: NextMiddleware = async (request) => {
     }
 
     /**
+     * Rewrite llms-full.txt
+     */
+    if (pathname.endsWith("/llms-full.txt")) {
+        const leadingPathname = pathname.replace(/\/llms-full\.txt$/, "") || "/";
+        const searchParams = new URLSearchParams(request.nextUrl.searchParams);
+        searchParams.set("path", leadingPathname);
+        pathname = "/api/fern-docs/llms-full.txt";
+        return NextResponse.rewrite(withPathname(request, pathname, `?${String(searchParams)}`));
+    }
+
+    /**
      * Rewrite Posthog analytics ingestion
      */
     if (pathname.includes("/api/fern-docs/analytics/posthog")) {

--- a/packages/ui/docs-bundle/src/middleware.ts
+++ b/packages/ui/docs-bundle/src/middleware.ts
@@ -52,6 +52,17 @@ export const middleware: NextMiddleware = async (request) => {
     }
 
     /**
+     * Rewrite llms.txt
+     */
+    if (pathname.endsWith("/llms.txt")) {
+        const leadingPathname = pathname.replace(/\/llms\.txt$/, "") || "/";
+        const searchParams = new URLSearchParams(request.nextUrl.searchParams);
+        searchParams.set("path", leadingPathname);
+        pathname = "/api/fern-docs/llms.txt";
+        return NextResponse.rewrite(withPathname(request, pathname, `?${String(searchParams)}`));
+    }
+
+    /**
      * Rewrite Posthog analytics ingestion
      */
     if (pathname.includes("/api/fern-docs/analytics/posthog")) {

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/llms-full.txt.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/llms-full.txt.ts
@@ -86,7 +86,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             if (page == null) {
                 return undefined;
             }
-            return convertToLlmTxtMarkdown(page.markdown, pageInfo.nodeTitle);
+            return convertToLlmTxtMarkdown(
+                page.markdown,
+                pageInfo.nodeTitle,
+                pageInfo.pageId.endsWith(".mdx") ? "mdx" : "md",
+            );
         })
         .filter(isNonNullish);
 

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/llms-full.txt.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/llms-full.txt.ts
@@ -1,0 +1,106 @@
+import { DocsLoader } from "@/server/DocsLoader";
+import { getSectionRoot } from "@/server/getSectionRoot";
+import { getStringParam } from "@/server/getStringParam";
+import { convertToLlmTxtMarkdown } from "@/server/llm-txt-md";
+import { getDocsDomainNode, getHostNode } from "@/server/xfernhost/node";
+import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
+import { CONTINUE, SKIP } from "@fern-api/fdr-sdk/traversers";
+import { isNonNullish } from "@fern-api/ui-core-utils";
+import { COOKIE_FERN_TOKEN } from "@fern-ui/fern-docs-utils";
+import { uniqWith } from "es-toolkit/array";
+import { NextApiRequest, NextApiResponse } from "next";
+
+/**
+ * This endpoint concatenates the markdown content of all pages in the docs, in the same order as it appears in the sidebar.
+ * Duplicates are automatically removed.
+ * - hidden and authed nodes are not included
+ * - noindexed nodes are not included
+ * - API reference pages are not included
+ * - the output is markdown-compatible
+ */
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<unknown> {
+    if (req.method === "OPTIONS") {
+        return res.status(200).setHeader("X-Robots-Tag", "noindex").setHeader("Allow", "OPTIONS, GET").end();
+    }
+
+    if (req.method !== "GET") {
+        return res.status(405).end();
+    }
+
+    const path = getStringParam(req, "path") ?? "/";
+    const domain = getDocsDomainNode(req);
+    const host = getHostNode(req) ?? domain;
+    const fern_token = req.cookies[COOKIE_FERN_TOKEN];
+    const loader = DocsLoader.for(domain, host, fern_token);
+
+    const root = getSectionRoot(await loader.root(), path);
+    const pages = await loader.pages();
+
+    if (root == null) {
+        return res.status(404).end();
+    }
+
+    const pageInfos: {
+        pageId: FernNavigation.PageId;
+        nodeTitle: string;
+    }[] = [];
+
+    // traverse the tree in a depth-first manner to collect all the nodes that have markdown content
+    // in the order that they appear in the sidebar
+    FernNavigation.traverseDF(root, (node) => {
+        // if the node is hidden or authed, don't include it in the list
+        // TODO: include "hidden" nodes in `llms-full.txt`
+        if (FernNavigation.hasMetadata(node)) {
+            if (node.hidden || node.authed) {
+                return SKIP;
+            }
+        }
+
+        if (FernNavigation.hasMarkdown(node)) {
+            // if the node is noindexed, don't include it in the list
+            // TODO: include "noindexed" nodes in `llms-full.txt`
+            if (node.noindex) {
+                return SKIP;
+            }
+
+            const pageId = FernNavigation.getPageId(node);
+            if (pageId != null) {
+                pageInfos.push({
+                    pageId,
+                    nodeTitle: node.title,
+                });
+            }
+        }
+
+        if (FernNavigation.isApiLeaf(node)) {
+            // TODO: construct a markdown-compatible page for the API reference
+        }
+
+        return CONTINUE;
+    });
+
+    const markdowns = uniqWith(pageInfos, (a, b) => a.pageId === b.pageId)
+        .map((pageInfo) => {
+            const page = pages[pageInfo.pageId];
+            if (page == null) {
+                return undefined;
+            }
+            return convertToLlmTxtMarkdown(page.markdown, pageInfo.nodeTitle);
+        })
+        .filter(isNonNullish);
+
+    if (markdowns.length === 0) {
+        return res.status(404).end();
+    }
+
+    res.status(200)
+        .setHeader("Content-Type", "text/plain; charset=utf-8")
+        // prevent search engines from indexing this page
+        .setHeader("X-Robots-Tag", "noindex")
+        // cannot guarantee that the content won't change, so we only cache for 60 seconds
+        .setHeader("Cache-Control", "s-maxage=60")
+        .send(markdowns.join("\n\n"));
+
+    return;
+}

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/llms.txt.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/llms.txt.ts
@@ -1,0 +1,130 @@
+import { DocsLoader } from "@/server/DocsLoader";
+import { convertToLlmTxtMarkdown } from "@/server/llm-txt-md";
+import { removeLeadingSlash } from "@/server/removeLeadingSlash";
+import { getDocsDomainNode, getHostNode } from "@/server/xfernhost/node";
+import { FernNavigation } from "@fern-api/fdr-sdk";
+import { CONTINUE, SKIP, STOP } from "@fern-api/fdr-sdk/traversers";
+import { isNonNullish } from "@fern-api/ui-core-utils";
+import { COOKIE_FERN_TOKEN } from "@fern-ui/fern-docs-utils";
+import { uniqWith } from "es-toolkit/array";
+import { NextApiRequest, NextApiResponse } from "next";
+
+function getStringParam(req: NextApiRequest, param: string): string | undefined {
+    const value = req.query[param];
+    return typeof value === "string" ? value : undefined;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<unknown> {
+    if (req.method === "OPTIONS") {
+        return res.status(200).setHeader("X-Robots-Tag", "noindex").setHeader("Allow", "OPTIONS, GET").end();
+    }
+
+    if (req.method !== "GET") {
+        return res.status(405).end();
+    }
+
+    const path = getStringParam(req, "path") ?? "/";
+    const domain = getDocsDomainNode(req);
+    const host = getHostNode(req) ?? domain;
+    const fern_token = req.cookies[COOKIE_FERN_TOKEN];
+    const loader = DocsLoader.for(domain, host, fern_token);
+
+    const root = getSectionRoot(await loader.root(), path);
+    const pages = await loader.pages();
+
+    if (root == null) {
+        return res.status(404).end();
+    }
+
+    const pageInfos: {
+        pageId: FernNavigation.PageId;
+        nodeTitle: string;
+        // TODO: pages that are canonical should be preferred when deduplicating
+        canonical: boolean;
+    }[] = [];
+
+    // traverse the tree in a depth-first manner to collect all the nodes that have markdown content
+    // in the order that they appear in the sidebar
+    FernNavigation.traverseDF(root, (node) => {
+        // if the node is hidden or authed, don't include it in the list
+        // TODO: include "hidden" nodes in `llms-full.txt`
+        if (FernNavigation.hasMetadata(node)) {
+            if (node.hidden || node.authed) {
+                return SKIP;
+            }
+        }
+
+        if (FernNavigation.hasMarkdown(node)) {
+            // if the node is noindexed, don't include it in the list
+            // TODO: include "noindexed" nodes in `llms-full.txt`
+            if (node.noindex) {
+                return SKIP;
+            }
+
+            const pageId = FernNavigation.getPageId(node);
+            if (pageId != null) {
+                pageInfos.push({
+                    pageId,
+                    nodeTitle: node.title,
+                    canonical: node.canonicalSlug == null || node.canonicalSlug === node.slug,
+                });
+            }
+        }
+
+        if (FernNavigation.isApiLeaf(node)) {
+            // TODO: construct a markdown-compatible page for the API reference
+        }
+
+        return CONTINUE;
+    });
+
+    const markdowns = uniqWith(pageInfos, (a, b) => a.pageId === b.pageId)
+        .map((pageInfo) => {
+            const page = pages[pageInfo.pageId];
+            if (page == null) {
+                return undefined;
+            }
+            return convertToLlmTxtMarkdown(page.markdown, pageInfo.nodeTitle);
+        })
+        .filter(isNonNullish);
+
+    if (markdowns.length === 0) {
+        return res.status(404).end();
+    }
+
+    res.status(200)
+        .setHeader("Content-Type", "text/plain; charset=utf-8")
+        // prevent search engines from indexing this page
+        .setHeader("X-Robots-Tag", "noindex")
+        // cannot guarantee that the content won't change, so we only cache for 60 seconds
+        .setHeader("Cache-Control", "s-maxage=60")
+        .send(markdowns.join("\n\n"));
+}
+
+function getSectionRoot(
+    root: FernNavigation.RootNode | undefined,
+    path: string,
+): FernNavigation.NavigationNodeWithMetadata | undefined {
+    if (root == null) {
+        return undefined;
+    }
+
+    if (path === "/" || root.slug === removeLeadingSlash(path)) {
+        return root;
+    }
+
+    let foundNode: FernNavigation.NavigationNodeWithMetadata | undefined;
+
+    // traverse the tree in a breadth-first manner because the node we're looking for is likely to be near the root
+    FernNavigation.traverseBF(root, (node) => {
+        if (FernNavigation.hasMetadata(node)) {
+            if (node.slug === removeLeadingSlash(path)) {
+                foundNode = node;
+                return STOP;
+            }
+        }
+        return CONTINUE;
+    });
+
+    return foundNode;
+}

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/markdown.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/markdown.ts
@@ -53,7 +53,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         .setHeader("X-Robots-Tag", "noindex")
         // cannot guarantee that the content won't change, so we only cache for 60 seconds
         .setHeader("Cache-Control", "s-maxage=60")
-        .send(convertToLlmTxtMarkdown(page.markdown, pageInfo.nodeTitle));
+        .send(
+            convertToLlmTxtMarkdown(page.markdown, pageInfo.nodeTitle, pageInfo.pageId.endsWith(".mdx") ? "mdx" : "md"),
+        );
 
     return;
 }

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/markdown.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/markdown.ts
@@ -1,8 +1,8 @@
 import { DocsLoader } from "@/server/DocsLoader";
+import { convertToLlmTxtMarkdown } from "@/server/llm-txt-md";
 import { removeLeadingSlash } from "@/server/removeLeadingSlash";
 import { getDocsDomainNode, getHostNode } from "@/server/xfernhost/node";
 import { FernNavigation } from "@fern-api/fdr-sdk";
-import { getFrontmatter } from "@fern-ui/fern-docs-mdx";
 import { COOKIE_FERN_TOKEN } from "@fern-ui/fern-docs-utils";
 import { NextApiRequest, NextApiResponse } from "next";
 
@@ -13,9 +13,8 @@ function getStringParam(req: NextApiRequest, param: string): string | undefined 
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<unknown> {
     const path = getStringParam(req, "path");
-    const format = getStringParam(req, "format");
 
-    if (path == null || format == null) {
+    if (path == null) {
         return res.status(400).end();
     }
 
@@ -41,31 +40,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(404).end();
     }
 
-    const extension = pageInfo.pageId.endsWith(".mdx") ? "mdx" : "md";
-
-    if (format !== extension) {
-        return res.status(404).end();
-    }
-
     const page = pages[pageInfo.pageId];
 
     if (!page) {
         return res.status(404).end();
     }
 
-    const { data: frontmatter, content } = getFrontmatter(page.markdown);
-
-    // TODO: parse the first h1 as the title
-    const title = frontmatter.title ?? pageInfo.nodeTitle;
-
     res.status(200)
-        .setHeader("Content-Type", `text/${extension === "mdx" ? "mdx" : "markdown"}`)
+        .setHeader("Content-Type", `text/${pageInfo.pageId.endsWith(".mdx") ? "mdx" : "markdown"}`)
         // prevent search engines from indexing this page
         .setHeader("X-Robots-Tag", "noindex")
         // cannot guarantee that the content won't change, so we only cache for 60 seconds
-        .setHeader("Cache-Control", "s-maxage=60");
-
-    return res.send(`# ${title}\n\n${content}`);
+        .setHeader("Cache-Control", "s-maxage=60")
+        .send(convertToLlmTxtMarkdown(page.markdown, pageInfo.nodeTitle));
 }
 
 function getPageInfo(

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/markdown.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/markdown.ts
@@ -1,15 +1,15 @@
 import { DocsLoader } from "@/server/DocsLoader";
+import { getStringParam } from "@/server/getStringParam";
 import { convertToLlmTxtMarkdown } from "@/server/llm-txt-md";
 import { removeLeadingSlash } from "@/server/removeLeadingSlash";
 import { getDocsDomainNode, getHostNode } from "@/server/xfernhost/node";
-import { FernNavigation } from "@fern-api/fdr-sdk";
+import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import { COOKIE_FERN_TOKEN } from "@fern-ui/fern-docs-utils";
 import { NextApiRequest, NextApiResponse } from "next";
 
-function getStringParam(req: NextApiRequest, param: string): string | undefined {
-    const value = req.query[param];
-    return typeof value === "string" ? value : undefined;
-}
+/**
+ * This endpoint returns the markdown content of a any page in the docs by adding `.md` or `.mdx` to the end of any docs page.
+ */
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<unknown> {
     const path = getStringParam(req, "path");
@@ -36,6 +36,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const pageInfo = getPageInfo(root, FernNavigation.Slug(removeLeadingSlash(path)));
 
+    // TODO: add support for api reference endpoint pages
     if (pageInfo == null) {
         return res.status(404).end();
     }
@@ -53,6 +54,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         // cannot guarantee that the content won't change, so we only cache for 60 seconds
         .setHeader("Cache-Control", "s-maxage=60")
         .send(convertToLlmTxtMarkdown(page.markdown, pageInfo.nodeTitle));
+
+    return;
 }
 
 function getPageInfo(

--- a/packages/ui/docs-bundle/src/server/getSectionRoot.ts
+++ b/packages/ui/docs-bundle/src/server/getSectionRoot.ts
@@ -1,0 +1,31 @@
+import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
+import { CONTINUE, STOP } from "@fern-api/fdr-sdk/traversers";
+import { removeLeadingSlash } from "./removeLeadingSlash";
+
+export function getSectionRoot(
+    root: FernNavigation.RootNode | undefined,
+    path: string,
+): FernNavigation.NavigationNodeWithMetadata | undefined {
+    if (root == null) {
+        return undefined;
+    }
+
+    if (path === "/" || root.slug === removeLeadingSlash(path)) {
+        return root;
+    }
+
+    let foundNode: FernNavigation.NavigationNodeWithMetadata | undefined;
+
+    // traverse the tree in a breadth-first manner because the node we're looking for is likely to be near the root
+    FernNavigation.traverseBF(root, (node) => {
+        if (FernNavigation.hasMetadata(node)) {
+            if (node.slug === removeLeadingSlash(path)) {
+                foundNode = node;
+                return STOP;
+            }
+        }
+        return CONTINUE;
+    });
+
+    return foundNode;
+}

--- a/packages/ui/docs-bundle/src/server/getStringParam.ts
+++ b/packages/ui/docs-bundle/src/server/getStringParam.ts
@@ -1,0 +1,6 @@
+import { NextApiRequest } from "next";
+
+export function getStringParam(req: NextApiRequest, param: string): string | undefined {
+    const value = req.query[param];
+    return typeof value === "string" ? value : undefined;
+}

--- a/packages/ui/docs-bundle/src/server/llm-txt-md.ts
+++ b/packages/ui/docs-bundle/src/server/llm-txt-md.ts
@@ -2,24 +2,37 @@ import { isNonNullish } from "@fern-api/ui-core-utils";
 import { getFrontmatter } from "@fern-ui/fern-docs-mdx";
 
 export function convertToLlmTxtMarkdown(markdown: string, nodeTitle: string): string {
-    const { data: frontmatter, content } = getFrontmatter(markdown);
-    // TODO: parse the first h1 as the title
-    const title = frontmatter.title ?? nodeTitle;
-
-    // note: the description field in the frontmatter is expected to be the most descriptive
-    // which is useful for LLM context. However, it's not always available, so we fall back
-    // to other fields. But, effectively only one is selected to avoid redundancy.
-    const description =
-        frontmatter.description ??
-        frontmatter["og:description"] ??
-        frontmatter.subtitle ??
-        frontmatter.headline ??
-        frontmatter.excerpt;
-
+    const { title, description, content } = getLlmTxtMetadata(markdown, nodeTitle);
     // TODO: add link-backs to the source of the content
     // TODO: parse the markdown content and delete any unnecessary content
 
     return [`# ${title}`, description != null ? `> ${description}` : undefined, content]
         .filter(isNonNullish)
         .join("\n\n");
+}
+
+interface LlmTxtMetadata {
+    title: string;
+    description: string | undefined;
+    content: string;
+}
+
+export function getLlmTxtMetadata(markdown: string, nodeTitle: string): LlmTxtMetadata {
+    const { data: frontmatter, content } = getFrontmatter(markdown);
+    return {
+        // TODO: parse the first h1 as the title
+        title: frontmatter.title ?? nodeTitle,
+        /**
+         * Note: the description field in the frontmatter is expected to be the most descriptive
+         * which is useful for LLM context. However, it's not always available, so we fall back
+         * to other fields. But, effectively only one is selected to avoid redundancy.
+         */
+        description:
+            frontmatter.description ??
+            frontmatter["og:description"] ??
+            frontmatter.subtitle ??
+            frontmatter.headline ??
+            frontmatter.excerpt,
+        content,
+    };
 }

--- a/packages/ui/docs-bundle/src/server/llm-txt-md.ts
+++ b/packages/ui/docs-bundle/src/server/llm-txt-md.ts
@@ -1,0 +1,25 @@
+import { isNonNullish } from "@fern-api/ui-core-utils";
+import { getFrontmatter } from "@fern-ui/fern-docs-mdx";
+
+export function convertToLlmTxtMarkdown(markdown: string, nodeTitle: string): string {
+    const { data: frontmatter, content } = getFrontmatter(markdown);
+    // TODO: parse the first h1 as the title
+    const title = frontmatter.title ?? nodeTitle;
+
+    // note: the description field in the frontmatter is expected to be the most descriptive
+    // which is useful for LLM context. However, it's not always available, so we fall back
+    // to other fields. But, effectively only one is selected to avoid redundancy.
+    const description =
+        frontmatter.description ??
+        frontmatter["og:description"] ??
+        frontmatter.subtitle ??
+        frontmatter.headline ??
+        frontmatter.excerpt;
+
+    // TODO: add link-backs to the source of the content
+    // TODO: parse the markdown content and delete any unnecessary content
+
+    return [`# ${title}`, description != null ? `> ${description}` : undefined, content]
+        .filter(isNonNullish)
+        .join("\n\n");
+}

--- a/packages/ui/docs-bundle/src/server/llm-txt-md.ts
+++ b/packages/ui/docs-bundle/src/server/llm-txt-md.ts
@@ -1,14 +1,76 @@
 import { isNonNullish } from "@fern-api/ui-core-utils";
-import { getFrontmatter } from "@fern-ui/fern-docs-mdx";
+import { getFrontmatter, isMdxJsxElementHast, mdastToMarkdown, toTree, visit } from "@fern-ui/fern-docs-mdx";
 
-export function convertToLlmTxtMarkdown(markdown: string, nodeTitle: string): string {
+export function convertToLlmTxtMarkdown(markdown: string, nodeTitle: string, format: "mdx" | "md"): string {
     const { title, description, content } = getLlmTxtMetadata(markdown, nodeTitle);
     // TODO: add link-backs to the source of the content
     // TODO: parse the markdown content and delete any unnecessary content
 
-    return [`# ${title}`, description != null ? `> ${description}` : undefined, content]
+    return [`# ${title}`, description != null ? `> ${description}` : undefined, stripMdxFeatures(content, format)]
         .filter(isNonNullish)
         .join("\n\n");
+}
+
+/**
+ * This is a living list of mdx features that we don't want to include in the LLM TXT format:
+ * - esm imports
+ * - <style> and <script> tags
+ * - img tags with data: urls
+ */
+function stripMdxFeatures(markdown: string, format: "mdx" | "md"): string {
+    if (format !== "mdx") {
+        return markdown;
+    }
+
+    const { mdast } = toTree(markdown, {
+        format,
+        sanitize: true,
+    });
+
+    visit(mdast, (node, idx, parent) => {
+        if (parent == null || idx == null) {
+            return;
+        }
+
+        if (isMdxJsxElementHast(node)) {
+            // remove <style> and <script> tags
+            if (node.name === "style" || node.name === "script") {
+                parent.children.splice(idx, 1);
+                return idx;
+            }
+
+            // remove imgs and related tags that reference data: urls
+            const src = node.attributes.find((attr) => attr.type === "mdxJsxAttribute" && attr.name === "src")?.value;
+            if (typeof src === "string" && src.startsWith("data:")) {
+                parent.children.splice(idx, 1);
+                return idx;
+            }
+
+            node.attributes = node.attributes.filter((attr) =>
+                attr.type === "mdxJsxAttribute" ? attr.name !== "className" && attr.name !== "style" : true,
+            );
+
+            if (node.name === "div" || node.name === "span" || node.name === "p" || node.name === "section") {
+                if (node.children.length === 0) {
+                    parent.children.splice(idx, 1);
+                    return idx;
+                }
+            }
+        }
+
+        if (node.type === "mdxjsEsm") {
+            if (node.data?.estree != null) {
+                if (node.data.estree.body[0]?.type !== "ExportNamedDeclaration") {
+                    parent.children.splice(idx, 1);
+                    return idx;
+                }
+            }
+        }
+
+        return;
+    });
+
+    return mdastToMarkdown(mdast);
 }
 
 interface LlmTxtMetadata {

--- a/packages/ui/fern-docs-mdx/src/strip-util.ts
+++ b/packages/ui/fern-docs-mdx/src/strip-util.ts
@@ -16,12 +16,15 @@ export function stripUtil(markdown: string, format: "md" | "mdx" = "mdx"): strin
         // mdast image, and hast img
         if (node.type === "element" && TAG_NAMES_TO_STRIP.includes(node.tagName)) {
             parent.children.splice(idx, 1);
+            return idx;
         }
 
         // jsx img
         if (isMdxJsxElementHast(node) && node.name && TAG_NAMES_TO_STRIP.includes(node.name)) {
             parent.children.splice(idx, 1);
+            return idx;
         }
+        return;
     });
 
     // TODO: (andrew), this might have some issues with formatting new lines


### PR DESCRIPTION
Introduces 2 new api routes based on the https://llmstxt.org/ specification.
- llms.txt -> a directory of all markdown files + landing page
- llms-full.txt -> concatenation of all markdown pages

Included in this PR:
- titles and descriptions are extracted from all markdown page frontmatters, and stitched back together
- content of landing pages will always be included in `llms.txt`

Not included in this PR:
- no support for api endpoint markdown -> need way to represent api endpoint definition as markdown, with links to code examples.
- no support for markdown snippets or code snippets -> CLI/FDR needs to store more metadata about code snippets and we need to decide what the pathname is.