### PR TITLE
fix(generator-cli): support title property on readme features

### DIFF
--- a/clis/generator-cli/src/__test__/__snapshots__/cohere-go-merged.test.ts.snap
+++ b/clis/generator-cli/src/__test__/__snapshots__/cohere-go-merged.test.ts.snap
@@ -105,37 +105,5 @@ otherwise they would be overwritten upon the next generated release. Feel free t
 a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
 an issue first to discuss with us!
 
-On the other hand, contributions to the README are always very welcome!
-## Advanced
-
-### Timeouts
-
-Setting a timeout for each individual request is as simple as
-using the standard \`context\` library. Setting a one second timeout
-for an individual API call looks like the following:
-
-\`\`\`go
-ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-defer cancel()
-
-response, err := client.Chat(
-	ctx,
-	&fern.ChatRequest{
-		Message: "Can you give me a global market overview of solar panels?",
-	},
-)
-\`\`\`
-
-\`\`\`go
-ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-defer cancel()
-
-response, err := client.Generate(
-	ctx,
-	&fern.GenerateRequest{
-		Prompt: "Please explain to me how LLMs work",
-	},
-)
-\`\`\`
-"
+On the other hand, contributions to the README are always very welcome!"
 `;

--- a/clis/generator-cli/src/__test__/__snapshots__/cohere-go-merged.test.ts.snap
+++ b/clis/generator-cli/src/__test__/__snapshots__/cohere-go-merged.test.ts.snap
@@ -10,6 +10,29 @@ exports[`cohere-go-merged > cohere-go-merged > generate readme 1`] = `
 
 The Cohere Go library provides convenient access to the Cohere API from Go.
 
+Starting merge process
+Comparing blocks: original[0] vs updated[0]
+Matched blocks: DOCUMENTATION
+Comparing blocks: original[1] vs updated[1]
+Matched blocks: INSTALLATION
+Comparing blocks: original[2] vs updated[2]
+Matched blocks: USAGE
+Comparing blocks: original[3] vs updated[3]
+Processing original blocks
+Adding original block: CUSTOM
+Adding original block: ONE
+Adding original block: TWO
+Skipping original block: ERRORS
+Comparing blocks: original[7] vs updated[3]
+Adding updated block: ERRORS
+Comparing blocks: original[7] vs updated[4]
+Matched blocks: ADVANCED
+Comparing blocks: original[8] vs updated[5]
+Adding updated block: contributing
+Processing remaining original blocks
+Adding remaining original block: CONTRIBUTING
+Processing remaining updated blocks
+Merge process completed
 ## Documentation
 
 API reference documentation is available [here](https://docs.cohere.com).
@@ -105,5 +128,15 @@ otherwise they would be overwritten upon the next generated release. Feel free t
 a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
 an issue first to discuss with us!
 
-On the other hand, contributions to the README are always very welcome!"
+On the other hand, contributions to the README are always very welcome!
+## Contributing
+
+While we value open-source contributions to this SDK, this library is generated programmatically.
+Additions made directly to this library would have to be moved over to our generation code,
+otherwise they would be overwritten upon the next generated release. Feel free to open a PR as
+a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
+an issue first to discuss with us!
+
+On the other hand, contributions to the README are always very welcome!
+"
 `;

--- a/clis/generator-cli/src/__test__/__snapshots__/cohere-go-merged.test.ts.snap
+++ b/clis/generator-cli/src/__test__/__snapshots__/cohere-go-merged.test.ts.snap
@@ -105,5 +105,37 @@ otherwise they would be overwritten upon the next generated release. Feel free t
 a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
 an issue first to discuss with us!
 
-On the other hand, contributions to the README are always very welcome!"
+On the other hand, contributions to the README are always very welcome!
+## Advanced
+
+### Timeouts
+
+Setting a timeout for each individual request is as simple as
+using the standard \`context\` library. Setting a one second timeout
+for an individual API call looks like the following:
+
+\`\`\`go
+ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+defer cancel()
+
+response, err := client.Chat(
+	ctx,
+	&fern.ChatRequest{
+		Message: "Can you give me a global market overview of solar panels?",
+	},
+)
+\`\`\`
+
+\`\`\`go
+ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+defer cancel()
+
+response, err := client.Generate(
+	ctx,
+	&fern.GenerateRequest{
+		Prompt: "Please explain to me how LLMs work",
+	},
+)
+\`\`\`
+"
 `;

--- a/clis/generator-cli/src/__test__/__snapshots__/title-merged.test.ts.snap
+++ b/clis/generator-cli/src/__test__/__snapshots__/title-merged.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`title-merged > title-merged > generate readme 1`] = `
+"# Title Go Library
+
+[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Title%2FGo)
+[![go shield](https://img.shields.io/badge/go-docs-blue)](https://pkg.go.dev/github.com/basic/basic-go)
+
+The Title Go library provides convenient access to the Title API from Go.
+
+Starting merge process
+Comparing blocks: original[0] vs updated[0]
+Processing original blocks
+Skipping original block: MY_CUSTOM_TITLE
+Comparing blocks: original[1] vs updated[0]
+Adding updated block: INSTALLATION
+Comparing blocks: original[1] vs updated[1]
+Processing original blocks
+Adding original block: MY_CUSTOM_SECTION
+Adding original block: CONTRIBUTING
+Processing remaining original blocks
+Processing remaining updated blocks
+Adding remaining updated block: My custom title!!!
+Adding remaining updated block: contributing
+Merge process completed
+## Installation
+
+\`\`\`sh
+go get github.com/basic/basic-go
+\`\`\`
+
+## My custom section!!
+
+This is a custom section that should stay between the usage and contributing sections.
+
+## Contributing
+
+While we value open-source contributions to this SDK, this library is generated programmatically.
+Additions made directly to this library would have to be moved over to our generation code,
+otherwise they would be overwritten upon the next generated release. Feel free to open a PR as
+a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
+an issue first to discuss with us!
+
+On the other hand, contributions to the README are always very welcome!
+
+## My custom title!!!
+
+This section has now changed!!
+
+## Contributing
+
+While we value open-source contributions to this SDK, this library is generated programmatically.
+Additions made directly to this library would have to be moved over to our generation code,
+otherwise they would be overwritten upon the next generated release. Feel free to open a PR as
+a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
+an issue first to discuss with us!
+
+On the other hand, contributions to the README are always very welcome!"
+`;

--- a/clis/generator-cli/src/__test__/__snapshots__/title.test.ts.snap
+++ b/clis/generator-cli/src/__test__/__snapshots__/title.test.ts.snap
@@ -1,0 +1,50 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`title > title > generate readme 1`] = `
+"# Title Go Library
+
+[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=Title%2FGo)
+[![go shield](https://img.shields.io/badge/go-docs-blue)](https://pkg.go.dev/github.com/basic/basic-go)
+
+The Title Go library provides convenient access to the Title API from Go.
+
+## Installation
+
+\`\`\`sh
+go get github.com/basic/basic-go
+\`\`\`
+
+## My custom title!
+
+Instantiate the client with the following:
+
+\`\`\`go
+import (
+	fern "github.com/custom/fern"
+	fernclient "github.com/custom/fern/client"
+	option "github.com/custom/fern/option"
+)
+
+client := fernclient.NewClient(
+	option.WithToken(
+		"<YOUR_AUTH_TOKEN>",
+	),
+)
+response, err := client.Chat(
+	ctx,
+	&fern.ChatRequest{
+		Message: "Can you give me a global market overview of solar panels?",
+	},
+)
+\`\`\`
+
+## Contributing
+
+While we value open-source contributions to this SDK, this library is generated programmatically.
+Additions made directly to this library would have to be moved over to our generation code,
+otherwise they would be overwritten upon the next generated release. Feel free to open a PR as
+a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
+an issue first to discuss with us!
+
+On the other hand, contributions to the README are always very welcome!"
+`;

--- a/clis/generator-cli/src/__test__/fixtures/title-merged/README.md
+++ b/clis/generator-cli/src/__test__/fixtures/title-merged/README.md
@@ -1,0 +1,46 @@
+# Cohere Go Library
+
+![](https://raw.githubusercontent.com/cohere-ai/cohere-typescript/5188b11a6e91727fdd4d46f4a690419ad204224d/banner.png)
+
+[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-SDK%20generated%20by%20Fern-brightgreen)](https://github.com/fern-api/fern)
+[![go shield](https://img.shields.io/badge/go-docs-blue)](https://pkg.go.dev/github.com/cohere-ai/cohere-go)
+
+The Cohere Go library provides convenient access to the Cohere API from Go.
+
+## My custom title!!!
+
+Instantiate the client with the following:
+
+```go
+import (
+	fern "github.com/custom/fern"
+	fernclient "github.com/custom/fern/client"
+	option "github.com/custom/fern/option"
+)
+
+client := fernclient.NewClient(
+	option.WithToken(
+		"<YOUR_AUTH_TOKEN>",
+	),
+)
+response, err := client.Chat(
+	ctx,
+	&fern.ChatRequest{
+		Message: "Can you give me a global market overview of solar panels?",
+	},
+)
+```
+
+## My custom section!!
+
+This is a custom section that should stay between the usage and contributing sections.
+
+## Contributing
+
+While we value open-source contributions to this SDK, this library is generated programmatically.
+Additions made directly to this library would have to be moved over to our generation code,
+otherwise they would be overwritten upon the next generated release. Feel free to open a PR as
+a proof of concept, but know that we will not be able to merge it as-is. We suggest opening
+an issue first to discuss with us!
+
+On the other hand, contributions to the README are always very welcome!

--- a/clis/generator-cli/src/__test__/fixtures/title-merged/readme.ts
+++ b/clis/generator-cli/src/__test__/fixtures/title-merged/readme.ts
@@ -1,0 +1,22 @@
+import { FernGeneratorCli } from "../../../configuration/generated";
+
+const CONFIG: FernGeneratorCli.ReadmeConfig = {
+    language: FernGeneratorCli.LanguageInfo.go({
+        publishInfo: {
+            owner: "basic",
+            repo: "basic-go",
+            version: "0.0.1",
+        },
+    }),
+    organization: "title",
+    features: [
+        {
+            id: "USAGE",
+            title: "My custom title!!!",
+            description: "This section has now changed!!",
+            snippetsAreOptional: true,
+        },
+    ],
+};
+
+export default CONFIG;

--- a/clis/generator-cli/src/__test__/fixtures/title/readme.ts
+++ b/clis/generator-cli/src/__test__/fixtures/title/readme.ts
@@ -1,0 +1,25 @@
+import { FernGeneratorCli } from "../../../configuration/generated";
+
+const CONFIG: FernGeneratorCli.ReadmeConfig = {
+    language: FernGeneratorCli.LanguageInfo.go({
+        publishInfo: {
+            owner: "basic",
+            repo: "basic-go",
+            version: "0.0.1",
+        },
+    }),
+    organization: "title",
+    features: [
+        {
+            id: "USAGE",
+            title: "My custom title!",
+            description: "Instantiate the client with the following:\n",
+            snippets: [
+                'import (\n\tfern "github.com/custom/fern"\n\tfernclient "github.com/custom/fern/client"\n\toption "github.com/custom/fern/option"\n)\n\nclient := fernclient.NewClient(\n\toption.WithToken(\n\t\t"\u003cYOUR_AUTH_TOKEN\u003e",\n\t),\n)\nresponse, err := client.Chat(\n\tctx,\n\t\u0026fern.ChatRequest{\n\t\tMessage: "Can you give me a global market overview of solar panels?",\n\t},\n)\n',
+            ],
+            snippetsAreOptional: true,
+        },
+    ],
+};
+
+export default CONFIG;

--- a/clis/generator-cli/src/__test__/title-merged.test.ts
+++ b/clis/generator-cli/src/__test__/title-merged.test.ts
@@ -1,0 +1,10 @@
+import { default as CONFIG } from "./fixtures/title-merged/readme";
+import { testGenerateReadme } from "./testGenerateReadme";
+
+describe("title-merged", () => {
+    testGenerateReadme({
+        fixtureName: "title-merged",
+        config: CONFIG,
+        originalReadme: "README.md",
+    });
+});

--- a/clis/generator-cli/src/__test__/title.test.ts
+++ b/clis/generator-cli/src/__test__/title.test.ts
@@ -1,0 +1,9 @@
+import { default as CONFIG } from "./fixtures/title/readme";
+import { testGenerateReadme } from "./testGenerateReadme";
+
+describe("title", () => {
+    testGenerateReadme({
+        fixtureName: "title",
+        config: CONFIG,
+    });
+});

--- a/clis/generator-cli/src/configuration/generated/api/resources/feature/types/FeatureSpec.ts
+++ b/clis/generator-cli/src/configuration/generated/api/resources/feature/types/FeatureSpec.ts
@@ -11,6 +11,7 @@ import * as FernGeneratorCli from "../../../index";
  */
 export interface FeatureSpec {
     id: FernGeneratorCli.FeatureId;
+    title?: string;
     description?: string;
     addendum?: string;
     advanced?: boolean;

--- a/clis/generator-cli/src/configuration/generated/serialization/resources/feature/types/FeatureSpec.ts
+++ b/clis/generator-cli/src/configuration/generated/serialization/resources/feature/types/FeatureSpec.ts
@@ -10,6 +10,7 @@ import { FeatureId } from "./FeatureId";
 export const FeatureSpec: core.serialization.ObjectSchema<serializers.FeatureSpec.Raw, FernGeneratorCli.FeatureSpec> =
     core.serialization.object({
         id: FeatureId,
+        title: core.serialization.string().optional(),
         description: core.serialization.string().optional(),
         addendum: core.serialization.string().optional(),
         advanced: core.serialization.boolean().optional(),
@@ -18,6 +19,7 @@ export const FeatureSpec: core.serialization.ObjectSchema<serializers.FeatureSpe
 export declare namespace FeatureSpec {
     interface Raw {
         id: FeatureId.Raw;
+        title?: string | null;
         description?: string | null;
         addendum?: string | null;
         advanced?: boolean | null;

--- a/clis/generator-cli/src/readme/ParsedBlock.ts
+++ b/clis/generator-cli/src/readme/ParsedBlock.ts
@@ -1,0 +1,41 @@
+import { snakeCase } from "lodash-es";
+import { Writer } from "../utils/Writer";
+
+/**
+ * Represents a block of content parsed from an existing README file.
+ * Each block is identified by its section name (e.g. from a ## heading)
+ * and contains the raw content that follows until the next section.
+ * Used to preserve custom sections when regenerating README files.
+ */
+export class ParsedBlock {
+    public sectionName: string;
+    public content: string;
+    public computedId: string;
+
+    constructor({ sectionName, content }: { sectionName: string; content: string }) {
+        this.sectionName = sectionName;
+        this.content = content;
+        this.computedId = sectionNameToID(sectionName);
+    }
+
+    public write(writer: Writer): void {
+        writer.write(this.content);
+        if (!this.content.endsWith("\n")) {
+            writer.writeLine();
+        }
+    }
+}
+
+function sectionNameToID(rawSectionName: string): string {
+    return snakeCase(
+        rawSectionName
+            .split(" ")
+            .map((word, index) => {
+                if (index === 0) {
+                    return word;
+                }
+                return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+            })
+            .join(""),
+    ).toUpperCase();
+}

--- a/clis/generator-cli/src/readme/ReadmeGenerator.ts
+++ b/clis/generator-cli/src/readme/ReadmeGenerator.ts
@@ -9,7 +9,7 @@ import { BlockMerger } from "./BlockMerger";
 import { ReadmeParser } from "./ReadmeParser";
 
 export class ReadmeGenerator {
-    private ADVANCED_FEATURE_ID = "ADVANCED";
+    private static readonly ADVANCED_FEATURE_ID = "advanced";
     private ADVANCED_FEATURES: Set<FernGeneratorCli.FeatureId> = new Set([
         FernGeneratorCli.StructuredFeatureId.Retries,
         FernGeneratorCli.StructuredFeatureId.Timeouts,
@@ -82,8 +82,7 @@ export class ReadmeGenerator {
             );
         }
 
-        const advancedFeatureBlock = this.generateNestedFeatureBlock({
-            featureId: this.ADVANCED_FEATURE_ID,
+        const advancedFeatureBlock = this.generateAdvancedFeatureBlock({
             features: advancedFeatures,
         });
         if (advancedFeatureBlock != null) {
@@ -102,11 +101,9 @@ export class ReadmeGenerator {
         return feat.advanced ?? false;
     }
 
-    private generateNestedFeatureBlock({
-        featureId,
+    private generateAdvancedFeatureBlock({
         features,
     }: {
-        featureId: string;
         features: FernGeneratorCli.ReadmeFeature[];
     }): Block | undefined {
         if (!this.shouldGenerateFeatures({ features })) {
@@ -114,7 +111,7 @@ export class ReadmeGenerator {
         }
 
         const writer = new StringWriter();
-        writer.writeLine(`## ${featureIDToTitle(featureId)}`);
+        writer.writeLine(`## ${featureIDToTitle(ReadmeGenerator.ADVANCED_FEATURE_ID)}`);
         writer.writeLine();
 
         for (const feature of features) {
@@ -128,7 +125,7 @@ export class ReadmeGenerator {
             });
         }
         return new Block({
-            id: featureId,
+            id: ReadmeGenerator.ADVANCED_FEATURE_ID,
             content: writer.toString(),
         });
     }
@@ -143,7 +140,7 @@ export class ReadmeGenerator {
         maybeWriter?: StringWriter;
     }): Block {
         const writer = maybeWriter ?? new StringWriter();
-        writer.writeLine(`${heading} ${featureIDToTitle(feature.id)}`);
+        writer.writeLine(`${heading} ${feature.title ?? featureIDToTitle(feature.id)}`);
         writer.writeLine();
         if (feature.description != null) {
             writer.writeLine(feature.description);

--- a/clis/generator-cli/src/readme/ReadmeGenerator.ts
+++ b/clis/generator-cli/src/readme/ReadmeGenerator.ts
@@ -156,7 +156,7 @@ export class ReadmeGenerator {
         }
         writer.writeLine();
         return new Block({
-            id: feature.id,
+            id: feature.title ?? feature.id,
             content: writer.toString(),
         });
     }

--- a/clis/generator-cli/src/readme/ReadmeGenerator.ts
+++ b/clis/generator-cli/src/readme/ReadmeGenerator.ts
@@ -9,7 +9,7 @@ import { BlockMerger } from "./BlockMerger";
 import { ReadmeParser } from "./ReadmeParser";
 
 export class ReadmeGenerator {
-    private static readonly ADVANCED_FEATURE_ID = "advanced";
+    private static readonly ADVANCED_FEATURE_ID = "ADVANCED";
     private ADVANCED_FEATURES: Set<FernGeneratorCli.FeatureId> = new Set([
         FernGeneratorCli.StructuredFeatureId.Retries,
         FernGeneratorCli.StructuredFeatureId.Timeouts,

--- a/clis/generator-cli/src/readme/ReadmeParser.ts
+++ b/clis/generator-cli/src/readme/ReadmeParser.ts
@@ -1,25 +1,23 @@
-import { snakeCase } from "lodash-es";
-import { Block } from "./Block";
+import { ParsedBlock } from "./ParsedBlock";
 
 export interface ParseResult {
     header: string;
-    blocks: Block[];
+    blocks: ParsedBlock[];
 }
-
 export class ReadmeParser {
     public parse({ content }: { content: string }): ParseResult {
         let header: string = "";
-        let currentBlock: Block | undefined;
-        const blocks: Block[] = [];
+        let currentBlock: ParsedBlock | undefined;
+        const blocks: ParsedBlock[] = [];
         const lines = content.split("\n");
         for (const line of lines) {
-            const h2Match = line.match(/^##\s+(.*)/);
+            const h2Match = getH2Match(line);
             if (h2Match) {
                 if (currentBlock) {
                     blocks.push(currentBlock);
                 }
-                currentBlock = new Block({
-                    id: sectionNameToID(h2Match[1] ?? ""),
+                currentBlock = new ParsedBlock({
+                    sectionName: h2Match[1] ?? "",
                     content: "",
                 });
             }
@@ -29,6 +27,9 @@ export class ReadmeParser {
             }
             currentBlock.content += line + "\n";
         }
+        if (currentBlock) {
+            blocks.push(currentBlock);
+        }
         return {
             header,
             blocks,
@@ -36,16 +37,6 @@ export class ReadmeParser {
     }
 }
 
-function sectionNameToID(sectionName: string): string {
-    return snakeCase(
-        sectionName
-            .split(" ")
-            .map((word, index) => {
-                if (index === 0) {
-                    return word;
-                }
-                return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
-            })
-            .join(""),
-    ).toUpperCase();
+function getH2Match(line: string): RegExpMatchArray | null {
+    return line.match(/^##\s+(.*)/);
 }

--- a/fern/apis/generator-cli/definition/feature.yml
+++ b/fern/apis/generator-cli/definition/feature.yml
@@ -41,6 +41,7 @@ types:
       included in the README.md.
     properties:
       id: FeatureId
+      title: optional<string>
       description: optional<string>
       addendum: optional<string>
       advanced: optional<boolean>

--- a/packages/ui/fern-dashboard/src/lib/utils.ts
+++ b/packages/ui/fern-dashboard/src/lib/utils.ts
@@ -1,6 +1,0 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}


### PR DESCRIPTION
## Short description of the changes made
Adds `title` so we can control titles on features in README generation. 

## What was the motivation & context behind this PR?
Want to add custom title to a feature in the TypeScript SDK. 

## How has this PR been tested?
Yup, see newly added testcase. 
