### PR TITLE
fix: fallback to string when response is not JSONable.

### DIFF
--- a/packages/fern-docs/ui/src/playground/endpoint/PlaygroundEndpoint.tsx
+++ b/packages/fern-docs/ui/src/playground/endpoint/PlaygroundEndpoint.tsx
@@ -144,7 +144,6 @@ export const PlaygroundEndpoint = ({
             break;
           }
           result += decoder.decode(value);
-          console.log(result);
           setResponse(
             loaded({
               type: "stream",

--- a/packages/fern-docs/ui/src/playground/fetch-utils/executeProxyRest.ts
+++ b/packages/fern-docs/ui/src/playground/fetch-utils/executeProxyRest.ts
@@ -101,7 +101,7 @@ export async function executeProxyRest(
             String(new TextEncoder().encode(text).length),
         };
       }
-    } catch (e) {
+    } catch () {
       throw new Error("Failed to read response body");
     }
   }

--- a/packages/fern-docs/ui/src/playground/types/playgroundResponse.ts
+++ b/packages/fern-docs/ui/src/playground/types/playgroundResponse.ts
@@ -10,6 +10,14 @@ export declare namespace PlaygroundResponse {
     time: number;
   }
 
+  export interface String {
+    type: "string";
+    response: ProxyResponse.SerializableBody;
+    contentType: string;
+    time: number;
+    size: string | null;
+  }
+
   export interface Json {
     type: "json";
     response: ProxyResponse.SerializableBody;
@@ -30,4 +38,5 @@ export declare namespace PlaygroundResponse {
 export type PlaygroundResponse =
   | PlaygroundResponse.Stream
   | PlaygroundResponse.Json
+  | PlaygroundResponse.String
   | PlaygroundResponse.File;

--- a/packages/fern-docs/ui/src/playground/utils/oauth.ts
+++ b/packages/fern-docs/ui/src/playground/utils/oauth.ts
@@ -88,6 +88,9 @@ export const oAuthClientCredentialReferencedEndpointLoginFlow = async ({
         setDisplayFailedLogin && setDisplayFailedLogin(true);
       }
     },
+    string: () => {
+      setDisplayFailedLogin && setDisplayFailedLogin(true);
+    },
     file: () => {
       setDisplayFailedLogin && setDisplayFailedLogin(true);
     },


### PR DESCRIPTION
## Short description of the changes made
Fallback to returning a string response when response text cannot be JSON-ed.

## What was the motivation & context behind this PR?
Twelvelabs Incident.

## How has this PR been tested?
Run on Twelvelabs broken SSE endpoint.