### PR TITLE
chore: algolia service turn off v2

### DIFF
--- a/servers/fdr/src/services/algolia/AlgoliaService.ts
+++ b/servers/fdr/src/services/algolia/AlgoliaService.ts
@@ -56,9 +56,6 @@ export class AlgoliaServiceImpl implements AlgoliaService {
             if (config == null) {
                 return [];
             }
-            // const generator = getConfig().algoliaSearchV2Domains.some((domains) => url.includes(domains))
-            //     ? new AlgoliaSearchRecordGeneratorV2({ docsDefinition, apiDefinitionsById })
-            //     : new AlgoliaSearchRecordGenerator({ docsDefinition, apiDefinitionsById });
             return generator.generateAlgoliaSearchRecordsForSpecificDocsVersion(config, indexSegment);
         });
     }

--- a/servers/fdr/src/services/algolia/AlgoliaService.ts
+++ b/servers/fdr/src/services/algolia/AlgoliaService.ts
@@ -1,7 +1,7 @@
 import { APIV1Db, DocsV1Db } from "@fern-api/fdr-sdk";
 import algolia, { type SearchClient } from "algoliasearch";
 import { type FdrApplication } from "../../app";
-import { AlgoliaSearchRecordGeneratorV2 } from "./AlgoliaSearchRecordGeneratorV2";
+import { AlgoliaSearchRecordGenerator } from "./AlgoliaSearchRecordGenerator";
 import type { AlgoliaSearchRecord, ConfigSegmentTuple } from "./types";
 
 export interface AlgoliaService {
@@ -51,7 +51,7 @@ export class AlgoliaServiceImpl implements AlgoliaService {
         configSegmentTuples: ConfigSegmentTuple[];
     }) {
         return configSegmentTuples.flatMap(([config, indexSegment]) => {
-            const generator = new AlgoliaSearchRecordGeneratorV2({ docsDefinition, apiDefinitionsById });
+            const generator = new AlgoliaSearchRecordGenerator({ docsDefinition, apiDefinitionsById });
 
             if (config == null) {
                 return [];

--- a/servers/fdr/src/services/algolia/AlgoliaService.ts
+++ b/servers/fdr/src/services/algolia/AlgoliaService.ts
@@ -2,6 +2,7 @@ import { APIV1Db, DocsV1Db } from "@fern-api/fdr-sdk";
 import algolia, { type SearchClient } from "algoliasearch";
 import { type FdrApplication } from "../../app";
 import { AlgoliaSearchRecordGenerator } from "./AlgoliaSearchRecordGenerator";
+import { AlgoliaSearchRecordGeneratorV2 } from "./AlgoliaSearchRecordGeneratorV2";
 import type { AlgoliaSearchRecord, ConfigSegmentTuple } from "./types";
 
 export interface AlgoliaService {
@@ -51,7 +52,9 @@ export class AlgoliaServiceImpl implements AlgoliaService {
         configSegmentTuples: ConfigSegmentTuple[];
     }) {
         return configSegmentTuples.flatMap(([config, indexSegment]) => {
-            const generator = new AlgoliaSearchRecordGenerator({ docsDefinition, apiDefinitionsById });
+            const generator = new (
+                url.includes("workato") ? AlgoliaSearchRecordGeneratorV2 : AlgoliaSearchRecordGenerator
+            )({ docsDefinition, apiDefinitionsById });
 
             if (config == null) {
                 return [];


### PR DESCRIPTION
Fixes FER-

## Short description of the changes made

* Turns off v2 generation of records in favor of legacy v1 records

## What was the motivation & context behind this PR?

* Cost

## How has this PR been tested?

* will test with dev FDR generations
