### PR TITLE
fix: reduce the amount of data sent between ld server-side and ld client-side.

### DIFF
--- a/packages/fern-docs/ui/src/atoms/types.ts
+++ b/packages/fern-docs/ui/src/atoms/types.ts
@@ -56,12 +56,13 @@ export interface LaunchDarklyInfo {
   clientSideId: string;
   contextEndpoint: string;
   context: LDContext | undefined;
-  defaultFlags: Record<string, unknown> | undefined;
+  defaultFlags: object | undefined;
   options:
     | {
         baseUrl: string | undefined;
         streamUrl: string | undefined;
         eventsUrl: string | undefined;
+        hash: string | undefined;
       }
     | undefined;
 }

--- a/packages/fern-docs/ui/src/feature-flags/LDFeatureFlagProvider.tsx
+++ b/packages/fern-docs/ui/src/feature-flags/LDFeatureFlagProvider.tsx
@@ -22,12 +22,13 @@ interface Props extends PropsWithChildren {
    */
   defaultContext?: LDContext;
 
-  defaultFlags?: Record<string, unknown>;
+  defaultFlags?: object;
 
   options?: {
     baseUrl?: string;
     streamUrl?: string;
     eventsUrl?: string;
+    hash?: string;
   };
 }
 
@@ -90,7 +91,7 @@ const IdentifyWrapper = ({
       const res = await fetch(endpoint, { credentials: "include" });
       return {
         context: (await res.json()) as LDContext,
-        hash: res.headers.get("x-hash"),
+        hash: res.headers.get("x-secure-mode-hash"),
       };
     },
     {


### PR DESCRIPTION
- use a singleton to hopefully share _some_ resources between serverless function
- consume `x-secure-mode-hash` to validate the security of the server-generated flag
- disable diagnostics and events on the server-side
- disable non client-side flags (reduce payload, prevent leaking server-only flags(