### PR TITLE
chore(docs): temporarily log request info on failed oauth2 callback

### DIFF
--- a/packages/fern-docs/bundle/src/server/auth/ory.ts
+++ b/packages/fern-docs/bundle/src/server/auth/ory.ts
@@ -47,6 +47,13 @@ export class OryOAuth2Client {
     if (response.ok) {
       return OAuthTokenResponseSchema.parse(await response.json());
     }
+    console.log("OAuth token request form parameters:", {
+      code,
+      client_secret: this.clientSecret,
+      grant_type: "authorization_code",
+      client_id: this.clientId,
+      redirect_uri: this.redirectUri,
+    });
     throw new Error(
       `Failed to get OAuth token: ${response.status} ${await response.text()}`
     );


### PR DESCRIPTION
## Short description of the changes made
This PR logs the token fetch request if the oauth callback fails. 

## What was the motivation & context behind this PR?
Cannot locally reproduce failed oauth token fetch. 

## How has this PR been tested?
N/A
