### PR TITLE
fix: missing code block borders

### DIFF
--- a/packages/ui/components/src/CopyToClipboardButton.tsx
+++ b/packages/ui/components/src/CopyToClipboardButton.tsx
@@ -1,8 +1,8 @@
 import { useCopyToClipboard } from "@fern-ui/react-commons";
-import cn from "clsx";
 import { Check, Copy } from "iconoir-react";
 import { FernButton } from "./FernButton";
 import { FernTooltip, FernTooltipProvider } from "./FernTooltip";
+import { cn } from "./cn";
 
 export declare namespace CopyToClipboardButton {
     export interface Props {

--- a/packages/ui/components/src/index.ts
+++ b/packages/ui/components/src/index.ts
@@ -24,6 +24,7 @@ export * from "./FernToast";
 export * from "./FernTooltip";
 export * from "./FontAwesomeIcon";
 export * from "./badges";
+export * from "./cn";
 export * from "./colors";
 export * from "./kbd";
 export * from "./util/shared-component-types";

--- a/packages/ui/fern-docs-syntax-highlighter/src/CodeBlockWithClipboardButton.tsx
+++ b/packages/ui/fern-docs-syntax-highlighter/src/CodeBlockWithClipboardButton.tsx
@@ -1,5 +1,4 @@
-import { CopyToClipboardButton } from "@fern-ui/components";
-import cn, { clsx } from "clsx";
+import { CopyToClipboardButton, cn } from "@fern-ui/components";
 import React, { PropsWithChildren } from "react";
 import { useFeatureFlags } from "./SyntaxHighlighterFeatureFlags";
 
@@ -14,11 +13,9 @@ export const CodeBlockWithClipboardButton: React.FC<PropsWithChildren<CodeBlockW
     const { isDarkCodeEnabled } = useFeatureFlags();
     return (
         <div
-            className={clsx(
-                "not-prose group/cb-container bg-card relative mb-6 mt-4 flex w-full rounded-lg shadow-sm ring-[var(--border-color-card)] ring-1 ring-inset",
-                {
-                    "dark bg-card-solid": isDarkCodeEnabled,
-                },
+            className={cn(
+                "not-prose group/cb-container bg-card relative mb-6 mt-4 flex w-full rounded-lg shadow-sm border border-[var(--grayscale-a5)]",
+                { "dark bg-card-solid": isDarkCodeEnabled },
             )}
         >
             {children}


### PR DESCRIPTION
Current:
<img width="717" alt="Screenshot 2024-12-07 at 3 43 59 PM" src="https://github.com/user-attachments/assets/ba1ff8ac-b920-40a8-81b2-befcaccd23f9">


Restored:
<img width="743" alt="Screenshot 2024-12-07 at 3 43 27 PM" src="https://github.com/user-attachments/assets/04d26b50-e930-437d-ae65-820cf66109e8">
