### PR TITLE
chore(fdr): make sure that cdk does not reset files response header p…

### DIFF
--- a/servers/fdr-deploy/scripts/fdr-deploy-stack.ts
+++ b/servers/fdr-deploy/scripts/fdr-deploy-stack.ts
@@ -201,6 +201,12 @@ export class FdrDeployStack extends Stack {
           viewerProtocolPolicy:
             cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          responseHeadersPolicy:
+            cloudfront.ResponseHeadersPolicy.fromResponseHeadersPolicyId(
+              this,
+              "PublicDocsFilesResponseHeadersPolicy",
+              "558f36e4-4213-4bdd-950f-2a86d52c1caf"
+            ),
         },
         domainNames: [publicDocsFilesDomainName],
         certificate,


### PR DESCRIPTION
## Short description of the changes made
Makes sure that the files.buildwithfern.com cloudfront returns a * header for the access control origin. 

## What was the motivation & context behind this PR?
Do not want to roll back the response header policy on the next FDR release. 

## How has this PR been tested?
References the exact policy that we manually created. 
