### PR TITLE
fix: allow .buildwithfern.com

### DIFF
--- a/packages/ui/docs-bundle/src/server/FernNextResponse.ts
+++ b/packages/ui/docs-bundle/src/server/FernNextResponse.ts
@@ -32,6 +32,7 @@ export class FernNextResponse {
 function isBuildWithFern(host: string): boolean {
     return (
         host.toLowerCase().endsWith(".buildwithfern.com") ||
+        host.toLowerCase().endsWith(".buildwithfern.dev") ||
         host.toLowerCase().endsWith(".ferndocs.app") ||
         host.toLowerCase().endsWith(".ferndocs.com") ||
         host.toLowerCase().endsWith(".ferndocs.dev")

--- a/packages/ui/docs-bundle/src/server/FernNextResponse.ts
+++ b/packages/ui/docs-bundle/src/server/FernNextResponse.ts
@@ -30,5 +30,10 @@ export class FernNextResponse {
 }
 
 function isBuildWithFern(host: string): boolean {
-    return host.toLowerCase().endsWith(".buildwithfern.com");
+    return (
+        host.toLowerCase().endsWith(".buildwithfern.com") ||
+        host.toLowerCase().endsWith(".ferndocs.app") ||
+        host.toLowerCase().endsWith(".ferndocs.com") ||
+        host.toLowerCase().endsWith(".ferndocs.dev")
+    );
 }

--- a/packages/ui/docs-bundle/src/server/FernNextResponse.ts
+++ b/packages/ui/docs-bundle/src/server/FernNextResponse.ts
@@ -20,11 +20,15 @@ export class FernNextResponse {
         const allowedDomains = [getHostEdge(req), ...(allowedDestinations ?? []).map((url) => new URL(url).host)];
         const redirectLocation = new URL(destination);
 
-        if (!allowedDomains.includes(redirectLocation.host)) {
+        if (!allowedDomains.includes(redirectLocation.host) || isBuildWithFern(redirectLocation.host)) {
             // open redirect to unknown host detected:
             return new NextResponse(null, { status: 410 });
         }
 
         return NextResponse.redirect(redirectLocation, init);
     }
+}
+
+function isBuildWithFern(host: string): boolean {
+    return host.toLowerCase().endsWith(".buildwithfern.com");
 }


### PR DESCRIPTION
Allow "open" redirects to domains ending with `.buildwithfern.com` to satisfy the edge case in WorkOS `redirect_uri` getting set to `app.buildwithfern.com` for `*.docs.buildwithfern.com` urls.