### PR TITLE
fix(playground): dont pascal case header key when making request

### DIFF
--- a/packages/fern-docs/ui/src/playground/utils/auth-headers.ts
+++ b/packages/fern-docs/ui/src/playground/utils/auth-headers.ts
@@ -39,7 +39,7 @@ export function buildAuthHeaders(
         if (redacted) {
           value = obfuscateSecret(value);
         }
-        headers[pascalCaseHeaderKey(header.headerWireValue)] =
+        headers[header.headerWireValue] =
           header.prefix != null ? `${header.prefix} ${value}` : value;
       },
       basicAuth: () => {


### PR DESCRIPTION
## Short description of the changes made
If there is a header with the key `api_key`, the docs currently sends that as `ApiKey` when making a request. This PR updates the playground to send the correct wire value. 

## What was the motivation & context behind this PR?
Customer reported issue above. 

## How has this PR been tested?
Preview URLs. 
