### PR TITLE
fix: multiple responses even if only one response status code

### DIFF
--- a/packages/fern-docs/ui/src/api-reference/endpoints/EndpointContentCodeSnippets.tsx
+++ b/packages/fern-docs/ui/src/api-reference/endpoints/EndpointContentCodeSnippets.tsx
@@ -134,7 +134,10 @@ const UnmemoizedEndpointContentCodeSnippets: React.FC<
   );
 
   const errorSelector =
-    showErrors && Object.keys(examplesByStatusCode).length > 1 ? (
+    showErrors &&
+    Object.values(examplesByStatusCode).some(
+      (examples) => examples.length > 1
+    ) ? (
       <ErrorExampleSelect
         examplesByStatusCode={examplesByStatusCode}
         selectedExample={selectedExample}
@@ -166,6 +169,8 @@ const UnmemoizedEndpointContentCodeSnippets: React.FC<
             examples[0]?.name != null)
       );
   }, [examplesByKeyAndStatusCode]);
+
+  console.log("a", segmentedControlExamples, selectedExample);
 
   // note: .fern-endpoint-code-snippets is used to detect clicks outside of the code snippets
   // this is used to clear the selected error when the user clicks outside of the error

--- a/packages/fern-docs/ui/src/api-reference/endpoints/EndpointContentCodeSnippets.tsx
+++ b/packages/fern-docs/ui/src/api-reference/endpoints/EndpointContentCodeSnippets.tsx
@@ -170,8 +170,6 @@ const UnmemoizedEndpointContentCodeSnippets: React.FC<
       );
   }, [examplesByKeyAndStatusCode]);
 
-  console.log("a", segmentedControlExamples, selectedExample);
-
   // note: .fern-endpoint-code-snippets is used to detect clicks outside of the code snippets
   // this is used to clear the selected error when the user clicks outside of the error
   return (


### PR DESCRIPTION
## Short description of the changes made

* Previously, we would check if there was more than one status code to render the cross product of status code x example. Now, we check the total number of examples instead to check if we should render a dropdown

## What was the motivation & context behind this PR?

* customer go live 

## How has this PR been tested?


<img width="1720" alt="Screenshot 2025-02-04 at 5 00 21 PM" src="https://github.com/user-attachments/assets/e53c2566-cac5-4206-8804-348290b191ed" />
