### PR TITLE
fix(docs): li in card

### DIFF
--- a/packages/ui/components/src/FernCard.scss
+++ b/packages/ui/components/src/FernCard.scss
@@ -15,5 +15,9 @@
         &.elevated {
             @apply shadow-card-elevated border-primary;
         }
+        
+        li {
+            @apply list-inside;
+        }
     }
 }

--- a/packages/ui/components/src/FernCard.scss
+++ b/packages/ui/components/src/FernCard.scss
@@ -15,7 +15,7 @@
         &.elevated {
             @apply shadow-card-elevated border-primary;
         }
-        
+
         li {
             @apply list-inside;
         }


### PR DESCRIPTION
fixes alignment of list items inside of cards

before: 
![Screenshot 2024-11-23 at 11 20 14 AM](https://github.com/user-attachments/assets/d4e24941-a4b5-44a1-aa9f-6053cfcc8985)

after:
![Screenshot 2024-11-23 at 11 27 31 AM](https://github.com/user-attachments/assets/f7d28f6c-867b-4b26-998f-f00335923d86)
