### PR TITLE
fix: openapi parser design partner patches

### DIFF
--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fern-api/docs-parsers",
-  "version": "0.0.14",
+  "version": "0.0.20",
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern-platform.git",

--- a/packages/parsers/src/__test__/__snapshots__/openapi/cohere.json
+++ b/packages/parsers/src/__test__/__snapshots__/openapi/cohere.json
@@ -38256,27 +38256,33 @@
   "subpackages": {
     "v2": {
       "id": "v2",
-      "name": "v2"
+      "name": "v2",
+      "displayName": "v2"
     },
-    "embed-jobs": {
-      "id": "embed-jobs",
-      "name": "embed-jobs"
+    "embedJobs": {
+      "id": "embedJobs",
+      "name": "embed-jobs",
+      "displayName": "embed-jobs"
     },
     "datasets": {
       "id": "datasets",
-      "name": "datasets"
+      "name": "datasets",
+      "displayName": "datasets"
     },
     "connectors": {
       "id": "connectors",
-      "name": "connectors"
+      "name": "connectors",
+      "displayName": "connectors"
     },
     "models": {
       "id": "models",
-      "name": "models"
+      "name": "models",
+      "displayName": "models"
     },
     "finetuning": {
       "id": "finetuning",
-      "name": "finetuning"
+      "name": "finetuning",
+      "displayName": "finetuning"
     }
   },
   "auths": {

--- a/packages/parsers/src/__test__/__snapshots__/openapi/deeptune.json
+++ b/packages/parsers/src/__test__/__snapshots__/openapi/deeptune.json
@@ -910,13 +910,15 @@
     }
   },
   "subpackages": {
-    "text_to_speech": {
-      "id": "text_to_speech",
-      "name": "text_to_speech"
+    "textToSpeech": {
+      "id": "textToSpeech",
+      "name": "text_to_speech",
+      "displayName": "text_to_speech"
     },
     "voices": {
       "id": "voices",
-      "name": "voices"
+      "name": "voices",
+      "displayName": "voices"
     }
   },
   "auths": {}

--- a/packages/parsers/src/__test__/__snapshots__/openapi/petstore.json
+++ b/packages/parsers/src/__test__/__snapshots__/openapi/petstore.json
@@ -830,11 +830,13 @@
   "subpackages": {
     "pet": {
       "id": "pet",
-      "name": "pet"
+      "name": "pet",
+      "displayName": "pet"
     },
     "pets": {
       "id": "pets",
-      "name": "pets"
+      "name": "pets",
+      "displayName": "pets"
     }
   },
   "auths": {}

--- a/packages/parsers/src/__test__/__snapshots__/openapi/uploadcare.json
+++ b/packages/parsers/src/__test__/__snapshots__/openapi/uploadcare.json
@@ -15052,37 +15052,45 @@
     }
   },
   "subpackages": {
-    "File": {
-      "id": "File",
-      "name": "File"
+    "file": {
+      "id": "file",
+      "name": "File",
+      "displayName": "File"
     },
-    "Add-Ons": {
-      "id": "Add-Ons",
-      "name": "Add-Ons"
+    "addOns": {
+      "id": "addOns",
+      "name": "Add-Ons",
+      "displayName": "Add-Ons"
     },
-    "File metadata": {
-      "id": "File metadata",
-      "name": "File metadata"
+    "fileMetadata": {
+      "id": "fileMetadata",
+      "name": "File metadata",
+      "displayName": "File metadata"
     },
-    "Group": {
-      "id": "Group",
-      "name": "Group"
+    "group": {
+      "id": "group",
+      "name": "Group",
+      "displayName": "Group"
     },
-    "Project": {
-      "id": "Project",
-      "name": "Project"
+    "project": {
+      "id": "project",
+      "name": "Project",
+      "displayName": "Project"
     },
-    "Webhook": {
-      "id": "Webhook",
-      "name": "Webhook"
+    "webhook": {
+      "id": "webhook",
+      "name": "Webhook",
+      "displayName": "Webhook"
     },
-    "Webhook Callbacks": {
-      "id": "Webhook Callbacks",
-      "name": "Webhook Callbacks"
+    "webhookCallbacks": {
+      "id": "webhookCallbacks",
+      "name": "Webhook Callbacks",
+      "displayName": "Webhook Callbacks"
     },
-    "Conversion": {
-      "id": "Conversion",
-      "name": "Conversion"
+    "conversion": {
+      "id": "conversion",
+      "name": "Conversion",
+      "displayName": "Conversion"
     }
   },
   "auths": {

--- a/packages/parsers/src/openapi/3.1/OpenApiDocumentConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/OpenApiDocumentConverter.node.ts
@@ -1,3 +1,4 @@
+import { camelCase } from "es-toolkit";
 import { OpenAPIV3_1 } from "openapi-types";
 import { v4 } from "uuid";
 import { FernRegistry } from "../../client/generated";
@@ -141,11 +142,12 @@ export class OpenApiDocumentConverterNode extends BaseOpenApiV3_1ConverterNode<
       Object.values(endpoints).forEach((endpoint) =>
         endpoint.namespace?.forEach((subpackage) => {
           const qualifiedPath: string[] = [];
-          subpackages[subpackage] = {
-            id: subpackage,
-            name: [...qualifiedPath, subpackage].join("/"),
-            displayName: undefined,
-          };
+          subpackages[FernRegistry.api.v1.SubpackageId(camelCase(subpackage))] =
+            {
+              id: FernRegistry.api.v1.SubpackageId(camelCase(subpackage)),
+              name: [...qualifiedPath, subpackage].join("/"),
+              displayName: subpackage,
+            };
           qualifiedPath.push(subpackage);
         })
       );
@@ -154,11 +156,12 @@ export class OpenApiDocumentConverterNode extends BaseOpenApiV3_1ConverterNode<
       Object.values(webhookEndpoints).forEach((webhook) =>
         webhook.namespace?.forEach((subpackage) => {
           const qualifiedPath: string[] = [];
-          subpackages[subpackage] = {
-            id: subpackage,
-            name: [...qualifiedPath, subpackage].join("/"),
-            displayName: undefined,
-          };
+          subpackages[FernRegistry.api.v1.SubpackageId(camelCase(subpackage))] =
+            {
+              id: FernRegistry.api.v1.SubpackageId(camelCase(subpackage)),
+              name: [...qualifiedPath, subpackage].join("/"),
+              displayName: subpackage,
+            };
           qualifiedPath.push(subpackage);
         })
       );

--- a/packages/parsers/src/openapi/3.1/schemas/OneOfConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/OneOfConverter.node.ts
@@ -27,10 +27,12 @@ export class OneOfConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample<
   }
 
   parse(): void {
-    if (this.input.oneOf != null) {
+    if (this.input.oneOf != null || this.input.anyOf != null) {
       if (this.input.discriminator == null) {
         this.discriminated = false;
-        this.undiscriminatedMapping = this.input.oneOf?.map((schema) => {
+        this.undiscriminatedMapping = (
+          this.input.oneOf ?? this.input.anyOf
+        )?.map((schema) => {
           return new SchemaConverterNode({
             input: schema,
             context: this.context,

--- a/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
@@ -95,7 +95,10 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample
           accessPath: this.accessPath,
           pathId: this.pathId,
         });
-      } else if (isNonArraySchema(this.input) && this.input.oneOf != null) {
+      } else if (
+        isNonArraySchema(this.input) &&
+        (this.input.oneOf != null || this.input.anyOf != null)
+      ) {
         this.typeShapeNode = new OneOfConverterNode({
           input: this.input,
           context: this.context,

--- a/servers/fdr/src/__test__/local/services/api.test.ts
+++ b/servers/fdr/src/__test__/local/services/api.test.ts
@@ -1,4 +1,5 @@
 import { APIV1Write, FdrAPI } from "@fern-api/fdr-sdk";
+import { v4 } from "uuid";
 import { expect, inject, it } from "vitest";
 import {
   createApiDefinition,
@@ -95,7 +96,7 @@ const EMPTY_REGISTER_API_LATEST_DEFINITION: FdrAPI.api.latest.ApiDefinition = {
   subpackages: {},
   websockets: {},
   webhooks: {},
-  id: FdrAPI.ApiDefinitionId("api"),
+  id: FdrAPI.ApiDefinitionId(v4()),
   auths: {},
   globalHeaders: undefined,
 };

--- a/servers/fdr/src/__test__/local/util.ts
+++ b/servers/fdr/src/__test__/local/util.ts
@@ -1,5 +1,6 @@
 import { APIResponse, APIV1Write, FdrAPI, FdrClient } from "@fern-api/fdr-sdk";
 import type { DocsV2, IndexSegment } from "@prisma/client";
+import { v4 } from "uuid";
 
 export function getUniqueDocsForUrl(prefix: string): string {
   return `${prefix}_${Math.random()}.fern.com`;
@@ -71,6 +72,8 @@ export function createApiDefinitionLatest({
         id: FdrAPI.EndpointId(endpointId),
         method: endpointMethod,
         path: endpointPath,
+        displayName: undefined,
+        operationId: undefined,
         requestHeaders: undefined,
         responseHeaders: undefined,
         queryParameters: undefined,
@@ -92,7 +95,7 @@ export function createApiDefinitionLatest({
     subpackages: {},
     websockets: {},
     webhooks: {},
-    id: FdrAPI.ApiDefinitionId("api"),
+    id: FdrAPI.ApiDefinitionId(v4()),
     auths: {},
     globalHeaders: undefined,
   };

--- a/servers/fdr/src/controllers/api/getRegisterApiService.ts
+++ b/servers/fdr/src/controllers/api/getRegisterApiService.ts
@@ -35,6 +35,10 @@ export function getRegisterApiService(app: FdrApplication): APIV1WriteService {
       });
 
       let apiDefinitionId = FdrAPI.ApiDefinitionId(uuidv4());
+      app.logger.debug(
+        `Creating API Definition in database with name=${req.body.apiId} for org ${req.body.orgId}`,
+        REGISTER_API_DEFINITION_META
+      );
       let transformedApiDefinition:
         | APIV1Db.DbApiDefinition
         | FdrAPI.api.latest.ApiDefinition

--- a/servers/fdr/src/controllers/api/getRegisterApiService.ts
+++ b/servers/fdr/src/controllers/api/getRegisterApiService.ts
@@ -164,7 +164,9 @@ export function getRegisterApiService(app: FdrApplication): APIV1WriteService {
         REGISTER_API_DEFINITION_META
       );
       return res.send({
-        apiDefinitionId,
+        apiDefinitionId: isLatest
+          ? transformedApiDefinition.id
+          : apiDefinitionId,
         sources,
       });
     },

--- a/servers/fdr/src/controllers/api/getRegisterApiService.ts
+++ b/servers/fdr/src/controllers/api/getRegisterApiService.ts
@@ -40,7 +40,6 @@ export function getRegisterApiService(app: FdrApplication): APIV1WriteService {
         | FdrAPI.api.latest.ApiDefinition
         | undefined;
 
-      console.log(req.body.definition);
       if (
         req.body.definition != null &&
         Object.keys(req.body.definition).length > 0
@@ -152,7 +151,9 @@ export function getRegisterApiService(app: FdrApplication): APIV1WriteService {
           : app.services.db.prisma.apiDefinitionsV2
       ).create({
         data: {
-          apiDefinitionId,
+          apiDefinitionId: isLatest
+            ? transformedApiDefinition.id
+            : apiDefinitionId,
           apiName: req.body.apiId,
           orgId: req.body.orgId,
           definition: writeBuffer(transformedApiDefinition),

--- a/servers/fdr/src/controllers/api/getRegisterApiService.ts
+++ b/servers/fdr/src/controllers/api/getRegisterApiService.ts
@@ -147,7 +147,7 @@ export function getRegisterApiService(app: FdrApplication): APIV1WriteService {
       }
 
       app.logger.debug(
-        `Creating API Definition in database with name=${req.body.apiId} for org ${req.body.orgId}`,
+        `Creating API Definition in database with id=${apiDefinitionId}, name=${req.body.apiId} for org ${req.body.orgId}`,
         REGISTER_API_DEFINITION_META
       );
       await (

--- a/servers/fdr/src/controllers/api/getRegisterApiService.ts
+++ b/servers/fdr/src/controllers/api/getRegisterApiService.ts
@@ -34,7 +34,7 @@ export function getRegisterApiService(app: FdrApplication): APIV1WriteService {
         orgId: req.body.orgId,
       });
 
-      const apiDefinitionId = FdrAPI.ApiDefinitionId(uuidv4());
+      let apiDefinitionId = FdrAPI.ApiDefinitionId(uuidv4());
       let transformedApiDefinition:
         | APIV1Db.DbApiDefinition
         | FdrAPI.api.latest.ApiDefinition
@@ -121,6 +121,7 @@ export function getRegisterApiService(app: FdrApplication): APIV1WriteService {
         }
         transformedApiDefinition = req.body.definitionV2;
         isLatest = true;
+        apiDefinitionId = transformedApiDefinition.id;
       }
 
       let sources: Record<string, APIV1Write.SourceUpload> | undefined;
@@ -151,9 +152,7 @@ export function getRegisterApiService(app: FdrApplication): APIV1WriteService {
           : app.services.db.prisma.apiDefinitionsV2
       ).create({
         data: {
-          apiDefinitionId: isLatest
-            ? transformedApiDefinition.id
-            : apiDefinitionId,
+          apiDefinitionId,
           apiName: req.body.apiId,
           orgId: req.body.orgId,
           definition: writeBuffer(transformedApiDefinition),
@@ -164,9 +163,7 @@ export function getRegisterApiService(app: FdrApplication): APIV1WriteService {
         REGISTER_API_DEFINITION_META
       );
       return res.send({
-        apiDefinitionId: isLatest
-          ? transformedApiDefinition.id
-          : apiDefinitionId,
+        apiDefinitionId,
         sources,
       });
     },

--- a/servers/fdr/src/controllers/api/getRegisterApiService.ts
+++ b/servers/fdr/src/controllers/api/getRegisterApiService.ts
@@ -36,7 +36,7 @@ export function getRegisterApiService(app: FdrApplication): APIV1WriteService {
 
       let apiDefinitionId = FdrAPI.ApiDefinitionId(uuidv4());
       app.logger.debug(
-        `Creating API Definition in database with name=${req.body.apiId} for org ${req.body.orgId}`,
+        `Creating API Definition in database with id=${apiDefinitionId} for org ${req.body.orgId}`,
         REGISTER_API_DEFINITION_META
       );
       let transformedApiDefinition:

--- a/servers/fdr/src/controllers/api/getRegisterApiService.ts
+++ b/servers/fdr/src/controllers/api/getRegisterApiService.ts
@@ -35,10 +35,6 @@ export function getRegisterApiService(app: FdrApplication): APIV1WriteService {
       });
 
       let apiDefinitionId = FdrAPI.ApiDefinitionId(uuidv4());
-      app.logger.debug(
-        `Creating API Definition in database with id=${apiDefinitionId} for org ${req.body.orgId}`,
-        REGISTER_API_DEFINITION_META
-      );
       let transformedApiDefinition:
         | APIV1Db.DbApiDefinition
         | FdrAPI.api.latest.ApiDefinition


### PR DESCRIPTION
## Short description of the changes made

Fixes a few specific pieces for the OpenApi Parser:
* Addresses anyOf (treats as oneOf), since both are expected to output a type of union
* Aligns ids from generated registration as opposed to using a randomly generated ID (fixes publish bug)
* Correctly cases pieces for subpackage metadata for slug generation and indexing

## What was the motivation & context behind this PR?

* Design partner bugfixes

## How has this PR been tested?

* `fern docs dev` on design partner customer