### PR TITLE
fix(docs): preview bundle shows curl examples

### DIFF
--- a/packages/fern-docs/local-preview-bundle/src/utils/getDocsPageProps.ts
+++ b/packages/fern-docs/local-preview-bundle/src/utils/getDocsPageProps.ts
@@ -1,12 +1,25 @@
-import { FdrAPI, type DocsV2Read } from "@fern-api/fdr-sdk/client/types";
+import {
+  ApiDefinition,
+  CodeSnippet,
+  convertToCurl,
+  EndpointDefinition,
+  ExampleEndpointCall,
+  toSnippetHttpRequest,
+  Transformer,
+} from "@fern-api/fdr-sdk/api-definition";
+import {
+  APIV1Read,
+  FdrAPI,
+  type DocsV2Read,
+} from "@fern-api/fdr-sdk/client/types";
 import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
 import { visitDiscriminatedUnion } from "@fern-api/ui-core-utils";
 import {
   DocsPage,
-  NavbarLink,
   getGitHubInfo,
   getGitHubRepo,
   getSeoProps,
+  NavbarLink,
   renderThemeStylesheet,
   resolveDocsContent,
 } from "@fern-docs/ui";
@@ -81,7 +94,17 @@ export async function getDocsPageProps(
     prev: node.prev,
     next: node.next,
     apis: docs.definition.apis,
-    apisV2: docs.definition.apisV2,
+    apisV2:
+      docs.definition.apisV2 != null
+        ? Object.fromEntries(
+            await Promise.all(
+              Object.values(docs.definition.apisV2).map(async (api) => {
+                const resolved = await resolveHttpCodeSnippets(api);
+                return [api.id, resolved] as const;
+              })
+            )
+          )
+        : {},
     pages: docs.definition.pages,
     edgeFlags,
     mdxOptions: {
@@ -263,3 +286,79 @@ export async function getDocsPageProps(
 
   return { props };
 }
+
+// TODO: actually need to add http examples here
+const resolveHttpCodeSnippets = async (
+  apiDefinition: ApiDefinition
+): Promise<ApiDefinition> => {
+  // Collect all endpoints first, so that we can resolve descriptions in a single batch
+  const collected: EndpointDefinition[] = [];
+  Transformer.with({
+    EndpointDefinition: (endpoint) => {
+      collected.push(endpoint);
+      return endpoint;
+    },
+  }).apiDefinition(apiDefinition);
+
+  // Resolve example code snippets in parallel
+  const result = Object.fromEntries(
+    await Promise.all(
+      collected.map(async (endpoint) => {
+        if (endpoint.examples == null || endpoint.examples.length === 0) {
+          return [endpoint.id, endpoint] as const;
+        }
+
+        const examples = await Promise.all(
+          endpoint.examples.map((example) =>
+            resolveExample(apiDefinition, endpoint, example)
+          )
+        );
+
+        return [endpoint.id, { ...endpoint, examples }] as const;
+      })
+    )
+  );
+
+  // reduce the api definition with newly resolved examples
+  return {
+    ...apiDefinition,
+    endpoints: { ...apiDefinition.endpoints, ...result },
+  };
+};
+
+const resolveExample = async (
+  apiDefinition: ApiDefinition,
+  endpoint: EndpointDefinition,
+  example: ExampleEndpointCall
+): Promise<ExampleEndpointCall> => {
+  const snippets = { ...example.snippets };
+
+  const pushSnippet = (snippet: CodeSnippet) => {
+    (snippets[snippet.language] ??= []).push(snippet);
+  };
+
+  // Check if curl snippet exists
+  if (!snippets[APIV1Read.SupportedLanguage.Curl]?.length) {
+    const endpointAuth = endpoint.auth?.[0];
+    const curlCode = convertToCurl(
+      toSnippetHttpRequest(
+        endpoint,
+        example,
+        endpointAuth != null ? apiDefinition.auths[endpointAuth] : undefined
+      ),
+      {
+        usesApplicationJsonInFormDataValue: false,
+      }
+    );
+    pushSnippet({
+      name: undefined,
+      language: APIV1Read.SupportedLanguage.Curl,
+      install: undefined,
+      code: curlCode,
+      generated: true,
+      description: undefined,
+    });
+  }
+
+  return { ...example, snippets };
+};


### PR DESCRIPTION
## Short description of the changes made
For `apiV2` it would be great if the local preview showed curl examples. 

## What was the motivation & context behind this PR?
`fern docs dev` has a poor UX without these examples. 

## How has this PR been tested?
Planning to test on dev. 
