### PR TITLE
fix(openrpc): set subpackages in fdr latest

### DIFF
--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fern-api/docs-parsers",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern-platform.git",

--- a/packages/parsers/src/openapi/3.1/OpenApiDocumentConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/OpenApiDocumentConverter.node.ts
@@ -1,7 +1,7 @@
-import { camelCase } from "es-toolkit";
 import { OpenAPIV3_1 } from "openapi-types";
 import { v4 } from "uuid";
 import { FernRegistry } from "../../client/generated";
+import { computeSubpackages } from "../../utils/computeSubpackages";
 import {
   BaseOpenApiV3_1ConverterNode,
   BaseOpenApiV3_1ConverterNodeConstructorArgs,
@@ -146,35 +146,7 @@ export class OpenApiDocumentConverterNode extends BaseOpenApiV3_1ConverterNode<
     const subpackages: Record<
       FernRegistry.api.v1.SubpackageId,
       FernRegistry.api.latest.SubpackageMetadata
-    > = {};
-    if (endpoints != null) {
-      Object.values(endpoints).forEach((endpoint) =>
-        endpoint.namespace?.forEach((subpackage) => {
-          const qualifiedPath: string[] = [];
-          subpackages[FernRegistry.api.v1.SubpackageId(camelCase(subpackage))] =
-            {
-              id: FernRegistry.api.v1.SubpackageId(camelCase(subpackage)),
-              name: [...qualifiedPath, subpackage].join("/"),
-              displayName: subpackage,
-            };
-          qualifiedPath.push(subpackage);
-        })
-      );
-    }
-    if (webhookEndpoints != null) {
-      Object.values(webhookEndpoints).forEach((webhook) =>
-        webhook.namespace?.forEach((subpackage) => {
-          const qualifiedPath: string[] = [];
-          subpackages[FernRegistry.api.v1.SubpackageId(camelCase(subpackage))] =
-            {
-              id: FernRegistry.api.v1.SubpackageId(camelCase(subpackage)),
-              name: [...qualifiedPath, subpackage].join("/"),
-              displayName: subpackage,
-            };
-          qualifiedPath.push(subpackage);
-        })
-      );
-    }
+    > = computeSubpackages({ endpoints, webhookEndpoints });
 
     const types = this.components?.convert();
 

--- a/packages/parsers/src/openrpc/__test__/__snapshots__/petstore.json
+++ b/packages/parsers/src/openrpc/__test__/__snapshots__/petstore.json
@@ -419,7 +419,13 @@
   },
   "websockets": {},
   "webhooks": {},
-  "subpackages": {},
+  "subpackages": {
+    "pets": {
+      "id": "pets",
+      "name": "pets",
+      "displayName": "pets"
+    }
+  },
   "auths": {},
   "globalHeaders": []
 }

--- a/packages/parsers/src/utils/computeSubpackages.ts
+++ b/packages/parsers/src/utils/computeSubpackages.ts
@@ -1,0 +1,58 @@
+import { camelCase } from "es-toolkit";
+import { FernRegistry } from "../client/generated";
+
+export declare namespace ComputeSubpackages {
+  interface Args {
+    endpoints?: Record<
+      FernRegistry.EndpointId,
+      FernRegistry.api.latest.EndpointDefinition
+    >;
+    webhookEndpoints?: Record<
+      FernRegistry.EndpointId,
+      FernRegistry.api.latest.WebhookDefinition
+    >;
+  }
+}
+
+export function computeSubpackages({
+  endpoints,
+  webhookEndpoints,
+}: ComputeSubpackages.Args): Record<
+  FernRegistry.api.v1.SubpackageId,
+  FernRegistry.api.latest.SubpackageMetadata
+> {
+  const subpackages: Record<
+    FernRegistry.api.v1.SubpackageId,
+    FernRegistry.api.latest.SubpackageMetadata
+  > = {};
+
+  if (endpoints != null) {
+    Object.values(endpoints).forEach((endpoint) =>
+      endpoint.namespace?.forEach((subpackage) => {
+        const qualifiedPath: string[] = [];
+        subpackages[FernRegistry.api.v1.SubpackageId(camelCase(subpackage))] = {
+          id: FernRegistry.api.v1.SubpackageId(camelCase(subpackage)),
+          name: [...qualifiedPath, subpackage].join("/"),
+          displayName: subpackage,
+        };
+        qualifiedPath.push(subpackage);
+      })
+    );
+  }
+
+  if (webhookEndpoints != null) {
+    Object.values(webhookEndpoints).forEach((webhook) =>
+      webhook.namespace?.forEach((subpackage) => {
+        const qualifiedPath: string[] = [];
+        subpackages[FernRegistry.api.v1.SubpackageId(camelCase(subpackage))] = {
+          id: FernRegistry.api.v1.SubpackageId(camelCase(subpackage)),
+          name: [...qualifiedPath, subpackage].join("/"),
+          displayName: subpackage,
+        };
+        qualifiedPath.push(subpackage);
+      })
+    );
+  }
+
+  return subpackages;
+}


### PR DESCRIPTION
## Short description of the changes made
This PR makes sure that OpenRPC conversion sets subpackages. A helper method is created from the OpenAPI parser. 

## What was the motivation & context behind this PR?
Allow users to use `tag` to configure API Reference layout. 

## How has this PR been tested?
snapshot tests
