### PR TITLE
fix: delete Embed which is crashing browser

### DIFF
--- a/packages/fern-docs/ui/src/mdx/plugins/rehypeFernComponents.ts
+++ b/packages/fern-docs/ui/src/mdx/plugins/rehypeFernComponents.ts
@@ -34,8 +34,6 @@ export function rehypeFernComponents(): (tree: Hast.Root) => void {
         } else if (node.name === "table") {
           // DO NOT coerce <table> into <Table> (see: https://buildwithfern.slack.com/archives/C06QKJWD4VD/p1722602687550179)
           // node.name = "Table";
-        } else if (node.name === "embed") {
-          node.name = "Embed";
         }
       }
     });


### PR DESCRIPTION
```
Error: Expected component `Embed` to be defined: you likely forgot to import, pass, or provide it.
    at l (eval at <anonymous> (/var/task/packages/fern-docs/bundle/.next/server/chunks/130.js:1:702), <anonymous>:18:313)
    at p (eval at <anonymous> (/var/task/packages/fern-docs/bundle/.next/server/chunks/130.js:1:702), <anonymous>:3:950)
    at m (eval at <anonymous> (/var/task/packages/fern-docs/bundle/.next/server/chunks/130.js:1:702), <anonymous>:18:286)
    at Wc (/var/task/node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:68:44)
    at Zc (/var/task/node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:70:253)
    at Z (/var/task/node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at Zc (/var/task/node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:74:209)
    at Z (/var/task/node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at Zc (/var/task/node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:70:481)
    at Z (/var/task/node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
```