### PR TITLE
fix: workos redirect

### DIFF
--- a/packages/fern-docs/bundle/src/app/api/fern-docs/auth/sso/callback/route.ts
+++ b/packages/fern-docs/bundle/src/app/api/fern-docs/auth/sso/callback/route.ts
@@ -5,6 +5,7 @@ import { encryptSession } from "@/server/auth/workos-session";
 import { FernNextResponse } from "@/server/FernNextResponse";
 import { safeUrl } from "@/server/safeUrl";
 import { getDocsDomainEdge } from "@/server/xfernhost/edge";
+import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import { COOKIE_FERN_TOKEN } from "@fern-docs/utils";
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
@@ -61,7 +62,10 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       url.origin
     );
     destination.searchParams.set(FORWARDED_HOST_QUERY, req.nextUrl.host);
-    return FernNextResponse.redirect(req, { destination });
+    return FernNextResponse.redirect(req, {
+      destination,
+      allowedDestinations: [withDefaultProtocol(getDocsDomainEdge(req))],
+    });
   }
 
   const code = req.nextUrl.searchParams.get(CODE_QUERY);

--- a/packages/fern-docs/bundle/src/server/xfernhost/edge.ts
+++ b/packages/fern-docs/bundle/src/server/xfernhost/edge.ts
@@ -27,12 +27,7 @@ export function getDocsDomainEdge(req: NextRequest): string {
   return "buildwithfern.com";
 }
 
-// use this for testing auth-based redirects on development and preview environments
+// if x-fern-host is set, assume it's proxied:
 export function getHostEdge(req: NextRequest): string {
-  // if x-fern-host is set, assume it's proxied:
-  return (
-    req.headers.get(HEADER_X_FERN_HOST) ??
-    req.headers.get("host") ??
-    req.nextUrl.host
-  );
+  return req.headers.get(HEADER_X_FERN_HOST) ?? req.nextUrl.host;
 }


### PR DESCRIPTION
for some reason, in the middleware, headers.get("host") returns app.buildwithfern.com rather than the custom domain.