### PR TITLE
fix: correct `python.ts` snippet generator for file uploads.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,11 +77,11 @@ The frontend is served at `localhost:3000`. You can configure which docs are loa
 
 ### Docs Dev Environment
 
-To run the docs dev environment, make sure vercel is installed:
+To run the docs dev environment, first make sure vercel is installed:
 
 - `npm install -g vercel`
 
-Then link vercel to the project:
+From the fern-platform repository, link vercel to the Fern project:
 
 - `vercel link --project app.buildwithfern.com`
 - When prompted to setup the project, say `yes`
@@ -92,7 +92,9 @@ Then, run `vercel pull`, which will create `/fern-platform/.vercel/.env.developm
 Then, copy that file (creating if necessary) to `/fern-platform/packages/fern-docs/bundle/.env.local`
 Finally, to run the dev server, `cd /packages/fern-docs/bundle` and run `pnpm docs:dev`, which should begin running on `localhost:3000`
 
-Optionally, to reroute to a different docs domain, add a `NEXT_PUBLIC_DOCS_DOMAIN` to `.env.local`
+To set a dev docs domain, add a `NEXT_PUBLIC_DOCS_DOMAIN` to `.env.local`. For instance:
+
+- `NEXT_PUBLIC_DOCS_DOMAIN=customer.docs.buildwithfern.com`
 
 ## Testing in Staging
 

--- a/packages/fern-docs/ui/src/playground/code-snippets/builders/python.ts
+++ b/packages/fern-docs/ui/src/playground/code-snippets/builders/python.ts
@@ -31,7 +31,7 @@ print(response.json())`;
 
 ${this.#buildRequests({})}`;
     }
- 
+
     return visitDiscriminatedUnion(this.formState.body, "type")._visit<string>({
       json: ({ value }) => `${imports.map((pkg) => `import ${pkg}`).join("\n")}
 

--- a/packages/fern-docs/ui/src/playground/code-snippets/builders/python.ts
+++ b/packages/fern-docs/ui/src/playground/code-snippets/builders/python.ts
@@ -31,7 +31,7 @@ print(response.json())`;
 
 ${this.#buildRequests({})}`;
     }
-
+ 
     return visitDiscriminatedUnion(this.formState.body, "type")._visit<string>({
       json: ({ value }) => `${imports.map((pkg) => `import ${pkg}`).join("\n")}
 
@@ -48,7 +48,7 @@ ${this.#buildRequests({ json: JSON.stringify(value, undefined, 2) })}`,
             if (v.value == null) {
               return undefined;
             }
-            return `'${k}': ('${v.value.name}', open('${v.value.name}', 'rb')),`;
+            return `('${k}', ('${v.value.name}', open('${v.value.name}', 'rb'))),`;
           })
           .filter(isNonNullish);
         const fileArrays = Object.entries(value)
@@ -60,19 +60,19 @@ ${this.#buildRequests({ json: JSON.stringify(value, undefined, 2) })}`,
           )
           .map(([k, v]) => {
             const fileStrings = v.value.map(
-              (file) => `('${file.name}', open('${file.name}', 'rb'))`
+              (file) => `('${k}', ('${file.name}', open('${file.name}', 'rb')))`
             );
             if (fileStrings.length === 0) {
               return;
             }
-            return `'${k}': [${fileStrings.length === 0 ? fileStrings[0] : indentAfter(`\n${fileStrings.join(",\n")},\n`, 2, 0)}],`;
+            return fileStrings.join(",\n");
           })
           .filter(isNonNullish);
 
         const fileEntries = [...singleFiles, ...fileArrays].join("\n");
         const files =
           fileEntries.length > 0
-            ? `{\n${indentAfter(fileEntries, 2)}\n}`
+            ? `[\n${indentAfter(fileEntries, 2)}\n]`
             : undefined;
 
         const dataEntries = Object.entries(value)


### PR DESCRIPTION
Fixes FER-3971

## Short description of the changes made
This corrects the file upload snippet which previously generated with a nested 'files' key.

## What was the motivation & context behind this PR?
See issue [here](https://github.com/fern-api/fern/issues/5563)

## How has this PR been tested?
Yes -- generated Instabase incorrect endpoint with and without the fix.
