### PR TITLE
chore(docs): playground -> explorer on user-facing things

### DIFF
--- a/packages/fern-docs/search-ui/src/components/shared/command-playground.tsx
+++ b/packages/fern-docs/search-ui/src/components/shared/command-playground.tsx
@@ -15,13 +15,13 @@ export const CommandGroupPlayground = forwardRef<
   }
 
   return (
-    <Command.Group heading="API Playground" ref={ref} {...props}>
+    <Command.Group heading="API Explorer" ref={ref} {...props}>
       <Command.Item
-        value={playgroundOpen ? "close api playground" : "open api playground"}
+        value={playgroundOpen ? "close api explorer" : "open api explorer"}
         onSelect={() => togglePlayground()}
       >
         <Play />
-        {playgroundOpen ? "Close API Playground" : "Open API Playground"}
+        {playgroundOpen ? "Close API Explorer" : "Open API Explorer"}
         <Kbd className="ml-auto">ctrl+&#96;</Kbd>
       </Command.Item>
     </Command.Group>

--- a/packages/fern-docs/ui/src/playground/PlaygroundButton.tsx
+++ b/packages/fern-docs/ui/src/playground/PlaygroundButton.tsx
@@ -27,15 +27,15 @@ export const PlaygroundButton: FC<{
         content={
           <span>
             Customize and run in{" "}
-            <span className="t-accent font-semibold">API Playground</span>
+            <span className="t-accent font-semibold">API Explorer</span>
           </span>
         }
       >
         <FernButton
           aria-description={
             settings?.button?.href
-              ? "Opens an API Playground in a new tab"
-              : "Opens the API Playground"
+              ? "Opens an API Explorer in a new tab"
+              : "Opens the API Explorer"
           }
           onClick={() => {
             if (settings?.button?.href) {

--- a/packages/fern-docs/ui/src/playground/PlaygroundDrawer.tsx
+++ b/packages/fern-docs/ui/src/playground/PlaygroundDrawer.tsx
@@ -100,7 +100,7 @@ export const PlaygroundDrawer = memo((): ReactElement | null => {
     <div className="flex h-10 w-full justify-between px-4">
       <div className="flex items-center">
         <span className="inline-flex items-center gap-2 text-sm font-semibold">
-          <span className="t-accent">API Playground</span>
+          <span className="t-accent">API Explorer</span>
           {selectedEndpoint != null && <span>{selectedEndpoint.title}</span>}
         </span>
       </div>
@@ -144,7 +144,7 @@ export const PlaygroundDrawer = memo((): ReactElement | null => {
             <motion.div style={{ height, maxHeight }}>
               <VisuallyHidden.Root>
                 <Dialog.Title>
-                  API Playground
+                  API Explorer
                   {selectedEndpoint != null
                     ? ` for ${selectedEndpoint.title}`
                     : ""}


### PR DESCRIPTION
This PR updates the naming of API Playground -> API Explorer for user-facing parts of the code base