### PR TITLE
feat: increase revalidate all concurrency to 500

### DIFF
--- a/packages/fern-docs/bundle/src/pages/api/fern-docs/revalidate-all/v3.ts
+++ b/packages/fern-docs/bundle/src/pages/api/fern-docs/revalidate-all/v3.ts
@@ -18,7 +18,7 @@ export const config = {
 };
 
 // reduce concurrency per domain
-const DEFAULT_BATCH_SIZE = 100;
+const DEFAULT_BATCH_SIZE = 500;
 
 function isSuccessResult(
   result: FernDocs.RevalidationResult


### PR DESCRIPTION
## Short description of the changes made
Increases revalidate batch size. Further reduce vercel cost and increase the performance of `fern generate --docs`

## What was the motivation & context behind this PR?
Building on recent architecture improvements. 

## How has this PR been tested?
Preview.
