### PR TITLE
Setting NODE_ENV to sanitize outgoing error messages

### DIFF
--- a/servers/fdr-deploy/scripts/fdr-deploy-stack.ts
+++ b/servers/fdr-deploy/scripts/fdr-deploy-stack.ts
@@ -215,6 +215,7 @@ export class FdrDeployStack extends Stack {
                         environmentType === "DEV2"
                             ? "https://files-dev2.buildwithfern.com"
                             : "https://files.buildwithfern.com",
+                    NODE_ENV: "production",
                 },
                 containerName: CONTAINER_NAME,
                 containerPort: 8080,


### PR DESCRIPTION
Tested with locally running FDR docker instance