### PR TITLE
fix(cli): don't open links in slack notifications

### DIFF
--- a/servers/fdr/src/services/slack/SlackService.ts
+++ b/servers/fdr/src/services/slack/SlackService.ts
@@ -43,12 +43,22 @@ export class SlackServiceImpl implements SlackService {
     }
 
     async notifyGeneratedDocs(request: GeneratingDocsNotification): Promise<void> {
-        if (this.config.enableCustomerNotifications) {
-            try {
-                await this.client.chat.postMessage({
-                    channel: "#customer-notifs",
-                    text: `:herb: ${request.orgId} is generating docs for urls [${request.urls.join(", ")}]`,
-                    blocks: [],
+    if (this.config.enableCustomerNotifications) {
+        try {
+            const urls = request.urls.join(", ");
+            await this.client.chat.postMessage({
+                channel: "#customer-notifs",
+                text: `:herb: ${request.orgId} is generating docs for URLs: ${urls}`,
+                blocks: [
+                    {
+                        type: "section",
+                        text: {
+                            type: "plain_text",
+                            text: `:herb: ${request.orgId} is generating docs for URLs: ${urls}`,
+                            emoji: true,
+                            },
+                        },
+                    ],
                 });
             } catch (err) {
                 this.logger.debug("Failed to send slack message: ", err);


### PR DESCRIPTION
https://chatgpt.com/share/6743cf95-0d58-8005-8e7e-be1319db0223

**Key Changes**
Original: Plain text field directly with Markdown-like formatting.

Updated: Added blocks with plain_text type for the message content.
Avoided Hyperlink Rendering: Removed <> around URLs to prevent Slack from converting them into hyperlinks.
Added Emoji Support: Explicitly included the emoji: true flag in the plain_text block for consistent rendering of emojis like :herb:.
Simplified URL Handling: Defined urls as a local variable to improve readability and maintain consistency.

The changes ensure that Slack doesn't render links automatically in the notifyGeneratedDocs method. You can apply the same approach to similar methods.