### PR TITLE
fix: OpenAPI parser v2 enum default for type reference

### DIFF
--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fern-api/docs-parsers",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern-platform.git",

--- a/packages/parsers/src/index.ts
+++ b/packages/parsers/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./client/generated";
 export * from "./ErrorCollector";
 export * from "./openapi";
 export * from "./openrpc";

--- a/packages/parsers/src/openapi/3.1/paths/request/RequestMediaTypeObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/request/RequestMediaTypeObjectConverter.node.ts
@@ -83,13 +83,16 @@ export class RequestMediaTypeObjectConverterNode extends BaseOpenApiV3_1Converte
           this.context.document,
           undefined
         );
-        this.schema = new ReferenceConverterNode({
-          input: this.input.schema,
-          context: this.context,
-          accessPath: this.accessPath,
-          pathId: "schema",
-          seenSchemas: new Set(),
-        });
+        this.schema = new ReferenceConverterNode(
+          {
+            input: this.input.schema,
+            context: this.context,
+            accessPath: this.accessPath,
+            pathId: "schema",
+            seenSchemas: new Set(),
+          },
+          false
+        );
       } else if (isObjectSchema(this.input.schema)) {
         this.resolvedSchema = this.input.schema;
         const mediaType = MediaType.parse(contentType);

--- a/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
@@ -321,6 +321,8 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
   }
 
   example(includeOptionals: boolean): unknown | undefined {
-    return this.typeShapeNode?.example(includeOptionals);
+    return this.availability?.availability !== "deprecated"
+      ? this.typeShapeNode?.example(includeOptionals)
+      : undefined;
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
@@ -56,7 +56,6 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
         | undefined
       >
     | undefined;
-  nullable: boolean | undefined;
   description: string | undefined;
   name: string | undefined;
   examples: unknown | undefined;
@@ -65,7 +64,8 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
   constructor(
     args: BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs<
       OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject
-    >
+    >,
+    protected nullable?: boolean | undefined
   ) {
     super(args);
     this.safeParse();
@@ -103,13 +103,16 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
       }
       this.seenSchemas.add(refPath);
 
-      this.typeShapeNode = new ReferenceConverterNode({
-        input: this.input,
-        context: this.context,
-        accessPath: this.accessPath,
-        pathId: refPath,
-        seenSchemas: this.seenSchemas,
-      });
+      this.typeShapeNode = new ReferenceConverterNode(
+        {
+          input: this.input,
+          context: this.context,
+          accessPath: this.accessPath,
+          pathId: refPath,
+          seenSchemas: this.seenSchemas,
+        },
+        this.nullable
+      );
     } else {
       // If the object is not a reference object, then it is a schema object, gather all appropriate variables
       this.name = this.input.title;
@@ -151,12 +154,15 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
           seenSchemas: this.seenSchemas,
         });
       } else if (isNonArraySchema(this.input) && this.input.enum != null) {
-        this.typeShapeNode = new EnumConverterNode({
-          input: this.input,
-          context: this.context,
-          accessPath: this.accessPath,
-          pathId: this.pathId,
-        });
+        this.typeShapeNode = new EnumConverterNode(
+          {
+            input: this.input,
+            context: this.context,
+            accessPath: this.accessPath,
+            pathId: this.pathId,
+          },
+          this.nullable
+        );
       }
       // We assume that if one of is defined, it is an object node
       else if (typeof this.input.type === "string") {
@@ -185,42 +191,54 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
             break;
           case "boolean":
             if (isBooleanSchema(this.input)) {
-              this.typeShapeNode = new BooleanConverterNode({
-                input: this.input,
-                context: this.context,
-                accessPath: this.accessPath,
-                pathId: this.pathId,
-              });
+              this.typeShapeNode = new BooleanConverterNode(
+                {
+                  input: this.input,
+                  context: this.context,
+                  accessPath: this.accessPath,
+                  pathId: this.pathId,
+                },
+                this.nullable
+              );
             }
             break;
           case "integer":
             if (isIntegerSchema(this.input)) {
-              this.typeShapeNode = new IntegerConverterNode({
-                input: this.input,
-                context: this.context,
-                accessPath: this.accessPath,
-                pathId: this.pathId,
-              });
+              this.typeShapeNode = new IntegerConverterNode(
+                {
+                  input: this.input,
+                  context: this.context,
+                  accessPath: this.accessPath,
+                  pathId: this.pathId,
+                },
+                this.nullable
+              );
             }
             break;
           case "number":
             if (isNumberSchema(this.input)) {
-              this.typeShapeNode = new NumberConverterNode({
-                input: this.input,
-                context: this.context,
-                accessPath: this.accessPath,
-                pathId: this.pathId,
-              });
+              this.typeShapeNode = new NumberConverterNode(
+                {
+                  input: this.input,
+                  context: this.context,
+                  accessPath: this.accessPath,
+                  pathId: this.pathId,
+                },
+                this.nullable
+              );
             }
             break;
           case "string":
             if (isStringSchema(this.input)) {
-              this.typeShapeNode = new StringConverterNode({
-                input: this.input,
-                context: this.context,
-                accessPath: this.accessPath,
-                pathId: this.pathId,
-              });
+              this.typeShapeNode = new StringConverterNode(
+                {
+                  input: this.input,
+                  context: this.context,
+                  accessPath: this.accessPath,
+                  pathId: this.pathId,
+                },
+                this.nullable
+              );
             }
             break;
           case "null":
@@ -246,16 +264,19 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
         const newType = this.input.type.filter((t) => t !== "null")[0];
 
         if (newType !== "array") {
-          this.typeShapeNode = new SchemaConverterNode({
-            input: {
-              ...this.input,
-              type: newType,
+          this.typeShapeNode = new SchemaConverterNode(
+            {
+              input: {
+                ...this.input,
+                type: newType,
+              },
+              context: this.context,
+              accessPath: this.accessPath,
+              pathId: this.pathId,
+              seenSchemas: this.seenSchemas,
             },
-            context: this.context,
-            accessPath: this.accessPath,
-            pathId: this.pathId,
-            seenSchemas: this.seenSchemas,
-          });
+            this.nullable
+          );
         }
       } else if (this.input.properties != null) {
         this.typeShapeNode = new ObjectConverterNode({

--- a/packages/parsers/src/openapi/3.1/schemas/primitives/BooleanConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/primitives/BooleanConverter.node.ts
@@ -25,7 +25,8 @@ export class BooleanConverterNode extends BaseOpenApiV3_1ConverterNodeWithExampl
   default: boolean | undefined;
 
   constructor(
-    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<BooleanConverterNode.Input>
+    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<BooleanConverterNode.Input>,
+    protected nullable: boolean | undefined
   ) {
     super(args);
     this.safeParse();
@@ -54,9 +55,12 @@ export class BooleanConverterNode extends BaseOpenApiV3_1ConverterNodeWithExampl
     };
   }
 
-  example(): boolean | undefined {
+  example(): string | boolean | undefined {
     return (
-      this.input.example ?? this.input.examples?.[0] ?? this.default ?? false
+      this.input.example ??
+      this.input.examples?.[0] ??
+      this.default ??
+      (this.nullable ? "null" : false)
     );
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/primitives/EnumConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/primitives/EnumConverter.node.ts
@@ -16,7 +16,8 @@ export class EnumConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample<
   values: string[] = [];
 
   constructor(
-    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<OpenAPIV3_1.NonArraySchemaObject>
+    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<OpenAPIV3_1.NonArraySchemaObject>,
+    protected nullable: boolean | undefined
   ) {
     super(args);
     this.safeParse();
@@ -82,7 +83,8 @@ export class EnumConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample<
       this.input.example ??
       this.input.examples?.[0] ??
       this.default ??
-      this.values[0]
+      this.values[0] ??
+      (this.nullable ? "null" : undefined)
     );
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/primitives/IntegerConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/primitives/IntegerConverter.node.ts
@@ -42,7 +42,8 @@ export class IntegerConverterNode extends BaseOpenApiV3_1ConverterNodeWithExampl
   default: number | undefined;
 
   constructor(
-    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<IntegerConverterNode.Input>
+    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<IntegerConverterNode.Input>,
+    protected nullable: boolean | undefined
   ) {
     super(args);
     this.safeParse();
@@ -105,7 +106,12 @@ export class IntegerConverterNode extends BaseOpenApiV3_1ConverterNodeWithExampl
     };
   }
 
-  example(): number | undefined {
-    return this.input.example ?? this.input.examples?.[0] ?? this.default ?? 0;
+  example(): string | number | undefined {
+    return (
+      this.input.example ??
+      this.input.examples?.[0] ??
+      this.default ??
+      (this.nullable ? "null" : 0)
+    );
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/primitives/NumberConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/primitives/NumberConverter.node.ts
@@ -42,7 +42,8 @@ export class NumberConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample
   default: number | undefined;
 
   constructor(
-    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<NumberConverterNode.Input>
+    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<NumberConverterNode.Input>,
+    protected nullable: boolean | undefined
   ) {
     super(args);
     this.safeParse();
@@ -103,7 +104,12 @@ export class NumberConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample
     };
   }
 
-  example(): number | undefined {
-    return this.input.example ?? this.input.examples?.[0] ?? this.default ?? 0;
+  example(): string | number | undefined {
+    return (
+      this.input.example ??
+      this.input.examples?.[0] ??
+      this.default ??
+      (this.nullable ? "null" : 0)
+    );
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/primitives/StringConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/primitives/StringConverter.node.ts
@@ -46,7 +46,8 @@ export class StringConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample
   mimeType: string | undefined;
 
   constructor(
-    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<StringConverterNode.Input>
+    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<StringConverterNode.Input>,
+    protected nullable: boolean | undefined
   ) {
     super(args);
     this.safeParse();
@@ -131,12 +132,15 @@ export class StringConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample
     }
 
     if (this.input.enum != null) {
-      this.enum = new EnumConverterNode({
-        input: this.input,
-        context: this.context,
-        accessPath: this.accessPath,
-        pathId: "enum",
-      });
+      this.enum = new EnumConverterNode(
+        {
+          input: this.input,
+          context: this.context,
+          accessPath: this.accessPath,
+          pathId: "enum",
+        },
+        this.nullable
+      );
     }
   }
 
@@ -178,7 +182,10 @@ export class StringConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample
 
   example(): string | undefined {
     return (
-      this.input.example ?? this.input.examples?.[0] ?? this.default ?? "string"
+      this.input.example ??
+      this.input.examples?.[0] ??
+      this.default ??
+      (this.nullable ? "null" : "string")
     );
   }
 }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/availability.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/availability.json
@@ -265,36 +265,7 @@
         }
       ],
       "errors": [],
-      "examples": [
-        {
-          "path": "/collection/string/string/string/{x-fern-availability_path_param}",
-          "responseStatusCode": 200,
-          "pathParameters": {
-            "id": "string",
-            "active_id": "string",
-            "deprecated_ref_id": "string",
-            "x-fern-availability_path_param": "string"
-          },
-          "queryParameters": {
-            "deprecated_lang": "string",
-            "active_lang": "string",
-            "deprecated_ref_lang": "string",
-            "x-fern-availability_query_param": "string"
-          },
-          "headers": {
-            "X-Deprecated-Header": "string",
-            "X-Active-Header": "string",
-            "X-Deprecated-Ref-Header": "string",
-            "x-fern-availability_header": "string"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "fine_setting": false
-            }
-          }
-        }
-      ],
+      "examples": [],
       "protocol": {
         "type": "rest"
       }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/cohere.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/cohere.json
@@ -27509,7 +27509,10 @@
                       "value": {
                         "type": "id",
                         "id": "Status",
-                        "default": "STATUS_UNSPECIFIED"
+                        "default": {
+                          "type": "enum",
+                          "value": "STATUS_UNSPECIFIED"
+                        }
                       }
                     }
                   }
@@ -37109,7 +37112,10 @@
               "value": {
                 "type": "id",
                 "id": "AuthTokenType",
-                "default": "noscheme"
+                "default": {
+                  "type": "enum",
+                  "value": "noscheme"
+                }
               }
             }
           },
@@ -38733,7 +38739,10 @@
               "value": {
                 "type": "id",
                 "id": "BaseType",
-                "default": "BASE_TYPE_UNSPECIFIED"
+                "default": {
+                  "type": "enum",
+                  "value": "BASE_TYPE_UNSPECIFIED"
+                }
               }
             },
             "description": "The type of the base model."
@@ -38749,7 +38758,10 @@
                   "value": {
                     "type": "id",
                     "id": "Strategy",
-                    "default": "STRATEGY_UNSPECIFIED"
+                    "default": {
+                      "type": "enum",
+                      "value": "STRATEGY_UNSPECIFIED"
+                    }
                   }
                 }
               }
@@ -38886,7 +38898,10 @@
               "value": {
                 "type": "id",
                 "id": "LoraTargetModules",
-                "default": "LORA_TARGET_MODULES_UNSPECIFIED"
+                "default": {
+                  "type": "enum",
+                  "value": "LORA_TARGET_MODULES_UNSPECIFIED"
+                }
               }
             },
             "description": "The combination of LoRA modules to target."
@@ -39172,7 +39187,10 @@
                   "value": {
                     "type": "id",
                     "id": "Status",
-                    "default": "STATUS_UNSPECIFIED"
+                    "default": {
+                      "type": "enum",
+                      "value": "STATUS_UNSPECIFIED"
+                    }
                   }
                 }
               }
@@ -39433,7 +39451,10 @@
               "value": {
                 "type": "id",
                 "id": "Status",
-                "default": "STATUS_UNSPECIFIED"
+                "default": {
+                  "type": "enum",
+                  "value": "STATUS_UNSPECIFIED"
+                }
               }
             },
             "description": "Status of the fine-tuned model."

--- a/packages/parsers/src/openapi/__test__/__snapshots__/nullable.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/nullable.json
@@ -52,15 +52,15 @@
               "id": "string",
               "name": "string",
               "email": "string",
-              "createdAt": "string",
+              "createdAt": "null",
               "settings": {
                 "theme": "string",
                 "notifications": false,
-                "lastModified": "string"
+                "lastModified": "null"
               },
               "stats": {
-                "totalLogins": 0,
-                "lastLoginTime": "string",
+                "totalLogins": "null",
+                "lastLoginTime": "null",
                 "accountStatus": "active"
               }
             }
@@ -122,15 +122,15 @@
               "id": "string",
               "name": "string",
               "email": "string",
-              "createdAt": "string",
+              "createdAt": "null",
               "settings": {
                 "theme": "string",
                 "notifications": false,
-                "lastModified": "string"
+                "lastModified": "null"
               },
               "stats": {
-                "totalLogins": 0,
-                "lastLoginTime": "string",
+                "totalLogins": "null",
+                "lastLoginTime": "null",
                 "accountStatus": "active"
               }
             }
@@ -241,15 +241,15 @@
               "id": "string",
               "name": "string",
               "email": "string",
-              "createdAt": "string",
+              "createdAt": "null",
               "settings": {
                 "theme": "string",
                 "notifications": false,
-                "lastModified": "string"
+                "lastModified": "null"
               },
               "stats": {
-                "totalLogins": 0,
-                "lastLoginTime": "string",
+                "totalLogins": "null",
+                "lastLoginTime": "null",
                 "accountStatus": "active"
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/only-include-referenced-schemas.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/only-include-referenced-schemas.json
@@ -50,7 +50,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -227,7 +230,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -606,7 +612,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -844,7 +853,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -1053,7 +1065,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -1281,7 +1296,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -1899,7 +1917,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -3003,7 +3024,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -3686,7 +3710,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -4835,7 +4862,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -5127,7 +5157,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -5798,7 +5831,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -6206,7 +6242,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -6844,7 +6883,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -7286,7 +7328,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -7957,7 +8002,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -8194,7 +8242,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -8416,7 +8467,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -8694,7 +8748,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -8999,7 +9056,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -9319,7 +9379,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -9608,7 +9671,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -9897,7 +9963,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -10135,7 +10204,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -10479,7 +10551,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -10760,7 +10835,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -11042,7 +11120,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -11319,7 +11400,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -11551,7 +11635,7 @@
               "pages": {
                 "type": "pages",
                 "page": 1,
-                "next": "string",
+                "next": "null",
                 "per_page": 50,
                 "total_pages": 1
               }
@@ -11644,7 +11728,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -12135,7 +12222,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -12451,7 +12541,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -12748,7 +12841,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -13143,7 +13239,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -13398,7 +13497,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -13699,7 +13801,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -14100,7 +14205,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -14388,7 +14496,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -14641,7 +14752,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -15018,7 +15132,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -15270,7 +15387,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -15627,7 +15747,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -16009,7 +16132,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -16179,7 +16305,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -16528,7 +16657,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -16802,7 +16934,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -17063,7 +17198,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -17445,7 +17583,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -17591,7 +17732,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -17738,7 +17882,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -18085,7 +18232,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -18455,7 +18605,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -18767,7 +18920,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -19078,7 +19234,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -19402,7 +19561,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -19628,7 +19787,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -19882,7 +20044,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -20091,7 +20253,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -20281,7 +20443,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -20477,7 +20642,7 @@
                         "height": 100
                       }
                     ],
-                    "url": "string",
+                    "url": "null",
                     "redacted": false
                   },
                   "contacts": {
@@ -20703,7 +20868,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -20954,7 +21122,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -21160,7 +21328,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -21366,7 +21534,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -21572,7 +21740,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -21785,7 +21953,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -22043,7 +22214,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -22257,7 +22428,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -22470,7 +22641,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -22685,7 +22856,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -22900,7 +23071,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -23113,7 +23284,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -23454,7 +23628,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -23667,7 +23841,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -23918,7 +24095,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -24124,7 +24301,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -24358,7 +24535,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -24672,7 +24852,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -24879,7 +25059,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -25086,7 +25266,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -25293,7 +25473,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -25483,7 +25663,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -25685,7 +25868,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -25888,7 +26071,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -26101,7 +26284,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -26645,7 +26831,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -27071,7 +27260,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -27537,7 +27729,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -28115,7 +28310,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -28298,7 +28496,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -28436,7 +28637,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -28582,7 +28786,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -28743,7 +28950,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -28889,7 +29099,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -29043,7 +29256,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -29114,7 +29330,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -29531,7 +29750,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -29778,7 +30000,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -30019,7 +30244,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -30296,7 +30524,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -30619,7 +30850,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -30864,7 +31098,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -31074,7 +31311,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -31316,7 +31556,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -31503,7 +31746,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -31770,7 +32016,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -31979,7 +32228,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -32192,7 +32444,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -32388,7 +32643,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -32598,7 +32856,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -32767,7 +33028,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -33149,7 +33413,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -33383,7 +33650,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -33593,7 +33863,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -33785,7 +34058,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -34034,7 +34310,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -34254,7 +34533,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -34423,7 +34705,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -34692,7 +34977,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -34897,7 +35185,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -35185,7 +35476,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -35400,7 +35694,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -35862,7 +36159,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -36209,7 +36509,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -36537,7 +36840,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -36823,7 +37129,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -37227,7 +37536,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -37763,7 +38075,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -38147,7 +38462,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -38510,7 +38828,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -39016,7 +39337,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/openapi-filter.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/openapi-filter.json
@@ -50,7 +50,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -227,7 +230,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -606,7 +612,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -844,7 +853,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -1053,7 +1065,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -1281,7 +1296,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -1899,7 +1917,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -3003,7 +3024,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -3686,7 +3710,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -4835,7 +4862,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -5127,7 +5157,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -5798,7 +5831,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -6206,7 +6242,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -6844,7 +6883,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -7286,7 +7328,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -7957,7 +8002,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -8194,7 +8242,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -8416,7 +8467,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -8694,7 +8748,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -8999,7 +9056,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -9319,7 +9379,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -9608,7 +9671,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -9897,7 +9963,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -10135,7 +10204,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -10479,7 +10551,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -10760,7 +10835,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -11042,7 +11120,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -11319,7 +11400,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -11551,7 +11635,7 @@
               "pages": {
                 "type": "pages",
                 "page": 1,
-                "next": "string",
+                "next": "null",
                 "per_page": 50,
                 "total_pages": 1
               }
@@ -11644,7 +11728,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -12135,7 +12222,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -12451,7 +12541,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -12748,7 +12841,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -13143,7 +13239,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -13398,7 +13497,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -13699,7 +13801,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -14100,7 +14205,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -14388,7 +14496,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -14641,7 +14752,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -15018,7 +15132,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -15270,7 +15387,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -15627,7 +15747,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -16009,7 +16132,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -16179,7 +16305,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -16528,7 +16657,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -16802,7 +16934,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -17063,7 +17198,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -17445,7 +17583,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -17591,7 +17732,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -17738,7 +17882,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -18085,7 +18232,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -18455,7 +18605,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -18767,7 +18920,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -19078,7 +19234,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -19402,7 +19561,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -19628,7 +19787,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -19882,7 +20044,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -20091,7 +20253,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -20281,7 +20443,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -20477,7 +20642,7 @@
                         "height": 100
                       }
                     ],
-                    "url": "string",
+                    "url": "null",
                     "redacted": false
                   },
                   "contacts": {
@@ -20703,7 +20868,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -20954,7 +21122,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -21160,7 +21328,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -21366,7 +21534,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -21572,7 +21740,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -21785,7 +21953,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -22043,7 +22214,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -22257,7 +22428,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -22470,7 +22641,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -22685,7 +22856,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -22900,7 +23071,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -23113,7 +23284,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -23454,7 +23628,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -23667,7 +23841,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -23918,7 +24095,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -24124,7 +24301,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -24358,7 +24535,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -24672,7 +24852,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -24879,7 +25059,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -25086,7 +25266,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -25293,7 +25473,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -25483,7 +25663,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -25685,7 +25868,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -25888,7 +26071,7 @@
                     "height": 100
                   }
                 ],
-                "url": "string",
+                "url": "null",
                 "redacted": false
               },
               "contacts": {
@@ -26101,7 +26284,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -26645,7 +26831,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -27071,7 +27260,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -27537,7 +27729,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -28115,7 +28310,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -28298,7 +28496,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -28436,7 +28637,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -28582,7 +28786,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -28743,7 +28950,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -28889,7 +29099,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -29043,7 +29256,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -29114,7 +29330,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -29531,7 +29750,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -29778,7 +30000,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -30019,7 +30244,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -30296,7 +30524,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -30619,7 +30850,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -30864,7 +31098,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -31074,7 +31311,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -31316,7 +31556,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -31503,7 +31746,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -31770,7 +32016,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -31979,7 +32228,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -32192,7 +32444,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -32388,7 +32643,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -32598,7 +32856,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -32767,7 +33028,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -33149,7 +33413,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -33383,7 +33650,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -33593,7 +33863,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -33785,7 +34058,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -34034,7 +34310,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -34254,7 +34533,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -34423,7 +34705,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -34692,7 +34977,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -34897,7 +35185,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -35185,7 +35476,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -35400,7 +35694,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -35862,7 +36159,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -36209,7 +36509,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -36537,7 +36840,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -36823,7 +37129,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -37227,7 +37536,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -37763,7 +38075,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -38147,7 +38462,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -38510,7 +38828,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }
@@ -39016,7 +39337,10 @@
                 "value": {
                   "type": "id",
                   "id": "intercom_version",
-                  "default": "2.11"
+                  "default": {
+                    "type": "enum",
+                    "value": "2.11"
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/uploadcare.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/uploadcare.json
@@ -4661,13 +4661,13 @@
             "value": {
               "type": "file",
               "result": {
-                "datetime_removed": "string",
-                "datetime_stored": "string",
+                "datetime_removed": "null",
+                "datetime_stored": "null",
                 "datetime_uploaded": "string",
                 "is_image": true,
                 "is_ready": true,
                 "mime_type": "image/jpeg",
-                "original_file_url": "string",
+                "original_file_url": "null",
                 "original_filename": "EU_4.jpg",
                 "size": 0,
                 "url": "string",
@@ -17700,8 +17700,7 @@
               "type": "alias",
               "value": {
                 "type": "id",
-                "id": "webhook_is_active",
-                "default": true
+                "id": "webhook_is_active"
               }
             }
           },
@@ -17801,8 +17800,7 @@
               "type": "alias",
               "value": {
                 "type": "id",
-                "id": "webhook_is_active",
-                "default": true
+                "id": "webhook_is_active"
               }
             }
           },
@@ -18032,8 +18030,7 @@
               "type": "alias",
               "value": {
                 "type": "id",
-                "id": "webhook_is_active",
-                "default": true
+                "id": "webhook_is_active"
               }
             }
           },


### PR DESCRIPTION
## Short description of the changes made

* adds correct enum default only for reference types
* adds null for example values if none found
* exports FDR types from package

## What was the motivation & context behind this PR?

* papercuts

## How has this PR been tested?

* Snapshot tests
