### PR TITLE
Rohin/openapi known schema object papercuts

### DIFF
--- a/packages/parsers/src/__test__/__snapshots__/openapi/cohere.json
+++ b/packages/parsers/src/__test__/__snapshots__/openapi/cohere.json
@@ -28,9 +28,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -39,12 +45,18 @@
         {
           "key": "Accepts",
           "valueShape": {
-            "type": "enum",
-            "values": [
-              {
-                "value": "text/event-stream"
+            "type": "alias",
+            "value": {
+              "type": "optional",
+              "shape": {
+                "type": "enum",
+                "values": [
+                  {
+                    "value": "text/event-stream"
+                  }
+                ]
               }
-            ]
+            }
           },
           "description": "Pass text/event-stream to receive the streamed response as server-sent events. The default is `\\n` delimited events.\n"
         }
@@ -73,9 +85,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               },
@@ -86,9 +104,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "boolean"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "boolean"
+                      }
+                    }
                   }
                 }
               },
@@ -99,9 +123,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               },
@@ -112,12 +142,18 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
+                  "type": "optional",
+                  "shape": {
                     "type": "alias",
                     "value": {
-                      "type": "id",
-                      "id": "Message"
+                      "type": "list",
+                      "itemShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "id",
+                          "id": "Message"
+                        }
+                      }
                     }
                   }
                 }
@@ -129,9 +165,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               },
@@ -140,18 +182,24 @@
             {
               "key": "prompt_truncation",
               "valueShape": {
-                "type": "enum",
-                "values": [
-                  {
-                    "value": "OFF"
-                  },
-                  {
-                    "value": "AUTO"
-                  },
-                  {
-                    "value": "AUTO_PRESERVE_ORDER"
+                "type": "alias",
+                "value": {
+                  "type": "optional",
+                  "shape": {
+                    "type": "enum",
+                    "values": [
+                      {
+                        "value": "OFF"
+                      },
+                      {
+                        "value": "AUTO"
+                      },
+                      {
+                        "value": "AUTO_PRESERVE_ORDER"
+                      }
+                    ]
                   }
-                ]
+                }
               },
               "description": "Defaults to `AUTO` when `connectors` are specified and `OFF` in all other cases.\n\nDictates how the prompt will be constructed.\n\nWith `prompt_truncation` set to \"AUTO\", some elements from `chat_history` and `documents` will be dropped in an attempt to construct a prompt that fits within the model's context length limit. During this process the order of the documents and chat history will be changed and ranked by relevance.\n\nWith `prompt_truncation` set to \"AUTO_PRESERVE_ORDER\", some elements from `chat_history` and `documents` will be dropped in an attempt to construct a prompt that fits within the model's context length limit. During this process the order of the documents and chat history will be preserved as they are inputted into the API.\n\nWith `prompt_truncation` set to \"OFF\", no elements will be dropped. If the sum of the inputs exceeds the model's context length limit, a `TooManyTokens` error will be returned.\n\nCompatible Deployments: \n - AUTO: Cohere Platform Only\n - AUTO_PRESERVE_ORDER: Azure, AWS Sagemaker/Bedrock, Private Deployments\n"
             },
@@ -160,12 +208,18 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
+                  "type": "optional",
+                  "shape": {
                     "type": "alias",
                     "value": {
-                      "type": "id",
-                      "id": "ChatConnector"
+                      "type": "list",
+                      "itemShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "id",
+                          "id": "ChatConnector"
+                        }
+                      }
                     }
                   }
                 }
@@ -177,9 +231,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "boolean"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "boolean"
+                      }
+                    }
                   }
                 }
               },
@@ -190,12 +250,18 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
+                  "type": "optional",
+                  "shape": {
                     "type": "alias",
                     "value": {
-                      "type": "id",
-                      "id": "ChatDocument"
+                      "type": "list",
+                      "itemShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "id",
+                          "id": "ChatDocument"
+                        }
+                      }
                     }
                   }
                 }
@@ -205,18 +271,24 @@
             {
               "key": "citation_quality",
               "valueShape": {
-                "type": "enum",
-                "values": [
-                  {
-                    "value": "fast"
-                  },
-                  {
-                    "value": "accurate"
-                  },
-                  {
-                    "value": "off"
+                "type": "alias",
+                "value": {
+                  "type": "optional",
+                  "shape": {
+                    "type": "enum",
+                    "values": [
+                      {
+                        "value": "fast"
+                      },
+                      {
+                        "value": "accurate"
+                      },
+                      {
+                        "value": "off"
+                      }
+                    ]
                   }
-                ]
+                }
               },
               "description": "Defaults to `\"accurate\"`.\n\nDictates the approach taken to generating citations as part of the RAG flow by allowing the user to specify whether they want `\"accurate\"` results, `\"fast\"` results or no results.\n\nCompatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments\n"
             },
@@ -225,11 +297,17 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "double",
-                    "minimum": 0,
-                    "maximum": 1
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "double",
+                        "minimum": 0,
+                        "maximum": 1
+                      }
+                    }
                   }
                 }
               },
@@ -240,9 +318,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "integer"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "integer"
+                      }
+                    }
                   }
                 }
               },
@@ -253,9 +337,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "integer"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "integer"
+                      }
+                    }
                   }
                 }
               },
@@ -266,12 +356,18 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 500,
-                    "default": 0
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 500,
+                        "default": 0
+                      }
+                    }
                   }
                 }
               },
@@ -282,12 +378,18 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "double",
-                    "minimum": 0.01,
-                    "maximum": 0.99,
-                    "default": 0.75
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "double",
+                        "minimum": 0.01,
+                        "maximum": 0.99,
+                        "default": 0.75
+                      }
+                    }
                   }
                 }
               },
@@ -298,11 +400,17 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 18446744073709552000
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 18446744073709552000
+                      }
+                    }
                   }
                 }
               },
@@ -313,13 +421,19 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
+                  "type": "optional",
+                  "shape": {
                     "type": "alias",
                     "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
+                      "type": "list",
+                      "itemShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "primitive",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   }
@@ -332,9 +446,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "double"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "double"
+                      }
+                    }
                   }
                 }
               },
@@ -345,9 +465,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "double"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "double"
+                      }
+                    }
                   }
                 }
               },
@@ -358,12 +484,18 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
+                  "type": "optional",
+                  "shape": {
                     "type": "alias",
                     "value": {
-                      "type": "id",
-                      "id": "Tool"
+                      "type": "list",
+                      "itemShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "id",
+                          "id": "Tool"
+                        }
+                      }
                     }
                   }
                 }
@@ -375,12 +507,18 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
+                  "type": "optional",
+                  "shape": {
                     "type": "alias",
                     "value": {
-                      "type": "id",
-                      "id": "ToolResult"
+                      "type": "list",
+                      "itemShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "id",
+                          "id": "ToolResult"
+                        }
+                      }
                     }
                   }
                 }
@@ -392,9 +530,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "boolean"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "boolean"
+                      }
+                    }
                   }
                 }
               },
@@ -405,26 +549,38 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "id",
-                  "id": "ResponseFormat"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "id",
+                      "id": "ResponseFormat"
+                    }
+                  }
                 }
               }
             },
             {
               "key": "safety_mode",
               "valueShape": {
-                "type": "enum",
-                "values": [
-                  {
-                    "value": "CONTEXTUAL"
-                  },
-                  {
-                    "value": "STRICT"
-                  },
-                  {
-                    "value": "NONE"
+                "type": "alias",
+                "value": {
+                  "type": "optional",
+                  "shape": {
+                    "type": "enum",
+                    "values": [
+                      {
+                        "value": "CONTEXTUAL"
+                      },
+                      {
+                        "value": "STRICT"
+                      },
+                      {
+                        "value": "NONE"
+                      }
+                    ]
                   }
-                ]
+                }
               },
               "description": "Used to select the [safety instruction](https://docs.cohere.com/docs/safety-modes) inserted into the prompt. Defaults to `CONTEXTUAL`.\nWhen `NONE` is specified, the safety instruction will be omitted.\n\nSafety modes are not yet configurable in combination with `tools`, `tool_results` and `documents` parameters.\n\n**Note**: This parameter is only compatible with models [Command R 08-2024](https://docs.cohere.com/docs/command-r#august-2024-release), [Command R+ 08-2024](https://docs.cohere.com/docs/command-r-plus#august-2024-release) and newer.\n\nCompatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments\n"
             }
@@ -729,9 +885,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -772,12 +934,18 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
+                  "type": "optional",
+                  "shape": {
                     "type": "alias",
                     "value": {
-                      "type": "id",
-                      "id": "ToolV2"
+                      "type": "list",
+                      "itemShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "id",
+                          "id": "ToolV2"
+                        }
+                      }
                     }
                   }
                 }
@@ -789,9 +957,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "boolean"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "boolean"
+                      }
+                    }
                   }
                 }
               },
@@ -802,10 +976,16 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
-                    "type": "undiscriminatedUnion",
-                    "variants": []
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "list",
+                      "itemShape": {
+                        "type": "undiscriminatedUnion",
+                        "variants": []
+                      }
+                    }
                   }
                 }
               },
@@ -816,8 +996,14 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "id",
-                  "id": "CitationOptions"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "id",
+                      "id": "CitationOptions"
+                    }
+                  }
                 }
               }
             },
@@ -826,26 +1012,38 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "id",
-                  "id": "ResponseFormatV2"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "id",
+                      "id": "ResponseFormatV2"
+                    }
+                  }
                 }
               }
             },
             {
               "key": "safety_mode",
               "valueShape": {
-                "type": "enum",
-                "values": [
-                  {
-                    "value": "CONTEXTUAL"
-                  },
-                  {
-                    "value": "STRICT"
-                  },
-                  {
-                    "value": "OFF"
+                "type": "alias",
+                "value": {
+                  "type": "optional",
+                  "shape": {
+                    "type": "enum",
+                    "values": [
+                      {
+                        "value": "CONTEXTUAL"
+                      },
+                      {
+                        "value": "STRICT"
+                      },
+                      {
+                        "value": "OFF"
+                      }
+                    ]
                   }
-                ]
+                }
               },
               "description": "Used to select the [safety instruction](https://docs.cohere.com/v2/docs/safety-modes) inserted into the prompt. Defaults to `CONTEXTUAL`.\nWhen `OFF` is specified, the safety instruction will be omitted.\n\nSafety modes are not yet configurable in combination with `tools`, `tool_results` and `documents` parameters.\n\n**Note**: This parameter is only compatible with models [Command R 08-2024](https://docs.cohere.com/v2/docs/command-r#august-2024-release), [Command R+ 08-2024](https://docs.cohere.com/v2/docs/command-r-plus#august-2024-release) and newer.\n"
             },
@@ -854,9 +1052,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "integer"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "integer"
+                      }
+                    }
                   }
                 }
               },
@@ -867,13 +1071,19 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
+                  "type": "optional",
+                  "shape": {
                     "type": "alias",
                     "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
+                      "type": "list",
+                      "itemShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "primitive",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   }
@@ -886,11 +1096,17 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "double",
-                    "minimum": 0,
-                    "maximum": 1
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "double",
+                        "minimum": 0,
+                        "maximum": 1
+                      }
+                    }
                   }
                 }
               },
@@ -901,11 +1117,17 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 18446744073709552000
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 18446744073709552000
+                      }
+                    }
                   }
                 }
               },
@@ -916,9 +1138,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "double"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "double"
+                      }
+                    }
                   }
                 }
               },
@@ -929,9 +1157,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "double"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "double"
+                      }
+                    }
                   }
                 }
               },
@@ -942,12 +1176,18 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "double",
-                    "minimum": 0,
-                    "maximum": 500,
-                    "default": 0
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "double",
+                        "minimum": 0,
+                        "maximum": 500,
+                        "default": 0
+                      }
+                    }
                   }
                 }
               },
@@ -958,12 +1198,18 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "double",
-                    "minimum": 0.01,
-                    "maximum": 0.99,
-                    "default": 0.75
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "double",
+                        "minimum": 0.01,
+                        "maximum": 0.99,
+                        "default": 0.75
+                      }
+                    }
                   }
                 }
               },
@@ -974,9 +1220,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "boolean"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "boolean"
+                      }
+                    }
                   }
                 }
               },
@@ -1280,9 +1532,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -1295,9 +1553,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -1328,9 +1592,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               },
@@ -1341,9 +1611,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "integer"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "integer"
+                      }
+                    }
                   }
                 }
               },
@@ -1354,9 +1630,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "boolean"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "boolean"
+                      }
+                    }
                   }
                 }
               },
@@ -1367,9 +1649,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "integer"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "integer"
+                      }
+                    }
                   }
                 }
               },
@@ -1378,19 +1666,26 @@
             {
               "key": "truncate",
               "valueShape": {
-                "type": "enum",
-                "values": [
-                  {
-                    "value": "NONE"
+                "type": "alias",
+                "value": {
+                  "type": "optional",
+                  "shape": {
+                    "type": "enum",
+                    "values": [
+                      {
+                        "value": "NONE"
+                      },
+                      {
+                        "value": "START"
+                      },
+                      {
+                        "value": "END"
+                      }
+                    ],
+                    "default": "END"
                   },
-                  {
-                    "value": "START"
-                  },
-                  {
-                    "value": "END"
-                  }
-                ],
-                "default": "END"
+                  "default": "END"
+                }
               },
               "description": "One of `NONE|START|END` to specify how the API will handle inputs longer than the maximum token length.\n\nPassing `START` will discard the start of the input. `END` will discard the end of the input. In both cases, input is discarded until the remaining input is exactly the maximum input token length for the model.\n\nIf `NONE` is selected, when the input exceeds the maximum input token length an error will be returned."
             },
@@ -1399,9 +1694,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "double"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "double"
+                      }
+                    }
                   }
                 }
               },
@@ -1412,11 +1713,17 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 18446744073709552000
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 18446744073709552000
+                      }
+                    }
                   }
                 }
               },
@@ -1427,9 +1734,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               },
@@ -1440,13 +1753,19 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
+                  "type": "optional",
+                  "shape": {
                     "type": "alias",
                     "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
+                      "type": "list",
+                      "itemShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "primitive",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   }
@@ -1459,13 +1778,19 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
+                  "type": "optional",
+                  "shape": {
                     "type": "alias",
                     "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
+                      "type": "list",
+                      "itemShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "primitive",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   }
@@ -1478,9 +1803,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "integer"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "integer"
+                      }
+                    }
                   }
                 }
               },
@@ -1491,9 +1822,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "double"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "double"
+                      }
+                    }
                   }
                 }
               },
@@ -1504,9 +1841,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "double"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "double"
+                      }
+                    }
                   }
                 }
               },
@@ -1517,9 +1860,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "double"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "double"
+                      }
+                    }
                   }
                 }
               },
@@ -1528,19 +1877,26 @@
             {
               "key": "return_likelihoods",
               "valueShape": {
-                "type": "enum",
-                "values": [
-                  {
-                    "value": "GENERATION"
+                "type": "alias",
+                "value": {
+                  "type": "optional",
+                  "shape": {
+                    "type": "enum",
+                    "values": [
+                      {
+                        "value": "GENERATION"
+                      },
+                      {
+                        "value": "ALL"
+                      },
+                      {
+                        "value": "NONE"
+                      }
+                    ],
+                    "default": "NONE"
                   },
-                  {
-                    "value": "ALL"
-                  },
-                  {
-                    "value": "NONE"
-                  }
-                ],
-                "default": "NONE"
+                  "default": "NONE"
+                }
               },
               "description": "One of `GENERATION|ALL|NONE` to specify how and if the token likelihoods are returned with the response. Defaults to `NONE`.\n\nIf `GENERATION` is selected, the token likelihoods will only be provided for generated text.\n\nIf `ALL` is selected, the token likelihoods will be provided both for the prompt and the generated text."
             },
@@ -1549,9 +1905,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "boolean"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "boolean"
+                      }
+                    }
                   }
                 }
               },
@@ -1866,9 +2228,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -2279,9 +2647,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -2294,9 +2668,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -2314,13 +2694,19 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
+                  "type": "optional",
+                  "shape": {
                     "type": "alias",
                     "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
+                      "type": "list",
+                      "itemShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "primitive",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   }
@@ -2333,13 +2719,19 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
+                  "type": "optional",
+                  "shape": {
                     "type": "alias",
                     "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
+                      "type": "list",
+                      "itemShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "primitive",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   }
@@ -2390,19 +2782,26 @@
             {
               "key": "truncate",
               "valueShape": {
-                "type": "enum",
-                "values": [
-                  {
-                    "value": "NONE"
+                "type": "alias",
+                "value": {
+                  "type": "optional",
+                  "shape": {
+                    "type": "enum",
+                    "values": [
+                      {
+                        "value": "NONE"
+                      },
+                      {
+                        "value": "START"
+                      },
+                      {
+                        "value": "END"
+                      }
+                    ],
+                    "default": "END"
                   },
-                  {
-                    "value": "START"
-                  },
-                  {
-                    "value": "END"
-                  }
-                ],
-                "default": "END"
+                  "default": "END"
+                }
               },
               "description": "One of `NONE|START|END` to specify how the API will handle inputs longer than the maximum token length.\n\nPassing `START` will discard the start of the input. `END` will discard the end of the input. In both cases, input is discarded until the remaining input is exactly the maximum input token length for the model.\n\nIf `NONE` is selected, when the input exceeds the maximum input token length an error will be returned."
             }
@@ -2718,9 +3117,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -2733,9 +3138,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -3051,9 +3462,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -3066,9 +3483,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -3413,9 +3836,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -3428,9 +3857,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -3769,9 +4204,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -4073,9 +4514,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -4093,9 +4540,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               },
@@ -4133,10 +4586,16 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "integer",
-                    "minimum": 1
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "integer",
+                        "minimum": 1
+                      }
+                    }
                   }
                 }
               },
@@ -4147,13 +4606,19 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
+                  "type": "optional",
+                  "shape": {
                     "type": "alias",
                     "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
+                      "type": "list",
+                      "itemShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "primitive",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   }
@@ -4166,10 +4631,16 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "boolean",
-                    "default": false
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "boolean",
+                        "default": false
+                      }
+                    }
                   }
                 }
               },
@@ -4180,10 +4651,16 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "integer",
-                    "default": 10
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "integer",
+                        "default": 10
+                      }
+                    }
                   }
                 }
               },
@@ -4203,9 +4680,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }
@@ -4223,23 +4706,29 @@
                       {
                         "key": "document",
                         "valueShape": {
-                          "type": "object",
-                          "extends": [],
-                          "properties": [
-                            {
-                              "key": "text",
-                              "valueShape": {
-                                "type": "alias",
-                                "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "string"
-                                  }
+                          "type": "alias",
+                          "value": {
+                            "type": "optional",
+                            "shape": {
+                              "type": "object",
+                              "extends": [],
+                              "properties": [
+                                {
+                                  "key": "text",
+                                  "valueShape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "description": "The text of the document to rerank"
                                 }
-                              },
-                              "description": "The text of the document to rerank"
+                              ]
                             }
-                          ]
+                          }
                         },
                         "description": "If `return_documents` is set as `false` this will return none, if `true` it will return the documents passed in"
                       },
@@ -4280,8 +4769,14 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "id",
-                  "id": "ApiMeta"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "id",
+                      "id": "ApiMeta"
+                    }
+                  }
                 }
               }
             }
@@ -4587,9 +5082,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -4652,10 +5153,16 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "integer",
-                    "minimum": 1
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "integer",
+                        "minimum": 1
+                      }
+                    }
                   }
                 }
               },
@@ -4666,9 +5173,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "integer"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "integer"
+                      }
+                    }
                   }
                 }
               },
@@ -4688,9 +5201,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }
@@ -4742,8 +5261,14 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "id",
-                  "id": "ApiMeta"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "id",
+                      "id": "ApiMeta"
+                    }
+                  }
                 }
               }
             }
@@ -5046,9 +5571,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -5061,9 +5592,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -5100,12 +5637,18 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "list",
-                  "itemShape": {
+                  "type": "optional",
+                  "shape": {
                     "type": "alias",
                     "value": {
-                      "type": "id",
-                      "id": "ClassifyExample"
+                      "type": "list",
+                      "itemShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "id",
+                          "id": "ClassifyExample"
+                        }
+                      }
                     }
                   }
                 }
@@ -5117,9 +5660,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               },
@@ -5130,9 +5679,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               },
@@ -5141,19 +5696,26 @@
             {
               "key": "truncate",
               "valueShape": {
-                "type": "enum",
-                "values": [
-                  {
-                    "value": "NONE"
+                "type": "alias",
+                "value": {
+                  "type": "optional",
+                  "shape": {
+                    "type": "enum",
+                    "values": [
+                      {
+                        "value": "NONE"
+                      },
+                      {
+                        "value": "START"
+                      },
+                      {
+                        "value": "END"
+                      }
+                    ],
+                    "default": "END"
                   },
-                  {
-                    "value": "START"
-                  },
-                  {
-                    "value": "END"
-                  }
-                ],
-                "default": "END"
+                  "default": "END"
+                }
               },
               "description": "One of `NONE|START|END` to specify how the API will handle inputs longer than the maximum token length.\nPassing `START` will discard the start of the input. `END` will discard the end of the input. In both cases, input is discarded until the remaining input is exactly the maximum input token length for the model.\nIf `NONE` is selected, when the input exceeds the maximum input token length an error will be returned."
             }
@@ -5205,9 +5767,15 @@
                         "valueShape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
+                            "type": "optional",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
                             }
                           }
                         },
@@ -5218,9 +5786,15 @@
                         "valueShape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
+                            "type": "optional",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
                             }
                           }
                         },
@@ -5251,9 +5825,15 @@
                         "valueShape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "double"
+                            "type": "optional",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "double"
+                                }
+                              }
                             }
                           }
                         },
@@ -5313,8 +5893,14 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "id",
-                  "id": "ApiMeta"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "id",
+                      "id": "ApiMeta"
+                    }
+                  }
                 }
               }
             }
@@ -5620,9 +6206,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -5633,9 +6225,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "datetime"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "datetime"
+                  }
+                }
               }
             }
           },
@@ -5646,9 +6244,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "datetime"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "datetime"
+                  }
+                }
               }
             }
           },
@@ -5659,9 +6263,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "double"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "double"
+                  }
+                }
               }
             }
           },
@@ -5672,9 +6282,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "double"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "double"
+                  }
+                }
               }
             }
           },
@@ -5685,8 +6301,14 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "id",
-              "id": "DatasetValidationStatus"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "id",
+                  "id": "DatasetValidationStatus"
+                }
+              }
             }
           },
           "description": "optional filter by validation status"
@@ -5698,9 +6320,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -6055,9 +6683,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "boolean"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "boolean"
+                  }
+                }
               }
             }
           },
@@ -6068,9 +6702,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "boolean"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "boolean"
+                  }
+                }
               }
             }
           },
@@ -6081,13 +6721,19 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "list",
-              "itemShape": {
+              "type": "optional",
+              "shape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "list",
+                  "itemShape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }
@@ -6100,13 +6746,19 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "list",
-              "itemShape": {
+              "type": "optional",
+              "shape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "list",
+                  "itemShape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }
@@ -6119,9 +6771,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -6132,9 +6790,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -6147,9 +6811,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -6501,9 +7171,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -6849,9 +7525,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -7194,9 +7876,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -7507,9 +8195,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -7522,9 +8216,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -7553,35 +8253,49 @@
             {
               "key": "length",
               "valueShape": {
-                "type": "enum",
-                "values": [
-                  {
-                    "value": "short"
+                "type": "alias",
+                "value": {
+                  "type": "optional",
+                  "shape": {
+                    "type": "enum",
+                    "values": [
+                      {
+                        "value": "short"
+                      },
+                      {
+                        "value": "medium"
+                      },
+                      {
+                        "value": "long"
+                      }
+                    ],
+                    "default": "medium"
                   },
-                  {
-                    "value": "medium"
-                  },
-                  {
-                    "value": "long"
-                  }
-                ],
-                "default": "medium"
+                  "default": "medium"
+                }
               },
               "description": "One of `short`, `medium`, `long`, or `auto` defaults to `auto`. Indicates the approximate length of the summary. If `auto` is selected, the best option will be picked based on the input text."
             },
             {
               "key": "format",
               "valueShape": {
-                "type": "enum",
-                "values": [
-                  {
-                    "value": "paragraph"
+                "type": "alias",
+                "value": {
+                  "type": "optional",
+                  "shape": {
+                    "type": "enum",
+                    "values": [
+                      {
+                        "value": "paragraph"
+                      },
+                      {
+                        "value": "bullets"
+                      }
+                    ],
+                    "default": "paragraph"
                   },
-                  {
-                    "value": "bullets"
-                  }
-                ],
-                "default": "paragraph"
+                  "default": "paragraph"
+                }
               },
               "description": "One of `paragraph`, `bullets`, or `auto`, defaults to `auto`. Indicates the style in which the summary will be delivered - in a free form paragraph or in bullet points. If `auto` is selected, the best option will be picked based on the input text."
             },
@@ -7590,9 +8304,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               },
@@ -7601,19 +8321,26 @@
             {
               "key": "extractiveness",
               "valueShape": {
-                "type": "enum",
-                "values": [
-                  {
-                    "value": "low"
+                "type": "alias",
+                "value": {
+                  "type": "optional",
+                  "shape": {
+                    "type": "enum",
+                    "values": [
+                      {
+                        "value": "low"
+                      },
+                      {
+                        "value": "medium"
+                      },
+                      {
+                        "value": "high"
+                      }
+                    ],
+                    "default": "low"
                   },
-                  {
-                    "value": "medium"
-                  },
-                  {
-                    "value": "high"
-                  }
-                ],
-                "default": "low"
+                  "default": "low"
+                }
               },
               "description": "One of `low`, `medium`, `high`, or `auto`, defaults to `auto`. Controls how close to the original text the summary is. `high` extractiveness summaries will lean towards reusing sentences verbatim, while `low` extractiveness summaries will tend to paraphrase more. If `auto` is selected, the best option will be picked based on the input text."
             },
@@ -7622,12 +8349,18 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "double",
-                    "minimum": 0,
-                    "maximum": 5,
-                    "default": 0.3
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "double",
+                        "minimum": 0,
+                        "maximum": 5,
+                        "default": 0.3
+                      }
+                    }
                   }
                 }
               },
@@ -7638,9 +8371,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               },
@@ -7990,9 +8729,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -8005,9 +8750,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -8097,8 +8848,14 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "id",
-                  "id": "ApiMeta"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "id",
+                      "id": "ApiMeta"
+                    }
+                  }
                 }
               }
             }
@@ -8401,9 +9158,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -8416,9 +9179,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -8490,8 +9259,14 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "id",
-                  "id": "ApiMeta"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "id",
+                      "id": "ApiMeta"
+                    }
+                  }
                 }
               }
             }
@@ -8797,10 +9572,16 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "double",
-                "default": 30
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "double",
+                    "default": 30
+                  }
+                }
               }
             }
           },
@@ -8811,10 +9592,16 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "double",
-                "default": 0
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "double",
+                    "default": 0
+                  }
+                }
               }
             }
           },
@@ -8827,9 +9614,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -9145,9 +9938,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -9492,9 +10291,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -9829,9 +10634,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -10174,9 +10985,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -10189,9 +11006,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -10525,9 +11348,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -10540,9 +11369,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -10858,9 +11693,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "double"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "double"
+                  }
+                }
               }
             }
           },
@@ -10871,9 +11712,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -10884,8 +11731,14 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "id",
-              "id": "CompatibleEndpoint"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "id",
+                  "id": "CompatibleEndpoint"
+                }
+              }
             }
           },
           "description": "When provided, filters the list of models to only those that are compatible with the specified endpoint."
@@ -10895,9 +11748,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "boolean"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "boolean"
+                  }
+                }
               }
             }
           },
@@ -11210,9 +12069,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -11242,9 +12107,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }
@@ -11254,9 +12125,15 @@
               "valueShape": {
                 "type": "alias",
                 "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
+                  "type": "optional",
+                  "shape": {
+                    "type": "alias",
+                    "value": {
+                      "type": "primitive",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }
@@ -11566,9 +12443,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "integer"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "integer"
+                  }
+                }
               }
             }
           },
@@ -11579,9 +12462,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -11592,9 +12481,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -11607,9 +12502,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -11736,9 +12637,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -11894,9 +12801,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -12042,9 +12955,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -12194,9 +13113,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "integer"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "integer"
+                  }
+                }
               }
             }
           },
@@ -12207,9 +13132,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -12220,9 +13151,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -12235,9 +13172,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -12387,9 +13330,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "integer"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "integer"
+                  }
+                }
               }
             }
           },
@@ -12400,9 +13349,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -12415,9 +13370,15 @@
           "valueShape": {
             "type": "alias",
             "value": {
-              "type": "primitive",
-              "value": {
-                "type": "string"
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -12602,12 +13563,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ToolCall"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ToolCall"
+                      }
+                    }
                   }
                 }
               }
@@ -12671,12 +13638,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ToolResult"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ToolResult"
+                      }
+                    }
                   }
                 }
               }
@@ -12726,12 +13699,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "ToolCall"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "ToolCall"
+                          }
+                        }
                       }
                     }
                   }
@@ -12773,12 +13752,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "ToolCall"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "ToolCall"
+                          }
+                        }
                       }
                     }
                   }
@@ -12820,12 +13805,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "ToolCall"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "ToolCall"
+                          }
+                        }
                       }
                     }
                   }
@@ -12854,12 +13845,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "ToolResult"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "ToolResult"
+                          }
+                        }
                       }
                     }
                   }
@@ -12894,9 +13891,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -12907,9 +13910,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -12918,9 +13927,15 @@
           {
             "key": "options",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": []
+                }
+              }
             },
             "description": "Provides the connector with different settings at request time. The key/value pairs of this object are specific to each connector.\n\nFor example, the connector `web-search` supports the `site` option, which limits search results to the specified domain.\n"
           }
@@ -12992,9 +14007,15 @@
           {
             "key": "parameter_definitions",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": []
+                }
+              }
             },
             "description": "The input parameters of the tool. Accepts a dictionary where the key is the name of the parameter and the value is the parameter spec. Valid parameter names contain only the characters `a-z`, `A-Z`, `0-9`, `_` and must not begin with a digit.\n```\n{\n  \"my_param\": {\n    \"description\": <string>,\n    \"type\": <string>, // any python data type, such as 'str', 'bool'\n    \"required\": <boolean>\n  }\n}\n```\n"
           }
@@ -13054,9 +14075,15 @@
           {
             "key": "schema",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": []
+                }
+              }
             },
             "description": "A JSON schema object that the output will adhere to. There are some restrictions we have on the schema, refer to [our guide](https://docs.cohere.com/docs/structured-outputs-json#schema-constraints) for more information.\nExample (required name and age object):\n```json\n{\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": {\"type\": \"string\"},\n    \"age\": {\"type\": \"integer\"}\n  },\n  \"required\": [\"name\", \"age\"]\n}\n```\n\n**Note**: This field must not be specified when the `type` is set to `\"text\"`.\n"
           }
@@ -13104,9 +14131,15 @@
               {
                 "key": "schema",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": []
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": []
+                    }
+                  }
                 },
                 "description": "A JSON schema object that the output will adhere to. There are some restrictions we have on the schema, refer to [our guide](https://docs.cohere.com/docs/structured-outputs-json#schema-constraints) for more information.\nExample (required name and age object):\n```json\n{\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": {\"type\": \"string\"},\n    \"age\": {\"type\": \"integer\"}\n  },\n  \"required\": [\"name\", \"age\"]\n}\n```\n\n**Note**: This field must not be specified when the `type` is set to `\"text\"`.\n"
               }
@@ -13254,8 +14287,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ChatSearchQuery"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ChatSearchQuery"
+                  }
+                }
               }
             }
           },
@@ -13294,9 +14333,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -13307,9 +14352,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -13376,9 +14427,15 @@
                   "valueShape": {
                     "type": "alias",
                     "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "boolean"
+                      "type": "optional",
+                      "shape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "primitive",
+                          "value": {
+                            "type": "boolean"
+                          }
+                        }
                       }
                     }
                   }
@@ -13388,9 +14445,15 @@
                   "valueShape": {
                     "type": "alias",
                     "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "boolean"
+                      "type": "optional",
+                      "shape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "primitive",
+                          "value": {
+                            "type": "boolean"
+                          }
+                        }
                       }
                     }
                   }
@@ -13552,9 +14615,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             },
@@ -13565,9 +14634,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             },
@@ -13578,12 +14653,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ChatCitation"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ChatCitation"
+                      }
+                    }
                   }
                 }
               }
@@ -13595,12 +14676,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ChatDocument"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ChatDocument"
+                      }
+                    }
                   }
                 }
               }
@@ -13612,9 +14699,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -13625,12 +14718,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ChatSearchQuery"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ChatSearchQuery"
+                      }
+                    }
                   }
                 }
               }
@@ -13642,12 +14741,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ChatSearchResult"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ChatSearchResult"
+                      }
+                    }
                   }
                 }
               }
@@ -13659,8 +14764,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "FinishReason"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "FinishReason"
+                  }
+                }
               }
             }
           },
@@ -13669,12 +14780,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ToolCall"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ToolCall"
+                      }
+                    }
                   }
                 }
               }
@@ -13685,12 +14802,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Message"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Message"
+                      }
+                    }
                   }
                 }
               }
@@ -13702,8 +14825,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ApiMeta"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ApiMeta"
+                  }
+                }
               }
             }
           }
@@ -14366,12 +15495,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ToolCallV2"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ToolCallV2"
+                      }
+                    }
                   }
                 }
               }
@@ -14382,9 +15517,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -14393,8 +15534,14 @@
           {
             "key": "content",
             "valueShape": {
-              "type": "undiscriminatedUnion",
-              "variants": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "undiscriminatedUnion",
+                  "variants": []
+                }
+              }
             }
           },
           {
@@ -14402,12 +15549,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Citation"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Citation"
+                      }
+                    }
                   }
                 }
               }
@@ -14471,9 +15624,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -14681,12 +15840,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "ToolCallV2"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "ToolCallV2"
+                          }
+                        }
                       }
                     }
                   }
@@ -14697,9 +15862,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -14708,8 +15879,14 @@
               {
                 "key": "content",
                 "valueShape": {
-                  "type": "undiscriminatedUnion",
-                  "variants": []
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "undiscriminatedUnion",
+                      "variants": []
+                    }
+                  }
                 }
               },
               {
@@ -14717,12 +15894,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "Citation"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "Citation"
+                          }
+                        }
                       }
                     }
                   }
@@ -14963,9 +16146,15 @@
           {
             "key": "json_schema",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": []
+                }
+              }
             },
             "description": "A [JSON schema](https://json-schema.org/overview/what-is-jsonschema) object that the output will adhere to. There are some restrictions we have on the schema, refer to [our guide](https://docs.cohere.com/docs/structured-outputs-json#schema-constraints) for more information.\nExample (required name and age object):\n```json\n{\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": {\"type\": \"string\"},\n    \"age\": {\"type\": \"integer\"}\n  },\n  \"required\": [\"name\", \"age\"]\n}\n```\n\n**Note**: This field must not be specified when the `type` is set to `\"text\"`.\n"
           }
@@ -15013,9 +16202,15 @@
               {
                 "key": "json_schema",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": []
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": []
+                    }
+                  }
                 },
                 "description": "A [JSON schema](https://json-schema.org/overview/what-is-jsonschema) object that the output will adhere to. There are some restrictions we have on the schema, refer to [our guide](https://docs.cohere.com/docs/structured-outputs-json#schema-constraints) for more information.\nExample (required name and age object):\n```json\n{\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": {\"type\": \"string\"},\n    \"age\": {\"type\": \"integer\"}\n  },\n  \"required\": [\"name\", \"age\"]\n}\n```\n\n**Note**: This field must not be specified when the `type` is set to `\"text\"`.\n"
               }
@@ -15071,12 +16266,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ToolCallV2"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ToolCallV2"
+                      }
+                    }
                   }
                 }
               }
@@ -15087,9 +16288,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -15100,43 +16307,49 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
-                  "type": "discriminatedUnion",
-                  "discriminant": "type",
-                  "variants": [
-                    {
-                      "discriminantValue": "text",
-                      "description": "Text content of the message.",
-                      "type": "object",
-                      "extends": [],
-                      "properties": [
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "list",
+                    "itemShape": {
+                      "type": "discriminatedUnion",
+                      "discriminant": "type",
+                      "variants": [
                         {
-                          "key": "type",
-                          "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "text"
+                          "discriminantValue": "text",
+                          "description": "Text content of the message.",
+                          "type": "object",
+                          "extends": [],
+                          "properties": [
+                            {
+                              "key": "type",
+                              "valueShape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "text"
+                                  }
+                                ]
                               }
-                            ]
-                          }
-                        },
-                        {
-                          "key": "text",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                            },
+                            {
+                              "key": "text",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
                               }
                             }
-                          }
+                          ]
                         }
                       ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -15146,12 +16359,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Citation"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Citation"
+                      }
+                    }
                   }
                 }
               }
@@ -15277,9 +16496,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -15309,13 +16534,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 }
@@ -15370,8 +16601,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Usage"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Usage"
+                  }
+                }
               }
             }
           },
@@ -15380,12 +16617,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "LogprobItem"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "LogprobItem"
+                      }
+                    }
                   }
                 }
               }
@@ -15718,9 +16961,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -15731,9 +16980,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             }
@@ -15743,36 +16998,42 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "token",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "list",
+                    "itemShape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "token",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "key": "likelihood",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "double"
+                              }
+                            }
                           }
                         }
-                      }
-                    },
-                    {
-                      "key": "likelihood",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "double"
-                          }
-                        }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             },
@@ -15804,9 +17065,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -15834,8 +17101,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ApiMeta"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ApiMeta"
+                  }
+                }
               }
             }
           }
@@ -15914,9 +17187,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -16106,15 +17385,21 @@
           {
             "key": "response_type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "embeddings_floats"
-                },
-                {
-                  "value": "embeddings_by_type"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "embeddings_floats"
+                    },
+                    {
+                      "value": "embeddings_by_type"
+                    }
+                  ]
                 }
-              ]
+              }
             }
           },
           {
@@ -16178,12 +17463,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Image"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Image"
+                      }
+                    }
                   }
                 }
               }
@@ -16195,8 +17486,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ApiMeta"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ApiMeta"
+                  }
+                }
               }
             }
           }
@@ -16212,15 +17509,21 @@
           {
             "key": "response_type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "embeddings_floats"
-                },
-                {
-                  "value": "embeddings_by_type"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "embeddings_floats"
+                    },
+                    {
+                      "value": "embeddings_by_type"
+                    }
+                  ]
                 }
-              ]
+              }
             }
           },
           {
@@ -16394,12 +17697,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Image"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Image"
+                      }
+                    }
                   }
                 }
               }
@@ -16411,8 +17720,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ApiMeta"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ApiMeta"
+                  }
+                }
               }
             }
           }
@@ -16443,9 +17758,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -16506,9 +17827,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -16547,8 +17874,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ApiMeta"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ApiMeta"
+                  }
+                }
               }
             }
           }
@@ -16627,9 +17960,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -16640,12 +17979,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "EmbeddingType"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "EmbeddingType"
+                      }
+                    }
                   }
                 }
               }
@@ -16655,16 +18000,23 @@
           {
             "key": "truncate",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "START"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "START"
+                    },
+                    {
+                      "value": "END"
+                    }
+                  ],
+                  "default": "END"
                 },
-                {
-                  "value": "END"
-                }
-              ],
-              "default": "END"
+                "default": "END"
+              }
             },
             "description": "One of `START|END` to specify how the API will handle inputs longer than the maximum token length.\n\nPassing `START` will discard the start of the input. `END` will discard the end of the input. In both cases, input is discarded until the remaining input is exactly the maximum input token length for the model.\n"
           }
@@ -16694,8 +18046,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ApiMeta"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ApiMeta"
+                  }
+                }
               }
             }
           }
@@ -16855,9 +18213,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -16868,9 +18232,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -16881,9 +18251,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -16894,9 +18270,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -16907,9 +18289,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -16920,13 +18308,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17403,9 +18797,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17416,9 +18816,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17429,13 +18835,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17447,13 +18859,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17465,12 +18883,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "DatasetPart"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "DatasetPart"
+                      }
+                    }
                   }
                 }
               }
@@ -17482,13 +18906,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17501,8 +18931,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ParseInfo"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ParseInfo"
+                  }
+                }
               }
             }
           },
@@ -17511,8 +18947,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Metrics"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Metrics"
+                  }
+                }
               }
             }
           }
@@ -17530,9 +18972,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17543,9 +18991,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17582,9 +19036,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17617,9 +19077,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17643,9 +19109,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17656,9 +19128,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17695,13 +19173,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17714,9 +19198,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17727,8 +19217,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ConnectorOAuth"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ConnectorOAuth"
+                  }
+                }
               }
             },
             "description": "The OAuth 2.0 configuration for the connector."
@@ -17736,15 +19232,21 @@
           {
             "key": "auth_status",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "valid"
-                },
-                {
-                  "value": "expired"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "valid"
+                    },
+                    {
+                      "value": "expired"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The OAuth status for the user making the request. One of [\"valid\", \"expired\", \"\"]. Empty string (field is omitted) means the user has not authorized the connector yet."
           },
@@ -17753,9 +19255,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -17766,9 +19274,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -17805,9 +19319,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -17827,9 +19347,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17840,9 +19366,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17853,9 +19385,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17866,9 +19404,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17879,9 +19423,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17965,9 +19515,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -17991,13 +19547,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18010,8 +19572,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "CreateConnectorOAuth"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "CreateConnectorOAuth"
+                  }
+                }
               }
             },
             "description": "The OAuth 2.0 configuration for the connector. Cannot be specified if service_auth is specified."
@@ -18021,10 +19589,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean",
-                  "default": true
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean",
+                      "default": true
+                    }
+                  }
                 }
               }
             },
@@ -18035,10 +19609,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean",
-                  "default": false
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean",
+                      "default": false
+                    }
+                  }
                 }
               }
             },
@@ -18049,8 +19629,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "CreateConnectorServiceAuth"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "CreateConnectorServiceAuth"
+                  }
+                }
               }
             },
             "description": "The service to service authentication configuration for the connector. Cannot be specified if oauth is specified."
@@ -18362,9 +19948,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -18541,8 +20133,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ApiMeta"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ApiMeta"
+                  }
+                }
               }
             }
           }
@@ -18653,9 +20251,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "datetime"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "datetime"
+                    }
+                  }
                 }
               }
             },
@@ -18666,9 +20270,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -18679,9 +20289,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -18692,9 +20308,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -18705,9 +20327,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -18718,9 +20346,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -18729,24 +20363,30 @@
           {
             "key": "status",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "unknown"
-                },
-                {
-                  "value": "processing"
-                },
-                {
-                  "value": "failed"
-                },
-                {
-                  "value": "complete"
-                },
-                {
-                  "value": "queued"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "unknown"
+                    },
+                    {
+                      "value": "processing"
+                    },
+                    {
+                      "value": "failed"
+                    },
+                    {
+                      "value": "complete"
+                    },
+                    {
+                      "value": "queued"
+                    }
+                  ]
                 }
-              ]
+              }
             }
           },
           {
@@ -18754,9 +20394,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -18767,9 +20413,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -18780,9 +20432,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -18793,12 +20451,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Cluster"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Cluster"
+                      }
+                    }
                   }
                 }
               }
@@ -18810,9 +20474,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -18822,8 +20492,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ApiMeta"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ApiMeta"
+                  }
+                }
               }
             }
           }
@@ -18858,9 +20534,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -18870,8 +20552,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ApiMeta"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ApiMeta"
+                  }
+                }
               }
             }
           }
@@ -18901,9 +20589,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -18913,11 +20607,17 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer",
-                  "minimum": 1,
-                  "default": 10
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "default": 10
+                    }
+                  }
                 }
               }
             },
@@ -18928,12 +20628,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer",
-                  "minimum": 2,
-                  "maximum": 100,
-                  "default": 15
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer",
+                      "minimum": 2,
+                      "maximum": 100,
+                      "default": 15
+                    }
+                  }
                 }
               }
             },
@@ -18944,10 +20650,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean",
-                  "default": true
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean",
+                      "default": true
+                    }
+                  }
                 }
               }
             },
@@ -18958,9 +20670,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -19265,9 +20983,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -19331,9 +21055,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -19344,9 +21074,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -19368,8 +21104,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Strategy"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Strategy"
+                  }
+                }
               }
             },
             "description": "Deprecated: The fine-tuning strategy."
@@ -19549,9 +21291,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -19596,8 +21344,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Hyperparameters"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Hyperparameters"
+                  }
+                }
               }
             },
             "description": "Fine-tuning hyper-parameters."
@@ -19607,9 +21361,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -19620,8 +21380,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "WandbConfig"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "WandbConfig"
+                  }
+                }
               }
             },
             "description": "The Weights & Biases configuration (Chat fine-tuning only)."
@@ -19678,9 +21444,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -19704,9 +21476,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -19717,9 +21495,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -19741,8 +21525,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Status"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Status"
+                  }
+                }
               }
             },
             "description": "read-only. Current stage in the life-cycle of the fine-tuned model."
@@ -19752,9 +21542,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "datetime"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "datetime"
+                    }
+                  }
                 }
               }
             },
@@ -19765,9 +21561,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "datetime"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "datetime"
+                    }
+                  }
                 }
               }
             },
@@ -19778,9 +21580,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "datetime"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "datetime"
+                    }
+                  }
                 }
               }
             },
@@ -19791,9 +21599,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "datetime"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "datetime"
+                    }
+                  }
                 }
               }
             },

--- a/packages/parsers/src/__test__/__snapshots__/openapi/deeptune.json
+++ b/packages/parsers/src/__test__/__snapshots__/openapi/deeptune.json
@@ -376,9 +376,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -389,9 +395,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -459,9 +471,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -472,9 +490,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -629,9 +653,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },

--- a/packages/parsers/src/__test__/__snapshots__/openapi/petstore.json
+++ b/packages/parsers/src/__test__/__snapshots__/openapi/petstore.json
@@ -541,9 +541,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "long"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "long"
+                    }
+                  }
                 }
               }
             }
@@ -565,8 +571,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Category"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Category"
+                  }
+                }
               }
             }
           },
@@ -593,12 +605,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Tag"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Tag"
+                      }
+                    }
                   }
                 }
               }
@@ -607,18 +625,24 @@
           {
             "key": "status",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "available"
-                },
-                {
-                  "value": "pending"
-                },
-                {
-                  "value": "sold"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "available"
+                    },
+                    {
+                      "value": "pending"
+                    },
+                    {
+                      "value": "sold"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "pet status in the store"
           }

--- a/packages/parsers/src/openapi/3.1/guards/isMixedSchema.ts
+++ b/packages/parsers/src/openapi/3.1/guards/isMixedSchema.ts
@@ -1,0 +1,10 @@
+import { MixedSchemaConverterNode } from "../schemas/MixedSchemaConverter.node";
+import { isArraySchema } from "./isArraySchema";
+import { isNonArraySchema } from "./isNonArraySchema";
+
+export function isMixedSchema(schema: unknown): schema is MixedSchemaConverterNode.Input {
+    return (
+        Array.isArray(schema) &&
+        schema.every((type) => type.type === "null" || isNonArraySchema(type) || isArraySchema(type))
+    );
+}

--- a/packages/parsers/src/openapi/3.1/paths/OperationObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/OperationObjectConverter.node.ts
@@ -6,7 +6,6 @@ import {
     BaseOpenApiV3_1ConverterNodeConstructorArgs,
 } from "../../BaseOpenApiV3_1Converter.node";
 import { coalesceServers } from "../../utils/3.1/coalesceServers";
-import { convertToObjectProperties } from "../../utils/3.1/convertToObjectProperties";
 import { resolveParameterReference } from "../../utils/3.1/resolveParameterReference";
 import { getEndpointId } from "../../utils/getEndpointId";
 import { SecurityRequirementObjectConverterNode } from "../auth/SecurityRequirementObjectConverter.node";
@@ -14,7 +13,10 @@ import { AvailabilityConverterNode } from "../extensions/AvailabilityConverter.n
 import { XFernGroupNameConverterNode } from "../extensions/XFernGroupNameConverter.node";
 import { isReferenceObject } from "../guards/isReferenceObject";
 import { ServerObjectConverterNode } from "./ServerObjectConverter.node";
-import { ParameterBaseObjectConverterNode } from "./parameters/ParameterBaseObjectConverter.node";
+import {
+    ParameterBaseObjectConverterNode,
+    convertOperationObjectProperties,
+} from "./parameters/ParameterBaseObjectConverter.node";
 import { RequestBodyObjectConverterNode } from "./request/RequestBodyObjectConverter.node";
 import { ResponsesObjectConverterNode } from "./response/ResponsesObjectConverter.node";
 
@@ -209,7 +211,7 @@ export class OperationObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
                 method: this.method,
                 // This is a little bit weird, consider changing the shape of fdr
                 path: this.convertPathToPathParts()?.map((part) => part.value.toString()) ?? [],
-                headers: convertToObjectProperties(this.requestHeaders),
+                headers: convertOperationObjectProperties(this.requestHeaders),
                 // TODO: figure out what this looks like to be able to parse
                 payload: undefined,
                 examples: undefined,
@@ -244,9 +246,9 @@ export class OperationObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
             auth: authIds?.map((id) => FernRegistry.api.latest.AuthSchemeId(id)),
             defaultEnvironment: environments?.[0]?.id,
             environments,
-            pathParameters: convertToObjectProperties(this.pathParameters),
-            queryParameters: convertToObjectProperties(this.queryParameters),
-            requestHeaders: convertToObjectProperties(this.requestHeaders),
+            pathParameters: convertOperationObjectProperties(this.pathParameters),
+            queryParameters: convertOperationObjectProperties(this.queryParameters),
+            requestHeaders: convertOperationObjectProperties(this.requestHeaders),
             responseHeaders: responses?.[0]?.headers,
             // TODO: revisit fdr shape to suport multiple requests
             request: this.requests?.convert()[0],

--- a/packages/parsers/src/openapi/3.1/paths/__test__/OperationObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/OperationObjectConverter.node.test.ts
@@ -48,9 +48,15 @@ describe("OperationObjectConverterNode", () => {
                         valueShape: {
                             type: "alias",
                             value: {
-                                type: "primitive",
-                                value: {
-                                    type: "string",
+                                type: "optional",
+                                shape: {
+                                    type: "alias",
+                                    value: {
+                                        type: "primitive",
+                                        value: {
+                                            type: "string",
+                                        },
+                                    },
                                 },
                             },
                         },

--- a/packages/parsers/src/openapi/3.1/paths/__test__/PathItemObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/PathItemObjectConverter.node.test.ts
@@ -69,9 +69,15 @@ describe("PathItemObjectConverterNode", () => {
                         valueShape: {
                             type: "alias",
                             value: {
-                                type: "primitive",
-                                value: {
-                                    type: "string",
+                                type: "optional",
+                                shape: {
+                                    type: "alias",
+                                    value: {
+                                        type: "primitive",
+                                        value: {
+                                            type: "string",
+                                        },
+                                    },
                                 },
                             },
                         },

--- a/packages/parsers/src/openapi/3.1/paths/parameters/ParameterBaseObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/parameters/ParameterBaseObjectConverter.node.ts
@@ -1,12 +1,29 @@
+import { isNonNullish } from "@fern-api/ui-core-utils";
 import { OpenAPIV3_1 } from "openapi-types";
 import { FernRegistry } from "../../../../client/generated";
 import {
     BaseOpenApiV3_1ConverterNode,
     BaseOpenApiV3_1ConverterNodeConstructorArgs,
 } from "../../../BaseOpenApiV3_1Converter.node";
+import { convertToObjectProperties } from "../../../utils/3.1/convertToObjectProperties";
 import { AvailabilityConverterNode } from "../../extensions/AvailabilityConverter.node";
 import { isReferenceObject } from "../../guards/isReferenceObject";
 import { SchemaConverterNode } from "../../schemas/SchemaConverter.node";
+
+export function convertOperationObjectProperties(
+    properties: Record<string, ParameterBaseObjectConverterNode> | undefined,
+): FernRegistry.api.latest.ObjectProperty[] | undefined {
+    if (properties == null) {
+        return undefined;
+    }
+
+    return convertToObjectProperties(
+        properties,
+        Object.entries(properties ?? {})
+            .map(([key, header]) => (header.required ? key : undefined))
+            .filter(isNonNullish),
+    );
+}
 
 export class ParameterBaseObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
     OpenAPIV3_1.ParameterBaseObject | OpenAPIV3_1.ReferenceObject,

--- a/packages/parsers/src/openapi/3.1/paths/response/ResponsesObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/response/ResponsesObjectConverter.node.ts
@@ -5,8 +5,8 @@ import {
     BaseOpenApiV3_1ConverterNode,
     BaseOpenApiV3_1ConverterNodeConstructorArgs,
 } from "../../../BaseOpenApiV3_1Converter.node";
-import { convertToObjectProperties } from "../../../utils/3.1/convertToObjectProperties";
 import { STATUS_CODE_MESSAGES } from "../../../utils/statusCodes";
+import { convertOperationObjectProperties } from "../parameters/ParameterBaseObjectConverter.node";
 import { ResponseObjectConverterNode } from "./ResponseObjectConverter.node";
 
 export class ResponsesObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
@@ -69,7 +69,7 @@ export class ResponsesObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
                     return undefined;
                 }
                 return {
-                    headers: convertToObjectProperties(response.headers),
+                    headers: convertOperationObjectProperties(response.headers),
                     response: {
                         statusCode: parseInt(statusCode),
                         body,

--- a/packages/parsers/src/openapi/3.1/schemas/ConstConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/ConstConverter.node.ts
@@ -1,0 +1,63 @@
+import { OpenAPIV3_1 } from "openapi-types";
+import { FernRegistry } from "../../../client/generated";
+import {
+    BaseOpenApiV3_1ConverterNode,
+    BaseOpenApiV3_1ConverterNodeConstructorArgs,
+} from "../../BaseOpenApiV3_1Converter.node";
+import { AvailabilityConverterNode } from "../extensions/AvailabilityConverter.node";
+
+export class ConstConverterNode extends BaseOpenApiV3_1ConverterNode<
+    OpenAPIV3_1.SchemaObject,
+    FernRegistry.api.latest.TypeShape.Enum
+> {
+    constValue: string | undefined;
+    description: string | undefined;
+    availability: AvailabilityConverterNode | undefined;
+
+    constructor(args: BaseOpenApiV3_1ConverterNodeConstructorArgs<OpenAPIV3_1.SchemaObject>) {
+        super(args);
+        this.safeParse();
+    }
+
+    parse(): void {
+        // TODO: this can be any primitive type, so Enum Value should be an FDR primitive
+        if (
+            this.input.const != null &&
+            (typeof this.input.const === "string" ||
+                typeof this.input.const === "number" ||
+                typeof this.input.const === "boolean")
+        ) {
+            this.constValue = this.input.const.toString();
+        } else {
+            this.context.errors.warning({
+                message: `Unsupported const type: ${typeof this.input}`,
+                path: this.accessPath,
+            });
+        }
+        this.description = this.input.description;
+        this.availability = new AvailabilityConverterNode({
+            input: this.input,
+            context: this.context,
+            accessPath: this.accessPath,
+            pathId: "x-fern-availability",
+        });
+    }
+
+    convert(): FernRegistry.api.latest.TypeShape.Enum | undefined {
+        if (this.constValue == null) {
+            return undefined;
+        }
+
+        return {
+            type: "enum",
+            default: this.constValue,
+            values: [
+                {
+                    value: this.constValue,
+                    description: this.description,
+                    availability: this.availability?.convert(),
+                },
+            ],
+        };
+    }
+}

--- a/packages/parsers/src/openapi/3.1/schemas/MixedSchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/MixedSchemaConverter.node.ts
@@ -1,0 +1,83 @@
+import { isNonNullish } from "@fern-api/ui-core-utils";
+import { OpenAPIV3_1 } from "openapi-types";
+import { FernRegistry } from "../../../client/generated";
+import {
+    BaseOpenApiV3_1ConverterNode,
+    BaseOpenApiV3_1ConverterNodeConstructorArgs,
+} from "../../BaseOpenApiV3_1Converter.node";
+import { SchemaConverterNode } from "./SchemaConverter.node";
+
+export declare namespace MixedSchemaConverterNode {
+    export type Input = (OpenAPIV3_1.ArraySchemaObject | OpenAPIV3_1.NonArraySchemaObject | { type: "null" })[];
+}
+
+export class MixedSchemaConverterNode extends BaseOpenApiV3_1ConverterNode<
+    MixedSchemaConverterNode.Input,
+    FernRegistry.api.latest.TypeShape.UndiscriminatedUnion | FernRegistry.api.latest.TypeShape.Alias
+> {
+    typeNodes: SchemaConverterNode[] | undefined;
+    nullable: boolean | undefined;
+
+    constructor(args: BaseOpenApiV3_1ConverterNodeConstructorArgs<MixedSchemaConverterNode.Input>) {
+        super(args);
+        this.parse();
+    }
+
+    parse(): void {
+        this.typeNodes = this.input
+            .map((type) => {
+                if (type.type === "null") {
+                    this.nullable = true;
+                } else {
+                    return new SchemaConverterNode({
+                        input: type,
+                        context: this.context,
+                        accessPath: this.accessPath,
+                        pathId: this.pathId,
+                    });
+                }
+                return undefined;
+            })
+            .filter(isNonNullish);
+    }
+
+    public convert():
+        | FernRegistry.api.latest.TypeShape.UndiscriminatedUnion
+        | FernRegistry.api.latest.TypeShape.Alias
+        | undefined {
+        if (this.typeNodes == null) {
+            return undefined;
+        }
+
+        const union = {
+            type: "undiscriminatedUnion",
+            variants: this.typeNodes
+                .map((typeNode) => {
+                    const shape = typeNode.convert();
+                    if (shape == null) {
+                        return undefined;
+                    }
+
+                    return {
+                        displayName: typeNode.name,
+                        shape,
+                        description: typeNode.description,
+                        availability: typeNode.availability?.convert(),
+                    };
+                })
+                .filter(isNonNullish),
+        } as const;
+
+        // TODO: right now, this is handled as an optional, but we should handle it as nullable
+        return this.nullable
+            ? {
+                  type: "alias",
+                  value: {
+                      type: "optional",
+                      default: union.variants[0],
+                      shape: union,
+                  },
+              }
+            : union;
+    }
+}

--- a/packages/parsers/src/openapi/3.1/schemas/ObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/ObjectConverter.node.ts
@@ -24,6 +24,7 @@ export class ObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
     extends: string[] = [];
     properties: Record<string, SchemaConverterNode> | undefined;
     extraProperties: string | SchemaConverterNode | undefined;
+    requiredProperties: string[] | undefined;
 
     constructor(args: BaseOpenApiV3_1ConverterNodeConstructorArgs<ObjectConverterNode.Input>) {
         super(args);
@@ -33,6 +34,7 @@ export class ObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
     parse(): void {
         this.extends = [];
 
+        this.requiredProperties = this.input.required;
         this.properties = Object.fromEntries(
             Object.entries(this.input.properties ?? {}).map(([key, property]) => {
                 return [
@@ -99,7 +101,7 @@ export class ObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
             return undefined;
         }
 
-        return convertToObjectProperties(this.properties);
+        return convertToObjectProperties(this.properties, this.requiredProperties);
     }
 
     convertExtraProperties(): FernRegistry.api.latest.TypeReference | undefined {

--- a/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
@@ -16,6 +16,7 @@ import { isObjectSchema } from "../guards/isObjectSchema";
 import { isReferenceObject } from "../guards/isReferenceObject";
 import { isStringSchema } from "../guards/isStringSchema";
 import { ArrayConverterNode } from "./ArrayConverter.node";
+import { ConstConverterNode } from "./ConstConverter.node";
 import { ObjectConverterNode } from "./ObjectConverter.node";
 import { OneOfConverterNode } from "./OneOfConverter.node";
 import { ReferenceConverterNode } from "./ReferenceConverter.node";
@@ -70,7 +71,14 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNode<
             // If the object is not a reference object, then it is a schema object, gather all appropriate variables
             this.name = this.input.title;
 
-            if (isNonArraySchema(this.input) && this.input.oneOf != null) {
+            if (this.input.const != null) {
+                this.typeShapeNode = new ConstConverterNode({
+                    input: this.input.const,
+                    context: this.context,
+                    accessPath: this.accessPath,
+                    pathId: "const",
+                });
+            } else if (isNonArraySchema(this.input) && this.input.oneOf != null) {
                 this.typeShapeNode = new OneOfConverterNode({
                     input: this.input,
                     context: this.context,
@@ -131,7 +139,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNode<
                     case "integer":
                         if (isIntegerSchema(this.input)) {
                             this.typeShapeNode = new IntegerConverterNode({
-                                input: this.input as IntegerConverterNode.Input,
+                                input: this.input,
                                 context: this.context,
                                 accessPath: this.accessPath,
                                 pathId: this.pathId,
@@ -141,7 +149,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNode<
                     case "number":
                         if (isNumberSchema(this.input)) {
                             this.typeShapeNode = new NumberConverterNode({
-                                input: this.input as NumberConverterNode.Input,
+                                input: this.input,
                                 context: this.context,
                                 accessPath: this.accessPath,
                                 pathId: this.pathId,
@@ -151,7 +159,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNode<
                     case "string":
                         if (isStringSchema(this.input)) {
                             this.typeShapeNode = new StringConverterNode({
-                                input: this.input as StringConverterNode.Input,
+                                input: this.input,
                                 context: this.context,
                                 accessPath: this.accessPath,
                                 pathId: this.pathId,
@@ -161,7 +169,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNode<
                     case "null":
                         if (isNullSchema(this.input)) {
                             this.typeShapeNode = new NullConverterNode({
-                                input: this.input as NullConverterNode.Input,
+                                input: this.input,
                                 context: this.context,
                                 accessPath: this.accessPath,
                                 pathId: this.pathId,

--- a/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
@@ -9,6 +9,7 @@ import { AvailabilityConverterNode } from "../extensions/AvailabilityConverter.n
 import { isArraySchema } from "../guards/isArraySchema";
 import { isBooleanSchema } from "../guards/isBooleanSchema";
 import { isIntegerSchema } from "../guards/isIntegerSchema";
+import { isMixedSchema } from "../guards/isMixedSchema";
 import { isNonArraySchema } from "../guards/isNonArraySchema";
 import { isNullSchema } from "../guards/isNullSchema";
 import { isNumberSchema } from "../guards/isNumberSchema";
@@ -17,6 +18,7 @@ import { isReferenceObject } from "../guards/isReferenceObject";
 import { isStringSchema } from "../guards/isStringSchema";
 import { ArrayConverterNode } from "./ArrayConverter.node";
 import { ConstConverterNode } from "./ConstConverter.node";
+import { MixedSchemaConverterNode } from "./MixedSchemaConverter.node";
 import { ObjectConverterNode } from "./ObjectConverter.node";
 import { OneOfConverterNode } from "./OneOfConverter.node";
 import { ReferenceConverterNode } from "./ReferenceConverter.node";
@@ -73,10 +75,17 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNode<
 
             if (this.input.const != null) {
                 this.typeShapeNode = new ConstConverterNode({
-                    input: this.input.const,
+                    input: this.input,
                     context: this.context,
                     accessPath: this.accessPath,
-                    pathId: "const",
+                    pathId: this.pathId,
+                });
+            } else if (isMixedSchema(this.input)) {
+                this.typeShapeNode = new MixedSchemaConverterNode({
+                    input: this.input,
+                    context: this.context,
+                    accessPath: this.accessPath,
+                    pathId: this.pathId,
                 });
             } else if (isNonArraySchema(this.input) && this.input.oneOf != null) {
                 this.typeShapeNode = new OneOfConverterNode({

--- a/packages/parsers/src/openapi/3.1/schemas/__test__/ConstConverterNode.test.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/__test__/ConstConverterNode.test.ts
@@ -1,0 +1,106 @@
+import { createMockContext } from "../../../../__test__/createMockContext.util";
+import { ConstConverterNode } from "../ConstConverter.node";
+
+describe("ConstConverterNode", () => {
+    const context = createMockContext();
+
+    describe("parse()", () => {
+        it("handles string const", () => {
+            const node = new ConstConverterNode({
+                input: {
+                    const: "test",
+                    description: "test description",
+                },
+                context,
+                accessPath: [],
+                pathId: "test",
+            });
+
+            expect(node.convert()).toEqual({
+                type: "enum",
+                default: "test",
+                values: [
+                    {
+                        value: "test",
+                        description: "test description",
+                        availability: undefined,
+                    },
+                ],
+            });
+        });
+
+        it("handles number const", () => {
+            const node = new ConstConverterNode({
+                input: {
+                    const: 123,
+                },
+                context,
+                accessPath: [],
+                pathId: "test",
+            });
+
+            expect(node.convert()).toEqual({
+                type: "enum",
+                default: "123",
+                values: [
+                    {
+                        value: "123",
+                        description: undefined,
+                        availability: undefined,
+                    },
+                ],
+            });
+        });
+
+        it("handles boolean const", () => {
+            const node = new ConstConverterNode({
+                input: {
+                    const: true,
+                },
+                context,
+                accessPath: [],
+                pathId: "test",
+            });
+
+            expect(node.convert()).toEqual({
+                type: "enum",
+                default: "true",
+                values: [
+                    {
+                        value: "true",
+                        description: undefined,
+                        availability: undefined,
+                    },
+                ],
+            });
+        });
+
+        it("handles unsupported const type", () => {
+            const node = new ConstConverterNode({
+                input: {
+                    const: { foo: "bar" },
+                },
+                context,
+                accessPath: [],
+                pathId: "test",
+            });
+
+            expect(node.convert()).toBeUndefined();
+            expect(context.errors.warning).toHaveBeenCalledWith({
+                message: expect.stringContaining("Unsupported const type"),
+                path: ["test"],
+            });
+        });
+
+        it("handles undefined const", () => {
+            const node = new ConstConverterNode({
+                input: {},
+                context,
+                accessPath: [],
+                pathId: "test",
+            });
+
+            expect(node.convert()).toBeUndefined();
+        });
+    });
+});

--- a/packages/parsers/src/openapi/3.1/schemas/__test__/MixedSchemaConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/__test__/MixedSchemaConverter.node.test.ts
@@ -1,0 +1,88 @@
+import { createMockContext } from "../../../../__test__/createMockContext.util";
+import { FernRegistry } from "../../../../client/generated";
+import { MixedSchemaConverterNode } from "../MixedSchemaConverter.node";
+
+describe("MixedSchemaConverterNode", () => {
+    const mockContext = createMockContext();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe("constructor", () => {
+        it("should handle mixed schema with null type", () => {
+            const input: MixedSchemaConverterNode.Input = [{ type: "null" }, { type: "string" }];
+
+            const node = new MixedSchemaConverterNode({
+                input,
+                context: mockContext,
+                accessPath: [],
+                pathId: "test",
+            });
+
+            expect(node.nullable).toBe(true);
+            expect(node.typeNodes?.length).toBe(1);
+        });
+
+        it("should handle mixed schema with multiple non-null types", () => {
+            const input: MixedSchemaConverterNode.Input = [{ type: "string" }, { type: "number" }];
+
+            const node = new MixedSchemaConverterNode({
+                input,
+                context: mockContext,
+                accessPath: [],
+                pathId: "test",
+            });
+
+            expect(node.nullable).toBeUndefined();
+            expect(node.typeNodes?.length).toBe(2);
+        });
+    });
+
+    describe("convert", () => {
+        it("should convert to undiscriminatedUnion when not nullable", () => {
+            const input: MixedSchemaConverterNode.Input = [{ type: "string" }, { type: "number" }];
+
+            const node = new MixedSchemaConverterNode({
+                input,
+                context: mockContext,
+                accessPath: [],
+                pathId: "test",
+            });
+
+            const result = node.convert();
+            expect(result?.type).toBe("undiscriminatedUnion");
+            expect((result as FernRegistry.api.latest.TypeShape.UndiscriminatedUnion)?.variants?.length).toBe(2);
+        });
+
+        it("should convert to optional alias when nullable", () => {
+            const input: MixedSchemaConverterNode.Input = [{ type: "null" }, { type: "string" }];
+
+            const node = new MixedSchemaConverterNode({
+                input,
+                context: mockContext,
+                accessPath: [],
+                pathId: "test",
+            });
+
+            const result = node.convert();
+            expect(result?.type).toBe("alias");
+            expect((result as FernRegistry.api.latest.TypeShape.Alias)?.value?.type).toBe("optional");
+        });
+
+        it("should return undefined when typeNodes is null", () => {
+            const input: MixedSchemaConverterNode.Input = [];
+
+            const node = new MixedSchemaConverterNode({
+                input,
+                context: mockContext,
+                accessPath: [],
+                pathId: "test",
+            });
+
+            node.typeNodes = undefined;
+            const result = node.convert();
+            expect(result).toBeUndefined();
+        });
+    });
+});

--- a/packages/parsers/src/openapi/utils/3.1/convertToObjectProperties.ts
+++ b/packages/parsers/src/openapi/utils/3.1/convertToObjectProperties.ts
@@ -4,16 +4,30 @@ import { ParameterBaseObjectConverterNode, SchemaConverterNode } from "../../3.1
 
 export function convertToObjectProperties(
     properties: Record<string, SchemaConverterNode | ParameterBaseObjectConverterNode> | undefined,
+    requiredProperties: string[] | undefined,
 ): FernRegistry.api.latest.ObjectProperty[] | undefined {
     if (properties == null) {
         return undefined;
     }
+
     return Object.entries(properties)
         .map(([key, node]) => {
-            const valueShape = node.convert();
+            let valueShape = node.convert();
             if (valueShape == null) {
                 return undefined;
             }
+
+            if (requiredProperties != null && !requiredProperties.includes(key)) {
+                valueShape = {
+                    type: "alias",
+                    value: {
+                        type: "optional",
+                        shape: valueShape,
+                        default: valueShape.type === "enum" ? valueShape.default : undefined,
+                    },
+                };
+            }
+
             return {
                 key: FernRegistry.PropertyKey(key),
                 valueShape,


### PR DESCRIPTION
## Short description of the changes made
* Handles schema type definitions like `[string, number, ...]`
* Handles `null` in array type definitions
* Handles `const` on schema for boolean, string, and number primitives
* Handles `required` for object properties and operation parameters

## What was the motivation & context behind this PR?
* Known asks and papercuts

## How has this PR been tested?
* Snapshot + unit tests
