### PR TITLE
fix: do not stringify final values that are not explicitly set to `application/json` contentType

### DIFF
--- a/packages/fern-docs/ui/src/playground/fetch-utils/requestToBodyInit.ts
+++ b/packages/fern-docs/ui/src/playground/fetch-utils/requestToBodyInit.ts
@@ -15,14 +15,21 @@ export async function toBodyInit(
       for (const [key, value] of Object.entries(body.value)) {
         switch (value.type) {
           case "json": {
-            formData.append(
-              key,
-              value.contentType
-                ? new Blob([JSON.stringify(value.value)], {
-                    type: value.contentType,
-                  })
-                : JSON.stringify(value.value)
-            );
+            if (value.contentType === "application/json") {
+              formData.append(
+                key,
+                new Blob([JSON.stringify(value.value)], {
+                  type: "application/json",
+                })
+              );
+            } else {
+              const finalValue =
+                typeof value.value === "string"
+                  ? value.value
+                  : JSON.stringify(value.value);
+
+              formData.append(key, finalValue);
+            }
             break;
           }
           case "file":


### PR DESCRIPTION
Fixes FER-4155

## Short description of the changes made
We no longer stringify strings, leading to '\"string_val\"' as the final stringified request body.

## What was the motivation & context behind this PR?
TwelveLabs incident.

## How has this PR been tested?
pnpm docs:dev
