### PR TITLE
fix(ai): only index nodes with unique canonical slugs

### DIFF
--- a/packages/fdr-sdk/src/navigation/NodeCollector.ts
+++ b/packages/fdr-sdk/src/navigation/NodeCollector.ts
@@ -241,7 +241,7 @@ export class NodeCollector {
 
     [...this.slugToNode.values()]
       .filter(({ node }) => FernNavigation.isPage(node))
-      .filter(({ node }) => !node.hidden && !node.authed)
+      .filter(({ node }) => !node.hidden)
       .filter(({ node }) =>
         FernNavigation.hasMarkdown(node) ? !node.noindex : true
       )

--- a/packages/fdr-sdk/src/navigation/NodeCollector.ts
+++ b/packages/fdr-sdk/src/navigation/NodeCollector.ts
@@ -236,7 +236,7 @@ export class NodeCollector {
     return this.#getIndexablePageSlugs();
   }
 
-  #getIndexablePageSlugsWithAuth = once((): NavigationNodeWithMetadata[] => {
+  #getIndexablePageNodesWithAuth = once((): NavigationNodeWithMetadata[] => {
     const slugRecord: Record<string, NavigationNodeWithMetadata> = {};
 
     [...this.slugToNode.values()]
@@ -255,8 +255,8 @@ export class NodeCollector {
 
     return Object.values(slugRecord);
   });
-  get indexablePageSlugsWithAuth(): NavigationNodeWithMetadata[] {
-    return this.#getIndexablePageSlugsWithAuth();
+  get indexablePageNodesWithAuth(): NavigationNodeWithMetadata[] {
+    return this.#getIndexablePageNodesWithAuth();
   }
 
   public getVersionNodes = (): FernNavigation.VersionNode[] => {

--- a/packages/fdr-sdk/src/navigation/NodeCollector.ts
+++ b/packages/fdr-sdk/src/navigation/NodeCollector.ts
@@ -2,6 +2,7 @@ import { EMPTY_ARRAY } from "@fern-api/ui-core-utils";
 import { once } from "es-toolkit/function";
 import { FernNavigation } from "./..";
 import { pruneVersionNode } from "./utils/pruneVersionNode";
+import { NavigationNodeWithMetadata } from "./versions";
 
 interface NavigationNodeWithMetadataAndParents {
   node: FernNavigation.NavigationNodeWithMetadata;
@@ -134,7 +135,6 @@ export class NodeCollector {
       this.#setNode(node.slug, node, parents);
     } else {
       if (FernNavigation.isPage(existing.node)) {
-        // eslint-disable-next-line no-console
         console.warn(`Duplicate slug found: ${node.slug}`, node.title);
       }
       this.orphanedNodes.push(node);
@@ -234,6 +234,29 @@ export class NodeCollector {
   });
   get indexablePageSlugs(): string[] {
     return this.#getIndexablePageSlugs();
+  }
+
+  #getIndexablePageSlugsWithAuth = once((): NavigationNodeWithMetadata[] => {
+    const slugRecord: Record<string, NavigationNodeWithMetadata> = {};
+
+    [...this.slugToNode.values()]
+      .filter(({ node }) => FernNavigation.isPage(node))
+      .filter(({ node }) => !node.hidden && !node.authed)
+      .filter(({ node }) =>
+        FernNavigation.hasMarkdown(node) ? !node.noindex : true
+      )
+      .forEach((node) => {
+        const canonicalSlug = node.node.canonicalSlug ?? node.node.slug;
+        // Only keep the first node we see for each canonical slug
+        if (!(canonicalSlug in slugRecord)) {
+          slugRecord[canonicalSlug] = node.node;
+        }
+      });
+
+    return Object.values(slugRecord);
+  });
+  get indexablePageSlugsWithAuth(): NavigationNodeWithMetadata[] {
+    return this.#getIndexablePageSlugsWithAuth();
   }
 
   public getVersionNodes = (): FernNavigation.VersionNode[] => {

--- a/packages/fern-docs/search-server/src/turbopuffer/records/create-base-record.ts
+++ b/packages/fern-docs/search-server/src/turbopuffer/records/create-base-record.ts
@@ -71,7 +71,7 @@ export function createBaseRecord({
   );
 
   return {
-    id: `${org_id}:${domain}:${node.id}`,
+    id: `${org_id}:${domain}:${node.slug}`,
     attributes: {
       type,
       org_id,

--- a/packages/fern-docs/search-server/src/turbopuffer/records/create-base-record.ts
+++ b/packages/fern-docs/search-server/src/turbopuffer/records/create-base-record.ts
@@ -71,7 +71,7 @@ export function createBaseRecord({
   );
 
   return {
-    id: `${org_id}:${domain}:${node.slug}`,
+    id: `${org_id}:${domain}:${node.id}`,
     attributes: {
       type,
       org_id,

--- a/packages/fern-docs/search-server/src/turbopuffer/records/create-turbopuffer-records.ts
+++ b/packages/fern-docs/search-server/src/turbopuffer/records/create-turbopuffer-records.ts
@@ -34,7 +34,7 @@ export async function createTurbopufferRecords({
 > {
   const collector = NodeCollector.collect(root);
 
-  const pageNodes = collector.indexablePageSlugsWithAuth;
+  const pageNodes = collector.indexablePageNodesWithAuth;
 
   const markdownNodes = pageNodes.filter(hasMarkdown);
   // const apiLeafNodes = pageNodes.filter(isApiLeaf);

--- a/packages/fern-docs/search-server/src/turbopuffer/records/create-turbopuffer-records.ts
+++ b/packages/fern-docs/search-server/src/turbopuffer/records/create-turbopuffer-records.ts
@@ -5,7 +5,6 @@ import {
   RootNode,
   getPageId,
   hasMarkdown,
-  isPage,
 } from "@fern-api/fdr-sdk/navigation";
 import { flatten } from "es-toolkit/array";
 import { FernTurbopufferRecordWithoutVector } from "../types";
@@ -35,12 +34,7 @@ export async function createTurbopufferRecords({
 > {
   const collector = NodeCollector.collect(root);
 
-  const pageNodes = Array.from(collector.slugMap.values())
-    .filter(isPage)
-    // exclude hidden pages
-    .filter((node) => node.hidden !== true)
-    // exclude pages that are noindexed
-    .filter((node) => (hasMarkdown(node) ? node.noindex !== true : true));
+  const pageNodes = collector.indexablePageSlugsWithAuth;
 
   const markdownNodes = pageNodes.filter(hasMarkdown);
   // const apiLeafNodes = pageNodes.filter(isApiLeaf);


### PR DESCRIPTION
## Short description of the changes made
Node IDs are getting duplicated (root cause is unclear so far) 

## What was the motivation & context behind this PR?
Unblock Turbopuffer indexing at a customer

## How has this PR been tested?
Yes, locally tested
