### PR TITLE
chore: plumb OAuth Client Credentials header name and token prefix

### DIFF
--- a/packages/ui/app/src/api-reference/endpoints/EndpointContentLeft.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointContentLeft.tsx
@@ -137,8 +137,10 @@ const UnmemoizedEndpointContentLeft: React.FC<EndpointContentLeft.Props> = ({
                     clientCredentials: (clientCredentialsValue) =>
                         visitDiscriminatedUnion(clientCredentialsValue.value, "type")._visit({
                             referencedEndpoint: () => ({
-                                key: ApiDefinition.PropertyKey("Authorization"),
-                                description: "OAuth authentication of the form Bearer <token>.",
+                                key: ApiDefinition.PropertyKey(
+                                    clientCredentialsValue.value.headerName || "Authorization",
+                                ),
+                                description: `OAuth authentication of the form ${clientCredentialsValue.value.tokenPrefix ?? "Bearer"} <token>.`,
                                 hidden: false,
                                 valueShape: stringShape,
                                 availability: undefined,

--- a/packages/ui/app/src/api-reference/endpoints/EndpointContentLeft.tsx
+++ b/packages/ui/app/src/api-reference/endpoints/EndpointContentLeft.tsx
@@ -140,7 +140,7 @@ const UnmemoizedEndpointContentLeft: React.FC<EndpointContentLeft.Props> = ({
                                 key: ApiDefinition.PropertyKey(
                                     clientCredentialsValue.value.headerName || "Authorization",
                                 ),
-                                description: `OAuth authentication of the form ${clientCredentialsValue.value.tokenPrefix ?? "Bearer"} <token>.`,
+                                description: `OAuth authentication of the form ${clientCredentialsValue.value.tokenPrefix ? `${clientCredentialsValue.value.tokenPrefix ?? "Bearer"} ` : ""}<token>.`,
                                 hidden: false,
                                 valueShape: stringShape,
                                 availability: undefined,

--- a/packages/ui/fern-docs-server/src/getHarRequest.ts
+++ b/packages/ui/fern-docs-server/src/getHarRequest.ts
@@ -122,7 +122,7 @@ export function getHarRequest(
                             referencedEndpoint: () => {
                                 request.headers.push({
                                     name: clientCredentials.value.headerName || "Authorization",
-                                    value: `${clientCredentials.value.tokenPrefix ?? "Bearer"} <token>`,
+                                    value: `${clientCredentials.value.tokenPrefix ? `${clientCredentials.value.tokenPrefix ?? "Bearer"} ` : ""}<token>.`,
                                 });
                             },
                         });

--- a/packages/ui/fern-docs-server/src/getHarRequest.ts
+++ b/packages/ui/fern-docs-server/src/getHarRequest.ts
@@ -121,8 +121,8 @@ export function getHarRequest(
                         visitDiscriminatedUnion(clientCredentials.value, "type")._visit({
                             referencedEndpoint: () => {
                                 request.headers.push({
-                                    name: "Authorization",
-                                    value: "Bearer <token>",
+                                    name: clientCredentials.value.headerName || "Authorization",
+                                    value: `${clientCredentials.value.tokenPrefix ?? "Bearer"} <token>`,
                                 });
                             },
                         });

--- a/servers/fdr/docker-compose.ete.yml
+++ b/servers/fdr/docker-compose.ete.yml
@@ -30,9 +30,9 @@ services:
       postgres:
         condition: service_healthy
       s3-mock:
-        condition: service_healthy
+        condition: service_started
       redis_0:
-        condition: service_healthy
+        condition: service_started
   postgres:
     image: postgres:10.3
     restart: always
@@ -46,6 +46,7 @@ services:
       retries: 5
     ports:
       - "5434:5432"
+
   s3-mock:
     image: adobe/s3mock
     ports:

--- a/servers/fdr/docker-compose.ete.yml
+++ b/servers/fdr/docker-compose.ete.yml
@@ -29,6 +29,10 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      s3-mock:
+        condition: service_healthy
+      redis_0:
+        condition: service_healthy
   postgres:
     image: postgres:10.3
     restart: always

--- a/servers/fdr/docker-compose.ete.yml
+++ b/servers/fdr/docker-compose.ete.yml
@@ -29,10 +29,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      s3-mock:
-        condition: service_started
-      redis_0:
-        condition: service_started
   postgres:
     image: postgres:10.3
     restart: always
@@ -46,7 +42,6 @@ services:
       retries: 5
     ports:
       - "5434:5432"
-
   s3-mock:
     image: adobe/s3mock
     ports:


### PR DESCRIPTION
## Short description of the changes made

* Very small fix to plumb the headerKey and tokenPrefix to various locations where the oAuth scheme is visited

## What was the motivation & context behind this PR?

* preemptive

## How has this PR been tested?

* local docs dev
