### PR TITLE
fix: changelog converter uses real year

### DIFF
--- a/packages/fdr-sdk/src/__test__/output/astronomer/node.json
+++ b/packages/fdr-sdk/src/__test__/output/astronomer/node.json
@@ -57,7 +57,7 @@
                     "id": "root.uv.platform-api-reference.log.2024.5",
                     "month": 5,
                     "slug": "docs/api/platform-api-reference/changelog/2024/5",
-                    "title": "May 1900",
+                    "title": "May 2024",
                     "type": "changelogMonth"
                   },
                   {
@@ -82,7 +82,7 @@
                     "id": "root.uv.platform-api-reference.log.2024.4",
                     "month": 4,
                     "slug": "docs/api/platform-api-reference/changelog/2024/4",
-                    "title": "April 1900",
+                    "title": "April 2024",
                     "type": "changelogMonth"
                   }
                 ],
@@ -469,7 +469,7 @@
                     "id": "root.uv.iam-api-reference.log.2024.4",
                     "month": 4,
                     "slug": "docs/api/iam-api-reference/changelog/2024/4",
-                    "title": "April 1900",
+                    "title": "April 2024",
                     "type": "changelogMonth"
                   }
                 ],

--- a/packages/fdr-sdk/src/navigation/versions/v1/converters/ChangelogConverter.ts
+++ b/packages/fdr-sdk/src/navigation/versions/v1/converters/ChangelogConverter.ts
@@ -70,13 +70,7 @@ export class ChangelogNavigationConverter {
         entries: FernNavigation.V1.ChangelogEntryNode[],
         parentSlug: SlugGenerator,
     ): FernNavigation.V1.ChangelogYearNode[] {
-        const years = new Map<number, FernNavigation.V1.ChangelogEntryNode[]>();
-        for (const entry of entries) {
-            const year = dayjs.utc(entry.date).year();
-            const yearEntries = years.get(year) ?? [];
-            yearEntries.push(entry);
-            years.set(year, yearEntries);
-        }
+        const years = groupByYear(entries);
         return orderBy(
             Array.from(years.entries()).map(([year, entries]) =>
                 this.#idgen.with(year.toString(), (id) => {
@@ -105,15 +99,7 @@ export class ChangelogNavigationConverter {
         entries: FernNavigation.V1.ChangelogEntryNode[],
         parentSlug: SlugGenerator,
     ): FernNavigation.V1.ChangelogMonthNode[] {
-        const months = new Map<number, [number, FernNavigation.V1.ChangelogEntryNode[]]>();
-        for (const entry of entries) {
-            const date = dayjs.utc(entry.date);
-            const month = date.month() + 1;
-            const year = date.year();
-            const monthEntries = months.get(month) ?? [year, []];
-            monthEntries[1].push(entry);
-            months.set(month, monthEntries);
-        }
+        const months = groupByMonth(entries);
         return orderBy(
             Array.from(months.entries()).map(([month, [year, entries]]) =>
                 this.#idgen.with(month.toString(), (id) => ({
@@ -182,4 +168,28 @@ function orderBy<K extends string, T extends Record<K, string | number>>(
         }
         return 0;
     });
+}
+
+export function groupByYear(entries: FernNavigation.V1.ChangelogEntryNode[]) {
+    const years = new Map<number, FernNavigation.V1.ChangelogEntryNode[]>();
+    for (const entry of entries) {
+        const year = dayjs.utc(entry.date).year();
+        const yearEntries = years.get(year) ?? [];
+        yearEntries.push(entry);
+        years.set(year, yearEntries);
+    }
+    return years;
+}
+
+export function groupByMonth(entries: FernNavigation.V1.ChangelogEntryNode[]) {
+    const months = new Map<number, [number, FernNavigation.V1.ChangelogEntryNode[]]>();
+    for (const entry of entries) {
+        const date = dayjs.utc(entry.date);
+        const month = date.month() + 1;
+        const year = date.year();
+        const monthEntries = months.get(month) ?? [year, []];
+        monthEntries[1].push(entry);
+        months.set(month, monthEntries);
+    }
+    return months;
 }

--- a/packages/fdr-sdk/src/navigation/versions/v1/converters/ChangelogConverter.ts
+++ b/packages/fdr-sdk/src/navigation/versions/v1/converters/ChangelogConverter.ts
@@ -105,19 +105,21 @@ export class ChangelogNavigationConverter {
         entries: FernNavigation.V1.ChangelogEntryNode[],
         parentSlug: SlugGenerator,
     ): FernNavigation.V1.ChangelogMonthNode[] {
-        const months = new Map<number, FernNavigation.V1.ChangelogEntryNode[]>();
+        const months = new Map<number, [number, FernNavigation.V1.ChangelogEntryNode[]]>();
         for (const entry of entries) {
-            const month = dayjs.utc(entry.date).month() + 1;
-            const monthEntries = months.get(month) ?? [];
-            monthEntries.push(entry);
+            const date = dayjs.utc(entry.date);
+            const month = date.month() + 1;
+            const year = date.year();
+            const monthEntries = months.get(month) ?? [year, []];
+            monthEntries[1].push(entry);
             months.set(month, monthEntries);
         }
         return orderBy(
-            Array.from(months.entries()).map(([month, entries]) =>
+            Array.from(months.entries()).map(([month, [year, entries]]) =>
                 this.#idgen.with(month.toString(), (id) => ({
                     id,
                     type: "changelogMonth" as const,
-                    title: dayjs(new Date(0, month - 1)).format("MMMM YYYY"),
+                    title: dayjs(new Date(year, month - 1)).format("MMMM YYYY"),
                     month,
                     slug: parentSlug.append(month.toString()).get(),
                     icon: undefined,

--- a/packages/fdr-sdk/src/navigation/versions/v1/converters/__test__/groupByTime.test.ts
+++ b/packages/fdr-sdk/src/navigation/versions/v1/converters/__test__/groupByTime.test.ts
@@ -1,0 +1,101 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import { FernNavigation } from "../../../../..";
+import { groupByMonth, groupByYear } from "../ChangelogConverter";
+
+dayjs.extend(utc);
+
+describe("Grouping Functions", () => {
+    const entries: FernNavigation.V1.ChangelogEntryNode[] = [
+        {
+            id: FernNavigation.V1.NodeId("entry-1"),
+            pageId: FernNavigation.PageId("entry-1"),
+            type: "changelogEntry",
+            date: "2024-11-01",
+            title: "Entry 1",
+            slug: FernNavigation.V1.Slug("entry-1"),
+            icon: undefined,
+            hidden: undefined,
+            authed: undefined,
+            viewers: undefined,
+            orphaned: undefined,
+            noindex: undefined,
+        },
+        {
+            id: FernNavigation.V1.NodeId("entry-2"),
+            pageId: FernNavigation.PageId("entry-2"),
+            type: "changelogEntry",
+            date: "2024-11-15",
+            title: "Entry 2",
+            slug: FernNavigation.V1.Slug("entry-2"),
+            icon: undefined,
+            hidden: undefined,
+            authed: undefined,
+            viewers: undefined,
+            orphaned: undefined,
+            noindex: undefined,
+        },
+        {
+            id: FernNavigation.V1.NodeId("entry-3"),
+            pageId: FernNavigation.PageId("entry-3"),
+            type: "changelogEntry",
+            date: "2024-10-20",
+            title: "Entry 3",
+            slug: FernNavigation.V1.Slug("entry-3"),
+            icon: undefined,
+            hidden: undefined,
+            authed: undefined,
+            viewers: undefined,
+            orphaned: undefined,
+            noindex: undefined,
+        },
+        {
+            id: FernNavigation.V1.NodeId("entry-4"),
+            pageId: FernNavigation.PageId("entry-4"),
+            type: "changelogEntry",
+            date: "2023-12-01",
+            title: "Entry 4",
+            slug: FernNavigation.V1.Slug("entry-4"),
+            icon: undefined,
+            hidden: undefined,
+            authed: undefined,
+            viewers: undefined,
+            orphaned: undefined,
+            noindex: undefined,
+        },
+    ];
+
+    describe("groupByYear", () => {
+        it("should group entries by year", () => {
+            const result = groupByYear(entries);
+
+            expect(result.size).toBe(2);
+            expect(result.get(2024)).toEqual(entries.slice(0, 3));
+            expect(result.get(2023)).toEqual([entries[3]]);
+        });
+
+        it("should return an empty map for empty input", () => {
+            const result = groupByYear([]);
+            expect(result.size).toBe(0);
+        });
+    });
+
+    describe("groupByMonth", () => {
+        it("should group entries by month and include the year", () => {
+            const result = groupByMonth(entries);
+
+            expect(result.size).toBe(3);
+
+            expect(result.get(11)).toEqual([2024, entries.slice(0, 2)]);
+
+            expect(result.get(10)).toEqual([2024, [entries[2]]]);
+
+            expect(result.get(12)).toEqual([2023, [entries[3]]]);
+        });
+
+        it("should return an empty map for empty input", () => {
+            const result = groupByMonth([]);
+            expect(result.size).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
## Short description of the changes made

* fixes bug where changelog records were rendering with 1900

## What was the motivation & context behind this PR?

* some changelogs were rendering 1900 as the year in which they were created, this is not correct

## How has this PR been tested?

* requires FDR update
