### PR TITLE
fix: simplifies FernImage and fixes how it's contained within width/height

### DIFF
--- a/packages/fern-docs/ui/src/components/FernImage.tsx
+++ b/packages/fern-docs/ui/src/components/FernImage.tsx
@@ -15,18 +15,8 @@ export const FernImage = forwardRef<
      * @default ""
      */
     alt?: string;
-    /**
-     * The maximum width of the image.
-     * We will use this to scale down the image if it is larger than the max width, using a "contains" strategy.
-     */
-    maxWidth?: number;
-    /**
-     * The maximum height of the image.
-     * We will use this to scale down the image if it is larger than the max height, using a "contains" strategy.
-     */
-    maxHeight?: number;
   }
->(({ src, maxWidth, maxHeight, ...props }, ref) => {
+>(({ src, ...props }, ref) => {
   if (src == null) {
     return null;
   }
@@ -51,6 +41,7 @@ export const FernImage = forwardRef<
       ref={ref}
       {...props}
       src={src.url}
+      overrideSrc={src.url}
       width={width}
       height={height}
       alt={props.alt ?? (src.type === "image" ? src.alt : undefined) ?? ""}
@@ -58,13 +49,6 @@ export const FernImage = forwardRef<
         props.placeholder ?? (blurDataURL != null ? "blur" : "empty")
       }
       blurDataURL={blurDataURL}
-      overrideSrc={src.url}
-      style={{
-        // if the user has provided a width or height, we don't want to apply the maxWidth/maxHeight
-        maxWidth: props.width || props.height ? undefined : maxWidth,
-        maxHeight: props.height || props.width ? undefined : maxHeight,
-        ...props.style,
-      }}
       unoptimized={
         pathname?.endsWith(".gif") ||
         pathname?.endsWith(".svg") ||

--- a/packages/fern-docs/ui/src/components/FernImage.tsx
+++ b/packages/fern-docs/ui/src/components/FernImage.tsx
@@ -1,68 +1,99 @@
+/* eslint-disable @next/next/no-img-element */
+
 import type { DocsV1Read } from "@fern-api/fdr-sdk/client/types";
 import { visitDiscriminatedUnion } from "@fern-api/ui-core-utils";
-import Image, { ImageProps } from "next/image";
-import { ReactElement } from "react";
+import Image from "next/image";
+import { ComponentPropsWithoutRef, forwardRef } from "react";
 
-export declare namespace FernImage {
-  export interface Props extends Omit<ImageProps, "src" | "alt"> {
-    // FDR may return a URL or an image object depending on the version of the Fern CLI used to build the docs.
-    // If the file has width/height metadata, we can render it using next/image for optimized loading.
+export const FernImage = forwardRef<
+  HTMLImageElement,
+  Omit<ComponentPropsWithoutRef<typeof Image>, "src" | "alt"> & {
+    /**
+     * FDR may return a URL or an image object depending on the version of the Fern CLI used to build the docs.
+     * If the file has width/height metadata, we can render it using next/image for optimized loading.
+     */
     src: DocsV1Read.File_ | undefined;
+    /**
+     * The alt text for the image.
+     * @default ""
+     */
     alt?: string;
+    /**
+     * The maximum width of the image.
+     * We will use this to scale down the image if it is larger than the max width, using a "contains" strategy.
+     */
     maxWidth?: number;
+    /**
+     * The maximum height of the image.
+     * We will use this to scale down the image if it is larger than the max height, using a "contains" strategy.
+     */
+    maxHeight?: number;
   }
-}
-
-export function FernImage({
-  src,
-  maxWidth,
-  ...props
-}: FernImage.Props): ReactElement | null {
+>(({ src, maxWidth, maxHeight, ...props }, ref) => {
   if (src == null) {
     return null;
   }
 
-  const {
-    fill,
-    loader,
-    quality,
-    priority,
-    placeholder,
-    blurDataURL,
-    unoptimized,
-    ...imgProps
-  } = props;
+  const style = {
+    // if the user has provided a width or height, we don't want to apply the maxWidth/maxHeight
+    maxWidth: props.width || props.height ? undefined : maxWidth,
+    maxHeight: props.height || props.width ? undefined : maxHeight,
+    ...props.style,
+  };
+
+  function renderImg(url: string) {
+    const {
+      fill,
+      loader,
+      quality,
+      priority,
+      placeholder,
+      blurDataURL,
+      unoptimized,
+      ...imgProps
+    } = props;
+
+    return (
+      <img
+        ref={ref}
+        {...imgProps}
+        src={url}
+        alt={props.alt ?? ""}
+        style={style}
+      />
+    );
+  }
 
   return visitDiscriminatedUnion(src, "type")._visit({
-    url: ({ url }) => {
-      // eslint-disable-next-line @next/next/no-img-element
-      return <img {...imgProps} src={url} alt={props.alt ?? ""} />;
-    },
+    url: ({ url }) => renderImg(url),
     image: ({
       url,
-      width: realWidth,
-      height: realHeight,
+      width: originalWidth,
+      height: originalHeight,
       blurDataUrl,
       alt,
     }) => {
       try {
         const pathname = new URL(url).pathname.toLowerCase();
         if (pathname.endsWith(".gif") || pathname.endsWith(".svg")) {
-          // eslint-disable-next-line @next/next/no-img-element
-          return <img {...imgProps} src={url} alt={props.alt ?? ""} />;
+          return renderImg(url);
         }
       } catch (_e) {
         // Ignore errors
       }
 
-      const { width, height } = getDimensions(
-        maxWidth ?? props.width,
-        realWidth,
-        realHeight
-      );
+      const { width, height } = getDimensions({
+        originalWidth,
+        originalHeight,
+        maxWidth,
+        maxHeight,
+        propWidth: props.width,
+        propHeight: props.height,
+      });
 
       return (
         <Image
+          ref={ref}
           {...props}
           src={url}
           width={width}
@@ -73,28 +104,80 @@ export function FernImage({
           }
           blurDataURL={props.blurDataURL ?? blurDataUrl}
           overrideSrc={url}
+          style={style}
         />
       );
     },
     _other: () => null,
   });
+});
+
+FernImage.displayName = "FernImage";
+
+/**
+ * Given the original dimensions of the image, compute the maximum dimensions
+ * that we can render the image at.
+ *
+ * There are 3 sources of width/height:
+ * 1. The user has explicitly set the width and height.
+ * 2. The layout has a maxWidth and maxHeight.
+ * 3. The image has width/height metadata.
+ *
+ * We will use the smallest of the 3 sources to determine the final width/height,
+ * and we'll infer the aspect ratio from the original dimensions.
+ *
+ * @visibleForTesting
+ */
+export function getDimensions({
+  originalWidth,
+  originalHeight,
+  maxWidth,
+  maxHeight,
+  propWidth,
+  propHeight,
+}: {
+  originalWidth: number;
+  originalHeight: number;
+  maxWidth?: number;
+  maxHeight?: number;
+  propWidth?: number | `${number}`;
+  propHeight?: number | `${number}`;
+}): { width: number; height: number } {
+  propWidth = asNumber(propWidth);
+  propHeight = asNumber(propHeight);
+
+  // If the user has explicitly set the width and height, use those values.
+  if (propWidth != null && propHeight != null) {
+    return { width: propWidth, height: propHeight };
+  }
+
+  const aspectRatio = originalWidth / originalHeight;
+
+  // if the user has the width and height, use that to determine the aspect ratio
+  if (propWidth != null) {
+    return { width: propWidth, height: propWidth / aspectRatio };
+  } else if (propHeight != null) {
+    return { width: propHeight * aspectRatio, height: propHeight };
+  }
+
+  // use the "contains" strategy to shrink the image to fit within the maxWidth/maxHeight
+  if (maxWidth != null || maxHeight != null) {
+    const widthRatio = maxWidth != null ? maxWidth / originalWidth : Infinity;
+    const heightRatio =
+      maxHeight != null ? maxHeight / originalHeight : Infinity;
+    const ratio = Math.min(widthRatio, heightRatio);
+    return { width: originalWidth * ratio, height: originalHeight * ratio };
+  }
+
+  return { width: originalWidth, height: originalHeight };
 }
 
-function getDimensions(
-  layoutWidth: number | `${number}` | undefined,
-  realWidth: number,
-  realHeight: number
-): { width: number; height: number } {
-  layoutWidth =
-    typeof layoutWidth === "string" ? parseInt(layoutWidth, 10) : layoutWidth;
-  if (layoutWidth != null && isNaN(layoutWidth)) {
-    layoutWidth = undefined;
+function asNumber(value: number | `${number}` | undefined): number | undefined {
+  if (value == null) {
+    return undefined;
   }
-  if (layoutWidth != null && layoutWidth < realWidth) {
-    return {
-      width: layoutWidth,
-      height: (layoutWidth / realWidth) * realHeight,
-    };
+  if (typeof value === "string") {
+    return parseInt(value, 10);
   }
-  return { width: realWidth, height: realHeight };
+  return value;
 }

--- a/packages/fern-docs/ui/src/components/FernImage.tsx
+++ b/packages/fern-docs/ui/src/components/FernImage.tsx
@@ -1,7 +1,4 @@
-/* eslint-disable @next/next/no-img-element */
-
 import type { DocsV1Read } from "@fern-api/fdr-sdk/client/types";
-import { visitDiscriminatedUnion } from "@fern-api/ui-core-utils";
 import Image from "next/image";
 import { ComponentPropsWithoutRef, forwardRef } from "react";
 
@@ -34,124 +31,80 @@ export const FernImage = forwardRef<
     return null;
   }
 
-  const style = {
-    // if the user has provided a width or height, we don't want to apply the maxWidth/maxHeight
-    maxWidth: props.width || props.height ? undefined : maxWidth,
-    maxHeight: props.height || props.width ? undefined : maxHeight,
-    ...props.style,
-  };
+  const { width, height } =
+    src.type === "image"
+      ? getDimensions({
+          intrinsicWidth: src.width,
+          intrinsicHeight: src.height,
+          width: props.width,
+          height: props.height,
+        })
+      : props;
 
-  function renderImg(url: string) {
-    const {
-      fill,
-      loader,
-      quality,
-      priority,
-      placeholder,
-      blurDataURL,
-      unoptimized,
-      ...imgProps
-    } = props;
+  const blurDataURL =
+    props.blurDataURL ?? (src.type === "image" ? src.blurDataUrl : undefined);
 
-    return (
-      <img
-        ref={ref}
-        {...imgProps}
-        src={url}
-        alt={props.alt ?? ""}
-        style={style}
-      />
-    );
-  }
+  const pathname = safeGetPathname(src.url);
 
-  return visitDiscriminatedUnion(src, "type")._visit({
-    url: ({ url }) => renderImg(url),
-    image: ({
-      url,
-      width: originalWidth,
-      height: originalHeight,
-      blurDataUrl,
-      alt,
-    }) => {
-      try {
-        const pathname = new URL(url).pathname.toLowerCase();
-        if (pathname.endsWith(".gif") || pathname.endsWith(".svg")) {
-          return renderImg(url);
-        }
-      } catch (_e) {
-        // Ignore errors
+  return (
+    <Image
+      ref={ref}
+      {...props}
+      src={src.url}
+      width={width}
+      height={height}
+      alt={props.alt ?? (src.type === "image" ? src.alt : undefined) ?? ""}
+      placeholder={
+        props.placeholder ?? (blurDataURL != null ? "blur" : "empty")
       }
-
-      const { width, height } = getDimensions({
-        originalWidth,
-        originalHeight,
-        maxWidth,
-        maxHeight,
-        propWidth: props.width,
-        propHeight: props.height,
-      });
-
-      return (
-        <Image
-          ref={ref}
-          {...props}
-          src={url}
-          width={width}
-          height={height}
-          alt={props.alt ?? alt ?? ""}
-          placeholder={
-            props.placeholder ?? (blurDataUrl != null ? "blur" : "empty")
-          }
-          blurDataURL={props.blurDataURL ?? blurDataUrl}
-          overrideSrc={url}
-          style={style}
-        />
-      );
-    },
-    _other: () => null,
-  });
+      blurDataURL={blurDataURL}
+      overrideSrc={src.url}
+      style={{
+        // if the user has provided a width or height, we don't want to apply the maxWidth/maxHeight
+        maxWidth: props.width || props.height ? undefined : maxWidth,
+        maxHeight: props.height || props.width ? undefined : maxHeight,
+        ...props.style,
+      }}
+      unoptimized={
+        pathname?.endsWith(".gif") ||
+        pathname?.endsWith(".svg") ||
+        props.unoptimized ||
+        src.type === "url" // if the src is a URL, we don't want to optimize it because it's likely not allowlisted in next.config.js
+      }
+    />
+  );
 });
 
 FernImage.displayName = "FernImage";
 
-/**
- * Given the original dimensions of the image, compute the maximum dimensions
- * that we can render the image at.
- *
- * There are 3 sources of width/height:
- * 1. The user has explicitly set the width and height.
- * 2. The layout has a maxWidth and maxHeight.
- * 3. The image has width/height metadata.
- *
- * We will use the smallest of the 3 sources to determine the final width/height,
- * and we'll infer the aspect ratio from the original dimensions.
- *
- * @visibleForTesting
- */
+function safeGetPathname(url: string): string | undefined {
+  try {
+    return new URL(url, "https://n").pathname.toLowerCase();
+  } catch (_e) {
+    return undefined;
+  }
+}
+
 export function getDimensions({
-  originalWidth,
-  originalHeight,
-  maxWidth,
-  maxHeight,
-  propWidth,
-  propHeight,
+  intrinsicWidth,
+  intrinsicHeight,
+  width,
+  height,
 }: {
-  originalWidth: number;
-  originalHeight: number;
-  maxWidth?: number;
-  maxHeight?: number;
-  propWidth?: number | `${number}`;
-  propHeight?: number | `${number}`;
+  intrinsicWidth: number;
+  intrinsicHeight: number;
+  width?: number | `${number}`;
+  height?: number | `${number}`;
 }): { width: number; height: number } {
-  propWidth = asNumber(propWidth);
-  propHeight = asNumber(propHeight);
+  const propWidth = asNumber(width);
+  const propHeight = asNumber(height);
 
   // If the user has explicitly set the width and height, use those values.
   if (propWidth != null && propHeight != null) {
     return { width: propWidth, height: propHeight };
   }
 
-  const aspectRatio = originalWidth / originalHeight;
+  const aspectRatio = intrinsicWidth / intrinsicHeight;
 
   // if the user has the width and height, use that to determine the aspect ratio
   if (propWidth != null) {
@@ -160,16 +113,7 @@ export function getDimensions({
     return { width: propHeight * aspectRatio, height: propHeight };
   }
 
-  // use the "contains" strategy to shrink the image to fit within the maxWidth/maxHeight
-  if (maxWidth != null || maxHeight != null) {
-    const widthRatio = maxWidth != null ? maxWidth / originalWidth : Infinity;
-    const heightRatio =
-      maxHeight != null ? maxHeight / originalHeight : Infinity;
-    const ratio = Math.min(widthRatio, heightRatio);
-    return { width: originalWidth * ratio, height: originalHeight * ratio };
-  }
-
-  return { width: originalWidth, height: originalHeight };
+  return { width: intrinsicWidth, height: intrinsicHeight };
 }
 
 function asNumber(value: number | `${number}` | undefined): number | undefined {

--- a/packages/fern-docs/ui/src/components/__test__/FernImage.test.ts
+++ b/packages/fern-docs/ui/src/components/__test__/FernImage.test.ts
@@ -1,0 +1,75 @@
+import { getDimensions } from "../FernImage";
+
+describe("getDimensions", () => {
+  it("should return the original dimensions if no maxWidth or maxHeight is provided", () => {
+    const dimensions = getDimensions({
+      originalWidth: 100,
+      originalHeight: 100,
+    });
+
+    expect(dimensions).toEqual({ width: 100, height: 100 });
+  });
+
+  it("should return the original dimensions if maxWidth is less than the original width", () => {
+    const dimensions = getDimensions({
+      originalWidth: 100,
+      originalHeight: 100,
+      maxWidth: 50,
+    });
+
+    expect(dimensions).toEqual({ width: 50, height: 50 });
+  });
+
+  it("should return the original dimensions if maxHeight is less than the original height", () => {
+    const dimensions = getDimensions({
+      originalWidth: 100,
+      originalHeight: 100,
+      maxHeight: 50,
+    });
+
+    expect(dimensions).toEqual({ width: 50, height: 50 });
+  });
+
+  it("should return the smallest of the maxWidth and maxHeight", () => {
+    const dimensions = getDimensions({
+      originalWidth: 150,
+      originalHeight: 100,
+      maxWidth: 50,
+      maxHeight: 25,
+    });
+
+    expect(dimensions).toEqual({ width: 37.5, height: 25 });
+  });
+
+  it("should use the user-provided width and height, even if they are larger than the original dimensions or has a different aspect ratio", () => {
+    const dimensions = getDimensions({
+      originalWidth: 100,
+      originalHeight: 100,
+      propWidth: 200,
+      propHeight: 250,
+    });
+
+    expect(dimensions).toEqual({ width: 200, height: 250 });
+  });
+
+  it("should use the user-provided width, and scale the height to maintain the aspect ratio", () => {
+    const dimensions = getDimensions({
+      originalWidth: 100,
+      originalHeight: 100,
+      propWidth: 200,
+    });
+
+    expect(dimensions).toEqual({ width: 200, height: 200 });
+  });
+
+  it("should use the user-provided height, and scale the width to maintain the aspect ratio and ignore provided maxWidth", () => {
+    const dimensions = getDimensions({
+      originalWidth: 100,
+      originalHeight: 100,
+      propHeight: 200,
+      maxWidth: 50,
+    });
+
+    expect(dimensions).toEqual({ width: 200, height: 200 });
+  });
+});

--- a/packages/fern-docs/ui/src/components/__test__/FernImage.test.ts
+++ b/packages/fern-docs/ui/src/components/__test__/FernImage.test.ts
@@ -1,52 +1,21 @@
 import { getDimensions } from "../FernImage";
 
 describe("getDimensions", () => {
-  it("should return the original dimensions if no maxWidth or maxHeight is provided", () => {
+  it("should return the intrinsic dimensions if no maxWidth or maxHeight is provided", () => {
     const dimensions = getDimensions({
-      originalWidth: 100,
-      originalHeight: 100,
+      intrinsicWidth: 100,
+      intrinsicHeight: 100,
     });
 
     expect(dimensions).toEqual({ width: 100, height: 100 });
   });
 
-  it("should return the original dimensions if maxWidth is less than the original width", () => {
+  it("should use the user-provided width and height, even if they are larger than the intrinsic dimensions or has a different aspect ratio", () => {
     const dimensions = getDimensions({
-      originalWidth: 100,
-      originalHeight: 100,
-      maxWidth: 50,
-    });
-
-    expect(dimensions).toEqual({ width: 50, height: 50 });
-  });
-
-  it("should return the original dimensions if maxHeight is less than the original height", () => {
-    const dimensions = getDimensions({
-      originalWidth: 100,
-      originalHeight: 100,
-      maxHeight: 50,
-    });
-
-    expect(dimensions).toEqual({ width: 50, height: 50 });
-  });
-
-  it("should return the smallest of the maxWidth and maxHeight", () => {
-    const dimensions = getDimensions({
-      originalWidth: 150,
-      originalHeight: 100,
-      maxWidth: 50,
-      maxHeight: 25,
-    });
-
-    expect(dimensions).toEqual({ width: 37.5, height: 25 });
-  });
-
-  it("should use the user-provided width and height, even if they are larger than the original dimensions or has a different aspect ratio", () => {
-    const dimensions = getDimensions({
-      originalWidth: 100,
-      originalHeight: 100,
-      propWidth: 200,
-      propHeight: 250,
+      intrinsicWidth: 100,
+      intrinsicHeight: 100,
+      width: 200,
+      height: 250,
     });
 
     expect(dimensions).toEqual({ width: 200, height: 250 });
@@ -54,22 +23,21 @@ describe("getDimensions", () => {
 
   it("should use the user-provided width, and scale the height to maintain the aspect ratio", () => {
     const dimensions = getDimensions({
-      originalWidth: 100,
-      originalHeight: 100,
-      propWidth: 200,
+      intrinsicWidth: 100,
+      intrinsicHeight: 150,
+      width: 200,
     });
 
-    expect(dimensions).toEqual({ width: 200, height: 200 });
+    expect(dimensions).toEqual({ width: 200, height: 300 });
   });
 
   it("should use the user-provided height, and scale the width to maintain the aspect ratio and ignore provided maxWidth", () => {
     const dimensions = getDimensions({
-      originalWidth: 100,
-      originalHeight: 100,
-      propHeight: 200,
-      maxWidth: 50,
+      intrinsicWidth: 100,
+      intrinsicHeight: 160,
+      height: 200,
     });
 
-    expect(dimensions).toEqual({ width: 200, height: 200 });
+    expect(dimensions).toEqual({ width: 125, height: 200 });
   });
 });

--- a/packages/fern-docs/ui/src/header/HeaderLogoImage.tsx
+++ b/packages/fern-docs/ui/src/header/HeaderLogoImage.tsx
@@ -1,27 +1,39 @@
 import { DocsV1Read } from "@fern-api/fdr-sdk";
 import { useAtomValue } from "jotai";
-import { ReactElement } from "react";
+import { ComponentPropsWithoutRef, forwardRef, ReactElement } from "react";
 import { DOCS_ATOM, LOGO_IMAGE_ATOM, useFile, useLogoHeight } from "../atoms";
 import { FernImage } from "../components/FernImage";
 
-function FernFileImage({
-  fileId,
-  ...props
-}: Omit<FernImage.Props, "src"> & { fileId: DocsV1Read.FileId }): ReactElement {
-  return <FernImage src={useFile(fileId)} {...props} />;
-}
-
-function FernFileOrUrlImage({
-  fileIdOrUrl,
-  ...props
-}: Omit<FernImage.Props, "src"> & {
-  fileIdOrUrl: DocsV1Read.FileIdOrUrl;
-}): ReactElement {
-  if (fileIdOrUrl.type === "fileId") {
-    return <FernFileImage fileId={fileIdOrUrl.value} {...props} />;
+const FernFileImage = forwardRef<
+  HTMLImageElement,
+  Omit<ComponentPropsWithoutRef<typeof FernImage>, "src"> & {
+    fileId: DocsV1Read.FileId;
   }
-  return <FernImage src={{ type: "url", url: fileIdOrUrl.value }} {...props} />;
-}
+>(({ fileId, ...props }, ref) => {
+  return <FernImage {...props} ref={ref} src={useFile(fileId)} />;
+});
+
+FernFileImage.displayName = "FernFileImage";
+
+const FernFileOrUrlImage = forwardRef<
+  HTMLImageElement,
+  Omit<ComponentPropsWithoutRef<typeof FernImage>, "src"> & {
+    fileIdOrUrl: DocsV1Read.FileIdOrUrl;
+  }
+>(({ fileIdOrUrl, ...props }, ref) => {
+  if (fileIdOrUrl.type === "fileId") {
+    return <FernFileImage {...props} ref={ref} fileId={fileIdOrUrl.value} />;
+  }
+  return (
+    <FernImage
+      {...props}
+      ref={ref}
+      src={{ type: "url", url: fileIdOrUrl.value }}
+    />
+  );
+});
+
+FernFileOrUrlImage.displayName = "FernFileOrUrlImage";
 
 export function HeaderLogoImage(): ReactElement | null {
   const logoImageHeight = useLogoHeight();
@@ -36,7 +48,6 @@ export function HeaderLogoImage(): ReactElement | null {
           fileIdOrUrl={light}
           className="fern-logo-light"
           height={logoImageHeight}
-          style={{ height: logoImageHeight }}
           priority={true}
           loading="eager"
           quality={100}
@@ -46,7 +57,6 @@ export function HeaderLogoImage(): ReactElement | null {
           fileIdOrUrl={dark}
           className="fern-logo-dark"
           height={logoImageHeight}
-          style={{ height: logoImageHeight }}
           priority={true}
           loading="eager"
           quality={100}

--- a/packages/fern-docs/ui/src/mdx/components/html/index.tsx
+++ b/packages/fern-docs/ui/src/mdx/components/html/index.tsx
@@ -142,11 +142,11 @@ export const Image = forwardRef<HTMLImageElement, ImgProps>((props, ref) => {
       src={src}
       width={toPixelValue(width)}
       height={toPixelValue(height)}
-      maxWidth={maxWidth}
       style={{
         // since the `toPixelValue` will return undefined for non-pixel values, we need to preserve the original values using the `style` prop
         width,
         height,
+        maxWidth,
         ...style,
       }}
       {...rest}

--- a/packages/fern-docs/ui/src/util/__test__/to-pixel-value.test.ts
+++ b/packages/fern-docs/ui/src/util/__test__/to-pixel-value.test.ts
@@ -22,15 +22,9 @@ describe("toPixelValue", () => {
   });
 
   it("should handle negative pixel values", () => {
-    expect(toPixelValue("-10px")).toEqual(-10);
-  });
-
-  it("should handle negative rem values", () => {
-    expect(toPixelValue("-1rem")).toEqual(-16);
-  });
-
-  it("should handle negative decimal rem values", () => {
-    expect(toPixelValue("-1.5rem")).toEqual(-24);
+    expect(toPixelValue("-10px")).toEqual(undefined);
+    expect(toPixelValue("-1rem")).toEqual(undefined);
+    expect(toPixelValue("-1.5rem")).toEqual(undefined);
   });
 
   it("should return undefined if the value is not a valid pixel value", () => {

--- a/packages/fern-docs/ui/src/util/__test__/to-pixel-value.test.ts
+++ b/packages/fern-docs/ui/src/util/__test__/to-pixel-value.test.ts
@@ -1,0 +1,79 @@
+import { toPixelValue } from "../to-pixel-value";
+
+describe("toPixelValue", () => {
+  it("should return number if the value is a number", () => {
+    expect(toPixelValue(10)).toEqual(10);
+  });
+
+  it("should return undefined if the value is not a string", () => {
+    expect(toPixelValue(undefined)).toEqual(undefined);
+  });
+
+  it("should strip units from a string", () => {
+    expect(toPixelValue("10px")).toEqual(10);
+  });
+
+  it("should handle rem units", () => {
+    expect(toPixelValue("1rem")).toEqual(16);
+  });
+
+  it("should handle decimal rem units", () => {
+    expect(toPixelValue("1.5rem")).toEqual(24);
+  });
+
+  it("should handle negative pixel values", () => {
+    expect(toPixelValue("-10px")).toEqual(-10);
+  });
+
+  it("should handle negative rem values", () => {
+    expect(toPixelValue("-1rem")).toEqual(-16);
+  });
+
+  it("should handle negative decimal rem values", () => {
+    expect(toPixelValue("-1.5rem")).toEqual(-24);
+  });
+
+  it("should return undefined if the value is not a valid pixel value", () => {
+    expect(toPixelValue("10em")).toEqual(undefined);
+  });
+
+  it("should return undefined if the value is not a valid rem value", () => {
+    expect(toPixelValue("1d0rem")).toEqual(undefined);
+  });
+
+  it("should handle em units", () => {
+    expect(toPixelValue("10em")).toEqual(undefined);
+  });
+
+  it("should handle vh units", () => {
+    expect(toPixelValue("10vh")).toEqual(undefined);
+  });
+
+  it("should handle vw units", () => {
+    expect(toPixelValue("10vw")).toEqual(undefined);
+  });
+
+  it("should handle percentage values", () => {
+    expect(toPixelValue("50%")).toEqual(undefined);
+  });
+
+  it("should handle cm units", () => {
+    expect(toPixelValue("10cm")).toEqual(undefined);
+  });
+
+  it("should handle mm units", () => {
+    expect(toPixelValue("10mm")).toEqual(undefined);
+  });
+
+  it("should handle in units", () => {
+    expect(toPixelValue("10in")).toEqual(undefined);
+  });
+
+  it("should handle pt units", () => {
+    expect(toPixelValue("10pt")).toEqual(undefined);
+  });
+
+  it("should handle pc units", () => {
+    expect(toPixelValue("10pc")).toEqual(undefined);
+  });
+});

--- a/packages/fern-docs/ui/src/util/to-pixel-value.ts
+++ b/packages/fern-docs/ui/src/util/to-pixel-value.ts
@@ -1,0 +1,21 @@
+/**
+ * Strips units from a size property.
+ *
+ * @param prop - The size property to strip units from.
+ * @returns The size property without units. undefined otherwise, or if the unit cannot be converted to a pixel value.
+ */
+export function toPixelValue(
+  prop: string | number | undefined
+): number | undefined {
+  if (prop == null || typeof prop === "number") {
+    return prop;
+  } else if (/^\d+$/.test(prop)) {
+    return Number(prop);
+  } else if (/^\d+(\.\d+)?(px)$/.test(prop)) {
+    return Number(prop.slice(0, -2));
+  } else if (/^\d+(\.\d+)?(rem)$/.test(prop)) {
+    return Number(prop.slice(0, -3)) * 16;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
Fixes several issues that were introduced by https://github.com/fern-api/fern-platform/pull/1955 in which the width and height are misconfigured (and misses the point of srcsets).