### PR TITLE
feat: add display name and operation id to FDR latest shape

### DIFF
--- a/fern/apis/fdr/definition/api/latest/endpoint.yml
+++ b/fern/apis/fdr/definition/api/latest/endpoint.yml
@@ -23,6 +23,8 @@ types:
       id: rootCommons.EndpointId # or original endpoint id?
       method: rootCommons.HttpMethod
       path: list<commons.PathPart>
+      displayName: optional<string>
+      operationId: optional<string>
 
       auth: optional<list<auth.AuthSchemeId>>
       defaultEnvironment: optional<rootCommons.EnvironmentId>

--- a/fern/apis/fdr/definition/api/latest/webhook.yml
+++ b/fern/apis/fdr/definition/api/latest/webhook.yml
@@ -14,6 +14,8 @@ types:
       - commons.WithNamespace
     properties:
       id: rootCommons.WebhookId
+      displayName: optional<string>
+      operationId: optional<string>
       method: WebhookHttpMethod
       path: list<string>
       headers: optional<list<type.ObjectProperty>>

--- a/fern/apis/fdr/definition/api/latest/websocket.yml
+++ b/fern/apis/fdr/definition/api/latest/websocket.yml
@@ -21,6 +21,8 @@ types:
       - commons.WithNamespace
     properties:
       id: rootCommons.WebSocketId
+      displayName: optional<string>
+      operationId: optional<string>
       path: list<commons.PathPart>
       messages:
         type: list<WebSocketMessage>

--- a/packages/fdr-sdk/src/api-definition/__test__/join.test.ts
+++ b/packages/fdr-sdk/src/api-definition/__test__/join.test.ts
@@ -16,6 +16,8 @@ const PRIMITIVE_SHAPE: Latest.TypeReference.Primitive = {
 const endpoint1: Latest.EndpointDefinition = {
   id: Latest.EndpointId("endpoint-1"),
   namespace: [],
+  displayName: "endpoint-1",
+  operationId: "endpoint-1",
   method: "GET",
   path: [],
   defaultEnvironment: Latest.EnvironmentId("production"),
@@ -56,6 +58,8 @@ const endpoint1: Latest.EndpointDefinition = {
 const endpoint2: Latest.EndpointDefinition = {
   id: Latest.EndpointId("endpoint-2"),
   namespace: [],
+  displayName: "endpoint-2",
+  operationId: "endpoint-2",
   method: "GET",
   path: [],
   defaultEnvironment: Latest.EnvironmentId("production"),
@@ -97,6 +101,8 @@ const websocket1: Latest.WebSocketChannel = {
   id: Latest.WebSocketId("websocket-1"),
   namespace: [],
   path: [],
+  displayName: "websocket-1",
+  operationId: "websocket-1",
   messages: [
     {
       type: APIV1Read.WebSocketMessageId("message-1"),

--- a/packages/fdr-sdk/src/api-definition/__test__/prune.test.ts
+++ b/packages/fdr-sdk/src/api-definition/__test__/prune.test.ts
@@ -15,6 +15,8 @@ const PRIMITIVE_SHAPE: Latest.TypeReference.Primitive = {
 
 const endpoint1: Latest.EndpointDefinition = {
   id: Latest.EndpointId("endpoint-1"),
+  displayName: "endpoint-1",
+  operationId: "endpoint-1",
   namespace: [],
   method: "GET",
   path: [],
@@ -55,6 +57,8 @@ const endpoint1: Latest.EndpointDefinition = {
 
 const endpoint2: Latest.EndpointDefinition = {
   id: Latest.EndpointId("endpoint-2"),
+  displayName: "endpoint-2",
+  operationId: "endpoint-2",
   namespace: [],
   method: "GET",
   path: [],
@@ -95,6 +99,8 @@ const endpoint2: Latest.EndpointDefinition = {
 
 const websocket1: Latest.WebSocketChannel = {
   id: Latest.WebSocketId("websocket-1"),
+  displayName: "websocket-1",
+  operationId: "websocket-1",
   namespace: [],
   path: [],
   messages: [

--- a/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
+++ b/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
@@ -181,6 +181,8 @@ export class ApiDefinitionV1ToLatest {
     const toRet: V2.EndpointDefinition = {
       id,
       namespace,
+      displayName: v1.name,
+      operationId: v1.urlSlug.split("/").pop(),
       description: v1.description,
       availability: v1.availability,
       method: v1.method,
@@ -213,6 +215,8 @@ export class ApiDefinitionV1ToLatest {
     return {
       id,
       namespace,
+      displayName: v1.name,
+      operationId: v1.urlSlug.split("/").pop(),
       description: v1.description,
       availability: v1.availability,
       path: v1.path.parts.filter((part) => part.value !== ""),
@@ -236,6 +240,8 @@ export class ApiDefinitionV1ToLatest {
     return {
       id,
       namespace,
+      displayName: v1.name,
+      operationId: v1.urlSlug.split("/").pop(),
       description: v1.description,
       availability: undefined,
       method: v1.method,

--- a/packages/fdr-sdk/src/client/generated/api/resources/api/resources/latest/resources/endpoint/types/EndpointDefinition.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/api/resources/latest/resources/endpoint/types/EndpointDefinition.ts
@@ -11,6 +11,8 @@ export interface EndpointDefinition
     id: FernRegistry.EndpointId;
     method: FernRegistry.HttpMethod;
     path: FernRegistry.api.latest.PathPart[];
+    displayName: string | undefined;
+    operationId: string | undefined;
     auth: FernRegistry.api.latest.AuthSchemeId[] | undefined;
     defaultEnvironment: FernRegistry.EnvironmentId | undefined;
     environments: FernRegistry.api.latest.Environment[] | undefined;

--- a/packages/fdr-sdk/src/client/generated/api/resources/api/resources/latest/resources/webhook/types/WebhookDefinition.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/api/resources/latest/resources/webhook/types/WebhookDefinition.ts
@@ -9,6 +9,8 @@ export interface WebhookDefinition
         FernRegistry.api.latest.WithAvailability,
         FernRegistry.api.latest.WithNamespace {
     id: FernRegistry.WebhookId;
+    displayName: string | undefined;
+    operationId: string | undefined;
     method: FernRegistry.api.latest.WebhookHttpMethod;
     path: string[];
     headers: FernRegistry.api.latest.ObjectProperty[] | undefined;

--- a/packages/fdr-sdk/src/client/generated/api/resources/api/resources/latest/resources/websocket/types/WebSocketChannel.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/api/resources/latest/resources/websocket/types/WebSocketChannel.ts
@@ -9,6 +9,8 @@ export interface WebSocketChannel
         FernRegistry.api.latest.WithAvailability,
         FernRegistry.api.latest.WithNamespace {
     id: FernRegistry.WebSocketId;
+    displayName: string | undefined;
+    operationId: string | undefined;
     path: FernRegistry.api.latest.PathPart[];
     /** The messages that can be sent and received on this channel */
     messages: FernRegistry.api.latest.WebSocketMessage[];

--- a/packages/fdr-sdk/src/client/generated/api/resources/api/resources/v1/resources/register/client/Client.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/api/resources/v1/resources/register/client/Client.ts
@@ -545,6 +545,8 @@ export class Register {
      *                                 "key": "value"
      *                             }
      *                         }],
+     *                     displayName: "string",
+     *                     operationId: "string",
      *                     auth: [{
      *                             "key": "value"
      *                         }],
@@ -594,6 +596,8 @@ export class Register {
      *             websockets: {
      *                 "string": {
      *                     id: FernRegistry.WebSocketId("string"),
+     *                     displayName: "string",
+     *                     operationId: "string",
      *                     path: [{
      *                             type: "literal",
      *                             value: {
@@ -644,6 +648,8 @@ export class Register {
      *             webhooks: {
      *                 "string": {
      *                     id: FernRegistry.WebhookId("string"),
+     *                     displayName: "string",
+     *                     operationId: "string",
      *                     method: "GET",
      *                     path: ["string"],
      *                     headers: [{

--- a/packages/fdr-sdk/src/client/generated/api/resources/api/resources/v1/resources/register/client/requests/RegisterApiDefinitionRequest.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/api/resources/v1/resources/register/client/requests/RegisterApiDefinitionRequest.ts
@@ -518,6 +518,8 @@ import * as FernRegistry from "../../../../../../../../index";
  *                                 "key": "value"
  *                             }
  *                         }],
+ *                     displayName: "string",
+ *                     operationId: "string",
  *                     auth: [{
  *                             "key": "value"
  *                         }],
@@ -567,6 +569,8 @@ import * as FernRegistry from "../../../../../../../../index";
  *             websockets: {
  *                 "string": {
  *                     id: FernRegistry.WebSocketId("string"),
+ *                     displayName: "string",
+ *                     operationId: "string",
  *                     path: [{
  *                             type: "literal",
  *                             value: {
@@ -617,6 +621,8 @@ import * as FernRegistry from "../../../../../../../../index";
  *             webhooks: {
  *                 "string": {
  *                     id: FernRegistry.WebhookId("string"),
+ *                     displayName: "string",
+ *                     operationId: "string",
  *                     method: "GET",
  *                     path: ["string"],
  *                     headers: [{

--- a/packages/fern-docs/ui/src/playground/code-snippets/__test__/code-snippets.test.ts
+++ b/packages/fern-docs/ui/src/playground/code-snippets/__test__/code-snippets.test.ts
@@ -47,6 +47,8 @@ describe("PlaygroundCodeSnippetBuilder", () => {
         baseUrl: "https://example.com",
       },
     ],
+    displayName: "endpoint-1",
+    operationId: "endpoint-1",
     method: "POST",
     path: [
       { type: "literal", value: "/test/" },

--- a/packages/parsers/src/client/generated/api/resources/api/resources/latest/resources/endpoint/types/EndpointDefinition.ts
+++ b/packages/parsers/src/client/generated/api/resources/api/resources/latest/resources/endpoint/types/EndpointDefinition.ts
@@ -11,6 +11,8 @@ export interface EndpointDefinition
     id: FernRegistry.EndpointId;
     method: FernRegistry.HttpMethod;
     path: FernRegistry.api.latest.PathPart[];
+    displayName: string | undefined;
+    operationId: string | undefined;
     auth: FernRegistry.api.latest.AuthSchemeId[] | undefined;
     defaultEnvironment: FernRegistry.EnvironmentId | undefined;
     environments: FernRegistry.api.latest.Environment[] | undefined;

--- a/packages/parsers/src/client/generated/api/resources/api/resources/latest/resources/webhook/types/WebhookDefinition.ts
+++ b/packages/parsers/src/client/generated/api/resources/api/resources/latest/resources/webhook/types/WebhookDefinition.ts
@@ -9,6 +9,8 @@ export interface WebhookDefinition
         FernRegistry.api.latest.WithAvailability,
         FernRegistry.api.latest.WithNamespace {
     id: FernRegistry.WebhookId;
+    displayName: string | undefined;
+    operationId: string | undefined;
     method: FernRegistry.api.latest.WebhookHttpMethod;
     path: string[];
     headers: FernRegistry.api.latest.ObjectProperty[] | undefined;

--- a/packages/parsers/src/client/generated/api/resources/api/resources/latest/resources/websocket/types/WebSocketChannel.ts
+++ b/packages/parsers/src/client/generated/api/resources/api/resources/latest/resources/websocket/types/WebSocketChannel.ts
@@ -9,6 +9,8 @@ export interface WebSocketChannel
         FernRegistry.api.latest.WithAvailability,
         FernRegistry.api.latest.WithNamespace {
     id: FernRegistry.WebSocketId;
+    displayName: string | undefined;
+    operationId: string | undefined;
     path: FernRegistry.api.latest.PathPart[];
     /** The messages that can be sent and received on this channel */
     messages: FernRegistry.api.latest.WebSocketMessage[];

--- a/packages/parsers/src/openapi/3.1/paths/OperationObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/OperationObjectConverter.node.ts
@@ -32,6 +32,8 @@ export class OperationObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
 > {
   endpointId: string | undefined;
   description: string | undefined;
+  displayName: string | undefined;
+  operationId: string | undefined;
   pathParameters: Record<string, ParameterBaseObjectConverterNode> | undefined;
   queryParameters: Record<string, ParameterBaseObjectConverterNode> | undefined;
   requestHeaders: Record<string, ParameterBaseObjectConverterNode> | undefined;
@@ -66,6 +68,8 @@ export class OperationObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
     }
 
     this.description = this.input.description;
+    this.displayName = this.input.summary;
+    this.operationId = this.input.operationId;
 
     this.availability = new AvailabilityConverterNode({
       input: this.input,
@@ -317,15 +321,17 @@ export class OperationObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
     }
 
     if (this.isWebhook) {
-      if (this.method !== "POST" && this.method !== "GET") {
+      if ((this.method !== "POST" && this.method !== "GET") || this.endpointId == null) {
         return undefined;
       }
 
       return {
+        id: FernRegistry.WebhookId(this.endpointId),
         description: this.description,
         availability: this.availability?.convert(),
+        displayName: this.displayName,
+        operationId: this.operationId,
         namespace: this.namespace?.convert(),
-        id: FernRegistry.WebhookId("x-fern-webhook-name"),
         method: this.method,
         // This is a little bit weird, consider changing the shape of fdr
         path:
@@ -374,10 +380,12 @@ export class OperationObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
     }
 
     return {
+      id: FernRegistry.EndpointId(this.endpointId),
       description: this.description,
       availability: this.availability?.convert(),
       namespace: this.namespace?.convert(),
-      id: FernRegistry.EndpointId(this.endpointId),
+      displayName: this.displayName,
+      operationId: this.operationId,
       method: this.method,
       path: pathParts,
       auth: authIds?.map((id) => FernRegistry.api.latest.AuthSchemeId(id)),

--- a/servers/fdr/src/api/generated/api/resources/api/resources/latest/resources/endpoint/types/EndpointDefinition.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/api/resources/latest/resources/endpoint/types/EndpointDefinition.d.ts
@@ -6,6 +6,8 @@ export interface EndpointDefinition extends FernRegistry.api.latest.WithDescript
     id: FernRegistry.EndpointId;
     method: FernRegistry.HttpMethod;
     path: FernRegistry.api.latest.PathPart[];
+    displayName: string | undefined;
+    operationId: string | undefined;
     auth: FernRegistry.api.latest.AuthSchemeId[] | undefined;
     defaultEnvironment: FernRegistry.EnvironmentId | undefined;
     environments: FernRegistry.api.latest.Environment[] | undefined;

--- a/servers/fdr/src/api/generated/api/resources/api/resources/latest/resources/webhook/types/WebhookDefinition.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/api/resources/latest/resources/webhook/types/WebhookDefinition.d.ts
@@ -4,6 +4,8 @@
 import * as FernRegistry from "../../../../../../../index";
 export interface WebhookDefinition extends FernRegistry.api.latest.WithDescription, FernRegistry.api.latest.WithAvailability, FernRegistry.api.latest.WithNamespace {
     id: FernRegistry.WebhookId;
+    displayName: string | undefined;
+    operationId: string | undefined;
     method: FernRegistry.api.latest.WebhookHttpMethod;
     path: string[];
     headers: FernRegistry.api.latest.ObjectProperty[] | undefined;

--- a/servers/fdr/src/api/generated/api/resources/api/resources/latest/resources/websocket/types/WebSocketChannel.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/api/resources/latest/resources/websocket/types/WebSocketChannel.d.ts
@@ -4,6 +4,8 @@
 import * as FernRegistry from "../../../../../../../index";
 export interface WebSocketChannel extends FernRegistry.api.latest.WithDescription, FernRegistry.api.latest.WithAvailability, FernRegistry.api.latest.WithNamespace {
     id: FernRegistry.WebSocketId;
+    displayName: string | undefined;
+    operationId: string | undefined;
     path: FernRegistry.api.latest.PathPart[];
     /** The messages that can be sent and received on this channel */
     messages: FernRegistry.api.latest.WebSocketMessage[];


### PR DESCRIPTION
## Short description of the changes made

* adds display name and operation id into latest FDR shape for use with `docs dev` and generation commands

## What was the motivation & context behind this PR?

* no information for generating slugs and/or display names was previously there for conversion into nav structure

## How has this PR been tested?

* To be tested
