### PR TITLE
fix api playground that was short circuiting too early

### DIFF
--- a/packages/ui/fern-docs-server/src/ApiDefinitionLoader.ts
+++ b/packages/ui/fern-docs-server/src/ApiDefinitionLoader.ts
@@ -101,15 +101,6 @@ export class ApiDefinitionLoader {
         // }
 
         const latest = await this.#getClient().api.latest.getApiLatest(this.apiDefinitionId);
-        if (!latest.ok) {
-            if (latest.error.error === "ApiDoesNotExistError") {
-                return undefined;
-            } else {
-                // eslint-disable-next-line no-console
-                console.error(latest?.error?.content);
-                throw new Error("Failed to load API definition");
-            }
-        }
         if (latest.ok) {
             return latest.body;
         }

--- a/packages/ui/fern-docs-server/src/ApiDefinitionLoader.ts
+++ b/packages/ui/fern-docs-server/src/ApiDefinitionLoader.ts
@@ -119,6 +119,16 @@ export class ApiDefinitionLoader {
             return ApiDefinitionV1ToLatest.from(v1.body, this.flags).migrate();
         }
 
+        if (!latest.ok) {
+            if (latest.error.error === "ApiDoesNotExistError") {
+                return undefined;
+            } else {
+                // eslint-disable-next-line no-console
+                console.error(latest?.error?.content);
+                throw new Error("Failed to load API definition");
+            }
+        }
+
         return undefined;
 
         // await this.cache.setApiDefinition(apiDefinition);


### PR DESCRIPTION
## Short description of the changes made

* API latest was short circuiting the api resolution too early

## What was the motivation & context behind this PR?

* Playground not loading during testing

## How has this PR been tested?

* To be tested during FDR dev
