### PR TITLE
feat: use trieve for demo /api/suggest route

### DIFF
--- a/packages/fern-docs/search-ui/src/app/(demo)/api/suggest/route.ts
+++ b/packages/fern-docs/search-ui/src/app/(demo)/api/suggest/route.ts
@@ -1,66 +1,33 @@
-import { algoliaAppId } from "@/server/env-variables";
-import { models } from "@/server/models";
-import { searchClient } from "@algolia/client-search";
 import { SuggestionsSchema } from "@fern-docs/search-server";
-import {
-  SEARCH_INDEX,
-  type AlgoliaRecord,
-} from "@fern-docs/search-server/algolia";
-import { streamObject } from "ai";
+import { TrieveSDK } from "trieve-ts-sdk";
 import { z } from "zod";
 
-// Allow streaming responses up to 30 seconds
-export const maxDuration = 30;
-
 const BodySchema = z.object({
-  algoliaSearchKey: z.string(),
-  model: z.string().optional(),
+  apiKey: z.string(),
+  datasetId: z.string(),
 });
 
 export async function POST(request: Request): Promise<Response> {
-  const { algoliaSearchKey, model: _model } = BodySchema.parse(
-    await request.json()
-  );
+  const { apiKey, datasetId } = BodySchema.parse(await request.json());
 
-  const model = models[(_model as keyof typeof models) ?? "gpt-4o-mini"];
+  const client = new TrieveSDK({
+    apiKey,
+    datasetId,
+  });
+  const suggestions = SuggestionsSchema.parse({
+    suggestions: [],
+  });
 
-  if (!algoliaSearchKey || typeof algoliaSearchKey !== "string") {
-    return new Response("Missing search key", { status: 400 });
+  try {
+    const suggestedQueriesResult = await client.suggestedQueries({
+      suggestion_type: "question",
+    });
+    suggestions.suggestions = suggestedQueriesResult.queries.slice(0, 5);
+  } catch (e) {
+    console.error("error getting suggestions from trieve", e);
   }
 
-  // const cacheKey = `suggestions:${algoliaSearchKey}`;
-  // const cachedSuggestions = await kv.get<string>(cacheKey);
-  // if (cachedSuggestions) {
-  //   return new Response(JSON.stringify(cachedSuggestions), {
-  //     headers: { "Content-Type": "text/plain; charset=utf-8" },
-  //   });
-  // }
-
-  const client = searchClient(algoliaAppId(), algoliaSearchKey);
-  const response = await client.searchSingleIndex<AlgoliaRecord>({
-    indexName: SEARCH_INDEX,
-    searchParams: { query: "", hitsPerPage: 100, attributesToSnippet: [] },
+  return new Response(JSON.stringify(suggestions), {
+    headers: { "Content-Type": "application/json" },
   });
-
-  const result = streamObject({
-    model,
-    system:
-      "You are a helpful assistant that suggestions of questions for the user to ask about the documentation. Generate 5 questions based on the following search results.",
-    prompt: response.hits
-      .map(
-        (hit) =>
-          `# ${hit.title}\n${hit.description ?? ""}\n${hit.type === "changelog" || hit.type === "markdown" ? (hit.content ?? "") : ""}`
-      )
-      .join("\n\n"),
-    maxRetries: 3,
-    schema: SuggestionsSchema,
-    // onFinish: async ({ object }) => {
-    //   if (object) {
-    //     await kv.set(cacheKey, object);
-    //     await kv.expire(cacheKey, 60 * 60);
-    //   }
-    // },
-  });
-
-  return result.toTextStreamResponse();
 }

--- a/packages/fern-docs/search-ui/src/app/(demo)/search-demo.tsx
+++ b/packages/fern-docs/search-ui/src/app/(demo)/search-demo.tsx
@@ -166,8 +166,6 @@ export function DemoInstantSearchClient({
                     datasetId: trieveDatasetId,
                     organizationId: trieveOrganizationId,
                     topicId: trieveTopicId,
-                    // for suggestions:
-                    algoliaSearchKey: apiKey,
                   }
                 : {
                     algoliaSearchKey: apiKey,


### PR DESCRIPTION
## Short description of the changes made

Uses Trieve instead of Algolia+LLM for AI suggestions.

## What was the motivation & context behind this PR?

Simplicity of query suggestions using Trieve's optimizations.

## How has this PR been tested?

Manual QA in local dev testing environment. Used `?domain=docs.vapi.ai&provider=trieve&apiKey=tr-wTEWkjHW13qwm8dO7FuA8CeFM4fsNlhx&datasetId=8f44e302-3b53-4cfc-90f9-0065e91b821f&organizationId=483afda5-0b7d-4913-a52d-b0908c18e558` query params.
