### PR TITLE
fix: playground endpoints handle writing streaming outputs

### DIFF
--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/proxy/file.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/proxy/file.ts
@@ -73,7 +73,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             response: res,
             status: response.status,
             headers: Object.fromEntries(response.headers.entries()),
-            stream: response.body,
+            stream: response.body as ReadableStream<Uint8Array>,
         });
     } catch (err) {
         // eslint-disable-next-line no-console

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/proxy/file.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/proxy/file.ts
@@ -81,10 +81,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const reader = stream.getReader();
         const read = async () => {
             try {
-                let isDone = false;
-                while (!isDone) {
+                // eslint-disable-next-line no-constant-condition
+                while (true) {
                     const { done, value } = await reader.read();
-                    isDone = done;
                     if (done) {
                         break;
                     }

--- a/packages/ui/docs-bundle/src/pages/api/fern-docs/proxy/file.ts
+++ b/packages/ui/docs-bundle/src/pages/api/fern-docs/proxy/file.ts
@@ -73,7 +73,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             response: res,
             status: response.status,
             headers: Object.fromEntries(response.headers.entries()),
-            stream: response.body as ReadableStream<Uint8Array>,
+            stream: response.body as any as ReadableStream<Uint8Array>,
         });
     } catch (err) {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
## Short description of the changes made
Makes sure the API playground returns streams. 

## What was the motivation & context behind this PR?
Returning audio streams in the API Playground. 

## How has this PR been tested?
N/A
