### PR TITLE
fix(docs): respect hide-toc frontmatter

### DIFF
--- a/packages/fern-docs/ui/src/layouts/GuideLayout.tsx
+++ b/packages/fern-docs/ui/src/layouts/GuideLayout.tsx
@@ -8,6 +8,7 @@ interface GuideLayoutProps {
   PageHeader: FC;
   TableOfContents: FC;
   children: ReactNode;
+  hideTableOfContents: boolean | undefined;
   editThisPageUrl: string | undefined;
   hideFeedback: boolean | undefined;
   hideNavLinks: boolean | undefined;
@@ -17,13 +18,14 @@ export function GuideLayout({
   PageHeader,
   TableOfContents,
   children,
+  hideTableOfContents,
   editThisPageUrl,
   hideFeedback,
   hideNavLinks,
 }: GuideLayoutProps): ReactElement {
   return (
     <main className="fern-guide-layout">
-      <TableOfContents />
+      {!hideTableOfContents && <TableOfContents />}
       <article className="fern-layout-content max-w-content-width">
         <PageHeader />
         <div className="prose dark:prose-invert prose-h1:mt-[1.5em] first:prose-h1:mt-0 max-w-full break-words">

--- a/packages/fern-docs/ui/src/layouts/LayoutEvaluatorContent.tsx
+++ b/packages/fern-docs/ui/src/layouts/LayoutEvaluatorContent.tsx
@@ -50,6 +50,7 @@ export function LayoutEvaluatorContent({
         <GuideLayout
           PageHeader={PageHeaderComponent}
           TableOfContents={TableOfContentsComponent}
+          hideTableOfContents={frontmatter["hide-toc"]}
           editThisPageUrl={frontmatter["edit-this-page-url"]}
           hideFeedback={frontmatter["hide-feedback"]}
           hideNavLinks={frontmatter["hide-nav-links"]}
@@ -62,6 +63,7 @@ export function LayoutEvaluatorContent({
         <OverviewLayout
           PageHeader={PageHeaderComponent}
           TableOfContents={TableOfContentsComponent}
+          hideTableOfContents={frontmatter["hide-toc"]}
           editThisPageUrl={frontmatter["edit-this-page-url"]}
           hideFeedback={frontmatter["hide-feedback"]}
         >

--- a/packages/fern-docs/ui/src/layouts/OverviewLayout.tsx
+++ b/packages/fern-docs/ui/src/layouts/OverviewLayout.tsx
@@ -9,18 +9,20 @@ interface OverviewLayoutProps {
   children: ReactNode;
   editThisPageUrl: string | undefined;
   hideFeedback: boolean | undefined;
+  hideTableOfContents: boolean | undefined;
 }
 
 export function OverviewLayout({
   PageHeader,
   TableOfContents,
   children,
+  hideTableOfContents,
   editThisPageUrl,
   hideFeedback,
 }: OverviewLayoutProps): ReactElement {
   return (
     <main className="fern-overview-layout">
-      <TableOfContents />
+      {!hideTableOfContents && <TableOfContents />}
       <article className="fern-layout-content max-w-content-wide-width">
         <PageHeader />
         <div className="prose dark:prose-invert prose-h1:mt-[1.5em] first:prose-h1:mt-0 max-w-full break-words">


### PR DESCRIPTION
This PR adds logic to respect the `hide-toc` property. 

Before:
![Screenshot 2024-12-24 at 11 35 18 AM](https://github.com/user-attachments/assets/4ee7111c-b7ff-4ddb-b208-ee014277d2a2)

After:
![Screenshot 2024-12-24 at 11 34 59 AM](https://github.com/user-attachments/assets/3f4f2b04-fd16-446f-a516-2df078b74e65)
