### PR TITLE
fix: disable preview url indexing

### DIFF
--- a/packages/ui/app/src/search/SearchV2.tsx
+++ b/packages/ui/app/src/search/SearchV2.tsx
@@ -62,6 +62,8 @@ export function SearchV2(): ReactElement | false {
     const { data } = useApiRouteSWRImmutable("/api/fern-docs/search/v2/key", {
         request: { headers: { "X-User-Token": userToken } },
         validate: ApiKeySchema,
+        // api key expires 24 hours, so we refresh it every 12 hours
+        refreshInterval: 60 * 60 * 12 * 1000,
     });
 
     const facetApiEndpoint = useApiRoute("/api/fern-docs/search/v2/facet");

--- a/packages/ui/app/src/search/SearchV2.tsx
+++ b/packages/ui/app/src/search/SearchV2.tsx
@@ -17,7 +17,6 @@ import {
     useFacetFilters,
     useIsMobile,
 } from "@fern-ui/fern-docs-search-ui";
-import { HEADER_X_ALGOLIA_API_KEY } from "@fern-ui/fern-docs-utils";
 import { useEventCallback } from "@fern-ui/react-commons";
 import { useAtomValue } from "jotai";
 import { useRouter } from "next/router";
@@ -73,12 +72,10 @@ export function SearchV2(): ReactElement | false {
                 return {};
             }
             const searchParams = new URLSearchParams();
+            searchParams.append("apiKey", data.apiKey);
             filters.forEach((filter) => searchParams.append("filters", filter));
             const search = String(searchParams);
-            const res = await fetch(`${facetApiEndpoint}${search ? `?${search}` : ""}`, {
-                method: "GET",
-                headers: { [HEADER_X_ALGOLIA_API_KEY]: data.apiKey },
-            });
+            const res = await fetch(`${facetApiEndpoint}?${search}`, { method: "GET" });
             return res.json();
         },
         [data, facetApiEndpoint],

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v3.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v3.ts
@@ -1,10 +1,12 @@
 import { DocsKVCache } from "@/server/DocsCache";
 import { DocsLoader } from "@/server/DocsLoader";
+import { getOrgMetadataForDomain } from "@/server/auth/metadata-for-url";
 import { queueAlgoliaReindex } from "@/server/queueAlgoliaReindex";
 import { Revalidator } from "@/server/revalidator";
 import { getDocsDomainNode, getHostNode } from "@/server/xfernhost/node";
 import { NodeCollector } from "@fern-api/fdr-sdk/navigation";
 import type { FernDocs } from "@fern-fern/fern-docs-sdk";
+import { withoutStaging } from "@fern-ui/fern-docs-utils";
 import { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
 
 export const config = {
@@ -53,7 +55,10 @@ const handler: NextApiHandler = async (
 
     // queue algolia reindexing
     try {
-        await queueAlgoliaReindex(domain, root.slug);
+        const orgMetadata = await getOrgMetadataForDomain(withoutStaging(domain));
+        if (orgMetadata?.isPreviewUrl === false) {
+            await queueAlgoliaReindex(host, withoutStaging(domain), root.slug);
+        }
     } catch (err) {
         // eslint-disable-next-line no-console
         console.error(err);

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v4.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/revalidate-all/v4.ts
@@ -1,10 +1,12 @@
 import { DocsKVCache } from "@/server/DocsCache";
 import { DocsLoader } from "@/server/DocsLoader";
+import { getOrgMetadataForDomain } from "@/server/auth/metadata-for-url";
 import { queueAlgoliaReindex } from "@/server/queueAlgoliaReindex";
 import { Revalidator } from "@/server/revalidator";
 import { getDocsDomainNode, getHostNode } from "@/server/xfernhost/node";
 import { NodeCollector } from "@fern-api/fdr-sdk/navigation";
 import type { FernDocs } from "@fern-fern/fern-docs-sdk";
+import { withoutStaging } from "@fern-ui/fern-docs-utils";
 import { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
 
 export const config = {
@@ -60,7 +62,10 @@ const handler: NextApiHandler = async (
     if (offset === 0) {
         // queue algolia reindexing
         try {
-            await queueAlgoliaReindex(domain, root.slug);
+            const orgMetadata = await getOrgMetadataForDomain(withoutStaging(domain));
+            if (orgMetadata?.isPreviewUrl === false) {
+                await queueAlgoliaReindex(host, withoutStaging(domain), root.slug);
+            }
         } catch (err) {
             // eslint-disable-next-line no-console
             console.error(err);

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/search/v2/facet.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/search/v2/facet.ts
@@ -2,7 +2,6 @@ import { algoliaAppId } from "@/server/env-variables";
 import { selectFirst } from "@/server/utils/selectFirst";
 import { toArray } from "@/server/utils/toArray";
 import { fetchFacetValues } from "@fern-ui/fern-docs-search-server/algolia";
-import { HEADER_X_ALGOLIA_API_KEY } from "@fern-ui/fern-docs-utils";
 import { algoliasearch } from "algoliasearch";
 import { NextApiRequest, NextApiResponse } from "next/types";
 
@@ -15,10 +14,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     const filters = toArray(req.query.filters);
-    const apiKey = selectFirst(req.headers[HEADER_X_ALGOLIA_API_KEY]);
+    const apiKey = selectFirst(req.query.apiKey);
 
     if (!apiKey) {
-        return res.status(400).send(`${HEADER_X_ALGOLIA_API_KEY} is required`);
+        return res.status(400).send("apiKey is required");
     }
 
     return res.json(await fetchFacetValues({ filters, client: algoliasearch(algoliaAppId(), apiKey) }));

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/search/v2/key.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/search/v2/key.ts
@@ -1,3 +1,4 @@
+import { getOrgMetadataForDomain } from "@/server/auth/metadata-for-url";
 import { algoliaAppId, algoliaSearchApikey } from "@/server/env-variables";
 import { selectFirst } from "@/server/utils/selectFirst";
 import { getDocsDomainNode } from "@/server/xfernhost/node";
@@ -18,6 +19,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     const domain = getDocsDomainNode(req);
+
+    const orgMetadata = await getOrgMetadataForDomain(withoutStaging(domain));
+    if (orgMetadata == null) {
+        return res.status(404).send("Not found");
+    }
+
+    if (orgMetadata.isPreviewUrl) {
+        return res.status(400).send("Search is not supported for preview URLs");
+    }
+
     const userToken = getXUserToken(req);
 
     const apiKey = getSearchApiKey({

--- a/packages/ui/docs-bundle/src/server/queueAlgoliaReindex.ts
+++ b/packages/ui/docs-bundle/src/server/queueAlgoliaReindex.ts
@@ -1,15 +1,23 @@
 import { Client } from "@upstash/qstash";
 
 import { qstashToken } from "@/server/env-variables";
-import { addLeadingSlash } from "@fern-ui/fern-docs-utils";
+import { HEADER_X_FERN_HOST, addLeadingSlash } from "@fern-ui/fern-docs-utils";
 import { removeTrailingSlash } from "next/dist/shared/lib/router/utils/remove-trailing-slash";
 import { conformTrailingSlash } from "./trailingSlash";
 
-export const queueAlgoliaReindex = async (domain: string, basepath_: string = ""): Promise<string | undefined> => {
+export const queueAlgoliaReindex = async (
+    host: string,
+    domain: string,
+    basepath_: string = "",
+): Promise<string | undefined> => {
     if (process.env.VERCEL && process.env.VERCEL_ENV !== "development") {
         const client = new Client({ token: qstashToken() });
 
         const headers = new Headers();
+
+        // add x-fern-host header to identify the docs domain (for compatibility with vercel preview urls)
+        headers.set(HEADER_X_FERN_HOST, domain);
+
         if (process.env.VERCEL_AUTOMATION_BYPASS_SECRET) {
             headers.set("x-vercel-protection-bypass", process.env.VERCEL_AUTOMATION_BYPASS_SECRET);
         }
@@ -18,9 +26,10 @@ export const queueAlgoliaReindex = async (domain: string, basepath_: string = ""
         const endpoint = addLeadingSlash(conformTrailingSlash("/api/fern-docs/search/v2/reindex"));
 
         const res = await client.publishJSON({
-            url: `https://${domain}${basepath}${endpoint}`,
+            url: `https://${host}${basepath}${endpoint}`,
             method: "POST",
             headers,
+            retries: 1,
         });
 
         return res.messageId;

--- a/packages/ui/fern-docs-utils/src/constants.ts
+++ b/packages/ui/fern-docs-utils/src/constants.ts
@@ -7,7 +7,7 @@ export const COOKIE_REFRESH_TOKEN = "refresh_token" as const; // for api key inj
 export const COOKIE_EMAIL = "email" as const; // for api key injection
 export const HEADER_X_FERN_HOST = "x-fern-host" as const;
 export const HEADER_X_MATCHED_PATH = "x-matched-path" as const;
-export const HEADER_X_ALGOLIA_API_KEY = "x-algolia-api-key" as const;
+
 /**
  * The role that is used to represent everyone (including unauthenticated users)
  */


### PR DESCRIPTION
fixes some issues based on real-world constraints:
- headers are not always forwarded (i.e. buildwithfern.com/learn) so we'll switch to using query parameters exclusively for search
- preview urls should trigger reindex
- qstash failures should be retried only once (3x is excessive, since the failures tend to be repetitive)
- don't return any ids in the reindex endpoint because it may include (and leak) data