### PR TITLE
chore(docs): fix list item displays

### DIFF
--- a/packages/ui/app/src/mdx/components/accordion/index.scss
+++ b/packages/ui/app/src/mdx/components/accordion/index.scss
@@ -1,6 +1,10 @@
 @layer components {
     .fern-accordion {
         @apply fern-card divide-default divide-y rounded-lg m-mdx;
+        
+        li {
+            @apply list-outside;
+        }
     }
 
     .fern-accordion-item {

--- a/packages/ui/app/src/mdx/components/accordion/index.scss
+++ b/packages/ui/app/src/mdx/components/accordion/index.scss
@@ -1,7 +1,7 @@
 @layer components {
     .fern-accordion {
         @apply fern-card divide-default divide-y rounded-lg m-mdx;
-        
+
         li {
             @apply list-outside;
         }

--- a/packages/ui/components/src/FernCard.scss
+++ b/packages/ui/components/src/FernCard.scss
@@ -19,7 +19,7 @@
         li {
             @apply list-outside;
         }
-        
+
         ul {
             @apply pl-5;
         }

--- a/packages/ui/components/src/FernCard.scss
+++ b/packages/ui/components/src/FernCard.scss
@@ -17,7 +17,11 @@
         }
 
         li {
-            @apply list-inside;
+            @apply list-outside;
+        }
+        
+        ul {
+            @apply pl-5;
         }
     }
 }


### PR DESCRIPTION
This PR fixes the list item display for both lists inside Cards and Accordions. 

Before:
![Screenshot 2024-12-11 at 1 52 01 PM](https://github.com/user-attachments/assets/410a5843-3b75-4792-812c-55e8826783c0)
 
![Screenshot 2024-12-11 at 1 52 11 PM](https://github.com/user-attachments/assets/deab3a3e-14e4-4023-84a2-126d200c9017)

After:
![Screenshot 2024-12-11 at 1 51 32 PM](https://github.com/user-attachments/assets/8cc0c49d-680e-4d2a-88aa-2be8f41aec9e)

![Screenshot 2024-12-11 at 1 51 43 PM](https://github.com/user-attachments/assets/cf17557d-6416-403e-b9cd-638d21be296c)
