### PR TITLE
fix: llms-txt with code snippets

### DIFF
--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/llms.txt.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/llms.txt.ts
@@ -167,7 +167,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         .map((endpointPageInfo) => {
             return {
                 title: endpointPageInfo.nodeTitle,
-                href: String(new URL(addLeadingSlash(endpointPageInfo.slug), withDefaultProtocol(domain))),
+                href: String(
+                    new URL(
+                        addLeadingSlash(endpointPageInfo.slug) + (endpointPageInfo.endpointId != null ? ".mdx" : ""),
+                        withDefaultProtocol(domain),
+                    ),
+                ),
                 breadcrumb: endpointPageInfo.breadcrumb,
             };
         })

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/llms.txt.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/llms.txt.ts
@@ -1,12 +1,14 @@
 import { DocsLoader } from "@/server/DocsLoader";
 import { addLeadingSlash } from "@/server/addLeadingSlash";
+import { getMarkdownForPath } from "@/server/getMarkdownForPath";
 import { getSectionRoot } from "@/server/getSectionRoot";
 import { getStringParam } from "@/server/getStringParam";
-import { convertToLlmTxtMarkdown, getLlmTxtMetadata } from "@/server/llm-txt-md";
+import { getLlmTxtMetadata } from "@/server/llm-txt-md";
 import { getDocsDomainNode, getHostNode } from "@/server/xfernhost/node";
 import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import { CONTINUE, SKIP } from "@fern-api/fdr-sdk/traversers";
 import { isNonNullish, withDefaultProtocol } from "@fern-api/ui-core-utils";
+import { getFeatureFlags } from "@fern-ui/fern-docs-edge-config";
 import { COOKIE_FERN_TOKEN } from "@fern-ui/fern-docs-utils";
 import { NextApiRequest, NextApiResponse } from "next";
 
@@ -44,7 +46,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const domain = getDocsDomainNode(req);
     const host = getHostNode(req) ?? domain;
     const fern_token = req.cookies[COOKIE_FERN_TOKEN];
-    const loader = DocsLoader.for(domain, host, fern_token);
+    const featureFlags = await getFeatureFlags(domain);
+    const loader = DocsLoader.for(domain, host, fern_token).withFeatureFlags(featureFlags);
 
     const root = getSectionRoot(await loader.root(), path);
     const pages = await loader.pages();
@@ -70,16 +73,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }[] = [];
 
     const landingPage = getLandingPage(root);
-    const landingPageId = landingPage != null ? FernNavigation.getPageId(landingPage) : undefined;
-    const landingPageRawMarkdown = landingPageId != null ? pages[landingPageId]?.markdown : undefined;
-    const landingPageLlmTxtMarkdown =
-        landingPageRawMarkdown != null
-            ? convertToLlmTxtMarkdown(
-                  landingPageRawMarkdown,
-                  landingPage?.title ?? root.title,
-                  landingPageId?.endsWith(".mdx") ? "mdx" : "md",
-              )
-            : undefined;
+    const markdown = landingPage != null ? await getMarkdownForPath(landingPage, loader, featureFlags) : undefined;
 
     // traverse the tree in a depth-first manner to collect all the nodes that have markdown content
     // in the order that they appear in the sidebar
@@ -188,7 +182,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         .send(
             [
                 // if there's a landing page, use the llm-friendly markdown version instead of the ${root.title}
-                landingPageLlmTxtMarkdown ?? `# ${root.title}`,
+                markdown?.content ?? `# ${root.title}`,
                 docs.length > 0 ? `## Docs\n\n${docs.join("\n")}` : undefined,
                 endpoints.length > 0 ? `## API Docs\n\n${endpoints.join("\n")}` : undefined,
             ]
@@ -201,7 +195,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
 function getLandingPage(
     root: FernNavigation.NavigationNodeWithMetadata,
-): FernNavigation.LandingPageNode | FernNavigation.NavigationNodeWithMarkdown | undefined {
+): FernNavigation.LandingPageNode | FernNavigation.NavigationNodePage | undefined {
     if (root.type === "version") {
         return root.landingPage;
     } else if (root.type === "root") {
@@ -213,7 +207,7 @@ function getLandingPage(
         }
     }
 
-    if (FernNavigation.hasMarkdown(root)) {
+    if (FernNavigation.isPage(root)) {
         return root;
     }
 

--- a/packages/ui/docs-bundle/src/server/DocsLoader.ts
+++ b/packages/ui/docs-bundle/src/server/DocsLoader.ts
@@ -1,7 +1,9 @@
 import type { DocsV1Read, DocsV2Read } from "@fern-api/fdr-sdk";
+import { ApiDefinition, ApiDefinitionV1ToLatest } from "@fern-api/fdr-sdk/api-definition";
 import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import type { AuthEdgeConfig } from "@fern-ui/fern-docs-auth";
 import { getAuthEdgeConfig } from "@fern-ui/fern-docs-edge-config";
+import { ApiDefinitionLoader } from "@fern-ui/fern-docs-server";
 import { getAuthState, type AuthState } from "./auth/getAuthState";
 import { loadWithUrl } from "./loadWithUrl";
 import { pruneWithAuthState } from "./withRbac";
@@ -9,6 +11,11 @@ import { pruneWithAuthState } from "./withRbac";
 interface DocsLoaderFlags {
     isBatchStreamToggleDisabled: boolean;
     isApiScrollingDisabled: boolean;
+
+    // for api definition:
+    useJavaScriptAsTypeScript: boolean;
+    alwaysEnableJavaScriptFetch: boolean;
+    usesApplicationJsonInFormDataValue: boolean;
 }
 
 export class DocsLoader {
@@ -25,6 +32,9 @@ export class DocsLoader {
     private featureFlags: DocsLoaderFlags = {
         isBatchStreamToggleDisabled: false,
         isApiScrollingDisabled: false,
+        useJavaScriptAsTypeScript: false,
+        alwaysEnableJavaScriptFetch: false,
+        usesApplicationJsonInFormDataValue: false,
     };
     public withFeatureFlags(featureFlags: DocsLoaderFlags): DocsLoader {
         this.featureFlags = featureFlags;
@@ -64,6 +74,24 @@ export class DocsLoader {
     public withLoadDocsForUrlResponse(loadForDocsUrlResponse: DocsV2Read.LoadDocsForUrlResponse): DocsLoader {
         this.#loadForDocsUrlResponse = loadForDocsUrlResponse;
         return this;
+    }
+
+    public async getApiDefinition(key: FernNavigation.ApiDefinitionId): Promise<ApiDefinition | undefined> {
+        const res = await this.loadDocs();
+        if (!res) {
+            return undefined;
+        }
+        const v1 = res.definition.apis[key];
+        if (!v1) {
+            return undefined;
+        }
+        const latest = ApiDefinitionV1ToLatest.from(v1, this.featureFlags).migrate();
+        return ApiDefinitionLoader.create(this.domain, key)
+            .withApiDefinition(latest)
+            .withFlags(this.featureFlags)
+            .withResolveDescriptions(false)
+            .withEnvironment(process.env.NEXT_PUBLIC_FDR_ORIGIN)
+            .load();
     }
 
     private async loadDocs(): Promise<DocsV2Read.LoadDocsForUrlResponse | undefined> {

--- a/packages/ui/docs-bundle/src/server/getMarkdownForPath.ts
+++ b/packages/ui/docs-bundle/src/server/getMarkdownForPath.ts
@@ -1,0 +1,207 @@
+import { ApiDefinition, FernNavigation } from "@fern-api/fdr-sdk";
+import { EndpointDefinition, TypeDefinition, TypeShape } from "@fern-api/fdr-sdk/api-definition";
+import { MarkdownText } from "@fern-api/fdr-sdk/docs";
+import { isNonNullish } from "@fern-api/ui-core-utils";
+import { FeatureFlags } from "@fern-ui/fern-docs-utils";
+import { isString } from "es-toolkit";
+import { DocsLoader } from "./DocsLoader";
+import { pascalCaseHeaderKey } from "./headerKeyCase";
+import { convertToLlmTxtMarkdown } from "./llm-txt-md";
+import { removeLeadingSlash } from "./removeLeadingSlash";
+
+export async function getMarkdownForPath(
+    node: FernNavigation.NavigationNodePage,
+    loader: DocsLoader,
+    featureFlags: FeatureFlags,
+): Promise<{ content: string; contentType: "markdown" | "mdx" } | undefined> {
+    loader = loader.withFeatureFlags(featureFlags);
+    const pages = await loader.pages();
+
+    if (FernNavigation.isApiLeaf(node)) {
+        const apiDefinition = await loader.getApiDefinition(node.apiDefinitionId);
+        if (apiDefinition == null) {
+            return undefined;
+        }
+
+        if (node.type === "endpoint") {
+            const endpoint = apiDefinition.endpoints[node.endpointId];
+            if (endpoint == null) {
+                return undefined;
+            }
+            return {
+                content: endpointDefinitionToMarkdown(
+                    endpoint,
+                    apiDefinition.globalHeaders,
+                    apiDefinition.types,
+                    node.title,
+                ),
+                contentType: "mdx",
+            };
+        }
+    }
+
+    const pageId = FernNavigation.getPageId(node);
+    if (pageId == null) {
+        return undefined;
+    }
+
+    const page = pages[pageId];
+    if (!page) {
+        return undefined;
+    }
+
+    return {
+        content: convertToLlmTxtMarkdown(page.markdown, node.title, pageId.endsWith(".mdx") ? "mdx" : "md"),
+        contentType: pageId.endsWith(".mdx") ? "mdx" : "markdown",
+    };
+}
+
+export function getPageNodeForPath(
+    root: FernNavigation.RootNode | undefined,
+    path: string,
+): FernNavigation.NavigationNodePage | undefined {
+    if (root == null) {
+        return undefined;
+    }
+    const found = FernNavigation.utils.findNode(root, FernNavigation.Slug(removeLeadingSlash(path)));
+    if (found.type !== "found" || !FernNavigation.isPage(found.node)) {
+        return undefined;
+    }
+    return found.node;
+}
+
+// function getPageInfo(
+//     root: FernNavigation.RootNode | undefined,
+//     slug: FernNavigation.Slug,
+// ):
+//     | {
+//           nodeTitle: string;
+//           pageId?: FernNavigation.PageId;
+//           apiLeaf?: FernNavigation.NavigationNodeApiLeaf;
+//       }
+//     | undefined {
+//     if (root == null) {
+//         return undefined;
+//     }
+
+//     const foundNode = FernNavigation.utils.findNode(root, slug);
+//     if (foundNode == null || foundNode.type !== "found" || !FernNavigation.isPage(foundNode.node)) {
+//         return undefined;
+//     }
+
+//     if (FernNavigation.isApiLeaf(foundNode.node)) {
+//         return {
+//             nodeTitle: foundNode.node.title,
+//             apiLeaf: foundNode.node,
+//         };
+//     }
+
+//     const pageId = FernNavigation.getPageId(foundNode.node);
+//     if (pageId == null) {
+//         return undefined;
+//     }
+
+//     return {
+//         nodeTitle: foundNode.node.title,
+//         pageId,
+//     };
+// }
+
+export function endpointDefinitionToMarkdown(
+    endpoint: EndpointDefinition,
+    globalHeaders: ApiDefinition.ObjectProperty[] | undefined,
+    types: Record<FernNavigation.TypeId, TypeDefinition>,
+    nodeTitle: string,
+): string {
+    const headers = [...(endpoint.requestHeaders ?? []), ...(globalHeaders ?? [])];
+    return [
+        `# ${nodeTitle}`,
+        [
+            "```http",
+            `${endpoint.method} ${endpoint.environments?.find((env) => env.id === endpoint.defaultEnvironment)?.baseUrl ?? endpoint.environments?.[0]?.baseUrl ?? ""}${ApiDefinition.toCurlyBraceEndpointPathLiteral(endpoint.path)}`,
+            endpoint.request != null ? `Content-Type: ${endpoint.request.contentType}` : undefined,
+            "```",
+        ]
+            .filter(isNonNullish)
+            .join("\n"),
+        typeof endpoint.description === "string" ? endpoint.description : undefined,
+        headers.length ? "## Request Headers" : undefined,
+        headers
+            ?.map(
+                (header) =>
+                    `- ${pascalCaseHeaderKey(header.key)}${getShorthand(header.valueShape, types, header.description)}`,
+            )
+            .join("\n"),
+        endpoint.pathParameters?.length ? "## Path Parameters" : undefined,
+        endpoint.pathParameters
+            ?.map(
+                (param) =>
+                    `- ${pascalCaseHeaderKey(param.key)}${getShorthand(param.valueShape, types, param.description)}`,
+            )
+            .join("\n"),
+        endpoint.queryParameters?.length ? "## Query Parameters" : undefined,
+        endpoint.queryParameters
+            ?.map(
+                (param) =>
+                    `- ${pascalCaseHeaderKey(param.key)}${getShorthand(param.valueShape, types, param.description)}`,
+            )
+            .join("\n"),
+        endpoint.request != null ? "## Request Body" : undefined,
+        typeof endpoint.request?.description === "string" ? endpoint.request?.description : undefined,
+        endpoint.request != null ? `\`\`\`json\n${JSON.stringify(endpoint.request.body)}\n\`\`\`` : undefined,
+        endpoint.responseHeaders?.length ? "## Response Headers" : undefined,
+        endpoint.responseHeaders
+            ?.map(
+                (header) =>
+                    `- ${pascalCaseHeaderKey(header.key)}${getShorthand(header.valueShape, types, header.description)}`,
+            )
+            .join("\n"),
+        endpoint.response != null || endpoint.errors?.length ? "## Response Body" : undefined,
+        endpoint.response != null || endpoint.errors?.length
+            ? [
+                  typeof endpoint.response?.description === "string"
+                      ? `- ${endpoint.response.statusCode}: ${endpoint.response?.description}`
+                      : undefined,
+                  ...(endpoint.errors
+                      ?.filter((error) => typeof error.description === "string")
+                      .map((error) => `- ${error.statusCode}: ${error.description}`) ?? []),
+              ].join("\n")
+            : undefined,
+
+        "## Examples",
+        endpoint.examples
+            ?.flatMap((example) =>
+                Object.entries(example.snippets ?? {}).flatMap(([language, snippets]) =>
+                    snippets.map(
+                        (snippet) =>
+                            ({
+                                language,
+                                snippet,
+                                name: snippet.name ?? example.name,
+                            }) as const,
+                    ),
+                ),
+            )
+            .map(
+                ({ language, snippet, name }) =>
+                    `\`\`\`${language === "curl" ? "shell" : language}${name != null ? ` ${name}` : ""}\n${snippet.code}\n\`\`\``,
+            )
+            .join("\n\n"),
+    ]
+        .filter(isNonNullish)
+        .join("\n\n");
+}
+
+function getShorthand(
+    shape: TypeShape,
+    types: Record<FernNavigation.TypeId, TypeDefinition>,
+    shapeDescription: MarkdownText | undefined,
+): string | undefined {
+    const unwrapped = ApiDefinition.unwrapReference(shape, types);
+    const description = [shapeDescription, ...unwrapped.descriptions].filter(isString)[0];
+    if (unwrapped.isOptional) {
+        return description ? ` (optional): ${description}` : " (optional)";
+    }
+
+    return description ? ` (required): ${description}` : " (required)";
+}

--- a/packages/ui/docs-bundle/src/server/headerKeyCase.ts
+++ b/packages/ui/docs-bundle/src/server/headerKeyCase.ts
@@ -1,0 +1,10 @@
+import { mapKeys } from "es-toolkit/object";
+import { pascalCase } from "es-toolkit/string";
+
+export function pascalCaseHeaderKey(key: string): string {
+    return key.split("-").map(pascalCase).join("-");
+}
+
+export function pascalCaseHeaderKeys(headers: Record<string, unknown> = {}): Record<string, unknown> {
+    return mapKeys(headers, (_, key) => pascalCaseHeaderKey(key));
+}

--- a/packages/ui/fern-docs-server/src/ApiDefinitionLoader.ts
+++ b/packages/ui/fern-docs-server/src/ApiDefinitionLoader.ts
@@ -64,8 +64,8 @@ export class ApiDefinitionLoader {
     }
 
     private flags: FeatureFlags = DEFAULT_FEATURE_FLAGS;
-    public withFlags = (flags: FeatureFlags): ApiDefinitionLoader => {
-        this.flags = flags;
+    public withFlags = (flags: Partial<FeatureFlags>): ApiDefinitionLoader => {
+        this.flags = { ...this.flags, ...flags };
         return this;
     };
 
@@ -238,7 +238,7 @@ export class ApiDefinitionLoader {
 
             if (code != null) {
                 pushSnippet({
-                    name: "HTTP Request",
+                    name: undefined,
                     language: targetId,
                     install: undefined,
                     code,


### PR DESCRIPTION
this PR hacks together request code snippets for endpoints to a structured markdown textfile consumed in llms.txt