### PR TITLE
fix(docs): use cdn when loading docs from public s3 bucket

### DIFF
--- a/packages/ui/docs-bundle/next.config.mjs
+++ b/packages/ui/docs-bundle/next.config.mjs
@@ -26,6 +26,16 @@ const DOCS_FILES_ALLOWLIST = [
         hostname: "fdr-dev2-docs-files-public.s3.amazonaws.com",
         port: "",
     },
+    {
+        protocol: "https",
+        hostname: "files.buildwithfern.com",
+        port: "",
+    },
+    {
+        protocol: "https",
+        hostname: "files-dev2.buildwithfern.com",
+        port: "",
+    },
 ];
 
 /** @type {import("next").NextConfig} */

--- a/servers/fdr-deploy/scripts/fdr-deploy-stack.ts
+++ b/servers/fdr-deploy/scripts/fdr-deploy-stack.ts
@@ -211,7 +211,10 @@ export class FdrDeployStack extends Stack {
                     REDIS_ENABLED: options.redis.toString(),
                     REDIS_CLUSTERING_MODE_ENABLED: options.redisClusteringModeEnabled.toString(),
                     APPLICATION_ENVIRONMENT: getEnvironmentVariableOrThrow("APPLICATION_ENVIRONMENT"),
-                    PUBLIC_DOCS_CDN_URL: environmentType === "DEV2" ? "https://files-dev2.buildwithfern.com" : "https://files.buildwithfern.com",
+                    PUBLIC_DOCS_CDN_URL:
+                        environmentType === "DEV2"
+                            ? "https://files-dev2.buildwithfern.com"
+                            : "https://files.buildwithfern.com",
                 },
                 containerName: CONTAINER_NAME,
                 containerPort: 8080,

--- a/servers/fdr-deploy/scripts/fdr-deploy-stack.ts
+++ b/servers/fdr-deploy/scripts/fdr-deploy-stack.ts
@@ -211,6 +211,7 @@ export class FdrDeployStack extends Stack {
                     REDIS_ENABLED: options.redis.toString(),
                     REDIS_CLUSTERING_MODE_ENABLED: options.redisClusteringModeEnabled.toString(),
                     APPLICATION_ENVIRONMENT: getEnvironmentVariableOrThrow("APPLICATION_ENVIRONMENT"),
+                    PUBLIC_DOCS_CDN_URL: environmentType === "DEV2" ? "https://files-dev2.buildwithfern.com" : "https://files.buildwithfern.com",
                 },
                 containerName: CONTAINER_NAME,
                 containerPort: 8080,

--- a/servers/fdr/src/__test__/local/s3.test.ts
+++ b/servers/fdr/src/__test__/local/s3.test.ts
@@ -37,6 +37,7 @@ describe("S3 Service", () => {
             redisEnabled: true,
             redisClusteringEnabled: true,
             applicationEnvironment: "string",
+            cdnPublicDocsUrl: "string",
         });
         const startUploadDocsResponse = await s3Service.createPresignedDocsAssetsUploadUrlWithClient({
             domain: "buildwithfern.com",

--- a/servers/fdr/src/__test__/mock.ts
+++ b/servers/fdr/src/__test__/mock.ts
@@ -118,6 +118,7 @@ class MockRevalidatorService implements RevalidatorService {
 export const baseMockFdrConfig: FdrConfig = {
     awsAccessKey: "",
     awsSecretKey: "",
+    cdnPublicDocsUrl: "https://files.buildwithfern.com",
     publicDocsS3: {
         bucketName: "fdr",
         bucketRegion: "us-east-1",

--- a/servers/fdr/src/app/FdrConfig.ts
+++ b/servers/fdr/src/app/FdrConfig.ts
@@ -27,6 +27,7 @@ const ENABLE_CUSTOMER_NOTIFICATIONS_ENV_VAR = "ENABLE_CUSTOMER_NOTIFICATIONS";
 const REDIS_ENABLED_ENV_VAR = "REDIS_ENABLED";
 const REDIS_CLUSTERING_ENABLED_ENV_VAR = "REDIS_CLUSTERING_ENABLED";
 const APPLICATION_ENVIRONMENT_ENV_VAR = "APPLICATION_ENVIRONMENT";
+const PUBLIC_DOCS_CDN_URL = "PUBLIC_DOCS_CDN_URL";
 
 export interface S3Config {
     bucketName: string;
@@ -38,6 +39,7 @@ export interface FdrConfig {
     venusUrl: string;
     awsAccessKey: string;
     awsSecretKey: string;
+    cdnPublidDocsUrl: string;
     publicDocsS3: S3Config;
     privateDocsS3: S3Config;
     privateApiDefinitionSourceS3: S3Config;
@@ -89,6 +91,7 @@ export function getConfig(): FdrConfig {
         redisEnabled: process.env[REDIS_ENABLED_ENV_VAR] === "true",
         redisClusteringEnabled: process.env[REDIS_CLUSTERING_ENABLED_ENV_VAR] === "true",
         applicationEnvironment: getEnvironmentVariableOrThrow(APPLICATION_ENVIRONMENT_ENV_VAR),
+        cdnPublidDocsUrl: getEnvironmentVariableOrThrow(PUBLIC_DOCS_CDN_URL),
     };
 }
 

--- a/servers/fdr/src/app/FdrConfig.ts
+++ b/servers/fdr/src/app/FdrConfig.ts
@@ -39,7 +39,7 @@ export interface FdrConfig {
     venusUrl: string;
     awsAccessKey: string;
     awsSecretKey: string;
-    cdnPublidDocsUrl: string;
+    cdnPublicDocsUrl: string;
     publicDocsS3: S3Config;
     privateDocsS3: S3Config;
     privateApiDefinitionSourceS3: S3Config;
@@ -91,7 +91,7 @@ export function getConfig(): FdrConfig {
         redisEnabled: process.env[REDIS_ENABLED_ENV_VAR] === "true",
         redisClusteringEnabled: process.env[REDIS_CLUSTERING_ENABLED_ENV_VAR] === "true",
         applicationEnvironment: getEnvironmentVariableOrThrow(APPLICATION_ENVIRONMENT_ENV_VAR),
-        cdnPublidDocsUrl: getEnvironmentVariableOrThrow(PUBLIC_DOCS_CDN_URL),
+        cdnPublicDocsUrl: getEnvironmentVariableOrThrow(PUBLIC_DOCS_CDN_URL),
     };
 }
 

--- a/servers/fdr/src/services/s3/S3Service.ts
+++ b/servers/fdr/src/services/s3/S3Service.ts
@@ -55,12 +55,14 @@ export interface S3Service {
 }
 
 export class S3ServiceImpl implements S3Service {
+    private publicDocsCDNUrl: string;
     private publicDocsS3: S3Client;
     private privateDocsS3: S3Client;
     private privateApiDefinitionSourceS3: S3Client;
     private presignedDownloadUrlCache = new Cache<string>(10_000, ONE_WEEK_IN_SECONDS);
 
     constructor(private readonly config: FdrConfig) {
+        this.publicDocsCDNUrl = config.cdnPublicDocsUrl;
         this.publicDocsS3 = new S3Client({
             ...(config.publicDocsS3.urlOverride != null ? { endpoint: config.publicDocsS3.urlOverride } : {}),
             region: config.publicDocsS3.bucketRegion,
@@ -111,7 +113,7 @@ export class S3ServiceImpl implements S3Service {
             return FdrAPI.Url(signedUrl);
         }
 
-        return FdrAPI.Url(`https://${this.config.publicDocsS3.bucketName}.s3.amazonaws.com/${key}`);
+        return FdrAPI.Url(`https://${this.publicDocsCDNUrl}/${key}`);
     }
 
     async getPresignedDocsAssetsUploadUrls({


### PR DESCRIPTION
## Short description of the changes made
Server now points to the CDN when public docs are being accessed.

## What was the motivation & context behind this PR?
When docs are accessed internationally, it takes too long for the docs site to load (Singapore = ~3 seconds). With those clients hitting the CDN instead of buckets directly, that drops to ~ms.

## How has this PR been tested?
Frontend server changes were tested locally, to make sure that hitting the CDN sped up the docs request. Server changes are not yet tested.
