### PR TITLE
break: rename default to fallbackValue for clarity

### DIFF
--- a/fern/apis/fdr/definition/navigation/latest/__package__.yml
+++ b/fern/apis/fdr/definition/navigation/latest/__package__.yml
@@ -378,10 +378,11 @@ types:
     properties:
       featureFlags: optional<list<FeatureFlagOptions>>
 
+  # note: do not change this type because it will cause a breaking change in the <Feature> mdx component
   FeatureFlagOptions:
     properties:
       flag: string
-      default: optional<unknown>
+      fallbackValue: optional<unknown>
       match: optional<unknown>
 
   BreadcrumbItem:

--- a/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/latest/types/FeatureFlagOptions.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/latest/types/FeatureFlagOptions.ts
@@ -4,6 +4,6 @@
 
 export interface FeatureFlagOptions {
     flag: string;
-    default: unknown | undefined;
+    fallbackValue: unknown | undefined;
     match: unknown | undefined;
 }

--- a/packages/fern-docs/bundle/src/server/ld-adapter.ts
+++ b/packages/fern-docs/bundle/src/server/ld-adapter.ts
@@ -96,9 +96,9 @@ function createDefaultFeatureFlagPredicate(): (
     node.featureFlags == null ||
     node.featureFlags.length === 0 ||
     node.featureFlags.some((flag) => {
-      const default_ = flag.default ?? false;
+      const fallbackValue = flag.fallbackValue ?? false;
       const match = flag.match ?? true;
-      return isEqual(default_, match);
+      return isEqual(fallbackValue, match);
     });
 }
 
@@ -113,7 +113,7 @@ export const createLdPredicate = async ({
     }
     return node.featureFlags.some((flag) => {
       const key = camelCase(flag.flag);
-      const flagValue = flags[key] ?? flag.default ?? false;
+      const flagValue = flags[key] ?? flag.fallbackValue ?? false;
       const match = flag.match ?? true;
       return isEqual(flagValue, match);
     });

--- a/packages/fern-docs/ui/src/feature-flags/WithFeatureFlags.tsx
+++ b/packages/fern-docs/ui/src/feature-flags/WithFeatureFlags.tsx
@@ -13,7 +13,6 @@ const LDFeatures = dynamic(
 export const WithFeatureFlags: React.FC<WithFeatureFlagsProps> = ({
   featureFlags,
   children,
-  fallback,
 }) => {
   // do not import LDFeatures if there are no feature flags
   if (!featureFlags?.length) {
@@ -22,9 +21,7 @@ export const WithFeatureFlags: React.FC<WithFeatureFlagsProps> = ({
 
   return (
     <FernErrorBoundary>
-      <LDFeatures featureFlags={featureFlags} fallback={fallback}>
-        {children}
-      </LDFeatures>
+      <LDFeatures featureFlags={featureFlags}>{children}</LDFeatures>
     </FernErrorBoundary>
   );
 };

--- a/packages/fern-docs/ui/src/feature-flags/types.ts
+++ b/packages/fern-docs/ui/src/feature-flags/types.ts
@@ -1,11 +1,6 @@
 import type { FernNavigation } from "@fern-api/fdr-sdk";
-import type { PropsWithChildren, ReactNode } from "react";
+import type { PropsWithChildren } from "react";
 
-export type FeatureProps =
-  PropsWithChildren<FernNavigation.FeatureFlagOptions> & {
-    fallback?: ReactNode;
-  };
+export type FeatureProps = PropsWithChildren<FernNavigation.FeatureFlagOptions>;
 export type WithFeatureFlagsProps =
-  PropsWithChildren<FernNavigation.WithFeatureFlags> & {
-    fallback?: ReactNode;
-  };
+  PropsWithChildren<FernNavigation.WithFeatureFlags>;

--- a/packages/parsers/src/client/generated/api/resources/navigation/resources/latest/types/FeatureFlagOptions.ts
+++ b/packages/parsers/src/client/generated/api/resources/navigation/resources/latest/types/FeatureFlagOptions.ts
@@ -4,6 +4,6 @@
 
 export interface FeatureFlagOptions {
     flag: string;
-    default: unknown | undefined;
+    fallbackValue: unknown | undefined;
     match: unknown | undefined;
 }

--- a/servers/fdr/src/api/generated/api/resources/navigation/resources/latest/types/FeatureFlagOptions.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/navigation/resources/latest/types/FeatureFlagOptions.d.ts
@@ -3,6 +3,6 @@
  */
 export interface FeatureFlagOptions {
     flag: string;
-    default: unknown | undefined;
+    fallbackValue: unknown | undefined;
     match: unknown | undefined;
 }


### PR DESCRIPTION
based on feedback from launchdarkly the terminology is clearer to say "fallbackValue" than "default".

https://docs.launchdarkly.com/home/getting-started/vocabulary#fallback-value