### PR TITLE
fix(search): make sure that calls to the search endpoint are GET requests

### DIFF
--- a/packages/fern-docs/bundle/.depcheckrc.json
+++ b/packages/fern-docs/bundle/.depcheckrc.json
@@ -16,7 +16,8 @@
     "esbuild",
     "glslify-import",
     "glslify-loader",
-    "raw-loader"
+    "raw-loader",
+    "@upstash/qstash"
   ],
   "ignore-patterns": ["dist"]
 }

--- a/packages/fern-docs/bundle/src/server/queue-reindex.ts
+++ b/packages/fern-docs/bundle/src/server/queue-reindex.ts
@@ -61,7 +61,10 @@ export const queueAlgoliaReindex = async (
     host,
     domain,
     basepath_,
-    "/api/fern-docs/search/v2/reindex/algolia"
+    "/api/fern-docs/search/v2/reindex/algolia",
+    request: {
+      method: "GET",
+    }
   );
 };
 
@@ -74,6 +77,9 @@ export const queueTurbopufferReindex = async (
     host,
     domain,
     basepath_,
-    "/api/fern-docs/search/v2/reindex/turbopuffer"
+    "/api/fern-docs/search/v2/reindex/turbopuffer",
+    request: {
+      method: "GET",
+    }
   );
 };

--- a/packages/fern-docs/bundle/src/server/queue-reindex.ts
+++ b/packages/fern-docs/bundle/src/server/queue-reindex.ts
@@ -62,7 +62,7 @@ export const queueAlgoliaReindex = async (
     domain,
     basepath_,
     "/api/fern-docs/search/v2/reindex/algolia",
-    request: {
+    {
       method: "GET",
     }
   );
@@ -78,7 +78,7 @@ export const queueTurbopufferReindex = async (
     domain,
     basepath_,
     "/api/fern-docs/search/v2/reindex/turbopuffer",
-    request: {
+    {
       method: "GET",
     }
   );


### PR DESCRIPTION
## Short description of the changes made
Reindexes for search v2 are throwing a 405 because qstash is using `POST` methods instead of `GET` methods. This PR updates the code to only use `GET` requests. 

## What was the motivation & context behind this PR?
Fixes failed search reindexes. 

## How has this PR been tested?
Will be tested on merge. 
