### PR TITLE
fix: width auto for logo

### DIFF
--- a/packages/fern-docs/ui/src/header/HeaderLogoImage.tsx
+++ b/packages/fern-docs/ui/src/header/HeaderLogoImage.tsx
@@ -20,7 +20,7 @@ export function HeaderLogoImage(): ReactElement | null {
           priority={true}
           loading="eager"
           quality={100}
-          style={{ height }}
+          style={{ height, width: "auto" }}
         />
         <FernImage
           alt={title}
@@ -32,7 +32,7 @@ export function HeaderLogoImage(): ReactElement | null {
           priority={true}
           loading="eager"
           quality={100}
-          style={{ height }}
+          style={{ height, width: "auto" }}
         />
       </>
     );
@@ -55,7 +55,7 @@ export function HeaderLogoImage(): ReactElement | null {
       priority={true}
       loading="eager"
       quality={100}
-      style={{ height }}
+      style={{ height, width: "auto" }}
     />
   );
 }


### PR DESCRIPTION
fixes:

<img width="854" alt="Screenshot 2025-01-24 at 5 55 03 PM" src="https://github.com/user-attachments/assets/b62e7497-bc2a-4780-98b7-238328120e5a" />

which regressed because of

https://github.com/fern-api/fern-platform/pull/2075