### PR TITLE
fix(docs): remove duplicate https from CDN url

### DIFF
--- a/servers/fdr/src/services/s3/S3Service.ts
+++ b/servers/fdr/src/services/s3/S3Service.ts
@@ -113,7 +113,7 @@ export class S3ServiceImpl implements S3Service {
             return FdrAPI.Url(signedUrl);
         }
 
-        return FdrAPI.Url(`https://${this.publicDocsCDNUrl}/${key}`);
+        return FdrAPI.Url(`${this.publicDocsCDNUrl}/${key}`);
     }
 
     async getPresignedDocsAssetsUploadUrls({


### PR DESCRIPTION
Fixes FER-3727

## Short description of the changes made
Duplicate https:// in url

## What was the motivation & context behind this PR?
Duplicate https:// in url

## How has this PR been tested?