### PR TITLE
fix: run search/v1/apikey in node

### DIFF
--- a/packages/fern-docs/bundle/src/app/api/fern-docs/search/v1/key/route.ts
+++ b/packages/fern-docs/bundle/src/app/api/fern-docs/search/v1/key/route.ts
@@ -5,7 +5,7 @@ import { SearchConfig, getSearchConfig } from "@fern-docs/search-utils";
 import { provideRegistryService } from "@fern-docs/ui";
 import { NextRequest, NextResponse } from "next/server";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 
 export async function GET(
   req: NextRequest


### PR DESCRIPTION
## Short description of the changes made
Run the search/v1/key route in nodejs. Load with URL from S3 uses `crypto` which is not vercel edge friendly. 

## What was the motivation & context behind this PR?
Seeing 1k+ failures in search/v1/key. 

## How has this PR been tested?
Previews