### PR TITLE
fix: OpenApi Parser v2 thrashing nullable check

### DIFF
--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fern-api/docs-parsers",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern-platform.git",

--- a/packages/parsers/src/openapi/3.1/schemas/MixedSchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/MixedSchemaConverter.node.ts
@@ -94,6 +94,8 @@ export class MixedSchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTr
   }
 
   example(includeOptionals: boolean): unknown | undefined {
-    return this.typeNodes?.[0]?.example(includeOptionals);
+    return this.nullable
+      ? "null"
+      : this.typeNodes?.[0]?.example(includeOptionals);
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/ReferenceConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/ReferenceConverter.node.ts
@@ -30,15 +30,13 @@ export class ReferenceConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrac
 
     const maybeEnum = resolveSchemaReference(this.input, this.context.document);
     if (maybeEnum?.enum != null && isNonArraySchema(maybeEnum)) {
-      this.maybeEnumConverterNode = new EnumConverterNode(
-        {
-          input: maybeEnum,
-          context: this.context,
-          accessPath: this.accessPath,
-          pathId: this.schemaId ?? "",
-        },
-        this.nullable
-      );
+      this.maybeEnumConverterNode = new EnumConverterNode({
+        input: maybeEnum,
+        context: this.context,
+        accessPath: this.accessPath,
+        pathId: this.schemaId ?? "",
+        nullable: this.nullable,
+      });
     }
 
     if (this.schemaId == null) {
@@ -82,6 +80,7 @@ export class ReferenceConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrac
       accessPath: this.accessPath,
       pathId: this.schemaId ?? "",
       seenSchemas: this.seenSchemas,
+      nullable: this.nullable,
     }).example(includeOptionals);
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
@@ -79,10 +79,13 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
       accessPath: this.accessPath,
       pathId: "x-fern-availability",
     });
-    this.nullable =
-      isNonArraySchema(this.input) && isNullableSchema(this.input)
-        ? this.input.nullable
-        : undefined;
+    // only check if the schema is nullable if not already set, via nullable: true
+    if (!this.nullable) {
+      this.nullable =
+        isNonArraySchema(this.input) && isNullableSchema(this.input)
+          ? this.input.nullable
+          : undefined;
+    }
 
     // Check if the input is a reference object
     if (isReferenceObject(this.input)) {

--- a/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
@@ -83,9 +83,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
     // check if nullable is set. If nullable is false, we will set it, otherwise we will ignore it
     if (isNonArraySchema(this.input) && isNullableSchema(this.input)) {
       this.nullable =
-        this.input.nullable != null && !this.input.nullable
-          ? false
-          : (this.nullable ?? this.input.nullable);
+        this.input.nullable != null ? this.input.nullable : this.nullable;
     }
 
     // Check if the input is a reference object

--- a/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
@@ -81,9 +81,10 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
     });
     // check if nullable is set. If nullable is false, we will set it, otherwise we will ignore it
     if (isNonArraySchema(this.input) && isNullableSchema(this.input)) {
-      this.nullable = !this.input.nullable
-        ? this.input.nullable
-        : this.nullable || this.input.nullable;
+      this.nullable =
+        this.input.nullable != null && !this.input.nullable
+          ? false
+          : (this.nullable ?? this.input.nullable);
     }
 
     // Check if the input is a reference object

--- a/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
@@ -65,7 +65,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
     args: BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs<
       OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject
     >,
-    protected nullable?: boolean | undefined
+    public nullable?: boolean | undefined
   ) {
     super(args);
     this.safeParse();
@@ -79,12 +79,11 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
       accessPath: this.accessPath,
       pathId: "x-fern-availability",
     });
-    // only check if the schema is nullable if not already set, via nullable: true
-    if (!this.nullable) {
-      this.nullable =
-        isNonArraySchema(this.input) && isNullableSchema(this.input)
-          ? this.input.nullable
-          : undefined;
+    // check if nullable is set. If nullable is false, we will set it, otherwise we will ignore it
+    if (isNonArraySchema(this.input) && isNullableSchema(this.input)) {
+      this.nullable = !this.input.nullable
+        ? this.input.nullable
+        : this.nullable || this.input.nullable;
     }
 
     // Check if the input is a reference object

--- a/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
@@ -60,14 +60,15 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
   name: string | undefined;
   examples: unknown | undefined;
   availability: AvailabilityConverterNode | undefined;
+  nullable?: boolean | undefined;
 
   constructor(
     args: BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs<
       OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject
-    >,
-    public nullable?: boolean | undefined
+    > & { nullable?: boolean | undefined }
   ) {
     super(args);
+    this.nullable = args.nullable;
     this.safeParse();
   }
 
@@ -157,15 +158,13 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
           seenSchemas: this.seenSchemas,
         });
       } else if (isNonArraySchema(this.input) && this.input.enum != null) {
-        this.typeShapeNode = new EnumConverterNode(
-          {
-            input: this.input,
-            context: this.context,
-            accessPath: this.accessPath,
-            pathId: this.pathId,
-          },
-          this.nullable
-        );
+        this.typeShapeNode = new EnumConverterNode({
+          input: this.input,
+          context: this.context,
+          accessPath: this.accessPath,
+          pathId: this.pathId,
+          nullable: this.nullable,
+        });
       }
       // We assume that if one of is defined, it is an object node
       else if (typeof this.input.type === "string") {
@@ -194,54 +193,46 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
             break;
           case "boolean":
             if (isBooleanSchema(this.input)) {
-              this.typeShapeNode = new BooleanConverterNode(
-                {
-                  input: this.input,
-                  context: this.context,
-                  accessPath: this.accessPath,
-                  pathId: this.pathId,
-                },
-                this.nullable
-              );
+              this.typeShapeNode = new BooleanConverterNode({
+                input: this.input,
+                context: this.context,
+                accessPath: this.accessPath,
+                pathId: this.pathId,
+                nullable: this.nullable,
+              });
             }
             break;
           case "integer":
             if (isIntegerSchema(this.input)) {
-              this.typeShapeNode = new IntegerConverterNode(
-                {
-                  input: this.input,
-                  context: this.context,
-                  accessPath: this.accessPath,
-                  pathId: this.pathId,
-                },
-                this.nullable
-              );
+              this.typeShapeNode = new IntegerConverterNode({
+                input: this.input,
+                context: this.context,
+                accessPath: this.accessPath,
+                pathId: this.pathId,
+                nullable: this.nullable,
+              });
             }
             break;
           case "number":
             if (isNumberSchema(this.input)) {
-              this.typeShapeNode = new NumberConverterNode(
-                {
-                  input: this.input,
-                  context: this.context,
-                  accessPath: this.accessPath,
-                  pathId: this.pathId,
-                },
-                this.nullable
-              );
+              this.typeShapeNode = new NumberConverterNode({
+                input: this.input,
+                context: this.context,
+                accessPath: this.accessPath,
+                pathId: this.pathId,
+                nullable: this.nullable,
+              });
             }
             break;
           case "string":
             if (isStringSchema(this.input)) {
-              this.typeShapeNode = new StringConverterNode(
-                {
-                  input: this.input,
-                  context: this.context,
-                  accessPath: this.accessPath,
-                  pathId: this.pathId,
-                },
-                this.nullable
-              );
+              this.typeShapeNode = new StringConverterNode({
+                input: this.input,
+                context: this.context,
+                accessPath: this.accessPath,
+                pathId: this.pathId,
+                nullable: this.nullable,
+              });
             }
             break;
           case "null":
@@ -263,23 +254,20 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
         this.input.type.includes("null") &&
         this.input.type.length === 2
       ) {
-        this.nullable = true;
         const newType = this.input.type.filter((t) => t !== "null")[0];
 
         if (newType !== "array") {
-          this.typeShapeNode = new SchemaConverterNode(
-            {
-              input: {
-                ...this.input,
-                type: newType,
-              },
-              context: this.context,
-              accessPath: this.accessPath,
-              pathId: this.pathId,
-              seenSchemas: this.seenSchemas,
+          this.typeShapeNode = new SchemaConverterNode({
+            input: {
+              ...this.input,
+              type: newType,
             },
-            this.nullable
-          );
+            context: this.context,
+            accessPath: this.accessPath,
+            pathId: this.pathId,
+            seenSchemas: this.seenSchemas,
+            nullable: true,
+          });
         }
       } else if (this.input.properties != null) {
         this.typeShapeNode = new ObjectConverterNode({

--- a/packages/parsers/src/openapi/3.1/schemas/__test__/SchemaConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/__test__/SchemaConverter.node.test.ts
@@ -222,5 +222,40 @@ describe("SchemaConverterNode", () => {
         },
       });
     });
+
+    it("should overwrite nullable if set to false", () => {
+      const input: OpenAPIV3_1.NonArraySchemaObject = {
+        type: "string",
+        nullable: false,
+      };
+      const node = new SchemaConverterNode(
+        {
+          input,
+          context: mockContext,
+          accessPath: [],
+          pathId: "test",
+          seenSchemas: new Set(),
+        },
+        true
+      );
+      expect(node.nullable).toBe(false);
+    });
+
+    it("should not overwrite nullable if set to false", () => {
+      const input: OpenAPIV3_1.NonArraySchemaObject = {
+        type: "string",
+      };
+      const node = new SchemaConverterNode(
+        {
+          input,
+          context: mockContext,
+          accessPath: [],
+          pathId: "test",
+          seenSchemas: new Set(),
+        },
+        true
+      );
+      expect(node.nullable).toBe(true);
+    });
   });
 });

--- a/packages/parsers/src/openapi/3.1/schemas/__test__/SchemaConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/__test__/SchemaConverter.node.test.ts
@@ -228,16 +228,14 @@ describe("SchemaConverterNode", () => {
         type: "string",
         nullable: false,
       };
-      const node = new SchemaConverterNode(
-        {
-          input,
-          context: mockContext,
-          accessPath: [],
-          pathId: "test",
-          seenSchemas: new Set(),
-        },
-        true
-      );
+      const node = new SchemaConverterNode({
+        input,
+        context: mockContext,
+        accessPath: [],
+        pathId: "test",
+        seenSchemas: new Set(),
+        nullable: true,
+      });
       expect(node.nullable).toBe(false);
     });
 
@@ -245,16 +243,14 @@ describe("SchemaConverterNode", () => {
       const input: OpenAPIV3_1.NonArraySchemaObject = {
         type: "string",
       };
-      const node = new SchemaConverterNode(
-        {
-          input,
-          context: mockContext,
-          accessPath: [],
-          pathId: "test",
-          seenSchemas: new Set(),
-        },
-        true
-      );
+      const node = new SchemaConverterNode({
+        input,
+        context: mockContext,
+        accessPath: [],
+        pathId: "test",
+        seenSchemas: new Set(),
+        nullable: true,
+      });
       expect(node.nullable).toBe(true);
     });
   });

--- a/packages/parsers/src/openapi/3.1/schemas/primitives/BooleanConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/primitives/BooleanConverter.node.ts
@@ -23,12 +23,15 @@ export class BooleanConverterNode extends BaseOpenApiV3_1ConverterNodeWithExampl
   BooleanConverterNode.Output
 > {
   default: boolean | undefined;
+  nullable: boolean | undefined;
 
   constructor(
-    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<BooleanConverterNode.Input>,
-    protected nullable: boolean | undefined
+    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<BooleanConverterNode.Input> & {
+      nullable: boolean | undefined;
+    }
   ) {
     super(args);
+    this.nullable = args.nullable;
     this.safeParse();
   }
 

--- a/packages/parsers/src/openapi/3.1/schemas/primitives/EnumConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/primitives/EnumConverter.node.ts
@@ -14,12 +14,15 @@ export class EnumConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample<
 > {
   default: string | undefined;
   values: string[] = [];
+  nullable: boolean | undefined;
 
   constructor(
-    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<OpenAPIV3_1.NonArraySchemaObject>,
-    protected nullable: boolean | undefined
+    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<OpenAPIV3_1.NonArraySchemaObject> & {
+      nullable: boolean | undefined;
+    }
   ) {
     super(args);
+    this.nullable = args.nullable;
     this.safeParse();
   }
 

--- a/packages/parsers/src/openapi/3.1/schemas/primitives/IntegerConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/primitives/IntegerConverter.node.ts
@@ -40,12 +40,15 @@ export class IntegerConverterNode extends BaseOpenApiV3_1ConverterNodeWithExampl
   minimum: number | undefined;
   maximum: number | undefined;
   default: number | undefined;
+  nullable: boolean | undefined;
 
   constructor(
-    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<IntegerConverterNode.Input>,
-    protected nullable: boolean | undefined
+    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<IntegerConverterNode.Input> & {
+      nullable: boolean | undefined;
+    }
   ) {
     super(args);
+    this.nullable = args.nullable;
     this.safeParse();
   }
 

--- a/packages/parsers/src/openapi/3.1/schemas/primitives/NumberConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/primitives/NumberConverter.node.ts
@@ -40,12 +40,15 @@ export class NumberConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample
   minimum: number | undefined;
   maximum: number | undefined;
   default: number | undefined;
+  nullable: boolean | undefined;
 
   constructor(
-    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<NumberConverterNode.Input>,
-    protected nullable: boolean | undefined
+    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<NumberConverterNode.Input> & {
+      nullable: boolean | undefined;
+    }
   ) {
     super(args);
+    this.nullable = args.nullable;
     this.safeParse();
   }
 

--- a/packages/parsers/src/openapi/3.1/schemas/primitives/StringConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/primitives/StringConverter.node.ts
@@ -44,12 +44,15 @@ export class StringConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample
   maxLength: number | undefined;
   enum: EnumConverterNode | undefined;
   mimeType: string | undefined;
+  nullable: boolean | undefined;
 
   constructor(
-    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<StringConverterNode.Input>,
-    protected nullable: boolean | undefined
+    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<StringConverterNode.Input> & {
+      nullable: boolean | undefined;
+    }
   ) {
     super(args);
+    this.nullable = args.nullable;
     this.safeParse();
   }
 
@@ -132,15 +135,13 @@ export class StringConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample
     }
 
     if (this.input.enum != null) {
-      this.enum = new EnumConverterNode(
-        {
-          input: this.input,
-          context: this.context,
-          accessPath: this.accessPath,
-          pathId: "enum",
-        },
-        this.nullable
-      );
+      this.enum = new EnumConverterNode({
+        input: this.input,
+        context: this.context,
+        accessPath: this.accessPath,
+        pathId: "enum",
+        nullable: this.nullable,
+      });
     }
   }
 


### PR DESCRIPTION
## Short description of the changes made

* fixes an issue where nullable was being rewritten by checking if `nullable` is set on the object
* now, we only set nullability if `nullable: false` if already set

## What was the motivation & context behind this PR?

* bugfix

## How has this PR been tested?

* unit tests
