### PR TITLE
chore: fix copy code styling

### DIFF
--- a/packages/fern-docs/components/src/FernButton.scss
+++ b/packages/fern-docs/components/src/FernButton.scss
@@ -431,6 +431,6 @@
   }
 
   .fern-copy-button {
-    @apply backdrop-blur;
+    @apply size-fit backdrop-blur;
   }
 }


### PR DESCRIPTION
Before:
![Screenshot 2025-01-25 at 11 09 58 AM](https://github.com/user-attachments/assets/7afec012-bd92-4e90-8618-1208ad24b056)

After:
![Screenshot 2025-01-25 at 11 11 50 AM](https://github.com/user-attachments/assets/343d20b2-a63e-4dbd-807b-749a79b00dcf)
