### PR TITLE
fix(openrpc): respect tags and name in openrpc

### DIFF
--- a/packages/fdr-sdk/src/navigation/NodeCollector.ts
+++ b/packages/fdr-sdk/src/navigation/NodeCollector.ts
@@ -134,9 +134,6 @@ export class NodeCollector {
       this.orphanedNodes.push(existing.node);
       this.#setNode(node.slug, node, parents);
     } else {
-      if (FernNavigation.isPage(existing.node)) {
-        console.warn(`Duplicate slug found: ${node.slug}`, node.title);
-      }
       this.orphanedNodes.push(node);
     }
   }

--- a/packages/parsers/src/openrpc/1.x/MethodConverter.node.ts
+++ b/packages/parsers/src/openrpc/1.x/MethodConverter.node.ts
@@ -12,6 +12,7 @@ import {
 import { resolveContentDescriptorObject } from "../utils/resolveContentDescriptorObject";
 import { resolveExample } from "../utils/resolveExample";
 import { resolveExamplePairingOrReference } from "../utils/resolveExamplePairing";
+import { resolveTag } from "../utils/resolveTags";
 
 const API_KEY_PATH_PARAMETER: FernRegistry.api.latest.ObjectProperty = {
   key: FernRegistry.PropertyKey("apiKey"),
@@ -251,10 +252,7 @@ export class MethodConverterNode extends BaseOpenrpcConverterNode<
         responseHeaders: [],
         snippetTemplates: undefined,
         // use the first tag as the namespace
-        namespace:
-          this.method.tags?.[0] != null
-            ? [FernRegistry.api.v1.SubpackageId(this.method.tags[0])]
-            : undefined,
+        namespace: this.getNamespace(),
       };
     } catch (_error) {
       this.context.errors.error({
@@ -263,6 +261,17 @@ export class MethodConverterNode extends BaseOpenrpcConverterNode<
       });
       return undefined;
     }
+  }
+
+  private getNamespace(): FernRegistry.api.v1.SubpackageId[] | undefined {
+    if (this.method.tags?.[0] == null) {
+      return undefined;
+    }
+    const resolvedTag = resolveTag(this.method.tags[0], this.context.openrpc);
+    if (resolvedTag?.name == null) {
+      return undefined;
+    }
+    return [FernRegistry.api.v1.SubpackageId(resolvedTag.name)];
   }
 
   private convertToHttpResponse(

--- a/packages/parsers/src/openrpc/__test__/__snapshots__/ethereum.json
+++ b/packages/parsers/src/openrpc/__test__/__snapshots__/ethereum.json
@@ -1284,15 +1284,28 @@
   "endpoints": {
     "web3_clientVersion": {
       "id": "web3_clientVersion",
-      "displayName": "web3ClientVersion",
+      "displayName": "web3_clientVersion",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -1337,20 +1350,32 @@
       "operationId": "web3_clientVersion",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "web3_sha3": {
       "id": "web3_sha3",
-      "displayName": "web3Sha3",
+      "displayName": "web3_sha3",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -1423,20 +1448,32 @@
       "operationId": "web3_sha3",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "net_listening": {
       "id": "net_listening",
-      "displayName": "netListening",
+      "displayName": "net_listening",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -1483,20 +1520,32 @@
       "operationId": "net_listening",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "net_peerCount": {
       "id": "net_peerCount",
-      "displayName": "netPeerCount",
+      "displayName": "net_peerCount",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -1541,20 +1590,32 @@
       "operationId": "net_peerCount",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "net_version": {
       "id": "net_version",
-      "displayName": "netVersion",
+      "displayName": "net_version",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -1600,20 +1661,32 @@
       "operationId": "net_version",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_blockNumber": {
       "id": "eth_blockNumber",
-      "displayName": "ethBlockNumber",
+      "displayName": "eth_blockNumber",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -1654,20 +1727,32 @@
       "operationId": "eth_blockNumber",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_call": {
       "id": "eth_call",
-      "displayName": "ethCall",
+      "displayName": "eth_call",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -1739,20 +1824,32 @@
       "operationId": "eth_call",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_chainId": {
       "id": "eth_chainId",
-      "displayName": "ethChainId",
+      "displayName": "eth_chainId",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -1798,20 +1895,32 @@
       "operationId": "eth_chainId",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_coinbase": {
       "id": "eth_coinbase",
-      "displayName": "ethCoinbase",
+      "displayName": "eth_coinbase",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -1852,20 +1961,32 @@
       "operationId": "eth_coinbase",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_estimateGas": {
       "id": "eth_estimateGas",
-      "displayName": "ethEstimateGas",
+      "displayName": "eth_estimateGas",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -1927,20 +2048,32 @@
       "operationId": "eth_estimateGas",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_gasPrice": {
       "id": "eth_gasPrice",
-      "displayName": "ethGasPrice",
+      "displayName": "eth_gasPrice",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -1981,20 +2114,32 @@
       "operationId": "eth_gasPrice",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getBalance": {
       "id": "eth_getBalance",
-      "displayName": "ethGetBalance",
+      "displayName": "eth_getBalance",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2068,20 +2213,32 @@
       "operationId": "eth_getBalance",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getBlockByHash": {
       "id": "eth_getBlockByHash",
-      "displayName": "ethGetBlockByHash",
+      "displayName": "eth_getBlockByHash",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2158,20 +2315,32 @@
       "operationId": "eth_getBlockByHash",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getBlockByNumber": {
       "id": "eth_getBlockByNumber",
-      "displayName": "ethGetBlockByNumber",
+      "displayName": "eth_getBlockByNumber",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2248,20 +2417,32 @@
       "operationId": "eth_getBlockByNumber",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getBlockTransactionCountByHash": {
       "id": "eth_getBlockTransactionCountByHash",
-      "displayName": "ethGetBlockTransactionCountByHash",
+      "displayName": "eth_getBlockTransactionCountByHash",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2323,20 +2504,32 @@
       "operationId": "eth_getBlockTransactionCountByHash",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getBlockTransactionCountByNumber": {
       "id": "eth_getBlockTransactionCountByNumber",
-      "displayName": "ethGetBlockTransactionCountByNumber",
+      "displayName": "eth_getBlockTransactionCountByNumber",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2398,20 +2591,32 @@
       "operationId": "eth_getBlockTransactionCountByNumber",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getCode": {
       "id": "eth_getCode",
-      "displayName": "ethGetCode",
+      "displayName": "eth_getCode",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2485,20 +2690,32 @@
       "operationId": "eth_getCode",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getFilterChanges": {
       "id": "eth_getFilterChanges",
-      "displayName": "ethGetFilterChanges",
+      "displayName": "eth_getFilterChanges",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2569,20 +2786,32 @@
       "operationId": "eth_getFilterChanges",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getFilterLogs": {
       "id": "eth_getFilterLogs",
-      "displayName": "ethGetFilterLogs",
+      "displayName": "eth_getFilterLogs",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2653,20 +2882,32 @@
       "operationId": "eth_getFilterLogs",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getRawTransactionByHash": {
       "id": "eth_getRawTransactionByHash",
-      "displayName": "ethGetRawTransactionByHash",
+      "displayName": "eth_getRawTransactionByHash",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2728,20 +2969,32 @@
       "operationId": "eth_getRawTransactionByHash",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getRawTransactionByBlockHashAndIndex": {
       "id": "eth_getRawTransactionByBlockHashAndIndex",
-      "displayName": "ethGetRawTransactionByBlockHashAndIndex",
+      "displayName": "eth_getRawTransactionByBlockHashAndIndex",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2814,20 +3067,32 @@
       "operationId": "eth_getRawTransactionByBlockHashAndIndex",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getRawTransactionByBlockNumberAndIndex": {
       "id": "eth_getRawTransactionByBlockNumberAndIndex",
-      "displayName": "ethGetRawTransactionByBlockNumberAndIndex",
+      "displayName": "eth_getRawTransactionByBlockNumberAndIndex",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2900,20 +3165,32 @@
       "operationId": "eth_getRawTransactionByBlockNumberAndIndex",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getLogs": {
       "id": "eth_getLogs",
-      "displayName": "ethGetLogs",
+      "displayName": "eth_getLogs",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -3025,20 +3302,32 @@
       "operationId": "eth_getLogs",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getStorageAt": {
       "id": "eth_getStorageAt",
-      "displayName": "ethGetStorageAt",
+      "displayName": "eth_getStorageAt",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -3120,20 +3409,32 @@
       "operationId": "eth_getStorageAt",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getTransactionByBlockHashAndIndex": {
       "id": "eth_getTransactionByBlockHashAndIndex",
-      "displayName": "ethGetTransactionByBlockHashAndIndex",
+      "displayName": "eth_getTransactionByBlockHashAndIndex",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -3219,20 +3520,32 @@
       "operationId": "eth_getTransactionByBlockHashAndIndex",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getTransactionByBlockNumberAndIndex": {
       "id": "eth_getTransactionByBlockNumberAndIndex",
-      "displayName": "ethGetTransactionByBlockNumberAndIndex",
+      "displayName": "eth_getTransactionByBlockNumberAndIndex",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -3311,20 +3624,32 @@
       "operationId": "eth_getTransactionByBlockNumberAndIndex",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getTransactionByHash": {
       "id": "eth_getTransactionByHash",
-      "displayName": "ethGetTransactionByHash",
+      "displayName": "eth_getTransactionByHash",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -3392,20 +3717,32 @@
       "operationId": "eth_getTransactionByHash",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getTransactionCount": {
       "id": "eth_getTransactionCount",
-      "displayName": "ethGetTransactionCount",
+      "displayName": "eth_getTransactionCount",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -3483,20 +3820,32 @@
       "operationId": "eth_getTransactionCount",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getTransactionReceipt": {
       "id": "eth_getTransactionReceipt",
-      "displayName": "ethGetTransactionReceipt",
+      "displayName": "eth_getTransactionReceipt",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -3564,20 +3913,32 @@
       "operationId": "eth_getTransactionReceipt",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getUncleByBlockHashAndIndex": {
       "id": "eth_getUncleByBlockHashAndIndex",
-      "displayName": "ethGetUncleByBlockHashAndIndex",
+      "displayName": "eth_getUncleByBlockHashAndIndex",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -3650,20 +4011,32 @@
       "operationId": "eth_getUncleByBlockHashAndIndex",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getUncleByBlockNumberAndIndex": {
       "id": "eth_getUncleByBlockNumberAndIndex",
-      "displayName": "ethGetUncleByBlockNumberAndIndex",
+      "displayName": "eth_getUncleByBlockNumberAndIndex",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -3744,20 +4117,32 @@
       "operationId": "eth_getUncleByBlockNumberAndIndex",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getUncleCountByBlockHash": {
       "id": "eth_getUncleCountByBlockHash",
-      "displayName": "ethGetUncleCountByBlockHash",
+      "displayName": "eth_getUncleCountByBlockHash",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -3819,20 +4204,32 @@
       "operationId": "eth_getUncleCountByBlockHash",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getUncleCountByBlockNumber": {
       "id": "eth_getUncleCountByBlockNumber",
-      "displayName": "ethGetUncleCountByBlockNumber",
+      "displayName": "eth_getUncleCountByBlockNumber",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -3894,20 +4291,32 @@
       "operationId": "eth_getUncleCountByBlockNumber",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getProof": {
       "id": "eth_getProof",
-      "displayName": "ethGetProof",
+      "displayName": "eth_getProof",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -4070,20 +4479,32 @@
       "operationId": "eth_getProof",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_getWork": {
       "id": "eth_getWork",
-      "displayName": "ethGetWork",
+      "displayName": "eth_getWork",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -4160,20 +4581,32 @@
       "operationId": "eth_getWork",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_hashrate": {
       "id": "eth_hashrate",
-      "displayName": "ethHashrate",
+      "displayName": "eth_hashrate",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -4214,20 +4647,32 @@
       "operationId": "eth_hashrate",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_mining": {
       "id": "eth_mining",
-      "displayName": "ethMining",
+      "displayName": "eth_mining",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -4271,20 +4716,32 @@
       "operationId": "eth_mining",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_newBlockFilter": {
       "id": "eth_newBlockFilter",
-      "displayName": "ethNewBlockFilter",
+      "displayName": "eth_newBlockFilter",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -4325,20 +4782,32 @@
       "operationId": "eth_newBlockFilter",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_newFilter": {
       "id": "eth_newFilter",
-      "displayName": "ethNewFilter",
+      "displayName": "eth_newFilter",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -4441,20 +4910,32 @@
       "operationId": "eth_newFilter",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_newPendingTransactionFilter": {
       "id": "eth_newPendingTransactionFilter",
-      "displayName": "ethNewPendingTransactionFilter",
+      "displayName": "eth_newPendingTransactionFilter",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -4495,20 +4976,32 @@
       "operationId": "eth_newPendingTransactionFilter",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_pendingTransactions": {
       "id": "eth_pendingTransactions",
-      "displayName": "ethPendingTransactions",
+      "displayName": "eth_pendingTransactions",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -4549,20 +5042,32 @@
       "operationId": "eth_pendingTransactions",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_protocolVersion": {
       "id": "eth_protocolVersion",
-      "displayName": "ethProtocolVersion",
+      "displayName": "eth_protocolVersion",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -4603,20 +5108,32 @@
       "operationId": "eth_protocolVersion",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_sendRawTransaction": {
       "id": "eth_sendRawTransaction",
-      "displayName": "ethSendRawTransaction",
+      "displayName": "eth_sendRawTransaction",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -4679,20 +5196,32 @@
       "operationId": "eth_sendRawTransaction",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_submitHashrate": {
       "id": "eth_submitHashrate",
-      "displayName": "ethSubmitHashrate",
+      "displayName": "eth_submitHashrate",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -4769,20 +5298,32 @@
       "environments": [],
       "availability": "Deprecated",
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_submitWork": {
       "id": "eth_submitWork",
-      "displayName": "ethSubmitWork",
+      "displayName": "eth_submitWork",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -4875,20 +5416,32 @@
       "operationId": "eth_submitWork",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_syncing": {
       "id": "eth_syncing",
-      "displayName": "ethSyncing",
+      "displayName": "eth_syncing",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -4984,20 +5537,32 @@
       "operationId": "eth_syncing",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "eth_uninstallFilter": {
       "id": "eth_uninstallFilter",
-      "displayName": "ethUninstallFilter",
+      "displayName": "eth_uninstallFilter",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -5062,8 +5627,7 @@
       "operationId": "eth_uninstallFilter",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     }
   },
   "websockets": {},

--- a/packages/parsers/src/openrpc/__test__/__snapshots__/petstore.json
+++ b/packages/parsers/src/openrpc/__test__/__snapshots__/petstore.json
@@ -83,15 +83,28 @@
   "endpoints": {
     "list_pets": {
       "id": "list_pets",
-      "displayName": "listPets",
+      "displayName": "list_pets",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -175,19 +188,34 @@
       ],
       "requestHeaders": [],
       "responseHeaders": [],
-      "namespace": []
+      "namespace": [
+        "pets"
+      ]
     },
     "create_pet": {
       "id": "create_pet",
-      "displayName": "createPet",
+      "displayName": "create_pet",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -278,19 +306,34 @@
       ],
       "requestHeaders": [],
       "responseHeaders": [],
-      "namespace": []
+      "namespace": [
+        "pets"
+      ]
     },
     "get_pet": {
       "id": "get_pet",
-      "displayName": "getPet",
+      "displayName": "get_pet",
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -369,7 +412,9 @@
       ],
       "requestHeaders": [],
       "responseHeaders": [],
-      "namespace": []
+      "namespace": [
+        "pets"
+      ]
     }
   },
   "websockets": {},

--- a/packages/parsers/src/openrpc/__test__/__snapshots__/solana.json
+++ b/packages/parsers/src/openrpc/__test__/__snapshots__/solana.json
@@ -8,11 +8,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -278,8 +291,7 @@
       "operationId": "getAccountInfo",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getBalance": {
       "id": "getBalance",
@@ -287,11 +299,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -406,8 +431,7 @@
       "operationId": "getBalance",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getBlock": {
       "id": "getBlock",
@@ -415,11 +439,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -1604,8 +1641,7 @@
       "operationId": "getBlock",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getBlockCommitment": {
       "id": "getBlockCommitment",
@@ -1613,11 +1649,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -1721,8 +1770,7 @@
       "operationId": "getBlockCommitment",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getBlockHeight": {
       "id": "getBlockHeight",
@@ -1730,11 +1778,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -1835,8 +1896,7 @@
       "operationId": "getBlockHeight",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getBlockProduction": {
       "id": "getBlockProduction",
@@ -1844,11 +1904,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2060,8 +2133,7 @@
       "operationId": "getBlockProduction",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getBlocks": {
       "id": "getBlocks",
@@ -2069,11 +2141,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2197,8 +2282,7 @@
       "operationId": "getBlocks",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getBlocksWithLimit": {
       "id": "getBlocksWithLimit",
@@ -2206,11 +2290,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2334,8 +2431,7 @@
       "operationId": "getBlocksWithLimit",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getBlockTime": {
       "id": "getBlockTime",
@@ -2343,11 +2439,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2429,8 +2538,7 @@
       "operationId": "getBlockTime",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getClusterNodes": {
       "id": "getClusterNodes",
@@ -2438,11 +2546,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -2626,8 +2747,7 @@
       "operationId": "getClusterNodes",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getEpochInfo": {
       "id": "getEpochInfo",
@@ -2635,11 +2755,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -2828,8 +2961,7 @@
       "operationId": "getEpochInfo",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getEpochSchedule": {
       "id": "getEpochSchedule",
@@ -2837,11 +2969,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -2953,8 +3098,7 @@
       "operationId": "getEpochSchedule",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getFeeForMessage": {
       "id": "getFeeForMessage",
@@ -2962,11 +3106,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -3099,8 +3256,7 @@
       "operationId": "getFeeForMessage",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getFirstAvailableBlock": {
       "id": "getFirstAvailableBlock",
@@ -3108,11 +3264,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -3156,8 +3325,7 @@
       "operationId": "getFirstAvailableBlock",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getGenesisHash": {
       "id": "getGenesisHash",
@@ -3165,11 +3333,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -3213,8 +3394,7 @@
       "operationId": "getGenesisHash",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getHealth": {
       "id": "getHealth",
@@ -3222,11 +3402,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -3270,8 +3463,7 @@
       "operationId": "getHealth",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getHighestSnapshotSlot": {
       "id": "getHighestSnapshotSlot",
@@ -3279,11 +3471,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -3359,8 +3564,7 @@
       "operationId": "getHighestSnapshotSlot",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getIdentity": {
       "id": "getIdentity",
@@ -3368,11 +3572,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -3428,8 +3645,7 @@
       "operationId": "getIdentity",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getInflationGovernor": {
       "id": "getInflationGovernor",
@@ -3437,11 +3653,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -3610,8 +3839,7 @@
       "operationId": "getInflationGovernor",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getInflationRate": {
       "id": "getInflationRate",
@@ -3619,11 +3847,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -3721,8 +3962,7 @@
       "operationId": "getInflationRate",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getInflationReward": {
       "id": "getInflationReward",
@@ -3730,11 +3970,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -3959,8 +4212,7 @@
       "operationId": "getInflationReward",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getLargestAccounts": {
       "id": "getLargestAccounts",
@@ -3968,11 +4220,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -4109,8 +4374,7 @@
       "operationId": "getLargestAccounts",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getLatestBlockhash": {
       "id": "getLatestBlockhash",
@@ -4118,11 +4382,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -4249,8 +4526,7 @@
       "operationId": "getLatestBlockhash",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getMaxRetransmitSlot": {
       "id": "getMaxRetransmitSlot",
@@ -4258,11 +4534,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -4306,8 +4595,7 @@
       "operationId": "getMaxRetransmitSlot",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getMaxShredInsertSlot": {
       "id": "getMaxShredInsertSlot",
@@ -4315,11 +4603,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -4363,8 +4664,7 @@
       "operationId": "getMaxShredInsertSlot",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getMinimumBalanceForRentExemption": {
       "id": "getMinimumBalanceForRentExemption",
@@ -4372,11 +4672,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -4489,8 +4802,7 @@
       "operationId": "getMinimumBalanceForRentExemption",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getMultipleAccounts": {
       "id": "getMultipleAccounts",
@@ -4498,11 +4810,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -4785,8 +5110,7 @@
       "operationId": "getMultipleAccounts",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getProgramAccounts": {
       "id": "getProgramAccounts",
@@ -4794,11 +5118,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -5113,8 +5450,7 @@
       "operationId": "getProgramAccounts",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getRecentPerformanceSamples": {
       "id": "getRecentPerformanceSamples",
@@ -5122,11 +5458,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -5272,8 +5621,7 @@
       "operationId": "getRecentPerformanceSamples",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getRecentPrioritizationFees": {
       "id": "getRecentPrioritizationFees",
@@ -5281,11 +5629,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -5397,8 +5758,7 @@
       "operationId": "getRecentPrioritizationFees",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getSignaturesForAddress": {
       "id": "getSignaturesForAddress",
@@ -5406,11 +5766,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -5678,8 +6051,7 @@
       "operationId": "getSignaturesForAddress",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getSignatureStatuses": {
       "id": "getSignatureStatuses",
@@ -5687,11 +6059,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -5881,8 +6266,7 @@
       "operationId": "getSignatureStatuses",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getSlot": {
       "id": "getSlot",
@@ -5890,11 +6274,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -5995,8 +6392,7 @@
       "operationId": "getSlot",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getSlotLeader": {
       "id": "getSlotLeader",
@@ -6004,11 +6400,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -6109,8 +6518,7 @@
       "operationId": "getSlotLeader",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getSlotLeaders": {
       "id": "getSlotLeaders",
@@ -6118,11 +6526,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -6214,8 +6635,7 @@
       "operationId": "getSlotLeaders",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getSupply": {
       "id": "getSupply",
@@ -6223,11 +6643,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -6390,8 +6823,7 @@
       "operationId": "getSupply",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getTokenAccountBalance": {
       "id": "getTokenAccountBalance",
@@ -6399,11 +6831,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -6564,8 +7009,7 @@
       "operationId": "getTokenAccountBalance",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getTokenAccountsByOwner": {
       "id": "getTokenAccountsByOwner",
@@ -6573,11 +7017,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -6916,8 +7373,7 @@
       "operationId": "getTokenAccountsByOwner",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getTokenSupply": {
       "id": "getTokenSupply",
@@ -6925,11 +7381,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -7090,8 +7559,7 @@
       "operationId": "getTokenSupply",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getTransaction": {
       "id": "getTransaction",
@@ -7099,11 +7567,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -7318,8 +7799,7 @@
       "operationId": "getTransaction",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getVersion": {
       "id": "getVersion",
@@ -7327,11 +7807,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -7401,8 +7894,7 @@
       "operationId": "getVersion",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "getVoteAccounts": {
       "id": "getVoteAccounts",
@@ -7410,11 +7902,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -7837,8 +8342,7 @@
       "operationId": "getVoteAccounts",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "isBlockhashValid": {
       "id": "isBlockhashValid",
@@ -7846,11 +8350,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -7979,8 +8496,7 @@
       "operationId": "isBlockhashValid",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "minimumLedgerSlot": {
       "id": "minimumLedgerSlot",
@@ -7988,11 +8504,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "responses": [
         {
@@ -8036,8 +8565,7 @@
       "operationId": "minimumLedgerSlot",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "requestAirdrop": {
       "id": "requestAirdrop",
@@ -8045,11 +8573,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -8164,8 +8705,7 @@
       "operationId": "requestAirdrop",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "sendTransaction": {
       "id": "sendTransaction",
@@ -8173,11 +8713,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -8339,8 +8892,7 @@
       "operationId": "sendTransaction",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     },
     "simulateTransaction": {
       "id": "simulateTransaction",
@@ -8348,11 +8900,24 @@
       "method": "POST",
       "path": [
         {
-          "type": "literal",
-          "value": ""
+          "type": "pathParameter",
+          "value": "apiKey"
         }
       ],
-      "pathParameters": [],
+      "pathParameters": [
+        {
+          "key": "apiKey",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
       "queryParameters": [],
       "requests": [
         {
@@ -8821,8 +9386,7 @@
       "operationId": "simulateTransaction",
       "environments": [],
       "requestHeaders": [],
-      "responseHeaders": [],
-      "namespace": []
+      "responseHeaders": []
     }
   },
   "websockets": {},

--- a/packages/parsers/src/openrpc/utils/resolveTags.ts
+++ b/packages/parsers/src/openrpc/utils/resolveTags.ts
@@ -1,0 +1,17 @@
+import {
+  OpenrpcDocument,
+  ReferenceObject,
+  TagObject,
+} from "@open-rpc/meta-schema";
+import { isReferenceObject } from "./isReferenceObject";
+import { resolveReference } from "./resolveReference";
+
+export function resolveTag(
+  tag: TagObject | ReferenceObject | undefined,
+  document: OpenrpcDocument
+): TagObject | undefined {
+  if (isReferenceObject(tag)) {
+    return resolveReference<TagObject | undefined>(tag, document, undefined);
+  }
+  return tag;
+}


### PR DESCRIPTION
## Short description of the changes made
This PR updates the OpenRPC converter to respect the method name and any tag assigned to the method. 

## What was the motivation & context behind this PR?
- Customer requests asking to respect name
- Customer requests asking about nesting methods in resources
- Customer requests around showing authentication

## How has this PR been tested?
Integration tests

**Note** also removing a log line from the node collector that is affecting print statements in the CLI @abvthecity 
