### PR TITLE
fix: handling optional fields in multipart form in the api playground

### DIFF
--- a/packages/fern-docs/ui/src/playground/fetch-utils/requestToBodyInit.ts
+++ b/packages/fern-docs/ui/src/playground/fetch-utils/requestToBodyInit.ts
@@ -15,14 +15,16 @@ export async function toBodyInit(
       for (const [key, value] of Object.entries(body.value)) {
         switch (value.type) {
           case "json": {
-            formData.append(
-              key,
-              value.contentType
-                ? new Blob([JSON.stringify(value.value)], {
-                    type: value.contentType,
-                  })
-                : JSON.stringify(value.value)
-            );
+            if (value.value !== undefined) {
+              formData.append(
+                key,
+                value.contentType
+                  ? new Blob([JSON.stringify(value.value)], {
+                      type: value.contentType,
+                    })
+                  : JSON.stringify(value.value)
+              );
+            }
             break;
           }
           case "file":


### PR DESCRIPTION
mirror same behavior as object properties for treating optional from data fields
- delete the entry when set to undefined
- add singular entries and add all entries from a dropdown