### PR TITLE
feat: enable configuring custom environments for launchdarkly

### DIFF
--- a/packages/fern-docs/bundle/src/middleware.ts
+++ b/packages/fern-docs/bundle/src/middleware.ts
@@ -7,6 +7,7 @@ import { MARKDOWN_PATTERN, RSS_PATTERN } from "./server/patterns";
 import { withMiddlewareAuth } from "./server/withMiddlewareAuth";
 import { withMiddlewareRewrite } from "./server/withMiddlewareRewrite";
 import { withPathname } from "./server/withPathname";
+import { getDocsDomainEdge } from "./server/xfernhost/edge";
 
 const API_FERN_DOCS_PATTERN = /^(?!\/api\/fern-docs\/).*(\/api\/fern-docs\/)/;
 
@@ -130,12 +131,14 @@ export const middleware: NextMiddleware = async (request) => {
   }
 
   // TODO: this adds additional latency to the page load. can we batch this somehow?
-  const launchDarkly = await getLaunchDarklySettings(request.nextUrl.origin);
+  const launchDarkly = await getLaunchDarklySettings(
+    getDocsDomainEdge(request)
+  );
 
   return withMiddlewareAuth(
     request,
     pathname,
-    withMiddlewareRewrite(request, pathname, !!launchDarkly?.["sdk-key"])
+    withMiddlewareRewrite(request, pathname, launchDarkly?.["sdk-key"] != null)
   );
 };
 

--- a/packages/fern-docs/bundle/src/server/ld-adapter.ts
+++ b/packages/fern-docs/bundle/src/server/ld-adapter.ts
@@ -50,9 +50,9 @@ interface LaunchDarklyInfo {
   defaultFlags: Record<string, unknown> | undefined;
   options:
     | {
-        baseUrl?: string;
-        streamUrl?: string;
-        eventsUrl?: string;
+        baseUrl: string | undefined;
+        streamUrl: string | undefined;
+        eventsUrl: string | undefined;
       }
     | undefined;
 }

--- a/packages/fern-docs/bundle/src/server/ld-adapter.ts
+++ b/packages/fern-docs/bundle/src/server/ld-adapter.ts
@@ -48,6 +48,13 @@ interface LaunchDarklyInfo {
   contextEndpoint: string;
   context: ld.LDContext | undefined;
   defaultFlags: Record<string, unknown> | undefined;
+  options:
+    | {
+        baseUrl?: string;
+        streamUrl?: string;
+        eventsUrl?: string;
+      }
+    | undefined;
 }
 
 export async function withLaunchDarkly(
@@ -69,8 +76,13 @@ export async function withLaunchDarkly(
       node,
       rawCookie
     );
+    const options = {
+      baseUrl: launchDarklyConfig.options?.["base-url"],
+      streamUrl: launchDarklyConfig.options?.["stream-url"],
+      eventsUrl: launchDarklyConfig.options?.["events-url"],
+    };
     const defaultFlags = launchDarklyConfig["sdk-key"]
-      ? await fetchInitialFlags(launchDarklyConfig["sdk-key"], context)
+      ? await fetchInitialFlags(launchDarklyConfig["sdk-key"], context, options)
       : undefined;
     return [
       {
@@ -78,6 +90,7 @@ export async function withLaunchDarkly(
         contextEndpoint: launchDarklyConfig["context-endpoint"],
         context,
         defaultFlags,
+        options,
       },
       // Note: if sdk-key is set, then middleware will automatically switch to 100% getServerSideProps
       // because getServerSideProps must determine whether any given page should be rendered or not.
@@ -122,10 +135,19 @@ export const createLdPredicate = async ({
 
 function fetchInitialFlags(
   sdkKey: string,
-  context: ld.LDContext
+  context: ld.LDContext,
+  options?: {
+    baseUrl?: string;
+    streamUrl?: string;
+    eventsUrl?: string;
+  }
 ): Promise<Record<string, unknown>> | undefined {
   try {
-    const ldClient = ld.init(sdkKey);
+    const ldClient = ld.init(sdkKey, {
+      baseUri: options?.baseUrl,
+      streamUri: options?.streamUrl,
+      eventsUri: options?.eventsUrl,
+    });
     return ldClient.allFlagsState(context).then((flags) => flags.allValues());
   } catch (error) {
     console.error(error);

--- a/packages/fern-docs/bundle/src/server/ld-adapter.ts
+++ b/packages/fern-docs/bundle/src/server/ld-adapter.ts
@@ -147,6 +147,7 @@ function fetchInitialFlags(
       baseUri: options?.baseUrl,
       streamUri: options?.streamUrl,
       eventsUri: options?.eventsUrl,
+      stream: false,
     });
     return ldClient.allFlagsState(context).then((flags) => flags.allValues());
   } catch (error) {

--- a/packages/fern-docs/edge-config/src/getLaunchDarklySettings.ts
+++ b/packages/fern-docs/edge-config/src/getLaunchDarklySettings.ts
@@ -11,6 +11,14 @@ const LaunchDarklyEdgeConfigSchema = z.object({
   // we should add a check to make sure the target domain is trusted. Trust should always be granted manually by a fern engineer,
   // so it should be managed in edge config, or FGA.
   "context-endpoint": z.string(),
+
+  options: z
+    .object({
+      "base-url": z.string().optional(),
+      "stream-url": z.string().optional(),
+      "events-url": z.string().optional(),
+    })
+    .optional(),
 });
 
 export type LaunchDarklyEdgeConfig = z.infer<

--- a/packages/fern-docs/ui/src/atoms/types.ts
+++ b/packages/fern-docs/ui/src/atoms/types.ts
@@ -57,6 +57,13 @@ export interface LaunchDarklyInfo {
   contextEndpoint: string;
   context: LDContext | undefined;
   defaultFlags: Record<string, unknown> | undefined;
+  options:
+    | {
+        baseUrl: string | undefined;
+        streamUrl: string | undefined;
+        eventsUrl: string | undefined;
+      }
+    | undefined;
 }
 
 export interface FeatureFlagsConfig {

--- a/packages/fern-docs/ui/src/feature-flags/FeatureFlagProvider.tsx
+++ b/packages/fern-docs/ui/src/feature-flags/FeatureFlagProvider.tsx
@@ -29,6 +29,7 @@ export const FeatureFlagProvider: FC<FeatureFlagProviderProps> = ({
       contextEndpoint={launchDarklyInfo.contextEndpoint}
       defaultContext={launchDarklyInfo.context}
       defaultFlags={launchDarklyInfo.defaultFlags}
+      options={launchDarklyInfo.options}
     >
       {children}
     </LDFeatureFlagProvider>

--- a/packages/fern-docs/ui/src/feature-flags/LDFeatureFlagProvider.tsx
+++ b/packages/fern-docs/ui/src/feature-flags/LDFeatureFlagProvider.tsx
@@ -23,6 +23,12 @@ interface Props extends PropsWithChildren {
   defaultContext?: LDContext;
 
   defaultFlags?: Record<string, unknown>;
+
+  options?: {
+    baseUrl?: string;
+    streamUrl?: string;
+    eventsUrl?: string;
+  };
 }
 
 export const LDFeatureFlagProvider: FC<Props> = ({
@@ -30,6 +36,7 @@ export const LDFeatureFlagProvider: FC<Props> = ({
   contextEndpoint,
   defaultContext,
   defaultFlags,
+  options,
   children,
 }) => {
   return (
@@ -37,6 +44,7 @@ export const LDFeatureFlagProvider: FC<Props> = ({
       clientSideID={clientSideId}
       context={defaultContext}
       flags={defaultFlags}
+      options={options}
     >
       <IdentifyWrapper
         contextEndpoint={contextEndpoint}


### PR DESCRIPTION
adds ability to pass in environments (relevant for launchdarkly's own docs)