### PR TITLE
fix: FDR generated code imports

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2750,6 +2750,9 @@ importers:
       '@types/express':
         specifier: ^4.17.13
         version: 4.17.21
+      '@types/express-serve-static-core':
+        specifier: 4.19.0
+        version: 4.19.0
       '@types/html-to-text':
         specifier: ^9.0.1
         version: 9.0.4

--- a/servers/fdr/package.json
+++ b/servers/fdr/package.json
@@ -80,6 +80,7 @@
     "@types/compression": "^1.7.5",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.13",
+    "@types/express-serve-static-core": "4.19.0",
     "@types/html-to-text": "^9.0.1",
     "@types/httpsnippet": "^1.23.1",
     "@types/marked": "^5.0.0",

--- a/servers/fdr/tsconfig.json
+++ b/servers/fdr/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "bundler"
   },
   "include": ["./src/**/*"],
-  "exclude": ["**/generated", "**/__test__"],
+  "exclude": ["**/__test__"],
   "references": [
     {
       "path": "../../packages/commons/github"


### PR DESCRIPTION
## Short description of the changes made

* Adds the explicit types that generated TS code relies on (`@types/express-serve-static-core@0.4.19`) that was causing fdr to not compile
* Removes excluding compiling generated code that is necessary for FDR to run (https://github.com/fern-api/fern-platform/blob/6506692288b1102cea252a6fd3cc99afffe5b18a/servers/fdr/tsconfig.json)
* Updates pnpm lock

## What was the motivation & context behind this PR?

* FDR deployments have been broken for some time

## How has this PR been tested?

* To be tested
