### PR TITLE
fix: safari css behavior for accordion and backdrop blur

### DIFF
--- a/packages/fern-docs/components/src/accordion.scss
+++ b/packages/fern-docs/components/src/accordion.scss
@@ -15,6 +15,11 @@
     @apply hover:bg-tag-default flex cursor-pointer items-center gap-3 rounded-[inherit] p-4 transition-colors hover:transition-none data-[state=open]:rounded-b-none;
     @apply list-none;
 
+    // Hide the default arrow on WebKit browsers
+    &::-webkit-details-marker {
+      @apply hidden;
+    }
+
     .fern-accordion-trigger-arrow {
       @apply t-muted ease-shift size-4 shrink-0 transition-transform duration-[400ms];
     }

--- a/packages/fern-docs/search-ui/src/components/desktop/desktop.scss
+++ b/packages/fern-docs/search-ui/src/components/desktop/desktop.scss
@@ -2,7 +2,6 @@
   overflow: hidden;
   border: 1px solid var(--grayscale-a6);
   background-color: var(--grayscale-a1);
-  backdrop-filter: blur(40px);
   border-radius: 0.75rem;
   transition: transform 100ms ease;
   position: relative;


### PR DESCRIPTION
safari's behavior for certain css rules is different from chrome. this fixes the following:

- `list-style-none` hides details > summary's arrow in chrome, but not safari. this PR hides it in safari too


<img width="381" alt="Screenshot 2025-01-21 at 6 37 50 PM" src="https://github.com/user-attachments/assets/dc59687e-5540-4591-a3ca-986313db620d" />

- applying backdrop blur twice in nested div elements causes the entire graphics rendering to go bezerk in safari. This removes blur(40px) on the outer div:

before:

<img width="707" alt="Screenshot 2025-01-21 at 6 36 53 PM" src="https://github.com/user-attachments/assets/c439a9af-31b3-4b51-a25f-1f3c6a1fb647" />

after:
<img width="714" alt="Screenshot 2025-01-21 at 6 37 33 PM" src="https://github.com/user-attachments/assets/729defe9-6025-443a-870f-fca677f5737a" />



