### PR TITLE
fix: image optimization

### DIFF
--- a/packages/fern-docs/ui/src/api-reference/ApiEndpointPage.tsx
+++ b/packages/fern-docs/ui/src/api-reference/ApiEndpointPage.tsx
@@ -6,9 +6,11 @@ import { useNavigationNodes, useWriteApiDefinitionAtom } from "../atoms";
 import { ALL_ENVIRONMENTS_ATOM } from "../atoms/environment";
 import { BottomNavigationNeighbors } from "../components/BottomNavigationNeighbors";
 import { FernErrorBoundary } from "../components/FernErrorBoundary";
-import { ApiPageContext } from "../contexts/api-page";
 import { DocsContent } from "../resolver/DocsContent";
-import { BuiltWithFern } from "../sidebar/BuiltWithFern";
+import {
+  BuiltWithFern,
+  HideBuiltWithFernContext,
+} from "../sidebar/BuiltWithFern";
 import {
   ApiPackageContent,
   isApiPackageContentNode,
@@ -50,22 +52,22 @@ export default function ApiEndpointPage({
   }
 
   return (
-    <ApiPageContext.Provider value={true}>
+    <>
       <FernErrorBoundary component="ApiEndpointPage">
-        <ApiPackageContent
-          node={node}
-          apiDefinition={content.apiDefinition}
-          breadcrumb={content.breadcrumb}
-          mdxs={EMPTY_OBJECT}
-          showErrors={content.showErrors}
-        />
+        <HideBuiltWithFernContext.Provider value={true}>
+          <ApiPackageContent
+            node={node}
+            apiDefinition={content.apiDefinition}
+            breadcrumb={content.breadcrumb}
+            mdxs={EMPTY_OBJECT}
+            showErrors={content.showErrors}
+          />
+        </HideBuiltWithFernContext.Provider>
       </FernErrorBoundary>
       <div className="px-4 md:px-6 lg:hidden lg:px-8">
         <BottomNavigationNeighbors />
       </div>
-      <div className="mx-auto my-8 w-fit">
-        <BuiltWithFern />
-      </div>
-    </ApiPageContext.Provider>
+      <BuiltWithFern className="mx-auto my-8 w-fit" />
+    </>
   );
 }

--- a/packages/fern-docs/ui/src/api-reference/ApiReferencePage.tsx
+++ b/packages/fern-docs/ui/src/api-reference/ApiReferencePage.tsx
@@ -4,9 +4,11 @@ import {
   useNavigationNodes,
   useWriteApiDefinitionAtom,
 } from "../atoms";
-import { ApiPageContext } from "../contexts/api-page";
 import { DocsContent } from "../resolver/DocsContent";
-import { BuiltWithFern } from "../sidebar/BuiltWithFern";
+import {
+  BuiltWithFern,
+  HideBuiltWithFernContext,
+} from "../sidebar/BuiltWithFern";
 import { ApiReferenceContent } from "./ApiReferenceContent";
 
 export default function ApiReferencePage({
@@ -28,22 +30,22 @@ export default function ApiReferencePage({
   }
 
   return (
-    <ApiPageContext.Provider value={true}>
-      <ApiReferenceContent
-        apiDefinition={content.apiDefinition}
-        showErrors={node.showErrors ?? false}
-        node={node}
-        breadcrumb={content.breadcrumb}
-        mdxs={content.mdxs}
-        slug={content.slug}
-      />
+    <>
+      <HideBuiltWithFernContext.Provider value={true}>
+        <ApiReferenceContent
+          apiDefinition={content.apiDefinition}
+          showErrors={node.showErrors ?? false}
+          node={node}
+          breadcrumb={content.breadcrumb}
+          mdxs={content.mdxs}
+          slug={content.slug}
+        />
+      </HideBuiltWithFernContext.Provider>
 
       {/* anchor links should get additional padding to scroll to on initial load */}
       {!hydrated && <div className="h-full" />}
       <div className="pb-36" />
-      <div className="mx-auto my-8 w-fit">
-        <BuiltWithFern />
-      </div>
-    </ApiPageContext.Provider>
+      <BuiltWithFern className="mx-auto my-8 w-fit" />
+    </>
   );
 }

--- a/packages/fern-docs/ui/src/api-reference/endpoints/Endpoint.tsx
+++ b/packages/fern-docs/ui/src/api-reference/endpoints/Endpoint.tsx
@@ -4,6 +4,7 @@ import {
 } from "@fern-api/fdr-sdk/api-definition";
 import type * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import { memo, useMemo } from "react";
+import { WithAside } from "../../contexts/api-page";
 import { EndpointContent } from "./EndpointContent";
 
 export declare namespace Endpoint {
@@ -36,13 +37,15 @@ const UnmemoizedEndpoint: React.FC<Endpoint.Props> = ({
   }
 
   return (
-    <EndpointContent
-      breadcrumb={breadcrumb}
-      showErrors={showErrors}
-      context={context}
-      streamToggle={streamToggle}
-      last={last}
-    />
+    <WithAside.Provider value={true}>
+      <EndpointContent
+        breadcrumb={breadcrumb}
+        showErrors={showErrors}
+        context={context}
+        streamToggle={streamToggle}
+        last={last}
+      />
+    </WithAside.Provider>
   );
 };
 

--- a/packages/fern-docs/ui/src/api-reference/web-socket/WebSocket.tsx
+++ b/packages/fern-docs/ui/src/api-reference/web-socket/WebSocket.tsx
@@ -16,6 +16,7 @@ import {
 } from "react";
 import { FernAnchor } from "../../components/FernAnchor";
 import { FernBreadcrumbs } from "../../components/FernBreadcrumbs";
+import { WithAside } from "../../contexts/api-page";
 import { useHref } from "../../hooks/useHref";
 import { Markdown } from "../../mdx/Markdown";
 import { PlaygroundButton } from "../../playground/PlaygroundButton";
@@ -49,11 +50,13 @@ export const WebSocket: FC<WebSocketProps> = (props) => {
   }
 
   return (
-    <WebhookContent
-      context={context}
-      breadcrumb={props.breadcrumb}
-      last={props.last}
-    />
+    <WithAside.Provider value={true}>
+      <WebhookContent
+        context={context}
+        breadcrumb={props.breadcrumb}
+        last={props.last}
+      />
+    </WithAside.Provider>
   );
 };
 

--- a/packages/fern-docs/ui/src/api-reference/webhooks/Webhook.tsx
+++ b/packages/fern-docs/ui/src/api-reference/webhooks/Webhook.tsx
@@ -1,6 +1,7 @@
 import * as ApiDefinition from "@fern-api/fdr-sdk/api-definition";
 import type * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import { useMemo } from "react";
+import { WithAside } from "../../contexts/api-page";
 import { WebhookContent } from "./WebhookContent";
 import { WebhookContextProvider } from "./webhook-context/WebhookContextProvider";
 
@@ -30,8 +31,10 @@ export const Webhook: React.FC<Webhook.Props> = ({
   }
 
   return (
-    <WebhookContextProvider>
-      <WebhookContent breadcrumb={breadcrumb} context={context} last={last} />
-    </WebhookContextProvider>
+    <WithAside.Provider value={true}>
+      <WebhookContextProvider>
+        <WebhookContent breadcrumb={breadcrumb} context={context} last={last} />
+      </WebhookContextProvider>
+    </WithAside.Provider>
   );
 };

--- a/packages/fern-docs/ui/src/changelog/ChangelogPage.tsx
+++ b/packages/fern-docs/ui/src/changelog/ChangelogPage.tsx
@@ -18,7 +18,10 @@ import { PageHeader } from "../components/PageHeader";
 import { useToHref } from "../hooks/useHref";
 import { Markdown } from "../mdx/Markdown";
 import { DocsContent } from "../resolver/DocsContent";
-import { BuiltWithFern } from "../sidebar/BuiltWithFern";
+import {
+  BuiltWithFern,
+  HideBuiltWithFernContext,
+} from "../sidebar/BuiltWithFern";
 import { ChangelogContentLayout } from "./ChangelogContentLayout";
 
 function flattenChangelogEntries(
@@ -151,63 +154,63 @@ export default function ChangelogPage({
       })}
     >
       <main>
-        <ChangelogContentLayout as="section" className="pb-8">
-          <PageHeader
-            title={content.node.title}
-            breadcrumb={content.breadcrumb}
-            subtitle={
-              typeof overview !== "string"
-                ? overview?.frontmatter.excerpt
-                : undefined
-            }
-          />
-          <Markdown mdx={overview} />
-        </ChangelogContentLayout>
-
-        {entries.map((entry) => {
-          const page = content.pages[entry.pageId];
-          const title =
-            typeof page !== "string" ? page?.frontmatter.title : undefined;
-          return (
-            <Fragment key={entry.id}>
-              <hr />
-              <ChangelogContentLayout
-                as="article"
-                id={entry.date}
-                stickyContent={
-                  <FernLink href={toHref(entry.slug)}>{entry.title}</FernLink>
-                }
-              >
-                <Markdown
-                  title={
-                    title != null ? (
-                      <h2>
-                        <FernLink
-                          href={toHref(entry.slug)}
-                          className="not-prose"
-                        >
-                          {title}
-                        </FernLink>
-                      </h2>
-                    ) : undefined
-                  }
-                  mdx={page}
-                />
-              </ChangelogContentLayout>
-            </Fragment>
-          );
-        })}
-
-        {(prev != null || next != null) && (
-          <ChangelogContentLayout as="div">
-            <BottomNavigationButtons prev={prev} next={next} alwaysShowGrid />
+        <HideBuiltWithFernContext.Provider value={true}>
+          <ChangelogContentLayout as="section" className="pb-8">
+            <PageHeader
+              title={content.node.title}
+              breadcrumb={content.breadcrumb}
+              subtitle={
+                typeof overview !== "string"
+                  ? overview?.frontmatter.excerpt
+                  : undefined
+              }
+            />
+            <Markdown mdx={overview} />
           </ChangelogContentLayout>
-        )}
+
+          {entries.map((entry) => {
+            const page = content.pages[entry.pageId];
+            const title =
+              typeof page !== "string" ? page?.frontmatter.title : undefined;
+            return (
+              <Fragment key={entry.id}>
+                <hr />
+                <ChangelogContentLayout
+                  as="article"
+                  id={entry.date}
+                  stickyContent={
+                    <FernLink href={toHref(entry.slug)}>{entry.title}</FernLink>
+                  }
+                >
+                  <Markdown
+                    title={
+                      title != null ? (
+                        <h2>
+                          <FernLink
+                            href={toHref(entry.slug)}
+                            className="not-prose"
+                          >
+                            {title}
+                          </FernLink>
+                        </h2>
+                      ) : undefined
+                    }
+                    mdx={page}
+                  />
+                </ChangelogContentLayout>
+              </Fragment>
+            );
+          })}
+
+          {(prev != null || next != null) && (
+            <ChangelogContentLayout as="div">
+              <BottomNavigationButtons prev={prev} next={next} alwaysShowGrid />
+            </ChangelogContentLayout>
+          )}
+        </HideBuiltWithFernContext.Provider>
 
         <div className="h-48" />
-        <div className="mx-auto my-8 w-fit">
-          <BuiltWithFern />
-        </div>
+        <BuiltWithFern className="mx-auto my-8 w-fit" />
       </main>
     </div>
   );

--- a/packages/fern-docs/ui/src/components/FernImage.tsx
+++ b/packages/fern-docs/ui/src/components/FernImage.tsx
@@ -57,7 +57,6 @@ export function FernImage({
 
       const { width, height } = getDimensions(
         maxWidth ?? props.width,
-        undefined,
         realWidth,
         realHeight
       );
@@ -83,35 +82,18 @@ export function FernImage({
 
 function getDimensions(
   layoutWidth: number | `${number}` | undefined,
-  layoutHeight: number | `${number}` | undefined,
   realWidth: number,
   realHeight: number
 ): { width: number; height: number } {
   layoutWidth =
     typeof layoutWidth === "string" ? parseInt(layoutWidth, 10) : layoutWidth;
-  layoutHeight =
-    typeof layoutHeight === "string"
-      ? parseInt(layoutHeight, 10)
-      : layoutHeight;
   if (layoutWidth != null && isNaN(layoutWidth)) {
     layoutWidth = undefined;
   }
-  if (layoutHeight != null && isNaN(layoutHeight)) {
-    layoutHeight = undefined;
-  }
-  if (layoutWidth != null && layoutHeight != null) {
-    return { width: layoutWidth, height: layoutHeight };
-  }
-  if (layoutWidth != null) {
+  if (layoutWidth != null && layoutWidth < realWidth) {
     return {
       width: layoutWidth,
       height: (layoutWidth / realWidth) * realHeight,
-    };
-  }
-  if (layoutHeight != null) {
-    return {
-      width: (layoutHeight / realHeight) * realWidth,
-      height: layoutHeight,
     };
   }
   return { width: realWidth, height: realHeight };

--- a/packages/fern-docs/ui/src/components/FernImage.tsx
+++ b/packages/fern-docs/ui/src/components/FernImage.tsx
@@ -9,28 +9,32 @@ export declare namespace FernImage {
     // If the file has width/height metadata, we can render it using next/image for optimized loading.
     src: DocsV1Read.File_ | undefined;
     alt?: string;
+    maxWidth?: number;
   }
 }
 
 export function FernImage({
   src,
+  maxWidth,
   ...props
 }: FernImage.Props): ReactElement | null {
   if (src == null) {
     return null;
   }
+
+  const {
+    fill,
+    loader,
+    quality,
+    priority,
+    placeholder,
+    blurDataURL,
+    unoptimized,
+    ...imgProps
+  } = props;
+
   return visitDiscriminatedUnion(src, "type")._visit({
     url: ({ url }) => {
-      const {
-        fill,
-        loader,
-        quality,
-        priority,
-        placeholder,
-        blurDataURL,
-        unoptimized,
-        ...imgProps
-      } = props;
       // eslint-disable-next-line @next/next/no-img-element
       return <img {...imgProps} src={url} alt={props.alt ?? ""} />;
     },
@@ -41,13 +45,23 @@ export function FernImage({
       blurDataUrl,
       alt,
     }) => {
-      const { width: layoutWidth, height: layoutHeight } = props;
+      try {
+        const pathname = new URL(url).pathname.toLowerCase();
+        if (pathname.endsWith(".gif") || pathname.endsWith(".svg")) {
+          // eslint-disable-next-line @next/next/no-img-element
+          return <img {...imgProps} src={url} alt={props.alt ?? ""} />;
+        }
+      } catch (_e) {
+        // Ignore errors
+      }
+
       const { width, height } = getDimensions(
-        layoutWidth,
-        layoutHeight,
+        maxWidth ?? props.width,
+        undefined,
         realWidth,
         realHeight
       );
+
       return (
         <Image
           {...props}
@@ -59,7 +73,6 @@ export function FernImage({
             props.placeholder ?? (blurDataUrl != null ? "blur" : "empty")
           }
           blurDataURL={props.blurDataURL ?? blurDataUrl}
-          unoptimized={props.unoptimized ?? url.includes(".svg")}
           overrideSrc={url}
         />
       );

--- a/packages/fern-docs/ui/src/contexts/api-page.ts
+++ b/packages/fern-docs/ui/src/contexts/api-page.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext } from "react";
 
-export const ApiPageContext = createContext<boolean>(false);
+export const WithAside = createContext<boolean>(false);
 
-export function useApiPageContext(): boolean {
-  return useContext(ApiPageContext);
+export function useWithAside(): boolean {
+  return useContext(WithAside);
 }

--- a/packages/fern-docs/ui/src/layouts/CustomLayout.tsx
+++ b/packages/fern-docs/ui/src/layouts/CustomLayout.tsx
@@ -10,9 +10,7 @@ export function CustomLayout({ children }: CustomLayoutProps): ReactElement {
     <main>
       {children}
 
-      <div className="mx-auto my-8 w-fit">
-        <BuiltWithFern />
-      </div>
+      <BuiltWithFern className="mx-auto my-8 w-fit" />
     </main>
   );
 }

--- a/packages/fern-docs/ui/src/layouts/GuideLayout.tsx
+++ b/packages/fern-docs/ui/src/layouts/GuideLayout.tsx
@@ -39,9 +39,7 @@ export function GuideLayout({
             </div>
 
             {!hideNavLinks && <BottomNavigationNeighbors />}
-            <div className="mx-auto my-8 w-fit">
-              <BuiltWithFern />
-            </div>
+            <BuiltWithFern className="mx-auto my-8 w-fit" />
           </footer>
         )}
       </article>

--- a/packages/fern-docs/ui/src/layouts/OverviewLayout.tsx
+++ b/packages/fern-docs/ui/src/layouts/OverviewLayout.tsx
@@ -34,9 +34,7 @@ export function OverviewLayout({
               <div>{!hideFeedback && <Feedback />}</div>
               <EditThisPageButton editThisPageUrl={editThisPageUrl} />
             </div>
-            <div className="mx-auto my-8 w-fit">
-              <BuiltWithFern />
-            </div>
+            <BuiltWithFern className="mx-auto my-8 w-fit" />
           </footer>
         )}
       </article>

--- a/packages/fern-docs/ui/src/layouts/PageLayout.tsx
+++ b/packages/fern-docs/ui/src/layouts/PageLayout.tsx
@@ -29,9 +29,7 @@ export function PageLayout({
             <div>{!hideFeedback && <Feedback />}</div>
             <EditThisPageButton editThisPageUrl={editThisPageUrl} />
           </div>
-          <div className="mx-auto my-8 w-fit">
-            <BuiltWithFern />
-          </div>
+          <BuiltWithFern className="mx-auto my-8 w-fit" />
         </footer>
       )}
     </main>

--- a/packages/fern-docs/ui/src/layouts/ReferenceLayout.tsx
+++ b/packages/fern-docs/ui/src/layouts/ReferenceLayout.tsx
@@ -1,6 +1,6 @@
 import { FC, type ReactElement, type ReactNode } from "react";
 import { EditThisPageButton } from "../components/EditThisPage";
-import { useApiPageContext } from "../contexts/api-page";
+import { WithAside } from "../contexts/api-page";
 import { Feedback } from "../feedback/Feedback";
 import { BuiltWithFern } from "../sidebar/BuiltWithFern";
 
@@ -26,17 +26,17 @@ export function ReferenceLayout({
   hideFeedback,
   hasAside,
 }: ReferenceLayoutProps): ReactElement {
-  const isApiPage = useApiPageContext();
-
   return (
     <main className="fern-reference-layout">
       <div className="z-10 w-full min-w-0 pt-8">
         <article className="max-w-content-width md:max-w-endpoint-width mx-auto w-full pb-20 lg:ml-0 xl:mx-auto">
           <PageHeader />
           {hasAside ? (
-            <div className="grid max-w-full gap-8 md:grid-cols-2 lg:gap-12">
-              {children}
-            </div>
+            <WithAside.Provider value={true}>
+              <div className="grid max-w-full gap-8 md:grid-cols-2 lg:gap-12">
+                {children}
+              </div>
+            </WithAside.Provider>
           ) : (
             <div className="prose dark:prose-invert prose-h1:mt-[1.5em] first:prose-h1:mt-0 max-w-full break-words">
               {children}
@@ -48,7 +48,7 @@ export function ReferenceLayout({
                 <div>{!hideFeedback && <Feedback />}</div>
                 <EditThisPageButton editThisPageUrl={editThisPageUrl} />
               </div>
-              {!isApiPage && <BuiltWithFern className="mx-auto my-8 w-fit" />}
+              <BuiltWithFern className="mx-auto my-8 w-fit" />
             </footer>
           )}
         </article>

--- a/packages/fern-docs/ui/src/search/SearchV2.tsx
+++ b/packages/fern-docs/ui/src/search/SearchV2.tsx
@@ -81,8 +81,8 @@ export function SearchV2(): ReactElement | false {
   const { data } = useApiRouteSWRImmutable("/api/fern-docs/search/v2/key", {
     request: { headers: { "X-User-Token": userToken } },
     validate: ApiKeySchema,
-    // api key expires 24 hours, so we refresh it every 12 hours
-    refreshInterval: 60 * 60 * 12 * 1000,
+    // api key expires 24 hours, so we refresh it every hour
+    refreshInterval: 60 * 60 * 1000,
   });
 
   const facetApiEndpoint = useApiRoute("/api/fern-docs/search/v2/facet");

--- a/packages/fern-docs/ui/src/sidebar/BuiltWithFern.tsx
+++ b/packages/fern-docs/ui/src/sidebar/BuiltWithFern.tsx
@@ -1,13 +1,15 @@
 import { BuiltWithFern as BuiltWithFernComponent } from "@fern-docs/components";
-import { useDomain, useFeatureFlags } from "../atoms";
+import { createContext, useContext } from "react";
+import { useDomain, useFeatureFlag } from "../atoms";
 
 export const BuiltWithFern: React.FC<{ className?: string }> = ({
   className,
 }) => {
   const domain = useDomain();
-  const { isWhitelabeled } = useFeatureFlags();
+  const isWhitelabeled = useFeatureFlag("isWhitelabeled");
+  const hideBuiltWithFern = useContext(HideBuiltWithFernContext);
 
-  if (isWhitelabeled) {
+  if (isWhitelabeled || hideBuiltWithFern) {
     return null;
   }
 
@@ -20,3 +22,5 @@ export const BuiltWithFern: React.FC<{ className?: string }> = ({
     />
   );
 };
+
+export const HideBuiltWithFernContext = createContext(false);

--- a/packages/fern-docs/ui/src/themes/stylesheet/getLayoutVariables.ts
+++ b/packages/fern-docs/ui/src/themes/stylesheet/getLayoutVariables.ts
@@ -19,7 +19,7 @@ export function getLayoutVariables(
 ): Record<Breakpoint, Record<string, string>> {
   const pageWidth =
     layout?.pageWidth == null
-      ? "88rem"
+      ? "88rem" // note: this is also hard-coded in LAYOUT_PAGE_WIDTH_ATOM
       : visitDiscriminatedUnion(layout.pageWidth, "type")._visit({
           px: (px) => `${px.value}px`,
           rem: (rem) => `${rem.value}rem`,
@@ -29,18 +29,18 @@ export function getLayoutVariables(
 
   const contentWidthRem =
     layout?.contentWidth == null
-      ? 44
+      ? 44 // note: this is also hard-coded in LAYOUT_CONTENT_WIDTH_ATOM
       : visitDiscriminatedUnion(layout.contentWidth, "type")._visit({
           px: (px) => px.value / 16,
           rem: (rem) => rem.value,
           _other: () => 44,
         });
 
-  const contentWideWidthRem = (contentWidthRem * 3) / 2 + 0.5;
+  const contentWideWidthRem = (contentWidthRem * 3) / 2 + 0.5; // note: this is also hard-coded in LAYOUT_CONTENT_WIDE_WIDTH_ATOM
 
   const sidebarWidth =
     layout?.sidebarWidth == null
-      ? "18rem"
+      ? "18rem" // note: this is also hard-coded in LAYOUT_SIDEBAR_WIDTH_ATOM
       : visitDiscriminatedUnion(layout.sidebarWidth, "type")._visit({
           px: (px) => `${px.value}px`,
           rem: (rem) => `${rem.value}rem`,


### PR DESCRIPTION
Update the image optimization widget inside of mdx to consider the maximum width of the layout that includes the image, and excludes SVGs and GIFs from optimization