### PR TITLE
fix(fdr): public s3 file uploads go through cloudfront

### DIFF
--- a/servers/fdr/src/services/s3/S3Service.ts
+++ b/servers/fdr/src/services/s3/S3Service.ts
@@ -223,7 +223,7 @@ export class S3ServiceImpl implements S3Service {
       input.ContentType = "image/svg+xml";
     }
     const command = new PutObjectCommand(input);
-    return {
+    const result = {
       url: await getSignedUrl(
         isPrivate ? this.privateDocsS3 : this.publicDocsS3,
         command,
@@ -231,6 +231,15 @@ export class S3ServiceImpl implements S3Service {
       ),
       key,
     };
+    if (!isPrivate) {
+      try {
+        const url = new URL(result.url);
+        result.url = result.url.replace(url.host, this.publicDocsCDNUrl);
+      } catch (error) {
+        console.error("Failed to replace S3 URL with CDN URL:", error);
+      }
+    }
+    return result;
   }
 
   async getPresignedApiDefinitionSourceDownloadUrl({


### PR DESCRIPTION
## Short description of the changes made
Public S3 file uploads go through CDN. 

## What was the motivation & context behind this PR?
Performance when connecting from other regions (i.e. github actions). 

## How has this PR been tested?
Will be tested on dev
