### PR TITLE
fix: add fallback logic for calculating proxy timing

### DIFF
--- a/packages/fern-docs/ui/src/playground/fetch-utils/executeProxyRest.ts
+++ b/packages/fern-docs/ui/src/playground/fetch-utils/executeProxyRest.ts
@@ -37,7 +37,14 @@ export async function executeProxyRest(
   if (
     res.headers.get("Content-Type")?.toLowerCase()?.includes("application/json")
   ) {
+    const startTime = Date.now();
     const json = await res.json();
+    const endTime = Date.now();
+
+    const fallbackTime =
+      Number(res.headers.get("X-Fern-Proxy-Origin-Latency") ?? 0) +
+      endTime -
+      startTime;
 
     return {
       type: "json",
@@ -52,14 +59,24 @@ export async function executeProxyRest(
         body: json,
       },
       contentType: res.headers.get("Content-Type") ?? "application/json",
-      time: Number(res.headers.get("X-Fern-Proxy-Response-Time") ?? 0),
+      time: Number(
+        res.headers.get("X-Fern-Proxy-Response-Time") ?? fallbackTime
+      ),
       size:
         res.headers.get("Content-Length") ??
         String(new TextEncoder().encode(JSON.stringify(json)).length),
     };
   }
 
+  const startTime = Date.now();
   const blob = await res.blob();
+  const endTime = Date.now();
+
+  const fallbackTime =
+    Number(res.headers.get("X-Fern-Proxy-Origin-Latency") ?? 0) +
+    endTime -
+    startTime;
+
   return {
     type: "file",
     response: {
@@ -73,7 +90,7 @@ export async function executeProxyRest(
       body: URL.createObjectURL(blob),
     },
     contentType: res.headers.get("Content-Type") ?? "application/octet-stream",
-    time: Number(res.headers.get("X-Fern-Proxy-Response-Time") ?? 0),
+    time: Number(res.headers.get("X-Fern-Proxy-Response-Time") ?? fallbackTime),
     size: res.headers.get("Content-Length") ?? String(blob.size),
   };
 }

--- a/packages/workers/proxy/src/index.ts
+++ b/packages/workers/proxy/src/index.ts
@@ -108,7 +108,11 @@ export default {
       response.headers
         .get("Content-Type")
         ?.toLowerCase()
-        .startsWith("text/event-stream")
+        .startsWith("text/event-stream") ||
+      response.headers
+        .get("Content-Type")
+        ?.toLowerCase()
+        .startsWith("application/octet-stream")
     ) {
       return new Response(response.body, {
         status: response.status,

--- a/packages/workers/proxy/src/index.ts
+++ b/packages/workers/proxy/src/index.ts
@@ -83,7 +83,7 @@ export default {
       // additional proxy headers
       [RESPONSE_HEADERS, [...response.headers.keys()].join(",")],
       [ORIGIN_LATENCY, `${latency}`],
-      ["Cache-Control", "no-transform"],
+      ["Cache-Control", "no-transform, no-cache"],
     ]);
 
     // set the response headers (and override cors headers from the original request)

--- a/packages/workers/proxy/src/index.ts
+++ b/packages/workers/proxy/src/index.ts
@@ -81,7 +81,7 @@ export default {
       ...response.headers,
 
       // additional proxy headers
-      [RESPONSE_HEADERS, [...response.headers.keys()].join(",")],
+      [RESPONSE_HEADERS, [...new Set(response.headers.keys())].join(",")],
       [ORIGIN_LATENCY, `${latency}`],
       ["Cache-Control", "no-transform, no-cache"],
     ]);
@@ -96,7 +96,7 @@ export default {
         RESPONSE_HEADERS.toLowerCase(),
         RESPONSE_TIME.toLowerCase(),
         ORIGIN_LATENCY.toLowerCase(),
-        ...response.headers.keys(),
+        ...new Set(response.headers.keys()),
       ].join(", ")
     );
 

--- a/packages/workers/proxy/wrangler.toml
+++ b/packages/workers/proxy/wrangler.toml
@@ -13,6 +13,10 @@ routes = [
 [observability]
 enabled = true
 
+[observability.logs]
+enabled = true
+
+
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure
 # rather than the end user may result in better performance.


### PR DESCRIPTION
Cloudflare tries to automatically optimize and compress the response from the proxy, which we'll attempt to avoid by setting `encodeBody="manual"`, which should give users a more realistic representation of the round-trip time it took to call the endpoint. Depending on where you are geographically, the proxy adds itself adds about 50ms-100ms of latency.

For requests where the `Content-Length` is known, we'll fetch and resolve the body inside the proxy's execution to measure the real round-trip time, and return that to the client.

The edge-case here is handling streaming (for endpoints with larger responses, like octet-stream, or SSE text streams), in which case it's impossible to know ahead of time how long it took to stream the entire content. As a result, we'll need to compute the time taken:

1. measure the round-trip time from proxy -> origin -> proxy (we'll call this `latency`)
2. measure the download time on the client side (from the moment after headers are returned, `download time`)

total time = `latency` + `download time`

this works because the stream is piped from origin -> proxy -> client, while negating the round-trip latency of the proxy itself. there's a chance of backpressure from the proxy -> client connection but it's negligible.