### PR TITLE
fix: OpenApi Parser v2: Strings, Webhooks, Objects

### DIFF
--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fern-api/docs-parsers",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern-platform.git",

--- a/packages/parsers/src/openapi/3.1/guards/isWebhookDefinition.ts
+++ b/packages/parsers/src/openapi/3.1/guards/isWebhookDefinition.ts
@@ -5,5 +5,5 @@ export function isWebhookDefinition(
     | FernRegistry.api.latest.EndpointDefinition
     | FernRegistry.api.latest.WebhookDefinition
 ): definition is FernRegistry.api.latest.WebhookDefinition {
-  return "payloads" in definition;
+  return "payloads" in definition && definition.payloads != null;
 }

--- a/packages/parsers/src/openapi/3.1/guards/isWebhookDefinition.ts
+++ b/packages/parsers/src/openapi/3.1/guards/isWebhookDefinition.ts
@@ -5,5 +5,5 @@ export function isWebhookDefinition(
     | FernRegistry.api.latest.EndpointDefinition
     | FernRegistry.api.latest.WebhookDefinition
 ): definition is FernRegistry.api.latest.WebhookDefinition {
-  return "payload" in definition;
+  return "payloads" in definition;
 }

--- a/packages/parsers/src/openapi/3.1/schemas/__test__/ObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/__test__/ObjectConverter.node.test.ts
@@ -141,7 +141,6 @@ describe("ObjectConverterNode", () => {
         pathId: "test",
       });
       const converted = node.convert();
-      console.log(JSON.stringify(converted, null, 2));
       expect(converted).toEqual([
         {
           type: "alias",

--- a/packages/parsers/src/openapi/3.1/schemas/__test__/ObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/__test__/ObjectConverter.node.test.ts
@@ -47,6 +47,9 @@ describe("ObjectConverterNode", () => {
     it("should handle additionalProperties as boolean true", () => {
       const input: ObjectConverterNode.Input = {
         type: "object",
+        properties: {
+          name: { type: "string" },
+        },
         additionalProperties: true,
         title: "TestObject",
       };
@@ -138,14 +141,28 @@ describe("ObjectConverterNode", () => {
         pathId: "test",
       });
       const converted = node.convert();
+      console.log(JSON.stringify(converted, null, 2));
       expect(converted).toEqual([
         {
-          type: "object",
-          extends: [],
-          properties: [],
-          extraProperties: {
-            type: "unknown",
-            displayName: "TestObject",
+          type: "alias",
+          value: {
+            type: "map",
+            keyShape: {
+              type: "alias",
+              value: {
+                type: "primitive",
+                value: {
+                  type: "string",
+                },
+              },
+            },
+            valueShape: {
+              type: "alias",
+              value: {
+                type: "unknown",
+                displayName: "TestObject",
+              },
+            },
           },
         },
       ]);

--- a/packages/parsers/src/openapi/3.1/schemas/primitives/StringConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/primitives/StringConverter.node.ts
@@ -104,6 +104,10 @@ export class StringConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample
   }
 
   parse(): void {
+    this.regex = this.input.pattern;
+    this.minLength = this.input.minLength;
+    this.maxLength = this.input.maxLength;
+
     if (this.input.default != null && typeof this.input.default !== "string") {
       this.context.errors.warning({
         message: `Expected default value to be a string. Received ${this.input.default}`,

--- a/packages/parsers/src/openapi/__test__/__snapshots__/cohere.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/cohere.json
@@ -18745,7 +18745,8 @@
             "value": {
               "type": "primitive",
               "value": {
-                "type": "string"
+                "type": "string",
+                "regex": "^(?!usage$).*$"
               }
             }
           }
@@ -19254,7 +19255,8 @@
             "value": {
               "type": "primitive",
               "value": {
-                "type": "string"
+                "type": "string",
+                "regex": "^(?!usage$).*$"
               }
             }
           }
@@ -19780,7 +19782,9 @@
                   "value": {
                     "type": "primitive",
                     "value": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 250,
+                      "maxLength": 50000
                     }
                   }
                 },
@@ -20560,7 +20564,9 @@
                   "value": {
                     "type": "primitive",
                     "value": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 65536
                     }
                   }
                 },
@@ -28822,7 +28828,8 @@
               "value": {
                 "type": "primitive",
                 "value": {
-                  "type": "string"
+                  "type": "string",
+                  "minLength": 1
                 }
               }
             },
@@ -28958,7 +28965,8 @@
                   "value": {
                     "type": "primitive",
                     "value": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     }
                   }
                 },
@@ -29011,7 +29019,8 @@
                   "value": {
                     "type": "primitive",
                     "value": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     }
                   }
                 },
@@ -29064,7 +29073,8 @@
                   "value": {
                     "type": "primitive",
                     "value": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     }
                   }
                 },
@@ -29150,7 +29160,8 @@
               "value": {
                 "type": "primitive",
                 "value": {
-                  "type": "string"
+                  "type": "string",
+                  "minLength": 1
                 }
               }
             },
@@ -29447,7 +29458,8 @@
               "value": {
                 "type": "primitive",
                 "value": {
-                  "type": "string"
+                  "type": "string",
+                  "minLength": 1
                 }
               }
             },
@@ -29525,7 +29537,8 @@
               "value": {
                 "type": "primitive",
                 "value": {
-                  "type": "string"
+                  "type": "string",
+                  "minLength": 1
                 }
               }
             },
@@ -29579,7 +29592,8 @@
                   "value": {
                     "type": "primitive",
                     "value": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     }
                   }
                 }
@@ -29863,7 +29877,8 @@
               "value": {
                 "type": "primitive",
                 "value": {
-                  "type": "string"
+                  "type": "string",
+                  "minLength": 1
                 }
               }
             },
@@ -30151,7 +30166,8 @@
               "value": {
                 "type": "primitive",
                 "value": {
-                  "type": "uuid"
+                  "type": "uuid",
+                  "minLength": 1
                 }
               }
             },
@@ -30248,7 +30264,8 @@
               "value": {
                 "type": "primitive",
                 "value": {
-                  "type": "string"
+                  "type": "string",
+                  "minLength": 1
                 }
               }
             },
@@ -30509,7 +30526,8 @@
                   "value": {
                     "type": "primitive",
                     "value": {
-                      "type": "uuid"
+                      "type": "uuid",
+                      "minLength": 1
                     }
                   }
                 },
@@ -30600,7 +30618,8 @@
                   "value": {
                     "type": "primitive",
                     "value": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     }
                   }
                 },
@@ -31284,13 +31303,26 @@
           {
             "key": "data",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [],
-              "extraProperties": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+              "type": "alias",
+              "value": {
+                "type": "map",
+                "keyShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "valueShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39155,13 +39187,26 @@
           {
             "key": "metrics",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [],
-              "extraProperties": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+              "type": "alias",
+              "value": {
+                "type": "map",
+                "keyShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "valueShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },

--- a/packages/parsers/src/openapi/__test__/__snapshots__/uploadcare.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/uploadcare.json
@@ -89,7 +89,7 @@
                 "value": {
                   "type": "primitive",
                   "value": {
-                    "type": "double",
+                    "type": "integer",
                     "minimum": 1,
                     "maximum": 1000,
                     "default": 100
@@ -6906,7 +6906,10 @@
             "value": {
               "type": "primitive",
               "value": {
-                "type": "string"
+                "type": "string",
+                "regex": "[\\w\\-\\.\\:]+",
+                "minLength": 1,
+                "maxLength": 64
               }
             }
           },
@@ -7186,7 +7189,10 @@
             "value": {
               "type": "primitive",
               "value": {
-                "type": "string"
+                "type": "string",
+                "regex": "[\\w\\-\\.\\:]+",
+                "minLength": 1,
+                "maxLength": 64
               }
             }
           },
@@ -7536,7 +7542,10 @@
             "value": {
               "type": "primitive",
               "value": {
-                "type": "string"
+                "type": "string",
+                "regex": "[\\w\\-\\.\\:]+",
+                "minLength": 1,
+                "maxLength": 64
               }
             }
           },
@@ -9597,241 +9606,6 @@
         }
       ]
     },
-    "endpoint_webhookCallbacks.fileUploaded": {
-      "id": "endpoint_webhookCallbacks.fileUploaded",
-      "description": "file.uploaded event payload",
-      "displayName": "file.uploaded",
-      "operationId": "fileUploaded",
-      "namespace": [
-        "Webhook Callbacks"
-      ],
-      "method": "POST",
-      "path": [
-        "/",
-        "file-uploaded"
-      ],
-      "headers": [
-        {
-          "key": "X-Uc-Signature",
-          "valueShape": {
-            "type": "alias",
-            "value": {
-              "type": "optional",
-              "shape": {
-                "type": "alias",
-                "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          "description": "Optional header with an HMAC-SHA256 signature that is sent to the `target_url`,\nif the webhook has a `signing_secret` associated with it.\n"
-        }
-      ],
-      "payloads": [
-        {
-          "shape": {
-            "type": "alias",
-            "value": {
-              "type": "id",
-              "id": "webhookFilePayload"
-            }
-          }
-        }
-      ],
-      "examples": []
-    },
-    "endpoint_webhookCallbacks.fileInfected": {
-      "id": "endpoint_webhookCallbacks.fileInfected",
-      "description": "file.infected event payload",
-      "displayName": "file.infected",
-      "operationId": "fileInfected",
-      "namespace": [
-        "Webhook Callbacks"
-      ],
-      "method": "POST",
-      "path": [
-        "/",
-        "file-infected"
-      ],
-      "headers": [
-        {
-          "key": "X-Uc-Signature",
-          "valueShape": {
-            "type": "alias",
-            "value": {
-              "type": "optional",
-              "shape": {
-                "type": "alias",
-                "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          "description": "Optional header with an HMAC-SHA256 signature that is sent to the `target_url`,\nif the webhook has a `signing_secret` associated with it.\n"
-        }
-      ],
-      "payloads": [
-        {
-          "shape": {
-            "type": "alias",
-            "value": {
-              "type": "id",
-              "id": "webhookFilePayload"
-            }
-          }
-        }
-      ],
-      "examples": []
-    },
-    "endpoint_webhookCallbacks.fileStored": {
-      "id": "endpoint_webhookCallbacks.fileStored",
-      "description": "file.stored event payload",
-      "displayName": "file.stored",
-      "operationId": "fileStored",
-      "namespace": [
-        "Webhook Callbacks"
-      ],
-      "method": "POST",
-      "path": [
-        "/",
-        "file-stored"
-      ],
-      "headers": [
-        {
-          "key": "X-Uc-Signature",
-          "valueShape": {
-            "type": "alias",
-            "value": {
-              "type": "optional",
-              "shape": {
-                "type": "alias",
-                "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          "description": "Optional header with an HMAC-SHA256 signature that is sent to the `target_url`,\nif the webhook has a `signing_secret` associated with it.\n"
-        }
-      ],
-      "payloads": [
-        {
-          "shape": {
-            "type": "alias",
-            "value": {
-              "type": "id",
-              "id": "webhookFilePayload"
-            }
-          }
-        }
-      ],
-      "examples": []
-    },
-    "endpoint_webhookCallbacks.fileDeleted": {
-      "id": "endpoint_webhookCallbacks.fileDeleted",
-      "description": "file.deleted event payload",
-      "displayName": "file.deleted",
-      "operationId": "fileDeleted",
-      "namespace": [
-        "Webhook Callbacks"
-      ],
-      "method": "POST",
-      "path": [
-        "/",
-        "file-deleted"
-      ],
-      "headers": [
-        {
-          "key": "X-Uc-Signature",
-          "valueShape": {
-            "type": "alias",
-            "value": {
-              "type": "optional",
-              "shape": {
-                "type": "alias",
-                "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          "description": "Optional header with an HMAC-SHA256 signature that is sent to the `target_url`,\nif the webhook has a `signing_secret` associated with it.\n"
-        }
-      ],
-      "payloads": [
-        {
-          "shape": {
-            "type": "alias",
-            "value": {
-              "type": "id",
-              "id": "webhookFilePayload"
-            }
-          }
-        }
-      ],
-      "examples": []
-    },
-    "endpoint_webhookCallbacks.fileInfoUpdated": {
-      "id": "endpoint_webhookCallbacks.fileInfoUpdated",
-      "description": "file.info_updated event payload",
-      "displayName": "file.info_updated",
-      "operationId": "fileInfoUpdated",
-      "namespace": [
-        "Webhook Callbacks"
-      ],
-      "method": "POST",
-      "path": [
-        "/",
-        "file-info-updated"
-      ],
-      "headers": [
-        {
-          "key": "X-Uc-Signature",
-          "valueShape": {
-            "type": "alias",
-            "value": {
-              "type": "optional",
-              "shape": {
-                "type": "alias",
-                "value": {
-                  "type": "primitive",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          "description": "Optional header with an HMAC-SHA256 signature that is sent to the `target_url`,\nif the webhook has a `signing_secret` associated with it.\n"
-        }
-      ],
-      "payloads": [
-        {
-          "shape": {
-            "type": "alias",
-            "value": {
-              "type": "id",
-              "id": "webhookFileInfoUpdatedPayload"
-            }
-          }
-        }
-      ],
-      "examples": []
-    },
     "endpoint_webhook.updateWebhook": {
       "id": "endpoint_webhook.updateWebhook",
       "description": "Update webhook attributes.",
@@ -10911,13 +10685,26 @@
               {
                 "key": "problems",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [],
-                  "extraProperties": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "uuid"
+                  "type": "alias",
+                  "value": {
+                    "type": "map",
+                    "keyShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "valueShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "uuid"
+                        }
+                      }
                     }
                   }
                 },
@@ -11716,13 +11503,26 @@
               {
                 "key": "problems",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [],
-                  "extraProperties": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "uuid"
+                  "type": "alias",
+                  "value": {
+                    "type": "map",
+                    "keyShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "valueShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "uuid"
+                        }
+                      }
                     }
                   }
                 },
@@ -12464,7 +12264,243 @@
     }
   },
   "websockets": {},
-  "webhooks": {},
+  "webhooks": {
+    "endpoint_webhookCallbacks.fileUploaded": {
+      "id": "endpoint_webhookCallbacks.fileUploaded",
+      "description": "file.uploaded event payload",
+      "displayName": "file.uploaded",
+      "operationId": "fileUploaded",
+      "namespace": [
+        "Webhook Callbacks"
+      ],
+      "method": "POST",
+      "path": [
+        "/",
+        "file-uploaded"
+      ],
+      "headers": [
+        {
+          "key": "X-Uc-Signature",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "description": "Optional header with an HMAC-SHA256 signature that is sent to the `target_url`,\nif the webhook has a `signing_secret` associated with it.\n"
+        }
+      ],
+      "payloads": [
+        {
+          "shape": {
+            "type": "alias",
+            "value": {
+              "type": "id",
+              "id": "webhookFilePayload"
+            }
+          }
+        }
+      ],
+      "examples": []
+    },
+    "endpoint_webhookCallbacks.fileInfected": {
+      "id": "endpoint_webhookCallbacks.fileInfected",
+      "description": "file.infected event payload",
+      "displayName": "file.infected",
+      "operationId": "fileInfected",
+      "namespace": [
+        "Webhook Callbacks"
+      ],
+      "method": "POST",
+      "path": [
+        "/",
+        "file-infected"
+      ],
+      "headers": [
+        {
+          "key": "X-Uc-Signature",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "description": "Optional header with an HMAC-SHA256 signature that is sent to the `target_url`,\nif the webhook has a `signing_secret` associated with it.\n"
+        }
+      ],
+      "payloads": [
+        {
+          "shape": {
+            "type": "alias",
+            "value": {
+              "type": "id",
+              "id": "webhookFilePayload"
+            }
+          }
+        }
+      ],
+      "examples": []
+    },
+    "endpoint_webhookCallbacks.fileStored": {
+      "id": "endpoint_webhookCallbacks.fileStored",
+      "description": "file.stored event payload",
+      "displayName": "file.stored",
+      "operationId": "fileStored",
+      "namespace": [
+        "Webhook Callbacks"
+      ],
+      "method": "POST",
+      "path": [
+        "/",
+        "file-stored"
+      ],
+      "headers": [
+        {
+          "key": "X-Uc-Signature",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "description": "Optional header with an HMAC-SHA256 signature that is sent to the `target_url`,\nif the webhook has a `signing_secret` associated with it.\n"
+        }
+      ],
+      "payloads": [
+        {
+          "shape": {
+            "type": "alias",
+            "value": {
+              "type": "id",
+              "id": "webhookFilePayload"
+            }
+          }
+        }
+      ],
+      "examples": []
+    },
+    "endpoint_webhookCallbacks.fileDeleted": {
+      "id": "endpoint_webhookCallbacks.fileDeleted",
+      "description": "file.deleted event payload",
+      "displayName": "file.deleted",
+      "operationId": "fileDeleted",
+      "namespace": [
+        "Webhook Callbacks"
+      ],
+      "method": "POST",
+      "path": [
+        "/",
+        "file-deleted"
+      ],
+      "headers": [
+        {
+          "key": "X-Uc-Signature",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "description": "Optional header with an HMAC-SHA256 signature that is sent to the `target_url`,\nif the webhook has a `signing_secret` associated with it.\n"
+        }
+      ],
+      "payloads": [
+        {
+          "shape": {
+            "type": "alias",
+            "value": {
+              "type": "id",
+              "id": "webhookFilePayload"
+            }
+          }
+        }
+      ],
+      "examples": []
+    },
+    "endpoint_webhookCallbacks.fileInfoUpdated": {
+      "id": "endpoint_webhookCallbacks.fileInfoUpdated",
+      "description": "file.info_updated event payload",
+      "displayName": "file.info_updated",
+      "operationId": "fileInfoUpdated",
+      "namespace": [
+        "Webhook Callbacks"
+      ],
+      "method": "POST",
+      "path": [
+        "/",
+        "file-info-updated"
+      ],
+      "headers": [
+        {
+          "key": "X-Uc-Signature",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "description": "Optional header with an HMAC-SHA256 signature that is sent to the `target_url`,\nif the webhook has a `signing_secret` associated with it.\n"
+        }
+      ],
+      "payloads": [
+        {
+          "shape": {
+            "type": "alias",
+            "value": {
+              "type": "id",
+              "id": "webhookFileInfoUpdatedPayload"
+            }
+          }
+        }
+      ],
+      "examples": []
+    }
+  },
   "types": {
     "addonExecutionStatus": {
       "name": "addonExecutionStatus",
@@ -13068,7 +13104,9 @@
         "value": {
           "type": "primitive",
           "value": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512
           }
         }
       },
@@ -14120,7 +14158,8 @@
           "type": "primitive",
           "value": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "maxLength": 255
           }
         }
       },
@@ -14172,7 +14211,8 @@
           "type": "primitive",
           "value": {
             "type": "string",
-            "format": "password"
+            "format": "password",
+            "maxLength": 32
           }
         }
       },
@@ -15479,15 +15519,15 @@
       "name": "Webhook",
       "displayName": "Webhook"
     },
-    "webhookCallbacks": {
-      "id": "webhookCallbacks",
-      "name": "Webhook Callbacks",
-      "displayName": "Webhook Callbacks"
-    },
     "conversion": {
       "id": "conversion",
       "name": "Conversion",
       "displayName": "Conversion"
+    },
+    "webhookCallbacks": {
+      "id": "webhookCallbacks",
+      "name": "Webhook Callbacks",
+      "displayName": "Webhook Callbacks"
     }
   },
   "auths": {

--- a/packages/parsers/src/openapi/__test__/fixtures/uploadcare/openapi.yml
+++ b/packages/parsers/src/openapi/__test__/fixtures/uploadcare/openapi.yml
@@ -76,7 +76,7 @@
                     "in": "query",
                     "name": "limit",
                     "description": "A preferred amount of files in a list for a single response. Defaults to 100, while the maximum is 1000.",
-                    "schema": { "type": "number", "maximum": 1000, "minimum": 1, "example": 100, "default": 100 },
+                    "schema": { "type": "integer", "maximum": 1000, "minimum": 1, "example": 100, "default": 100 },
                   },
                   {
                     "in": "query",

--- a/packages/parsers/src/openrpc/__test__/__snapshots__/ethereum.json
+++ b/packages/parsers/src/openrpc/__test__/__snapshots__/ethereum.json
@@ -151,7 +151,8 @@
         "value": {
           "type": "primitive",
           "value": {
-            "type": "string"
+            "type": "string",
+            "regex": "^0x[a-fA-F\\d]{64}$"
           }
         }
       },
@@ -659,7 +660,8 @@
               "value": {
                 "type": "primitive",
                 "value": {
-                  "type": "string"
+                  "type": "string",
+                  "regex": "^0x[a-fA-F\\d]+$"
                 }
               }
             },
@@ -1115,7 +1117,8 @@
         "value": {
           "type": "primitive",
           "value": {
-            "type": "string"
+            "type": "string",
+            "regex": "^0x[a-fA-F\\d]{64}$"
           }
         }
       },
@@ -1156,7 +1159,8 @@
         "value": {
           "type": "primitive",
           "value": {
-            "type": "string"
+            "type": "string",
+            "regex": "^0x[a-fA-F0-9]+$"
           }
         }
       },
@@ -1169,7 +1173,8 @@
         "value": {
           "type": "primitive",
           "value": {
-            "type": "string"
+            "type": "string",
+            "regex": "^0x[a-fA-F\\d]{40}$"
           }
         }
       }
@@ -1198,7 +1203,8 @@
         "value": {
           "type": "primitive",
           "value": {
-            "type": "string"
+            "type": "string",
+            "regex": "^0x([a-fA-F0-9]?)+$"
           }
         }
       },
@@ -1211,7 +1217,8 @@
         "value": {
           "type": "primitive",
           "value": {
-            "type": "string"
+            "type": "string",
+            "regex": "^0x([a-fA-F\\d]{64})?$"
           }
         }
       },
@@ -1224,7 +1231,8 @@
         "value": {
           "type": "primitive",
           "value": {
-            "type": "string"
+            "type": "string",
+            "regex": "^0x([a-fA-F0-9]?)+$"
           }
         }
       },
@@ -1293,7 +1301,8 @@
                   "value": {
                     "type": "primitive",
                     "value": {
-                      "type": "string"
+                      "type": "string",
+                      "regex": "^0x[a-fA-F\\d]+$"
                     }
                   }
                 },
@@ -1454,7 +1463,8 @@
             "value": {
               "type": "primitive",
               "value": {
-                "type": "string"
+                "type": "string",
+                "regex": "^[\\d]+$"
               }
             }
           },
@@ -1582,7 +1592,8 @@
             "value": {
               "type": "primitive",
               "value": {
-                "type": "string"
+                "type": "string",
+                "regex": "^0x[a-fA-F\\d]+$"
               }
             }
           },


### PR DESCRIPTION
## Short description of the changes made

* fixes pattern -> regex, min and max value plumbing for strings
* fixes webhook discrimination in parsing
* fixes object with only extra properties -> map type

## What was the motivation & context behind this PR?

* customer asks

## How has this PR been tested?

* Snapshot and unit tests
