### PR TITLE
feat: OpenApi Parser v2 support no content examples and change string example value names to keys

### DIFF
--- a/packages/fern-docs/ui/src/api-reference/endpoints/EndpointContentCodeSnippets.tsx
+++ b/packages/fern-docs/ui/src/api-reference/endpoints/EndpointContentCodeSnippets.tsx
@@ -134,7 +134,10 @@ const UnmemoizedEndpointContentCodeSnippets: React.FC<
   );
 
   const errorSelector =
-    showErrors && Object.keys(examplesByStatusCode).length > 1 ? (
+    showErrors &&
+    Object.values(examplesByStatusCode).some(
+      (examples) => examples.length > 1
+    ) ? (
       <ErrorExampleSelect
         examplesByStatusCode={examplesByStatusCode}
         selectedExample={selectedExample}

--- a/packages/parsers/src/openapi/3.1/paths/ExampleObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/ExampleObjectConverter.node.ts
@@ -415,19 +415,37 @@ export class ExampleObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
 
     const pathParameters = Object.fromEntries(
       Object.entries(this.shapes.pathParameters ?? {}).map(([key, value]) => {
-        return [key, value.example(false)];
+        return [
+          key,
+          value.example({
+            includeOptionals: false,
+            override: key,
+          }),
+        ];
       })
     );
 
     const queryParameters = Object.fromEntries(
       Object.entries(this.shapes.queryParameters ?? {}).map(([key, value]) => {
-        return [key, value.example(false)];
+        return [
+          key,
+          value.example({
+            includeOptionals: false,
+            override: key,
+          }),
+        ];
       })
     );
 
     const requestHeaders = Object.fromEntries(
       Object.entries(this.shapes.requestHeaders ?? {}).map(([key, value]) => {
-        return [key, value.example(false)];
+        return [
+          key,
+          value.example({
+            includeOptionals: false,
+            override: key,
+          }),
+        ];
       })
     );
 

--- a/packages/parsers/src/openapi/3.1/paths/__test__/PathItemObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/PathItemObjectConverter.node.test.ts
@@ -60,9 +60,9 @@ describe("PathItemObjectConverterNode", () => {
         errors: [],
         examples: [
           {
-            path: "/pets/string",
+            path: "/pets/petId",
             pathParameters: {
-              petId: "string",
+              petId: "petId",
             },
             responseStatusCode: 200,
           },

--- a/packages/parsers/src/openapi/3.1/paths/__test__/PathItemObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/PathItemObjectConverter.node.test.ts
@@ -58,7 +58,15 @@ describe("PathItemObjectConverterNode", () => {
         displayName: undefined,
         environments: [],
         errors: [],
-        examples: [],
+        examples: [
+          {
+            path: "/pets/string",
+            pathParameters: {
+              petId: "string",
+            },
+            responseStatusCode: 200,
+          },
+        ],
         id: "endpoint_.getPetsPetId",
         method: "GET",
         namespace: undefined,
@@ -160,7 +168,12 @@ describe("PathItemObjectConverterNode", () => {
           },
         ],
         errors: [],
-        examples: [],
+        examples: [
+          {
+            path: "/pets/{petId}",
+            responseStatusCode: 200,
+          },
+        ],
       });
     });
 

--- a/packages/parsers/src/openapi/3.1/paths/parameters/ParameterBaseObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/parameters/ParameterBaseObjectConverter.node.ts
@@ -2,6 +2,7 @@ import { isNonNullish } from "@fern-api/ui-core-utils";
 import { OpenAPIV3_1 } from "openapi-types";
 import { FernRegistry } from "../../../../client/generated";
 import {
+  BaseOpenApiV3_1ConverterExampleArgs,
   BaseOpenApiV3_1ConverterNodeConstructorArgs,
   BaseOpenApiV3_1ConverterNodeWithExample,
 } from "../../../BaseOpenApiV3_1Converter.node";
@@ -97,7 +98,9 @@ export class ParameterBaseObjectConverterNode extends BaseOpenApiV3_1ConverterNo
     return this.schema?.convert();
   }
 
-  example(includeOptionals: boolean): unknown | undefined {
-    return this.inputExample ?? this.schema?.example(includeOptionals);
+  example(
+    exampleArgs: BaseOpenApiV3_1ConverterExampleArgs
+  ): unknown | undefined {
+    return this.inputExample ?? this.schema?.example(exampleArgs);
   }
 }

--- a/packages/parsers/src/openapi/3.1/paths/request/RequestBodyObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/request/RequestBodyObjectConverter.node.ts
@@ -95,10 +95,12 @@ export class RequestBodyObjectConverterNode extends BaseOpenApiV3_1ConverterNode
 
   webhookExample(): FernRegistry.api.v1.read.ExampleWebhookPayload | undefined {
     return {
-      payload:
-        this.requestBodiesByContentType?.["application/json"]?.schema?.example(
-          true
-        ),
+      payload: this.requestBodiesByContentType?.[
+        "application/json"
+      ]?.schema?.example({
+        includeOptionals: true,
+        override: undefined,
+      }),
     };
   }
 }

--- a/packages/parsers/src/openapi/3.1/paths/request/RequestMediaTypeObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/request/RequestMediaTypeObjectConverter.node.ts
@@ -66,10 +66,19 @@ export class RequestMediaTypeObjectConverterNode extends BaseOpenApiV3_1Converte
     // In order to create a consistent shape, we add a default string key for an example, which should be treated as a global example
     // If there is no global example, we try to generate an example from underlying schemas, which may have examples, or defaults or fallback values
     this.examples = {
-      ...(this.input.example != null || this.schema?.example(false) != null
+      ...(this.input.example != null ||
+      this.schema?.example({
+        includeOptionals: true,
+        override: undefined,
+      }) != null
         ? {
             [GLOBAL_EXAMPLE_NAME]: {
-              value: this.input.example ?? this.schema?.example(false),
+              value:
+                this.input.example ??
+                this.schema?.example({
+                  includeOptionals: true,
+                  override: undefined,
+                }),
             },
           }
         : {}),

--- a/packages/parsers/src/openapi/3.1/paths/response/ResponseMediaTypeObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/response/ResponseMediaTypeObjectConverter.node.ts
@@ -172,7 +172,10 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
 
     responseExamples[GLOBAL_EXAMPLE_NAME] ??= [];
     if (responseExamples[GLOBAL_EXAMPLE_NAME]?.length === 0) {
-      const fallbackExample = this.schema?.example(true);
+      const fallbackExample = this.schema?.example({
+        includeOptionals: true,
+        override: undefined,
+      });
       responseExamples[GLOBAL_EXAMPLE_NAME]?.push(
         fallbackExample != null
           ? {

--- a/packages/parsers/src/openapi/3.1/paths/response/ResponseMediaTypeObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/response/ResponseMediaTypeObjectConverter.node.ts
@@ -53,6 +53,7 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
   unsupportedContentType: string | undefined;
   contentSubtype: string | undefined;
   examples: ExampleObjectConverterNode[] | undefined;
+  empty: boolean | undefined;
 
   constructor(
     args: BaseOpenApiV3_1ConverterNodeConstructorArgs<OpenAPIV3_1.MediaTypeObject>,
@@ -77,55 +78,59 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
   }
 
   parse(contentType: string | undefined): void {
-    const mediaType = MediaType.parse(contentType);
+    if (contentType === "empty") {
+      this.empty = true;
+    } else {
+      const mediaType = MediaType.parse(contentType);
 
-    if (mediaType?.isJSON() || mediaType?.isEventStream()) {
-      this.contentType = "application/json" as const;
-      if (this.input.schema == null) {
-        if (this.streamingFormat == null || this.streamingFormat === "json") {
-          this.context.errors.error({
-            message: "Expected schema for JSON response body. Received null",
-            path: this.accessPath,
+      if (mediaType?.isJSON() || mediaType?.isEventStream()) {
+        this.contentType = "application/json" as const;
+        if (this.input.schema == null) {
+          if (this.streamingFormat == null || this.streamingFormat === "json") {
+            this.context.errors.error({
+              message: "Expected schema for JSON response body. Received null",
+              path: this.accessPath,
+            });
+          }
+        } else {
+          this.schema = new SchemaConverterNode({
+            input: this.input.schema,
+            context: this.context,
+            accessPath: this.accessPath,
+            pathId: "type",
+            seenSchemas: new Set(),
           });
         }
+      } else if (mediaType?.isOctetStream()) {
+        this.contentType = "application/octet-stream" as const;
+        this.contentSubtype = resolveSchemaReference(
+          this.input.schema,
+          this.context.document
+        )?.contentMediaType;
       } else {
-        this.schema = new SchemaConverterNode({
-          input: this.input.schema,
-          context: this.context,
-          accessPath: this.accessPath,
-          pathId: "type",
-          seenSchemas: new Set(),
-        });
-      }
-    } else if (mediaType?.isOctetStream()) {
-      this.contentType = "application/octet-stream" as const;
-      this.contentSubtype = resolveSchemaReference(
-        this.input.schema,
-        this.context.document
-      )?.contentMediaType;
-    } else {
-      this.unsupportedContentType = contentType;
-      if (this.input.schema == null) {
-        this.context.errors.error({
-          message:
-            "Expected schema for plain text response body. Received null",
-          path: this.accessPath,
-        });
-        return;
-      } else {
-        this.schema = new SchemaConverterNode({
-          input: this.input.schema,
-          context: this.context,
-          accessPath: this.accessPath,
-          pathId: this.pathId,
-          seenSchemas: new Set(),
-        });
+        this.unsupportedContentType = contentType;
+        if (this.input.schema == null) {
+          this.context.errors.error({
+            message:
+              "Expected schema for plain text response body. Received null",
+            path: this.accessPath,
+          });
+          return;
+        } else {
+          this.schema = new SchemaConverterNode({
+            input: this.input.schema,
+            context: this.context,
+            accessPath: this.accessPath,
+            pathId: this.pathId,
+            seenSchemas: new Set(),
+          });
+        }
       }
     }
 
     let responseExamples: Record<
       string | symbol,
-      (OpenAPIV3_1.ReferenceObject | OpenAPIV3_1.ExampleObject)[]
+      (OpenAPIV3_1.ReferenceObject | OpenAPIV3_1.ExampleObject | undefined)[]
     > = {};
     if (this.input.example != null) {
       responseExamples[GLOBAL_EXAMPLE_NAME] = [
@@ -141,35 +146,42 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
       };
     }
 
-    if (this.contentType != null || this.unsupportedContentType != null) {
-      const resolvedSchema = resolveSchemaReference(
-        this.input.schema,
-        this.context.document
-      );
+    // if (this.contentType != null || this.unsupportedContentType != null) {
+    const resolvedSchema = resolveSchemaReference(
+      this.input.schema,
+      this.context.document
+    );
 
-      if (resolvedSchema != null) {
-        if (resolvedSchema.example != null) {
-          responseExamples[GLOBAL_EXAMPLE_NAME] ??= [];
-          responseExamples[GLOBAL_EXAMPLE_NAME]?.push({
-            value: resolvedSchema.example,
-          });
-        }
-
-        if (resolvedSchema.examples != null) {
-          responseExamples[GLOBAL_EXAMPLE_NAME] ??= [];
-          responseExamples[GLOBAL_EXAMPLE_NAME]?.push(
-            ...resolvedSchema.examples.map((v) => ({
-              value: v,
-            }))
-          );
-        }
+    if (resolvedSchema != null) {
+      if (resolvedSchema.example != null) {
+        responseExamples[GLOBAL_EXAMPLE_NAME] ??= [];
+        responseExamples[GLOBAL_EXAMPLE_NAME]?.push({
+          value: resolvedSchema.example,
+        });
       }
 
-      responseExamples[GLOBAL_EXAMPLE_NAME] ??= [];
-      responseExamples[GLOBAL_EXAMPLE_NAME]?.push({
-        value: this.schema?.example(true),
-      });
+      if (resolvedSchema.examples != null) {
+        responseExamples[GLOBAL_EXAMPLE_NAME] ??= [];
+        responseExamples[GLOBAL_EXAMPLE_NAME]?.push(
+          ...resolvedSchema.examples.map((v) => ({
+            value: v,
+          }))
+        );
+      }
     }
+
+    responseExamples[GLOBAL_EXAMPLE_NAME] ??= [];
+    if (responseExamples[GLOBAL_EXAMPLE_NAME]?.length === 0) {
+      const fallbackExample = this.schema?.example(true);
+      responseExamples[GLOBAL_EXAMPLE_NAME]?.push(
+        fallbackExample != null
+          ? {
+              value: fallbackExample,
+            }
+          : undefined
+      );
+    }
+    // }
 
     this.examples = singleUndefinedArrayIfNullOrEmpty(this.requests).flatMap(
       (request) =>
@@ -179,10 +191,11 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
           Object.entries(responseExamples)
             .flatMap(([exampleName, examples]) =>
               examples.map((responseExample) =>
-                matchExampleName(exampleName, requestExampleName) &&
-                (this.isExampleDefined(requestExample) ||
-                  this.isExampleDefined(responseExample))
-                  ? new ExampleObjectConverterNode(
+                matchExampleName(exampleName, requestExampleName)
+                  ? // &&
+                    //     (this.isExampleDefined(requestExample) ||
+                    //       this.isExampleDefined(responseExample))
+                    new ExampleObjectConverterNode(
                       {
                         input: {
                           requestExample,
@@ -190,7 +203,10 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
                         },
                         context: this.context,
                         accessPath: this.accessPath,
-                        pathId: ["examples", ""],
+                        pathId:
+                          exampleName != null && exampleName !== ""
+                            ? ["examples", exampleName]
+                            : "examples",
                       },
                       this.path,
                       this.statusCode,
@@ -240,6 +256,12 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
     | FernRegistry.api.latest.HttpResponseBodyShape
     | FernRegistry.api.latest.HttpResponseBodyShape[]
     | undefined {
+    if (this.empty) {
+      return {
+        type: "empty",
+      };
+    }
+
     if (this.contentType != null) {
       switch (this.contentType) {
         case "application/json":

--- a/packages/parsers/src/openapi/3.1/paths/response/ResponseMediaTypeObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/response/ResponseMediaTypeObjectConverter.node.ts
@@ -8,11 +8,14 @@ import {
   BaseOpenApiV3_1ConverterNodeConstructorArgs,
 } from "../../../BaseOpenApiV3_1Converter.node";
 import {
+  APPLICATION_JSON_CONTENT_TYPE,
+  APPLICATION_OCTET_STREAM_CONTENT_TYPE,
+} from "../../../constants";
+import {
   ConstArrayToType,
   SUPPORTED_RESPONSE_CONTENT_TYPES,
   SUPPORTED_STREAMING_FORMATS,
 } from "../../../types/format.types";
-import { resolveExampleReference } from "../../../utils/3.1/resolveExampleReference";
 import { resolveSchemaReference } from "../../../utils/3.1/resolveSchemaReference";
 import { maybeSingleValueToArray } from "../../../utils/maybeSingleValueToArray";
 import { MediaType } from "../../../utils/MediaType";
@@ -68,15 +71,6 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
     this.safeParse(contentType);
   }
 
-  private isExampleDefined(
-    example: OpenAPIV3_1.ExampleObject | OpenAPIV3_1.ReferenceObject | undefined
-  ): boolean {
-    return (
-      example != null &&
-      resolveExampleReference(example, this.context.document)?.value != null
-    );
-  }
-
   parse(contentType: string | undefined): void {
     if (contentType === "empty") {
       this.empty = true;
@@ -84,7 +78,7 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
       const mediaType = MediaType.parse(contentType);
 
       if (mediaType?.isJSON() || mediaType?.isEventStream()) {
-        this.contentType = "application/json" as const;
+        this.contentType = APPLICATION_JSON_CONTENT_TYPE;
         if (this.input.schema == null) {
           if (this.streamingFormat == null || this.streamingFormat === "json") {
             this.context.errors.error({
@@ -102,7 +96,7 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
           });
         }
       } else if (mediaType?.isOctetStream()) {
-        this.contentType = "application/octet-stream" as const;
+        this.contentType = APPLICATION_OCTET_STREAM_CONTENT_TYPE;
         this.contentSubtype = resolveSchemaReference(
           this.input.schema,
           this.context.document
@@ -146,7 +140,6 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
       };
     }
 
-    // if (this.contentType != null || this.unsupportedContentType != null) {
     const resolvedSchema = resolveSchemaReference(
       this.input.schema,
       this.context.document
@@ -184,7 +177,6 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
           : undefined
       );
     }
-    // }
 
     this.examples = singleUndefinedArrayIfNullOrEmpty(this.requests).flatMap(
       (request) =>
@@ -195,10 +187,7 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
             .flatMap(([exampleName, examples]) =>
               examples.map((responseExample) =>
                 matchExampleName(exampleName, requestExampleName)
-                  ? // &&
-                    //     (this.isExampleDefined(requestExample) ||
-                    //       this.isExampleDefined(responseExample))
-                    new ExampleObjectConverterNode(
+                  ? new ExampleObjectConverterNode(
                       {
                         input: {
                           requestExample,

--- a/packages/parsers/src/openapi/3.1/paths/response/ResponseObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/response/ResponseObjectConverter.node.ts
@@ -22,7 +22,6 @@ export class ResponseObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
   headers: Record<string, ParameterBaseObjectConverterNode> | undefined;
   responses: ResponseMediaTypeObjectConverterNode[] | undefined;
   description: string | undefined;
-  emptyResponse: boolean | undefined;
 
   constructor(
     args: BaseOpenApiV3_1ConverterNodeConstructorArgs<
@@ -62,7 +61,23 @@ export class ResponseObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
     });
 
     if (input.content == null) {
-      this.emptyResponse = true;
+      this.responses ??= [];
+      this.responses.push(
+        new ResponseMediaTypeObjectConverterNode(
+          {
+            input: {},
+            context: this.context,
+            accessPath: this.accessPath,
+            pathId: ["content"],
+          },
+          "empty",
+          streamingFormat,
+          this.path,
+          this.statusCode,
+          this.requests,
+          this.shapes
+        )
+      );
     } else {
       Object.entries(input.content ?? {}).forEach(
         ([contentType, contentTypeObject]) => {
@@ -90,10 +105,8 @@ export class ResponseObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
   }
 
   convert(): FernRegistry.api.latest.HttpResponseBodyShape[] | undefined {
-    return this.emptyResponse
-      ? [{ type: "empty" }]
-      : this.responses
-          ?.flatMap((response) => response.convert())
-          .filter(isNonNullish);
+    return this.responses
+      ?.flatMap((response) => response.convert())
+      .filter(isNonNullish);
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/ArrayConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/ArrayConverter.node.ts
@@ -1,6 +1,7 @@
 import { OpenAPIV3_1 } from "openapi-types";
 import { FernRegistry } from "../../../client/generated";
 import {
+  BaseOpenApiV3_1ConverterExampleArgs,
   BaseOpenApiV3_1ConverterNodeWithTracking,
   BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs,
 } from "../../BaseOpenApiV3_1Converter.node";
@@ -59,10 +60,12 @@ export class ArrayConverterNode extends BaseOpenApiV3_1ConverterNodeWithTracking
     }));
   }
 
-  example(includeOptionals: boolean): unknown[] | undefined {
+  example(
+    exampleArgs: BaseOpenApiV3_1ConverterExampleArgs
+  ): unknown[] | undefined {
     return (
       this.input.example ??
-      this.input.examples?.[0] ?? [this.item?.example(includeOptionals)]
+      this.input.examples?.[0] ?? [this.item?.example(exampleArgs)]
     );
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/MixedSchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/MixedSchemaConverter.node.ts
@@ -2,6 +2,7 @@ import { isNonNullish } from "@fern-api/ui-core-utils";
 import { OpenAPIV3_1 } from "openapi-types";
 import { FernRegistry } from "../../../client/generated";
 import {
+  BaseOpenApiV3_1ConverterExampleArgs,
   BaseOpenApiV3_1ConverterNodeWithTracking,
   BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs,
 } from "../../BaseOpenApiV3_1Converter.node";
@@ -93,9 +94,9 @@ export class MixedSchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTr
       : unions;
   }
 
-  example(includeOptionals: boolean): unknown | undefined {
-    return this.nullable
-      ? "null"
-      : this.typeNodes?.[0]?.example(includeOptionals);
+  example(
+    exampleArgs: BaseOpenApiV3_1ConverterExampleArgs
+  ): unknown | undefined {
+    return this.nullable ? "null" : this.typeNodes?.[0]?.example(exampleArgs);
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/ObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/ObjectConverter.node.ts
@@ -2,6 +2,7 @@ import { isNonNullish } from "@fern-api/ui-core-utils";
 import { OpenAPIV3_1 } from "openapi-types";
 import { FernRegistry } from "../../../client/generated";
 import {
+  BaseOpenApiV3_1ConverterExampleArgs,
   BaseOpenApiV3_1ConverterNodeWithTracking,
   BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs,
 } from "../../BaseOpenApiV3_1Converter.node";
@@ -204,7 +205,9 @@ export class ObjectConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
     });
   }
 
-  example(includeOptionals: boolean): Record<string, unknown> | undefined {
+  example({
+    includeOptionals,
+  }: BaseOpenApiV3_1ConverterExampleArgs): Record<string, unknown> | undefined {
     let objectWithAllProperties = {
       ...this.properties,
     };
@@ -240,9 +243,14 @@ export class ObjectConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
       this.requiredProperties != null &&
       this.requiredProperties.length > 0
         ? this.requiredProperties?.reduce<Record<string, unknown>>(
-            (acc, property) => {
-              acc[property] =
-                objectWithAllProperties?.[property]?.example(includeOptionals);
+            (acc, propertyKey) => {
+              console.log("b", propertyKey);
+              const propertyNode = objectWithAllProperties?.[propertyKey];
+              acc[propertyKey] = propertyNode?.example({
+                includeOptionals,
+                override: propertyKey,
+              });
+
               return acc;
             },
             {}
@@ -250,7 +258,11 @@ export class ObjectConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
         : Object.entries(objectWithAllProperties).reduce<
             Record<string, unknown>
           >((acc, [key, value]) => {
-            acc[key] = value?.example(includeOptionals);
+            console.log("c", key);
+            acc[key] = value?.example({
+              includeOptionals,
+              override: key,
+            });
             return acc;
           }, {}))
     );

--- a/packages/parsers/src/openapi/3.1/schemas/ObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/ObjectConverter.node.ts
@@ -244,7 +244,6 @@ export class ObjectConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
       this.requiredProperties.length > 0
         ? this.requiredProperties?.reduce<Record<string, unknown>>(
             (acc, propertyKey) => {
-              console.log("b", propertyKey);
               const propertyNode = objectWithAllProperties?.[propertyKey];
               acc[propertyKey] = propertyNode?.example({
                 includeOptionals,
@@ -258,7 +257,6 @@ export class ObjectConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
         : Object.entries(objectWithAllProperties).reduce<
             Record<string, unknown>
           >((acc, [key, value]) => {
-            console.log("c", key);
             acc[key] = value?.example({
               includeOptionals,
               override: key,

--- a/packages/parsers/src/openapi/3.1/schemas/OneOfConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/OneOfConverter.node.ts
@@ -2,6 +2,7 @@ import { isNonNullish } from "@fern-api/ui-core-utils";
 import { OpenAPIV3_1 } from "openapi-types";
 import { FernRegistry } from "../../../client/generated";
 import {
+  BaseOpenApiV3_1ConverterExampleArgs,
   BaseOpenApiV3_1ConverterNodeWithTracking,
   BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs,
 } from "../../BaseOpenApiV3_1Converter.node";
@@ -176,14 +177,14 @@ export class OneOfConverterNode extends BaseOpenApiV3_1ConverterNodeWithTracking
     return wrappedUnion != null ? [wrappedUnion] : undefined;
   }
 
-  example(includeOptionals: boolean): Record<string, unknown> | undefined {
+  example(
+    exampleArgs: BaseOpenApiV3_1ConverterExampleArgs
+  ): Record<string, unknown> | undefined {
     return (
       this.input.example ??
       this.input.examples?.[0] ??
-      this.undiscriminatedMapping?.[0]?.example(includeOptionals) ??
-      Object.values(this.discriminatedMapping ?? {})[0]?.example(
-        includeOptionals
-      )
+      this.undiscriminatedMapping?.[0]?.example(exampleArgs) ??
+      Object.values(this.discriminatedMapping ?? {})[0]?.example(exampleArgs)
     );
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/ReferenceConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/ReferenceConverter.node.ts
@@ -1,6 +1,7 @@
 import { OpenAPIV3_1 } from "openapi-types";
 import { FernRegistry } from "../../../client/generated";
 import {
+  BaseOpenApiV3_1ConverterExampleArgs,
   BaseOpenApiV3_1ConverterNodeWithTracking,
   BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs,
 } from "../../BaseOpenApiV3_1Converter.node";
@@ -68,7 +69,9 @@ export class ReferenceConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrac
     };
   }
 
-  example(includeOptionals: boolean): unknown | undefined {
+  example(
+    exampleArgs: BaseOpenApiV3_1ConverterExampleArgs
+  ): unknown | undefined {
     const schema = resolveSchemaReference(this.input, this.context.document);
     if (schema == null) {
       return undefined;
@@ -81,6 +84,6 @@ export class ReferenceConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrac
       pathId: this.schemaId ?? "",
       seenSchemas: this.seenSchemas,
       nullable: this.nullable,
-    }).example(includeOptionals);
+    }).example(exampleArgs);
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
@@ -3,6 +3,7 @@ import { OpenAPIV3_1 } from "openapi-types";
 import { UnreachableCaseError } from "ts-essentials";
 import { FernRegistry } from "../../../client/generated";
 import {
+  BaseOpenApiV3_1ConverterExampleArgs,
   BaseOpenApiV3_1ConverterNodeWithExample,
   BaseOpenApiV3_1ConverterNodeWithTracking,
   BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs,
@@ -309,9 +310,11 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
       : mappedShapes?.[0];
   }
 
-  example(includeOptionals: boolean): unknown | undefined {
+  example(
+    exampleArgs: BaseOpenApiV3_1ConverterExampleArgs
+  ): unknown | undefined {
     return this.availability?.availability !== "deprecated"
-      ? this.typeShapeNode?.example(includeOptionals)
+      ? this.typeShapeNode?.example(exampleArgs)
       : undefined;
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/primitives/StringConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/primitives/StringConverter.node.ts
@@ -3,6 +3,7 @@ import { UnreachableCaseError } from "ts-essentials";
 import { FernRegistry } from "../../../../client/generated";
 import { FdrStringType } from "../../../../types/fdr.types";
 import {
+  BaseOpenApiV3_1ConverterExampleArgs,
   BaseOpenApiV3_1ConverterNodeConstructorArgs,
   BaseOpenApiV3_1ConverterNodeWithExample,
 } from "../../../BaseOpenApiV3_1Converter.node";
@@ -181,12 +182,14 @@ export class StringConverterNode extends BaseOpenApiV3_1ConverterNodeWithExample
     };
   }
 
-  example(): string | undefined {
+  example({
+    override,
+  }: BaseOpenApiV3_1ConverterExampleArgs): string | undefined {
     return (
       this.input.example ??
       this.input.examples?.[0] ??
       this.default ??
-      (this.nullable ? "null" : "string")
+      (this.nullable ? "null" : (override ?? "string"))
     );
   }
 }

--- a/packages/parsers/src/openapi/BaseOpenApiV3_1Converter.node.ts
+++ b/packages/parsers/src/openapi/BaseOpenApiV3_1Converter.node.ts
@@ -16,6 +16,11 @@ export type BaseOpenApiV3_1ConverterNodeConstructorArgs<Input> = {
   readonly pathId: string | string[];
 };
 
+export type BaseOpenApiV3_1ConverterExampleArgs = {
+  includeOptionals: boolean;
+  override: unknown;
+};
+
 export abstract class BaseOpenApiV3_1ConverterNode<
   Input,
   Output,
@@ -73,7 +78,9 @@ export abstract class BaseOpenApiV3_1ConverterNodeWithExample<
   Input,
   Output,
 > extends BaseOpenApiV3_1ConverterNode<Input, Output> {
-  abstract example(includeOptionals: boolean): unknown | undefined;
+  abstract example(
+    args: BaseOpenApiV3_1ConverterExampleArgs
+  ): unknown | undefined;
 }
 
 export type BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs<Input> =

--- a/packages/parsers/src/openapi/__test__/__snapshots__/application-json.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/application-json.json
@@ -36,8 +36,8 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "foo": "string",
-              "bar": "string"
+              "foo": "foo",
+              "bar": "bar"
             }
           }
         }
@@ -81,8 +81,8 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "foo": "string",
-              "bar": "string"
+              "foo": "foo",
+              "bar": "bar"
             }
           }
         }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/availability.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/availability.json
@@ -267,22 +267,22 @@
       "errors": [],
       "examples": [
         {
-          "path": "/collection/string/string/{deprecated_ref_id}/{x-fern-availability_path_param}",
+          "path": "/collection/id/active_id/{deprecated_ref_id}/{x-fern-availability_path_param}",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string",
-            "active_id": "string",
-            "x-fern-availability_path_param": "string"
+            "id": "id",
+            "active_id": "active_id",
+            "x-fern-availability_path_param": "x-fern-availability_path_param"
           },
           "queryParameters": {
-            "deprecated_lang": "string",
-            "active_lang": "string",
-            "x-fern-availability_query_param": "string"
+            "deprecated_lang": "deprecated_lang",
+            "active_lang": "active_lang",
+            "x-fern-availability_query_param": "x-fern-availability_query_param"
           },
           "headers": {
-            "X-Deprecated-Header": "string",
-            "X-Active-Header": "string",
-            "x-fern-availability_header": "string"
+            "X-Deprecated-Header": "X-Deprecated-Header",
+            "X-Active-Header": "X-Active-Header",
+            "x-fern-availability_header": "x-fern-availability_header"
           }
         }
       ],

--- a/packages/parsers/src/openapi/__test__/__snapshots__/availability.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/availability.json
@@ -265,7 +265,27 @@
         }
       ],
       "errors": [],
-      "examples": [],
+      "examples": [
+        {
+          "path": "/collection/string/string/{deprecated_ref_id}/{x-fern-availability_path_param}",
+          "responseStatusCode": 200,
+          "pathParameters": {
+            "id": "string",
+            "active_id": "string",
+            "x-fern-availability_path_param": "string"
+          },
+          "queryParameters": {
+            "deprecated_lang": "string",
+            "active_lang": "string",
+            "x-fern-availability_query_param": "string"
+          },
+          "headers": {
+            "X-Deprecated-Header": "string",
+            "X-Active-Header": "string",
+            "x-fern-availability_header": "string"
+          }
+        }
+      ],
       "protocol": {
         "type": "rest"
       }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/cohere.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/cohere.json
@@ -654,7 +654,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -686,7 +686,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -718,7 +718,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -750,7 +750,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -782,7 +782,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -814,7 +814,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -846,7 +846,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -878,7 +878,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -910,7 +910,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -942,7 +942,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -974,7 +974,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -1006,7 +1006,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -1911,61 +1911,61 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "text": "string",
-              "generation_id": "string",
-              "response_id": "string",
+              "text": "text",
+              "generation_id": "generation_id",
+              "response_id": "response_id",
               "citations": [
                 {
                   "start": 0,
                   "end": 0,
-                  "text": "string",
+                  "text": "text",
                   "document_ids": [
-                    "string"
+                    "document_ids"
                   ]
                 }
               ],
               "documents": [
                 {
-                  "id": "string"
+                  "id": "id"
                 }
               ],
               "is_search_required": false,
               "search_queries": [
                 {
-                  "text": "string",
-                  "generation_id": "string"
+                  "text": "text",
+                  "generation_id": "generation_id"
                 }
               ],
               "search_results": [
                 {
                   "search_query": {
-                    "text": "string",
-                    "generation_id": "string"
+                    "text": "text",
+                    "generation_id": "generation_id"
                   },
                   "connector": {
-                    "id": "string"
+                    "id": "id"
                   },
                   "document_ids": [
-                    "string"
+                    "document_ids"
                   ],
-                  "error_message": "string",
+                  "error_message": "error_message",
                   "continue_on_failure": false
                 }
               ],
               "finish_reason": "COMPLETE",
               "tool_calls": [
                 {
-                  "name": "string",
+                  "name": "name",
                   "parameters": {}
                 }
               ],
               "chat_history": [
                 {
                   "role": "CHATBOT",
-                  "message": "string",
+                  "message": "message",
                   "tool_calls": [
                     {
-                      "name": "string",
+                      "name": "name",
                       "parameters": {}
                     }
                   ]
@@ -1973,7 +1973,7 @@
               ],
               "meta": {
                 "api_version": {
-                  "version": "string",
+                  "version": "version",
                   "is_deprecated": false,
                   "is_experimental": false
                 },
@@ -1989,7 +1989,7 @@
                   "output_tokens": 0
                 },
                 "warnings": [
-                  "string"
+                  "warnings"
                 ]
               }
             }
@@ -2054,61 +2054,61 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "text": "string",
-              "generation_id": "string",
-              "response_id": "string",
+              "text": "text",
+              "generation_id": "generation_id",
+              "response_id": "response_id",
               "citations": [
                 {
                   "start": 0,
                   "end": 0,
-                  "text": "string",
+                  "text": "text",
                   "document_ids": [
-                    "string"
+                    "document_ids"
                   ]
                 }
               ],
               "documents": [
                 {
-                  "id": "string"
+                  "id": "id"
                 }
               ],
               "is_search_required": false,
               "search_queries": [
                 {
-                  "text": "string",
-                  "generation_id": "string"
+                  "text": "text",
+                  "generation_id": "generation_id"
                 }
               ],
               "search_results": [
                 {
                   "search_query": {
-                    "text": "string",
-                    "generation_id": "string"
+                    "text": "text",
+                    "generation_id": "generation_id"
                   },
                   "connector": {
-                    "id": "string"
+                    "id": "id"
                   },
                   "document_ids": [
-                    "string"
+                    "document_ids"
                   ],
-                  "error_message": "string",
+                  "error_message": "error_message",
                   "continue_on_failure": false
                 }
               ],
               "finish_reason": "COMPLETE",
               "tool_calls": [
                 {
-                  "name": "string",
+                  "name": "name",
                   "parameters": {}
                 }
               ],
               "chat_history": [
                 {
                   "role": "CHATBOT",
-                  "message": "string",
+                  "message": "message",
                   "tool_calls": [
                     {
-                      "name": "string",
+                      "name": "name",
                       "parameters": {}
                     }
                   ]
@@ -2116,7 +2116,7 @@
               ],
               "meta": {
                 "api_version": {
-                  "version": "string",
+                  "version": "version",
                   "is_deprecated": false,
                   "is_experimental": false
                 },
@@ -2132,7 +2132,7 @@
                   "output_tokens": 0
                 },
                 "warnings": [
-                  "string"
+                  "warnings"
                 ]
               }
             }
@@ -3260,7 +3260,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -3292,7 +3292,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -3324,7 +3324,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -3356,7 +3356,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -3388,7 +3388,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -3420,7 +3420,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -3452,7 +3452,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -3484,7 +3484,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -3516,7 +3516,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -3548,7 +3548,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -3580,7 +3580,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -3612,7 +3612,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -4330,35 +4330,35 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string",
+              "id": "id",
               "finish_reason": "COMPLETE",
               "message": {
                 "role": "assistant",
                 "tool_calls": [
                   {
-                    "id": "string",
+                    "id": "id",
                     "type": "function",
                     "function": {
-                      "name": "string",
-                      "arguments": "string"
+                      "name": "name",
+                      "arguments": "arguments"
                     }
                   }
                 ],
-                "tool_plan": "string",
+                "tool_plan": "tool_plan",
                 "content": [
                   {
                     "type": "text",
-                    "text": "string"
+                    "text": "text"
                   }
                 ],
                 "citations": [
                   {
                     "start": 0,
                     "end": 0,
-                    "text": "string",
+                    "text": "text",
                     "sources": [
                       {
-                        "id": "string",
+                        "id": "id",
                         "tool_output": {}
                       }
                     ]
@@ -4379,7 +4379,7 @@
               },
               "logprobs": [
                 {
-                  "text": "string",
+                  "text": "text",
                   "token_ids": [
                     0
                   ],
@@ -4447,35 +4447,35 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string",
+              "id": "id",
               "finish_reason": "COMPLETE",
               "message": {
                 "role": "assistant",
                 "tool_calls": [
                   {
-                    "id": "string",
+                    "id": "id",
                     "type": "function",
                     "function": {
-                      "name": "string",
-                      "arguments": "string"
+                      "name": "name",
+                      "arguments": "arguments"
                     }
                   }
                 ],
-                "tool_plan": "string",
+                "tool_plan": "tool_plan",
                 "content": [
                   {
                     "type": "text",
-                    "text": "string"
+                    "text": "text"
                   }
                 ],
                 "citations": [
                   {
                     "start": 0,
                     "end": 0,
-                    "text": "string",
+                    "text": "text",
                     "sources": [
                       {
-                        "id": "string",
+                        "id": "id",
                         "tool_output": {}
                       }
                     ]
@@ -4496,7 +4496,7 @@
               },
               "logprobs": [
                 {
-                  "text": "string",
+                  "text": "text",
                   "token_ids": [
                     0
                   ],
@@ -5315,7 +5315,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -5347,7 +5347,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -5379,7 +5379,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -5411,7 +5411,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -5443,7 +5443,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -5475,7 +5475,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -5507,7 +5507,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -5539,7 +5539,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -5571,7 +5571,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -5603,7 +5603,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -5635,7 +5635,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -5667,7 +5667,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -6027,17 +6027,17 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string",
-              "prompt": "string",
+              "id": "id",
+              "prompt": "prompt",
               "generations": [
                 {
-                  "id": "string",
-                  "text": "string",
+                  "id": "id",
+                  "text": "text",
                   "index": 0,
                   "likelihood": 0,
                   "token_likelihoods": [
                     {
-                      "token": "string",
+                      "token": "token",
                       "likelihood": 0
                     }
                   ]
@@ -6045,7 +6045,7 @@
               ],
               "meta": {
                 "api_version": {
-                  "version": "string",
+                  "version": "version",
                   "is_deprecated": false,
                   "is_experimental": false
                 },
@@ -6061,7 +6061,7 @@
                   "output_tokens": 0
                 },
                 "warnings": [
-                  "string"
+                  "warnings"
                 ]
               }
             }
@@ -6131,7 +6131,7 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "text": "string",
+              "text": "text",
               "index": 0,
               "is_finished": false,
               "event_type": "text-generation"
@@ -6202,17 +6202,17 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string",
-              "prompt": "string",
+              "id": "id",
+              "prompt": "prompt",
               "generations": [
                 {
-                  "id": "string",
-                  "text": "string",
+                  "id": "id",
+                  "text": "text",
                   "index": 0,
                   "likelihood": 0,
                   "token_likelihoods": [
                     {
-                      "token": "string",
+                      "token": "token",
                       "likelihood": 0
                     }
                   ]
@@ -6220,7 +6220,7 @@
               ],
               "meta": {
                 "api_version": {
-                  "version": "string",
+                  "version": "version",
                   "is_deprecated": false,
                   "is_experimental": false
                 },
@@ -6236,7 +6236,7 @@
                   "output_tokens": 0
                 },
                 "warnings": [
-                  "string"
+                  "warnings"
                 ]
               }
             }
@@ -6306,7 +6306,7 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "text": "string",
+              "text": "text",
               "index": 0,
               "is_finished": false,
               "event_type": "text-generation"
@@ -6557,7 +6557,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -6589,7 +6589,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -6621,7 +6621,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -6653,7 +6653,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -6685,7 +6685,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -6717,7 +6717,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -6749,7 +6749,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -6781,7 +6781,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -6813,7 +6813,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -6845,7 +6845,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -6877,7 +6877,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -6909,7 +6909,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -7167,7 +7167,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -7199,7 +7199,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -7231,7 +7231,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -7263,7 +7263,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -7295,7 +7295,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -7327,7 +7327,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -7359,7 +7359,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -7391,7 +7391,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -7423,7 +7423,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -7455,7 +7455,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -7487,7 +7487,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -7519,7 +7519,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -10913,7 +10913,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -10945,7 +10945,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -10977,7 +10977,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11009,7 +11009,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11041,7 +11041,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11073,7 +11073,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11105,7 +11105,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11137,7 +11137,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11169,7 +11169,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11201,7 +11201,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11233,7 +11233,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11265,7 +11265,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11284,17 +11284,17 @@
             "value": {
               "embed_jobs": [
                 {
-                  "job_id": "string",
-                  "name": "string",
+                  "job_id": "job_id",
+                  "name": "name",
                   "status": "processing",
-                  "created_at": "string",
-                  "input_dataset_id": "string",
-                  "output_dataset_id": "string",
-                  "model": "string",
+                  "created_at": "created_at",
+                  "input_dataset_id": "input_dataset_id",
+                  "output_dataset_id": "output_dataset_id",
+                  "model": "model",
                   "truncate": "START",
                   "meta": {
                     "api_version": {
-                      "version": "string",
+                      "version": "version",
                       "is_deprecated": false,
                       "is_experimental": false
                     },
@@ -11310,7 +11310,7 @@
                       "output_tokens": 0
                     },
                     "warnings": [
-                      "string"
+                      "warnings"
                     ]
                   }
                 }
@@ -11502,7 +11502,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11534,7 +11534,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11566,7 +11566,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11598,7 +11598,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11630,7 +11630,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11662,7 +11662,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11694,7 +11694,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11726,7 +11726,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11758,7 +11758,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11790,7 +11790,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11822,7 +11822,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11854,7 +11854,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -11871,10 +11871,10 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "job_id": "string",
+              "job_id": "job_id",
               "meta": {
                 "api_version": {
-                  "version": "string",
+                  "version": "version",
                   "is_deprecated": false,
                   "is_experimental": false
                 },
@@ -11890,7 +11890,7 @@
                   "output_tokens": 0
                 },
                 "warnings": [
-                  "string"
+                  "warnings"
                 ]
               }
             }
@@ -12091,7 +12091,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12123,7 +12123,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12155,7 +12155,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12187,7 +12187,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12219,7 +12219,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12251,7 +12251,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12283,7 +12283,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12315,7 +12315,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12347,7 +12347,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12379,7 +12379,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12411,7 +12411,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12443,7 +12443,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12455,7 +12455,7 @@
           "path": "/v1/embed-jobs/{id}",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"
@@ -12463,17 +12463,17 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "job_id": "string",
-              "name": "string",
+              "job_id": "job_id",
+              "name": "name",
               "status": "processing",
-              "created_at": "string",
-              "input_dataset_id": "string",
-              "output_dataset_id": "string",
-              "model": "string",
+              "created_at": "created_at",
+              "input_dataset_id": "input_dataset_id",
+              "output_dataset_id": "output_dataset_id",
+              "model": "model",
               "truncate": "START",
               "meta": {
                 "api_version": {
-                  "version": "string",
+                  "version": "version",
                   "is_deprecated": false,
                   "is_experimental": false
                 },
@@ -12489,7 +12489,7 @@
                   "output_tokens": 0
                 },
                 "warnings": [
-                  "string"
+                  "warnings"
                 ]
               }
             }
@@ -12694,7 +12694,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12726,7 +12726,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12758,7 +12758,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12790,7 +12790,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12822,7 +12822,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12854,7 +12854,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12886,7 +12886,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12918,7 +12918,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12950,7 +12950,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -12982,7 +12982,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -13014,7 +13014,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -13046,7 +13046,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -13058,7 +13058,7 @@
           "path": "/v1/embed-jobs/{id}/cancel",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"
@@ -13606,7 +13606,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -13638,7 +13638,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -13670,7 +13670,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -13702,7 +13702,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -13734,7 +13734,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -13766,7 +13766,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -13798,7 +13798,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -13830,7 +13830,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -13862,7 +13862,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -13894,7 +13894,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -13926,7 +13926,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -13958,7 +13958,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -14347,7 +14347,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -14379,7 +14379,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -14411,7 +14411,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -14443,7 +14443,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -14475,7 +14475,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -14507,7 +14507,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -14539,7 +14539,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -14571,7 +14571,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -14603,7 +14603,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -14635,7 +14635,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -14667,7 +14667,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -14699,7 +14699,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -15211,7 +15211,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -15243,7 +15243,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -15275,7 +15275,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -15307,7 +15307,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -15339,7 +15339,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -15371,7 +15371,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -15403,7 +15403,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -15435,7 +15435,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -15467,7 +15467,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -15499,7 +15499,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -15531,7 +15531,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -15563,7 +15563,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -15967,7 +15967,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -15999,7 +15999,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16031,7 +16031,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16063,7 +16063,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16095,7 +16095,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16127,7 +16127,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16159,7 +16159,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16191,7 +16191,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16223,7 +16223,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16255,7 +16255,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16287,7 +16287,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16319,7 +16319,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16331,9 +16331,9 @@
           "path": "/v1/datasets",
           "responseStatusCode": 200,
           "queryParameters": {
-            "datasetType": "string",
-            "before": "string",
-            "after": "string",
+            "datasetType": "datasetType",
+            "before": "before",
+            "after": "after",
             "limit": 0,
             "offset": 0,
             "validationStatus": "unknown"
@@ -16346,40 +16346,40 @@
             "value": {
               "datasets": [
                 {
-                  "id": "string",
-                  "name": "string",
-                  "created_at": "string",
-                  "updated_at": "string",
+                  "id": "id",
+                  "name": "name",
+                  "created_at": "created_at",
+                  "updated_at": "updated_at",
                   "dataset_type": "embed-input",
                   "validation_status": "unknown",
-                  "validation_error": "string",
-                  "schema": "string",
+                  "validation_error": "validation_error",
+                  "schema": "schema",
                   "required_fields": [
-                    "string"
+                    "required_fields"
                   ],
                   "preserve_fields": [
-                    "string"
+                    "preserve_fields"
                   ],
                   "dataset_parts": [
                     {
-                      "id": "string",
-                      "name": "string",
-                      "url": "string",
+                      "id": "id",
+                      "name": "name",
+                      "url": "url",
                       "index": 0,
                       "size_bytes": 0,
                       "num_rows": 0,
-                      "original_url": "string",
+                      "original_url": "original_url",
                       "samples": [
-                        "string"
+                        "samples"
                       ]
                     }
                   ],
                   "validation_warnings": [
-                    "string"
+                    "validation_warnings"
                   ],
                   "parse_info": {
-                    "separator": "string",
-                    "delimiter": "string"
+                    "separator": "separator",
+                    "delimiter": "delimiter"
                   },
                   "metrics": {
                     "finetune_dataset_metrics": {
@@ -16400,15 +16400,15 @@
                       "chat_data_metrics": {
                         "num_train_turns": 0,
                         "num_eval_turns": 0,
-                        "preamble": "string"
+                        "preamble": "preamble"
                       },
                       "classify_data_metrics": {
                         "label_metrics": [
                           {
                             "total_examples": 0,
-                            "label": "string",
+                            "label": "label",
                             "samples": [
-                              "string"
+                              "samples"
                             ]
                           }
                         ]
@@ -16757,7 +16757,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16789,7 +16789,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16821,7 +16821,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16853,7 +16853,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16885,7 +16885,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16917,7 +16917,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16949,7 +16949,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -16981,7 +16981,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17013,7 +17013,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17045,7 +17045,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17077,7 +17077,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17109,7 +17109,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17121,18 +17121,18 @@
           "path": "/v1/datasets",
           "responseStatusCode": 200,
           "queryParameters": {
-            "name": "string",
+            "name": "name",
             "type": "embed-input",
             "keep_original_file": false,
             "skip_malformed_input": false,
             "keep_fields": [
-              "string"
+              "keep_fields"
             ],
             "optional_fields": [
-              "string"
+              "optional_fields"
             ],
-            "text_separator": "string",
-            "csv_delimiter": "string"
+            "text_separator": "text_separator",
+            "csv_delimiter": "csv_delimiter"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"
@@ -17140,7 +17140,7 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string"
+              "id": "id"
             }
           },
           "snippets": {
@@ -17315,7 +17315,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17347,7 +17347,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17379,7 +17379,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17411,7 +17411,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17443,7 +17443,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17475,7 +17475,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17507,7 +17507,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17539,7 +17539,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17571,7 +17571,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17603,7 +17603,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17635,7 +17635,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17667,7 +17667,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17871,7 +17871,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17903,7 +17903,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17935,7 +17935,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17967,7 +17967,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -17999,7 +17999,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18031,7 +18031,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18063,7 +18063,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18095,7 +18095,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18127,7 +18127,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18159,7 +18159,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18191,7 +18191,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18223,7 +18223,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18235,7 +18235,7 @@
           "path": "/v1/datasets/{id}",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"
@@ -18244,40 +18244,40 @@
             "type": "json",
             "value": {
               "dataset": {
-                "id": "string",
-                "name": "string",
-                "created_at": "string",
-                "updated_at": "string",
+                "id": "id",
+                "name": "name",
+                "created_at": "created_at",
+                "updated_at": "updated_at",
                 "dataset_type": "embed-input",
                 "validation_status": "unknown",
-                "validation_error": "string",
-                "schema": "string",
+                "validation_error": "validation_error",
+                "schema": "schema",
                 "required_fields": [
-                  "string"
+                  "required_fields"
                 ],
                 "preserve_fields": [
-                  "string"
+                  "preserve_fields"
                 ],
                 "dataset_parts": [
                   {
-                    "id": "string",
-                    "name": "string",
-                    "url": "string",
+                    "id": "id",
+                    "name": "name",
+                    "url": "url",
                     "index": 0,
                     "size_bytes": 0,
                     "num_rows": 0,
-                    "original_url": "string",
+                    "original_url": "original_url",
                     "samples": [
-                      "string"
+                      "samples"
                     ]
                   }
                 ],
                 "validation_warnings": [
-                  "string"
+                  "validation_warnings"
                 ],
                 "parse_info": {
-                  "separator": "string",
-                  "delimiter": "string"
+                  "separator": "separator",
+                  "delimiter": "delimiter"
                 },
                 "metrics": {
                   "finetune_dataset_metrics": {
@@ -18298,15 +18298,15 @@
                     "chat_data_metrics": {
                       "num_train_turns": 0,
                       "num_eval_turns": 0,
-                      "preamble": "string"
+                      "preamble": "preamble"
                     },
                     "classify_data_metrics": {
                       "label_metrics": [
                         {
                           "total_examples": 0,
-                          "label": "string",
+                          "label": "label",
                           "samples": [
-                            "string"
+                            "samples"
                           ]
                         }
                       ]
@@ -18489,7 +18489,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18521,7 +18521,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18553,7 +18553,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18585,7 +18585,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18617,7 +18617,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18649,7 +18649,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18681,7 +18681,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18713,7 +18713,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18745,7 +18745,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18777,7 +18777,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18809,7 +18809,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18841,7 +18841,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -18853,7 +18853,7 @@
           "path": "/v1/datasets/{id}",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"
@@ -19220,7 +19220,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19252,7 +19252,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19284,7 +19284,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19316,7 +19316,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19348,7 +19348,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19380,7 +19380,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19412,7 +19412,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19444,7 +19444,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19476,7 +19476,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19508,7 +19508,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19540,7 +19540,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19572,7 +19572,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19869,7 +19869,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19901,7 +19901,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19933,7 +19933,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19965,7 +19965,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -19997,7 +19997,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20029,7 +20029,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20061,7 +20061,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20093,7 +20093,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20125,7 +20125,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20157,7 +20157,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20189,7 +20189,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20221,7 +20221,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20610,7 +20610,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20642,7 +20642,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20674,7 +20674,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20706,7 +20706,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20738,7 +20738,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20770,7 +20770,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20802,7 +20802,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20834,7 +20834,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20866,7 +20866,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20898,7 +20898,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20930,7 +20930,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -20962,7 +20962,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21195,7 +21195,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21227,7 +21227,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21259,7 +21259,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21291,7 +21291,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21323,7 +21323,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21355,7 +21355,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21387,7 +21387,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21419,7 +21419,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21451,7 +21451,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21483,7 +21483,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21515,7 +21515,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21547,7 +21547,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21570,23 +21570,23 @@
             "value": {
               "connectors": [
                 {
-                  "id": "string",
-                  "organization_id": "string",
-                  "name": "string",
-                  "description": "string",
-                  "url": "string",
-                  "created_at": "string",
-                  "updated_at": "string",
+                  "id": "id",
+                  "organization_id": "organization_id",
+                  "name": "name",
+                  "description": "description",
+                  "url": "url",
+                  "created_at": "created_at",
+                  "updated_at": "updated_at",
                   "excludes": [
-                    "string"
+                    "excludes"
                   ],
-                  "auth_type": "string",
+                  "auth_type": "auth_type",
                   "oauth": {
-                    "client_id": "string",
-                    "client_secret": "string",
-                    "authorize_url": "string",
-                    "token_url": "string",
-                    "scope": "string"
+                    "client_id": "client_id",
+                    "client_secret": "client_secret",
+                    "authorize_url": "authorize_url",
+                    "token_url": "token_url",
+                    "scope": "scope"
                   },
                   "auth_status": "valid",
                   "active": false,
@@ -21760,7 +21760,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21792,7 +21792,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21824,7 +21824,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21856,7 +21856,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21888,7 +21888,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21920,7 +21920,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21952,7 +21952,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -21984,7 +21984,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22016,7 +22016,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22048,7 +22048,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22080,7 +22080,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22112,7 +22112,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22130,23 +22130,23 @@
             "type": "json",
             "value": {
               "connector": {
-                "id": "string",
-                "organization_id": "string",
-                "name": "string",
-                "description": "string",
-                "url": "string",
-                "created_at": "string",
-                "updated_at": "string",
+                "id": "id",
+                "organization_id": "organization_id",
+                "name": "name",
+                "description": "description",
+                "url": "url",
+                "created_at": "created_at",
+                "updated_at": "updated_at",
                 "excludes": [
-                  "string"
+                  "excludes"
                 ],
-                "auth_type": "string",
+                "auth_type": "auth_type",
                 "oauth": {
-                  "client_id": "string",
-                  "client_secret": "string",
-                  "authorize_url": "string",
-                  "token_url": "string",
-                  "scope": "string"
+                  "client_id": "client_id",
+                  "client_secret": "client_secret",
+                  "authorize_url": "authorize_url",
+                  "token_url": "token_url",
+                  "scope": "scope"
                 },
                 "auth_status": "valid",
                 "active": false,
@@ -22329,7 +22329,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22361,7 +22361,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22393,7 +22393,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22425,7 +22425,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22457,7 +22457,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22489,7 +22489,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22521,7 +22521,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22553,7 +22553,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22585,7 +22585,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22617,7 +22617,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22649,7 +22649,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22681,7 +22681,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22693,7 +22693,7 @@
           "path": "/v1/connectors/{id}",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"
@@ -22702,23 +22702,23 @@
             "type": "json",
             "value": {
               "connector": {
-                "id": "string",
-                "organization_id": "string",
-                "name": "string",
-                "description": "string",
-                "url": "string",
-                "created_at": "string",
-                "updated_at": "string",
+                "id": "id",
+                "organization_id": "organization_id",
+                "name": "name",
+                "description": "description",
+                "url": "url",
+                "created_at": "created_at",
+                "updated_at": "updated_at",
                 "excludes": [
-                  "string"
+                  "excludes"
                 ],
-                "auth_type": "string",
+                "auth_type": "auth_type",
                 "oauth": {
-                  "client_id": "string",
-                  "client_secret": "string",
-                  "authorize_url": "string",
-                  "token_url": "string",
-                  "scope": "string"
+                  "client_id": "client_id",
+                  "client_secret": "client_secret",
+                  "authorize_url": "authorize_url",
+                  "token_url": "token_url",
+                  "scope": "scope"
                 },
                 "auth_status": "valid",
                 "active": false,
@@ -22913,7 +22913,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22945,7 +22945,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -22977,7 +22977,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23009,7 +23009,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23041,7 +23041,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23073,7 +23073,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23105,7 +23105,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23137,7 +23137,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23169,7 +23169,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23201,7 +23201,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23233,7 +23233,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23265,7 +23265,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23277,7 +23277,7 @@
           "path": "/v1/connectors/{id}",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"
@@ -23286,23 +23286,23 @@
             "type": "json",
             "value": {
               "connector": {
-                "id": "string",
-                "organization_id": "string",
-                "name": "string",
-                "description": "string",
-                "url": "string",
-                "created_at": "string",
-                "updated_at": "string",
+                "id": "id",
+                "organization_id": "organization_id",
+                "name": "name",
+                "description": "description",
+                "url": "url",
+                "created_at": "created_at",
+                "updated_at": "updated_at",
                 "excludes": [
-                  "string"
+                  "excludes"
                 ],
-                "auth_type": "string",
+                "auth_type": "auth_type",
                 "oauth": {
-                  "client_id": "string",
-                  "client_secret": "string",
-                  "authorize_url": "string",
-                  "token_url": "string",
-                  "scope": "string"
+                  "client_id": "client_id",
+                  "client_secret": "client_secret",
+                  "authorize_url": "authorize_url",
+                  "token_url": "token_url",
+                  "scope": "scope"
                 },
                 "auth_status": "valid",
                 "active": false,
@@ -23485,7 +23485,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23517,7 +23517,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23549,7 +23549,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23581,7 +23581,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23613,7 +23613,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23645,7 +23645,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23677,7 +23677,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23709,7 +23709,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23741,7 +23741,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23773,7 +23773,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23805,7 +23805,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23837,7 +23837,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -23849,7 +23849,7 @@
           "path": "/v1/connectors/{id}",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"
@@ -24070,7 +24070,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24102,7 +24102,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24134,7 +24134,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24166,7 +24166,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24198,7 +24198,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24230,7 +24230,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24262,7 +24262,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24294,7 +24294,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24326,7 +24326,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24358,7 +24358,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24390,7 +24390,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24422,7 +24422,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24434,10 +24434,10 @@
           "path": "/v1/connectors/{id}/oauth/authorize",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "queryParameters": {
-            "after_token_redirect": "string"
+            "after_token_redirect": "after_token_redirect"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"
@@ -24445,7 +24445,7 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "redirect_url": "string"
+              "redirect_url": "redirect_url"
             }
           },
           "snippets": {
@@ -24643,7 +24643,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24675,7 +24675,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24707,7 +24707,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24739,7 +24739,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24771,7 +24771,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24803,7 +24803,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24835,7 +24835,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24867,7 +24867,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24899,7 +24899,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24931,7 +24931,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24963,7 +24963,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -24995,7 +24995,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25015,13 +25015,13 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "name": "string",
+              "name": "name",
               "endpoints": [
                 "chat"
               ],
               "finetuned": false,
               "context_length": 0,
-              "tokenizer_url": "string",
+              "tokenizer_url": "tokenizer_url",
               "default_endpoints": [
                 "chat"
               ]
@@ -25186,7 +25186,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25218,7 +25218,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25250,7 +25250,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25282,7 +25282,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25314,7 +25314,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25346,7 +25346,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25378,7 +25378,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25410,7 +25410,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25442,7 +25442,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25474,7 +25474,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25506,7 +25506,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25538,7 +25538,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25551,7 +25551,7 @@
           "responseStatusCode": 200,
           "queryParameters": {
             "page_size": 0,
-            "page_token": "string",
+            "page_token": "page_token",
             "endpoint": "chat",
             "default_only": false
           },
@@ -25560,19 +25560,19 @@
             "value": {
               "models": [
                 {
-                  "name": "string",
+                  "name": "name",
                   "endpoints": [
                     "chat"
                   ],
                   "finetuned": false,
                   "context_length": 0,
-                  "tokenizer_url": "string",
+                  "tokenizer_url": "tokenizer_url",
                   "default_endpoints": [
                     "chat"
                   ]
                 }
               ],
-              "next_page_token": "string"
+              "next_page_token": "next_page_token"
             }
           },
           "snippets": {
@@ -25771,7 +25771,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25803,7 +25803,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25835,7 +25835,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25867,7 +25867,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25899,7 +25899,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25931,7 +25931,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25963,7 +25963,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -25995,7 +25995,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -26027,7 +26027,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -26059,7 +26059,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -26091,7 +26091,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -26123,7 +26123,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "data": "string"
+                  "data": "data"
                 }
               }
             }
@@ -26141,8 +26141,8 @@
             "type": "json",
             "value": {
               "valid": false,
-              "organization_id": "string",
-              "owner_id": "string"
+              "organization_id": "organization_id",
+              "owner_id": "owner_id"
             }
           }
         }
@@ -26305,7 +26305,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -26327,7 +26327,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -26349,7 +26349,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -26371,7 +26371,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -26393,7 +26393,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -26415,7 +26415,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -26428,8 +26428,8 @@
           "responseStatusCode": 200,
           "queryParameters": {
             "page_size": 0,
-            "page_token": "string",
-            "order_by": "string"
+            "page_token": "page_token",
+            "order_by": "order_by"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"
@@ -26647,7 +26647,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -26669,7 +26669,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -26691,7 +26691,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -26713,7 +26713,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -26735,7 +26735,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -26757,7 +26757,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -26775,18 +26775,18 @@
             "type": "json",
             "value": {
               "finetuned_model": {
-                "id": "string",
-                "name": "string",
-                "creator_id": "string",
-                "organization_id": "string",
+                "id": "id",
+                "name": "name",
+                "creator_id": "creator_id",
+                "organization_id": "organization_id",
                 "settings": {
                   "base_model": {
-                    "name": "string",
-                    "version": "string",
+                    "name": "name",
+                    "version": "version",
                     "base_type": "BASE_TYPE_UNSPECIFIED",
                     "strategy": "STRATEGY_UNSPECIFIED"
                   },
-                  "dataset_id": "string",
+                  "dataset_id": "dataset_id",
                   "hyperparameters": {
                     "early_stopping_patience": 0,
                     "early_stopping_threshold": 0,
@@ -26799,16 +26799,16 @@
                   },
                   "multi_label": false,
                   "wandb": {
-                    "project": "string",
-                    "api_key": "string",
-                    "entity": "string"
+                    "project": "project",
+                    "api_key": "api_key",
+                    "entity": "entity"
                   }
                 },
                 "status": "STATUS_UNSPECIFIED",
-                "created_at": "string",
-                "updated_at": "string",
-                "completed_at": "string",
-                "last_used": "string"
+                "created_at": "created_at",
+                "updated_at": "updated_at",
+                "completed_at": "completed_at",
+                "last_used": "last_used"
               }
             }
           },
@@ -26984,7 +26984,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27006,7 +27006,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27028,7 +27028,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27050,7 +27050,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27072,7 +27072,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27094,7 +27094,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27106,7 +27106,7 @@
           "path": "/v1/finetuning/finetuned-models/{id}",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"
@@ -27484,7 +27484,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27506,7 +27506,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27528,7 +27528,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27550,7 +27550,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27572,7 +27572,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27594,7 +27594,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27606,7 +27606,7 @@
           "path": "/v1/finetuning/finetuned-models/{id}",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"
@@ -27618,18 +27618,18 @@
             "type": "json",
             "value": {
               "finetuned_model": {
-                "id": "string",
-                "name": "string",
-                "creator_id": "string",
-                "organization_id": "string",
+                "id": "id",
+                "name": "name",
+                "creator_id": "creator_id",
+                "organization_id": "organization_id",
                 "settings": {
                   "base_model": {
-                    "name": "string",
-                    "version": "string",
+                    "name": "name",
+                    "version": "version",
                     "base_type": "BASE_TYPE_UNSPECIFIED",
                     "strategy": "STRATEGY_UNSPECIFIED"
                   },
-                  "dataset_id": "string",
+                  "dataset_id": "dataset_id",
                   "hyperparameters": {
                     "early_stopping_patience": 0,
                     "early_stopping_threshold": 0,
@@ -27642,16 +27642,16 @@
                   },
                   "multi_label": false,
                   "wandb": {
-                    "project": "string",
-                    "api_key": "string",
-                    "entity": "string"
+                    "project": "project",
+                    "api_key": "api_key",
+                    "entity": "entity"
                   }
                 },
                 "status": "STATUS_UNSPECIFIED",
-                "created_at": "string",
-                "updated_at": "string",
-                "completed_at": "string",
-                "last_used": "string"
+                "created_at": "created_at",
+                "updated_at": "updated_at",
+                "completed_at": "completed_at",
+                "last_used": "last_used"
               }
             }
           },
@@ -27827,7 +27827,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27849,7 +27849,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27871,7 +27871,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27893,7 +27893,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27915,7 +27915,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27937,7 +27937,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -27949,7 +27949,7 @@
           "path": "/v1/finetuning/finetuned-models/{id}",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"
@@ -28197,7 +28197,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -28219,7 +28219,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -28241,7 +28241,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -28263,7 +28263,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -28285,7 +28285,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -28307,7 +28307,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -28319,12 +28319,12 @@
           "path": "/v1/finetuning/finetuned-models/{finetuned_model_id}/events",
           "responseStatusCode": 200,
           "pathParameters": {
-            "finetuned_model_id": "string"
+            "finetuned_model_id": "finetuned_model_id"
           },
           "queryParameters": {
             "page_size": 0,
-            "page_token": "string",
-            "order_by": "string"
+            "page_token": "page_token",
+            "order_by": "order_by"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"
@@ -28576,7 +28576,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -28598,7 +28598,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -28620,7 +28620,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -28642,7 +28642,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -28664,7 +28664,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -28686,7 +28686,7 @@
               "responseBody": {
                 "type": "json",
                 "value": {
-                  "message": "string"
+                  "message": "message"
                 }
               }
             }
@@ -28698,11 +28698,11 @@
           "path": "/v1/finetuning/finetuned-models/{finetuned_model_id}/training-step-metrics",
           "responseStatusCode": 200,
           "pathParameters": {
-            "finetuned_model_id": "string"
+            "finetuned_model_id": "finetuned_model_id"
           },
           "queryParameters": {
             "page_size": 0,
-            "page_token": "string"
+            "page_token": "page_token"
           },
           "headers": {
             "X-Client-Name": "my-cool-project"

--- a/packages/parsers/src/openapi/__test__/__snapshots__/cohere.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/cohere.json
@@ -13053,7 +13053,66 @@
           ]
         }
       ],
-      "examples": [],
+      "examples": [
+        {
+          "path": "/v1/embed-jobs/{id}/cancel",
+          "responseStatusCode": 200,
+          "pathParameters": {
+            "id": "string"
+          },
+          "headers": {
+            "X-Client-Name": "my-cool-project"
+          },
+          "snippets": {
+            "go": [
+              {
+                "name": "Cohere Go SDK",
+                "language": "go",
+                "code": "package main\n\nimport (\n\t\"context\"\n\t\"log\"\n\n\tclient \"github.com/cohere-ai/cohere-go/v2/client\"\n)\n\nfunc main() {\n\tco := client.NewClient()\n\n\terr := co.EmbedJobs.Cancel(context.TODO(), \"embed_job_id\")\n\n\tif err != nil {\n\t\tlog.Fatal(err)\n\t}\n\n}\n",
+                "generated": false
+              }
+            ],
+            "python": [
+              {
+                "name": "Sync",
+                "language": "python",
+                "code": "import cohere\n\nco = cohere.Client()\n\n# cancel an embed job\nco.embed_jobs.cancel(\"job_id\")\n",
+                "generated": false
+              },
+              {
+                "name": "Async",
+                "language": "python",
+                "code": "import cohere\nimport asyncio\n\nco = cohere.AsyncClient()\n\n\nasync def main():\n    await co.embed_jobs.cancel(\"job_id\")\n",
+                "generated": false
+              }
+            ],
+            "java": [
+              {
+                "name": "Cohere java SDK",
+                "language": "java",
+                "code": "/* (C)2024 */\nimport com.cohere.api.Cohere;\n\npublic class EmbedJobsCancel {\n  public static void main(String[] args) {\n    Cohere cohere = Cohere.builder().clientName(\"snippet\").build();\n\n    cohere.embedJobs().cancel(\"job_id\");\n  }\n}\n",
+                "generated": false
+              }
+            ],
+            "typescript": [
+              {
+                "name": "Cohere TypeScript SDK",
+                "language": "typescript",
+                "code": "const { CohereClient } = require('cohere-ai');\n\nconst cohere = new CohereClient({});\n\n(async () => {\n  const embedJob = await cohere.embedJobs.cancel('job_id');\n\n  console.log(embedJob);\n})();\n",
+                "generated": false
+              }
+            ],
+            "curl": [
+              {
+                "name": "cURL",
+                "language": "curl",
+                "code": "curl --request POST \\\n  --url https://api.cohere.com/v1/embed-jobs/id/cancel \\\n  --header 'accept: application/json' \\\n  --header 'content-type: application/json' \\\n  --header \"Authorization: bearer $CO_API_KEY\"",
+                "generated": false
+              }
+            ]
+          }
+        }
+      ],
       "protocol": {
         "type": "rest"
       }
@@ -26475,111 +26534,6 @@
               }
             ]
           }
-        },
-        {
-          "path": "/v1/finetuning/finetuned-models",
-          "responseStatusCode": 200,
-          "queryParameters": {
-            "page_size": 0,
-            "page_token": "string",
-            "order_by": "string"
-          },
-          "headers": {
-            "X-Client-Name": "my-cool-project"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "finetuned_models": [
-                {
-                  "id": "string",
-                  "name": "string",
-                  "creator_id": "string",
-                  "organization_id": "string",
-                  "settings": {
-                    "base_model": {
-                      "name": "string",
-                      "version": "string",
-                      "base_type": "BASE_TYPE_UNSPECIFIED",
-                      "strategy": "STRATEGY_UNSPECIFIED"
-                    },
-                    "dataset_id": "string",
-                    "hyperparameters": {
-                      "early_stopping_patience": 0,
-                      "early_stopping_threshold": 0,
-                      "train_batch_size": 0,
-                      "train_epochs": 0,
-                      "learning_rate": 0,
-                      "lora_alpha": 0,
-                      "lora_rank": 0,
-                      "lora_target_modules": "LORA_TARGET_MODULES_UNSPECIFIED"
-                    },
-                    "multi_label": false,
-                    "wandb": {
-                      "project": "string",
-                      "api_key": "string",
-                      "entity": "string"
-                    }
-                  },
-                  "status": "STATUS_UNSPECIFIED",
-                  "created_at": "string",
-                  "updated_at": "string",
-                  "completed_at": "string",
-                  "last_used": "string"
-                }
-              ],
-              "next_page_token": "string",
-              "total_size": 0
-            }
-          },
-          "snippets": {
-            "java": [
-              {
-                "name": "Cohere java SDK",
-                "language": "java",
-                "code": "/* (C)2024 */\npackage finetuning;\n\nimport com.cohere.api.Cohere;\nimport com.cohere.api.resources.finetuning.finetuning.types.ListFinetunedModelsResponse;\n\npublic class ListFinetunedModels {\n  public static void main(String[] args) {\n    Cohere cohere = Cohere.builder().clientName(\"snippet\").build();\n\n    ListFinetunedModelsResponse response = cohere.finetuning().listFinetunedModels();\n\n    System.out.println(response);\n  }\n}\n",
-                "generated": false
-              }
-            ],
-            "go": [
-              {
-                "name": "Cohere Go SDK",
-                "language": "go",
-                "code": "package main\n\nimport (\n\t\"context\"\n\t\"log\"\n\n\t\"github.com/cohere-ai/cohere-go/v2/client\"\n)\n\nfunc main() {\n\tco := client.NewClient()\n\n\tresp, err := co.Finetuning.ListFinetunedModels(context.TODO(), nil)\n\tif err != nil {\n\t\tlog.Fatal(err)\n\t}\n\n\tlog.Printf(\"%+v\", resp.FinetunedModels)\n}\n",
-                "generated": false
-              }
-            ],
-            "typescript": [
-              {
-                "name": "Cohere TypeScript SDK",
-                "language": "typescript",
-                "code": "const { CohereClient } = require('cohere-ai');\n\nconst cohere = new CohereClient({});\n\n(async () => {\n  const finetunedModels = await cohere.finetuning.listFinetunedModels();\n\n  console.log(finetunedModels);\n})();\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Sync",
-                "language": "python",
-                "code": "import cohere\n\nco = cohere.Client()\nresponse = co.finetuning.list_finetuned_models()\nprint(response)\n",
-                "generated": false
-              },
-              {
-                "name": "Async",
-                "language": "python",
-                "code": "import cohere\nimport asyncio\n\nco = cohere.AsyncClient()\n\n\nasync def main():\n    response = await co.finetuning.list_finetuned_models()\n    print(response)\n\n\nasyncio.run(main())\n",
-                "generated": false
-              }
-            ],
-            "curl": [
-              {
-                "name": "cURL",
-                "language": "curl",
-                "code": "curl --request GET \\\n  --url https://api.cohere.com/v1/finetuning/finetuned-models \\\n  --header 'accept: application/json' \\\n  --header \"Authorization: bearer $CO_API_KEY\"\n",
-                "generated": false
-              }
-            ]
-          }
         }
       ],
       "protocol": {
@@ -27185,105 +27139,6 @@
                 "created_at": "2024-01-17T20:11:42.907Z",
                 "updated_at": "2024-01-17T20:31:06.464Z",
                 "completed_at": "2024-01-17T20:31:05.047Z"
-              }
-            }
-          },
-          "snippets": {
-            "java": [
-              {
-                "name": "Cohere java SDK",
-                "language": "java",
-                "code": "/* (C)2024 */\npackage finetuning;\n\nimport com.cohere.api.Cohere;\nimport com.cohere.api.resources.finetuning.finetuning.types.GetFinetunedModelResponse;\n\npublic class GetFinetunedModel {\n  public static void main(String[] args) {\n    Cohere cohere = Cohere.builder().clientName(\"snippet\").build();\n\n    GetFinetunedModelResponse response = cohere.finetuning().getFinetunedModel(\"test-id\");\n\n    System.out.println(response);\n  }\n}\n",
-                "generated": false
-              }
-            ],
-            "go": [
-              {
-                "name": "Cohere Go SDK",
-                "language": "go",
-                "code": "package main\n\nimport (\n\t\"context\"\n\t\"log\"\n\n\t\"github.com/cohere-ai/cohere-go/v2/client\"\n)\n\nfunc main() {\n\tco := client.NewClient()\n\n\tresp, err := co.Finetuning.GetFinetunedModel(context.TODO(), \"test-id\")\n\tif err != nil {\n\t\tlog.Fatal(err)\n\t}\n\n\tlog.Printf(\"%+v\", resp.FinetunedModel)\n}\n",
-                "generated": false
-              }
-            ],
-            "typescript": [
-              {
-                "name": "Cohere TypeScript SDK",
-                "language": "typescript",
-                "code": "const { CohereClient } = require('cohere-ai');\n\nconst cohere = new CohereClient({});\n\n(async () => {\n  const finetunedModel = await cohere.finetuning.getFinetunedModel('test-id');\n\n  console.log(finetunedModel);\n})();\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Sync",
-                "language": "python",
-                "code": "import cohere\n\nco = cohere.Client()\nresponse = co.finetuning.get_finetuned_model(\"test-id\")\nprint(response)\n",
-                "generated": false
-              },
-              {
-                "name": "Async",
-                "language": "python",
-                "code": "import cohere\nimport asyncio\n\nco = cohere.AsyncClient()\n\n\nasync def main():\n    response = await co.finetuning.get_finetuned_model(\"test-id\")\n    print(response)\n\n\nasyncio.run(main())\n",
-                "generated": false
-              }
-            ],
-            "curl": [
-              {
-                "name": "cURL",
-                "language": "curl",
-                "code": "curl --request GET \\\n  --url https://api.cohere.com/v1/finetuning/finetuned-models/test-id \\\n  --header 'accept: application/json' \\\n  --header \"Authorization: bearer $CO_API_KEY\"\n",
-                "generated": false
-              }
-            ]
-          }
-        },
-        {
-          "path": "/v1/finetuning/finetuned-models/{id}",
-          "responseStatusCode": 200,
-          "pathParameters": {
-            "id": "string"
-          },
-          "headers": {
-            "X-Client-Name": "my-cool-project"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "finetuned_model": {
-                "id": "string",
-                "name": "string",
-                "creator_id": "string",
-                "organization_id": "string",
-                "settings": {
-                  "base_model": {
-                    "name": "string",
-                    "version": "string",
-                    "base_type": "BASE_TYPE_UNSPECIFIED",
-                    "strategy": "STRATEGY_UNSPECIFIED"
-                  },
-                  "dataset_id": "string",
-                  "hyperparameters": {
-                    "early_stopping_patience": 0,
-                    "early_stopping_threshold": 0,
-                    "train_batch_size": 0,
-                    "train_epochs": 0,
-                    "learning_rate": 0,
-                    "lora_alpha": 0,
-                    "lora_rank": 0,
-                    "lora_target_modules": "LORA_TARGET_MODULES_UNSPECIFIED"
-                  },
-                  "multi_label": false,
-                  "wandb": {
-                    "project": "string",
-                    "api_key": "string",
-                    "entity": "string"
-                  }
-                },
-                "status": "STATUS_UNSPECIFIED",
-                "created_at": "string",
-                "updated_at": "string",
-                "completed_at": "string",
-                "last_used": "string"
               }
             }
           },
@@ -28549,83 +28404,6 @@
               }
             ]
           }
-        },
-        {
-          "path": "/v1/finetuning/finetuned-models/{finetuned_model_id}/events",
-          "responseStatusCode": 200,
-          "pathParameters": {
-            "finetuned_model_id": "string"
-          },
-          "queryParameters": {
-            "page_size": 0,
-            "page_token": "string",
-            "order_by": "string"
-          },
-          "headers": {
-            "X-Client-Name": "my-cool-project"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "events": [
-                {
-                  "user_id": "string",
-                  "status": "STATUS_UNSPECIFIED",
-                  "created_at": "string"
-                }
-              ],
-              "next_page_token": "string",
-              "total_size": 0
-            }
-          },
-          "snippets": {
-            "java": [
-              {
-                "name": "Cohere java SDK",
-                "language": "java",
-                "code": "/* (C)2024 */\npackage finetuning;\n\nimport com.cohere.api.Cohere;\nimport com.cohere.api.resources.finetuning.finetuning.types.ListEventsResponse;\n\npublic class ListEvents {\n  public static void main(String[] args) {\n    Cohere cohere = Cohere.builder().clientName(\"snippet\").build();\n\n    ListEventsResponse response = cohere.finetuning().listEvents(\"test-id\");\n\n    System.out.println(response);\n  }\n}\n",
-                "generated": false
-              }
-            ],
-            "go": [
-              {
-                "name": "Cohere Go SDK",
-                "language": "go",
-                "code": "package main\n\nimport (\n\t\"context\"\n\t\"log\"\n\n\t\"github.com/cohere-ai/cohere-go/v2/client\"\n)\n\nfunc main() {\n\tco := client.NewClient()\n\n\tresp, err := co.Finetuning.ListEvents(\n\t\tcontext.TODO(),\n\t\t\"test-finetuned-model-id\",\n\t\tnil,\n\t)\n\tif err != nil {\n\t\tlog.Fatal(err)\n\t}\n\n\tlog.Printf(\"%+v\", resp.Events)\n}\n",
-                "generated": false
-              }
-            ],
-            "typescript": [
-              {
-                "name": "Cohere TypeScript SDK",
-                "language": "typescript",
-                "code": "const { CohereClient } = require('cohere-ai');\n\nconst cohere = new CohereClient({});\n\n(async () => {\n  const events = await cohere.finetuning.listEvents('test-finetuned-model-id');\n\n  console.log(events);\n})();\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Sync",
-                "language": "python",
-                "code": "import cohere\n\nco = cohere.Client()\nresponse = co.finetuning.list_events(finetuned_model_id=\"test-id\")\nprint(response)\n",
-                "generated": false
-              },
-              {
-                "name": "Async",
-                "language": "python",
-                "code": "import cohere\nimport asyncio\n\nco = cohere.AsyncClient()\n\n\nasync def main():\n    response = await co.finetuning.list_events(finetuned_model_id=\"test-id\")\n    print(response)\n\n\nasyncio.run(main())\n",
-                "generated": false
-              }
-            ],
-            "curl": [
-              {
-                "name": "cURL",
-                "language": "curl",
-                "code": "curl --request GET \\\n  --url https://api.cohere.com/v1/finetuning/finetuned-models/test-id/events \\\n  --header 'accept: application/json' \\\n  --header \"Authorization: bearer $CO_API_KEY\"\n",
-                "generated": false
-              }
-            ]
-          }
         }
       ],
       "protocol": {
@@ -28955,81 +28733,6 @@
                   }
                 }
               ]
-            }
-          },
-          "snippets": {
-            "java": [
-              {
-                "name": "Cohere java SDK",
-                "language": "java",
-                "code": "/* (C)2024 */\npackage finetuning;\n\nimport com.cohere.api.Cohere;\nimport com.cohere.api.resources.finetuning.finetuning.types.ListTrainingStepMetricsResponse;\n\npublic class ListTrainingStepMetrics {\n  public static void main(String[] args) {\n    Cohere cohere = Cohere.builder().clientName(\"snippet\").build();\n\n    ListTrainingStepMetricsResponse response =\n        cohere.finetuning().listTrainingStepMetrics(\"test-id\");\n\n    System.out.println(response);\n  }\n}\n",
-                "generated": false
-              }
-            ],
-            "go": [
-              {
-                "name": "Cohere Go SDK",
-                "language": "go",
-                "code": "package main\n\nimport (\n\t\"context\"\n\t\"log\"\n\n\t\"github.com/cohere-ai/cohere-go/v2/client\"\n)\n\nfunc main() {\n\tco := client.NewClient()\n\n\tresp, err := co.Finetuning.ListTrainingStepMetrics(\n\t\tcontext.TODO(),\n\t\t\"test-finetuned-model-id\",\n\t\tnil,\n\t)\n\tif err != nil {\n\t\tlog.Fatal(err)\n\t}\n\n\tlog.Printf(\"%+v\", resp.StepMetrics)\n}\n",
-                "generated": false
-              }
-            ],
-            "typescript": [
-              {
-                "name": "Cohere TypeScript SDK",
-                "language": "typescript",
-                "code": "const { CohereClient } = require('cohere-ai');\n\nconst cohere = new CohereClient({});\n\n(async () => {\n  const trainingStepMetrics = await cohere.finetuning.listTrainingStepMetrics(\n    'test-finetuned-model-id'\n  );\n\n  console.log(trainingStepMetrics);\n})();\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Sync",
-                "language": "python",
-                "code": "import cohere\n\nco = cohere.Client()\ntrain_step_metrics = co.finetuning.list_training_step_metrics(\n    finetuned_model_id=\"test-id\"\n)\nprint(train_step_metrics)\n",
-                "generated": false
-              },
-              {
-                "name": "Async",
-                "language": "python",
-                "code": "import cohere\nimport asyncio\n\nco = cohere.AsyncClient()\n\n\nasync def main():\n    response = await co.finetuning.list_train_step_metrics(finetuned_model_id=\"test-id\")\n    print(response)\n\n\nasyncio.run(main())\n",
-                "generated": false
-              }
-            ],
-            "curl": [
-              {
-                "name": "cURL",
-                "language": "curl",
-                "code": "curl --request GET \\\n  --url https://api.cohere.com/v1/finetuning/finetuned-models/test-id/training-step-metrics \\\n  --header 'accept: application/json' \\\n  --header \"Authorization: bearer $CO_API_KEY\"\n",
-                "generated": false
-              }
-            ]
-          }
-        },
-        {
-          "path": "/v1/finetuning/finetuned-models/{finetuned_model_id}/training-step-metrics",
-          "responseStatusCode": 200,
-          "pathParameters": {
-            "finetuned_model_id": "string"
-          },
-          "queryParameters": {
-            "page_size": 0,
-            "page_token": "string"
-          },
-          "headers": {
-            "X-Client-Name": "my-cool-project"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "step_metrics": [
-                {
-                  "created_at": "string",
-                  "step_number": 0,
-                  "metrics": {}
-                }
-              ],
-              "next_page_token": "string"
             }
           },
           "snippets": {

--- a/packages/parsers/src/openapi/__test__/__snapshots__/content-type.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/content-type.json
@@ -104,7 +104,7 @@
           "path": "/test",
           "responseStatusCode": 201,
           "pathParameters": {
-            "corpus_key": "string"
+            "corpus_key": "corpus_key"
           },
           "responseBody": {
             "type": "json",

--- a/packages/parsers/src/openapi/__test__/__snapshots__/deeptune.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/deeptune.json
@@ -574,7 +574,15 @@
         }
       ],
       "errors": [],
-      "examples": [],
+      "examples": [
+        {
+          "path": "/v1/voices/string",
+          "responseStatusCode": 204,
+          "pathParameters": {
+            "voice_id": "string"
+          }
+        }
+      ],
       "protocol": {
         "type": "rest"
       }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/deeptune.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/deeptune.json
@@ -68,7 +68,7 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "file": "string"
+              "file": "file"
             }
           }
         }
@@ -152,7 +152,7 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "file": "string"
+              "file": "file"
             }
           }
         }
@@ -217,9 +217,9 @@
             "type": "json",
             "value": [
               {
-                "id": "string",
-                "name": "string",
-                "description": "string",
+                "id": "id",
+                "name": "name",
+                "description": "description",
                 "is_public": false
               }
             ]
@@ -297,9 +297,9 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string",
-              "name": "string",
-              "description": "string",
+              "id": "id",
+              "name": "name",
+              "description": "description",
               "is_public": false
             }
           }
@@ -382,17 +382,17 @@
       "errors": [],
       "examples": [
         {
-          "path": "/v1/voices/string",
+          "path": "/v1/voices/voice_id",
           "responseStatusCode": 200,
           "pathParameters": {
-            "voice_id": "string"
+            "voice_id": "voice_id"
           },
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string",
-              "name": "string",
-              "description": "string",
+              "id": "id",
+              "name": "name",
+              "description": "description",
               "is_public": false
             }
           }
@@ -487,17 +487,17 @@
       "errors": [],
       "examples": [
         {
-          "path": "/v1/voices/string",
+          "path": "/v1/voices/voice_id",
           "responseStatusCode": 200,
           "pathParameters": {
-            "voice_id": "string"
+            "voice_id": "voice_id"
           },
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string",
-              "name": "string",
-              "description": "string",
+              "id": "id",
+              "name": "name",
+              "description": "description",
               "is_public": false
             }
           }
@@ -576,10 +576,10 @@
       "errors": [],
       "examples": [
         {
-          "path": "/v1/voices/string",
+          "path": "/v1/voices/voice_id",
           "responseStatusCode": 204,
           "pathParameters": {
-            "voice_id": "string"
+            "voice_id": "voice_id"
           }
         }
       ],

--- a/packages/parsers/src/openapi/__test__/__snapshots__/default-content.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/default-content.json
@@ -58,12 +58,12 @@
           "path": "/generateContent",
           "responseStatusCode": null,
           "pathParameters": {
-            "model": "string"
+            "model": "model"
           },
           "responseBody": {
             "type": "json",
             "value": {
-              "bar": "string"
+              "bar": "bar"
             }
           }
         }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/enum-casing.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/enum-casing.json
@@ -38,7 +38,7 @@
             "type": "json",
             "value": {
               "status": "success",
-              "message": "string",
+              "message": "message",
               "custom_fields": {}
             }
           }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/inline-path-parameters.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/inline-path-parameters.json
@@ -156,11 +156,11 @@
       "errors": [],
       "examples": [
         {
-          "path": "/organizations/string/users/string",
+          "path": "/organizations/organization_id/users/user_id",
           "responseStatusCode": 200,
           "pathParameters": {
-            "organization_id": "string",
-            "user_id": "string"
+            "organization_id": "organization_id",
+            "user_id": "user_id"
           },
           "queryParameters": {
             "limit": 0
@@ -169,7 +169,7 @@
             "type": "json",
             "value": {
               "results": [
-                "string"
+                "results"
               ]
             }
           }
@@ -291,13 +291,13 @@
           "path": "/organizations/{organization_id}/search",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "responseBody": {
             "type": "json",
             "value": {
               "results": [
-                "string"
+                "results"
               ]
             }
           }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/multi-url-generators-yml.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/multi-url-generators-yml.json
@@ -44,10 +44,10 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string",
-              "username": "string",
-              "email": "string",
-              "createdAt": "string"
+              "id": "id",
+              "username": "username",
+              "email": "email",
+              "createdAt": "createdAt"
             }
           }
         }
@@ -116,18 +116,18 @@
       "errors": [],
       "examples": [
         {
-          "path": "/users/string",
+          "path": "/users/userId",
           "responseStatusCode": 200,
           "pathParameters": {
-            "userId": "string"
+            "userId": "userId"
           },
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string",
-              "username": "string",
-              "email": "string",
-              "createdAt": "string"
+              "id": "id",
+              "username": "username",
+              "email": "email",
+              "createdAt": "createdAt"
             }
           }
         }
@@ -179,8 +179,8 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "accessToken": "string",
-              "tokenType": "string",
+              "accessToken": "accessToken",
+              "tokenType": "tokenType",
               "expiresIn": 0
             }
           }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/nullable.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/nullable.json
@@ -49,12 +49,12 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string",
-              "name": "string",
-              "email": "string",
+              "id": "id",
+              "name": "name",
+              "email": "email",
               "createdAt": "null",
               "settings": {
-                "theme": "string",
+                "theme": "theme",
                 "notifications": false,
                 "lastModified": "null"
               },
@@ -119,12 +119,12 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string",
-              "name": "string",
-              "email": "string",
+              "id": "id",
+              "name": "name",
+              "email": "email",
               "createdAt": "null",
               "settings": {
-                "theme": "string",
+                "theme": "theme",
                 "notifications": false,
                 "lastModified": "null"
               },
@@ -226,24 +226,24 @@
       "errors": [],
       "examples": [
         {
-          "path": "/users/string",
+          "path": "/users/userId",
           "responseStatusCode": 200,
           "pathParameters": {
-            "userId": "string"
+            "userId": "userId"
           },
           "queryParameters": {
-            "activated": "string",
-            "email": "string"
+            "activated": "activated",
+            "email": "email"
           },
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string",
-              "name": "string",
-              "email": "string",
+              "id": "id",
+              "name": "name",
+              "email": "email",
               "createdAt": "null",
               "settings": {
-                "theme": "string",
+                "theme": "theme",
                 "notifications": false,
                 "lastModified": "null"
               },

--- a/packages/parsers/src/openapi/__test__/__snapshots__/oauth.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/oauth.json
@@ -215,10 +215,10 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "access_token": "string",
+              "access_token": "access_token",
               "token_type": "Bearer",
               "expires_in": 0,
-              "refresh_token": "string"
+              "refresh_token": "refresh_token"
             }
           }
         }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/only-include-referenced-schemas.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/only-include-referenced-schemas.json
@@ -11197,7 +11197,7 @@
           "responseStatusCode": 200,
           "name": "Successful",
           "queryParameters": {
-            "scroll_param": "string"
+            "scroll_param": "scroll_param"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -11241,7 +11241,7 @@
           "path": "/companies/scroll",
           "responseStatusCode": 200,
           "queryParameters": {
-            "scroll_param": "string"
+            "scroll_param": "scroll_param"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -11917,11 +11917,11 @@
       ],
       "examples": [
         {
-          "path": "/contacts/string/companies",
+          "path": "/contacts/id/companies",
           "responseStatusCode": 200,
           "name": "Successful",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -11984,11 +11984,11 @@
           }
         },
         {
-          "path": "/contacts/string/companies",
+          "path": "/contacts/id/companies",
           "responseStatusCode": 200,
           "name": "Bad Request",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -12049,11 +12049,11 @@
           }
         },
         {
-          "path": "/contacts/string/companies",
+          "path": "/contacts/id/companies",
           "responseStatusCode": 200,
           "name": "Company Not Found",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -12713,7 +12713,7 @@
                   "id": "17495962",
                   "created_at": 1674589321,
                   "contact": {
-                    "type": "string",
+                    "type": "type",
                     "id": "214656d0c743eafcfde7f248"
                   },
                   "author": {
@@ -13016,7 +13016,7 @@
               "id": "17495962",
               "created_at": 1674589321,
               "contact": {
-                "type": "string",
+                "type": "type",
                 "id": "214656d0c743eafcfde7f248"
               },
               "author": {
@@ -13070,7 +13070,7 @@
               "id": "17495962",
               "created_at": 1674589321,
               "contact": {
-                "type": "string",
+                "type": "type",
                 "id": "214656d0c743eafcfde7f248"
               },
               "author": {
@@ -13124,7 +13124,7 @@
               "id": "17495962",
               "created_at": 1674589321,
               "contact": {
-                "type": "string",
+                "type": "type",
                 "id": "214656d0c743eafcfde7f248"
               },
               "author": {
@@ -16205,11 +16205,11 @@
       ],
       "examples": [
         {
-          "path": "/contacts/string",
+          "path": "/contacts/id",
           "responseStatusCode": 200,
           "name": "Successful",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -16225,10 +16225,10 @@
           }
         },
         {
-          "path": "/contacts/string",
+          "path": "/contacts/id",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -18729,7 +18729,7 @@
           "name": "Successful",
           "queryParameters": {
             "per_page": 20,
-            "starting_after": "string"
+            "starting_after": "starting_after"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -18816,7 +18816,7 @@
           "responseStatusCode": 200,
           "queryParameters": {
             "per_page": 20,
-            "starting_after": "string"
+            "starting_after": "starting_after"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -26501,7 +26501,7 @@
                 "icon": "🐞",
                 "workspace_id": "ecahpwf5",
                 "ticket_type_attributes": {
-                  "type": "string",
+                  "type": "type",
                   "ticket_type_attributes": [
                     {
                       "type": "ticket_type_attribute",
@@ -26596,8 +26596,8 @@
                 "total_count": 2
               },
               "is_shared": true,
-              "ticket_state_internal_label": "string",
-              "ticket_state_external_label": "string"
+              "ticket_state_internal_label": "ticket_state_internal_label",
+              "ticket_state_external_label": "ticket_state_external_label"
             }
           }
         },
@@ -26632,7 +26632,7 @@
                 "icon": "🐞",
                 "workspace_id": "ecahpwf5",
                 "ticket_type_attributes": {
-                  "type": "string",
+                  "type": "type",
                   "ticket_type_attributes": [
                     {
                       "type": "ticket_type_attribute",
@@ -26727,8 +26727,8 @@
                 "total_count": 2
               },
               "is_shared": true,
-              "ticket_state_internal_label": "string",
-              "ticket_state_external_label": "string"
+              "ticket_state_internal_label": "ticket_state_internal_label",
+              "ticket_state_external_label": "ticket_state_external_label"
             }
           }
         }
@@ -28388,9 +28388,9 @@
           "name": "Successful Response",
           "queryParameters": {
             "filter": {
-              "user_id": "string"
+              "user_id": "user_id"
             },
-            "type": "string",
+            "type": "type",
             "summary": false
           },
           "headers": {
@@ -28415,9 +28415,9 @@
           "responseStatusCode": 200,
           "queryParameters": {
             "filter": {
-              "user_id": "string"
+              "user_id": "user_id"
             },
-            "type": "string",
+            "type": "type",
             "summary": false
           },
           "headers": {
@@ -28992,11 +28992,11 @@
       "errors": [],
       "examples": [
         {
-          "path": "/export/content/data/string",
+          "path": "/export/content/data/job_identifier",
           "responseStatusCode": 200,
           "name": "Successful",
           "pathParameters": {
-            "job_identifier": "string"
+            "job_identifier": "job_identifier"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -29012,10 +29012,10 @@
           }
         },
         {
-          "path": "/export/content/data/string",
+          "path": "/export/content/data/job_identifier",
           "responseStatusCode": 200,
           "pathParameters": {
-            "job_identifier": "string"
+            "job_identifier": "job_identifier"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -29141,11 +29141,11 @@
       "errors": [],
       "examples": [
         {
-          "path": "/export/cancel/string",
+          "path": "/export/cancel/job_identifier",
           "responseStatusCode": 200,
           "name": "Successful",
           "pathParameters": {
-            "job_identifier": "string"
+            "job_identifier": "job_identifier"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -29161,10 +29161,10 @@
           }
         },
         {
-          "path": "/export/cancel/string",
+          "path": "/export/cancel/job_identifier",
           "responseStatusCode": 200,
           "pathParameters": {
-            "job_identifier": "string"
+            "job_identifier": "job_identifier"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -29294,10 +29294,10 @@
       "errors": [],
       "examples": [
         {
-          "path": "/download/content/data/string",
+          "path": "/download/content/data/job_identifier",
           "responseStatusCode": 200,
           "pathParameters": {
-            "job_identifier": "string"
+            "job_identifier": "job_identifier"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -31939,7 +31939,7 @@
               "id": "17495962",
               "created_at": 1674589321,
               "contact": {
-                "type": "string",
+                "type": "type",
                 "id": "214656d0c743eafcfde7f248"
               },
               "author": {
@@ -34433,11 +34433,11 @@
       ],
       "examples": [
         {
-          "path": "/ticket_types/string/attributes",
+          "path": "/ticket_types/ticket_type_id/attributes",
           "responseStatusCode": 200,
           "name": "Ticket Type Attribute Created",
           "pathParameters": {
-            "ticket_type_id": "string"
+            "ticket_type_id": "ticket_type_id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -34656,12 +34656,12 @@
       ],
       "examples": [
         {
-          "path": "/ticket_types/string/attributes/string",
+          "path": "/ticket_types/ticket_type_id/attributes/id",
           "responseStatusCode": 200,
           "name": "Ticket Type Attribute Updated",
           "pathParameters": {
-            "ticket_type_id": "string",
-            "id": "string"
+            "ticket_type_id": "ticket_type_id",
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -34919,7 +34919,7 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "type": "string",
+              "type": "type",
               "ticket_types": [
                 {
                   "type": "ticket_type",
@@ -34930,7 +34930,7 @@
                   "icon": "🐞",
                   "workspace_id": "ecahpwf5",
                   "ticket_type_attributes": {
-                    "type": "string",
+                    "type": "type",
                     "ticket_type_attributes": [
                       {
                         "type": "ticket_type_attribute",
@@ -35117,7 +35117,7 @@
               "icon": "🐞",
               "workspace_id": "ecahpwf5",
               "ticket_type_attributes": {
-                "type": "string",
+                "type": "type",
                 "ticket_type_attributes": [
                   {
                     "type": "ticket_type_attribute",
@@ -35296,11 +35296,11 @@
       ],
       "examples": [
         {
-          "path": "/ticket_types/string",
+          "path": "/ticket_types/id",
           "responseStatusCode": 200,
           "name": "Ticket Type Found",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -35389,10 +35389,10 @@
           }
         },
         {
-          "path": "/ticket_types/string",
+          "path": "/ticket_types/id",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -35408,7 +35408,7 @@
               "icon": "🐞",
               "workspace_id": "ecahpwf5",
               "ticket_type_attributes": {
-                "type": "string",
+                "type": "type",
                 "ticket_type_attributes": [
                   {
                     "type": "ticket_type_attribute",
@@ -35599,11 +35599,11 @@
       ],
       "examples": [
         {
-          "path": "/ticket_types/string",
+          "path": "/ticket_types/id",
           "responseStatusCode": 200,
           "name": "Ticket Type Updated",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -35619,7 +35619,7 @@
               "icon": "🐞",
               "workspace_id": "ecahpwf5",
               "ticket_type_attributes": {
-                "type": "string",
+                "type": "type",
                 "ticket_type_attributes": [
                   {
                     "type": "ticket_type_attribute",
@@ -36990,7 +36990,7 @@
                 "icon": "🐞",
                 "workspace_id": "ecahpwf5",
                 "ticket_type_attributes": {
-                  "type": "string",
+                  "type": "type",
                   "ticket_type_attributes": [
                     {
                       "type": "ticket_type_attribute",
@@ -37085,8 +37085,8 @@
                 "total_count": 2
               },
               "is_shared": true,
-              "ticket_state_internal_label": "string",
-              "ticket_state_external_label": "string"
+              "ticket_state_internal_label": "ticket_state_internal_label",
+              "ticket_state_external_label": "ticket_state_external_label"
             }
           }
         }
@@ -37240,11 +37240,11 @@
       ],
       "examples": [
         {
-          "path": "/tickets/string",
+          "path": "/tickets/id",
           "responseStatusCode": 200,
           "name": "Ticket Found",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -37368,10 +37368,10 @@
           }
         },
         {
-          "path": "/tickets/string",
+          "path": "/tickets/id",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -37397,7 +37397,7 @@
                 "icon": "🐞",
                 "workspace_id": "ecahpwf5",
                 "ticket_type_attributes": {
-                  "type": "string",
+                  "type": "type",
                   "ticket_type_attributes": [
                     {
                       "type": "ticket_type_attribute",
@@ -37492,8 +37492,8 @@
                 "total_count": 2
               },
               "is_shared": true,
-              "ticket_state_internal_label": "string",
-              "ticket_state_external_label": "string"
+              "ticket_state_internal_label": "ticket_state_internal_label",
+              "ticket_state_external_label": "ticket_state_external_label"
             }
           }
         }
@@ -37659,11 +37659,11 @@
       ],
       "examples": [
         {
-          "path": "/tickets/string",
+          "path": "/tickets/id",
           "responseStatusCode": 200,
           "name": "Successful Response",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -37689,7 +37689,7 @@
                 "icon": "🐞",
                 "workspace_id": "ecahpwf5",
                 "ticket_type_attributes": {
-                  "type": "string",
+                  "type": "type",
                   "ticket_type_attributes": [
                     {
                       "type": "ticket_type_attribute",
@@ -37784,17 +37784,17 @@
                 "total_count": 2
               },
               "is_shared": true,
-              "ticket_state_internal_label": "string",
-              "ticket_state_external_label": "string"
+              "ticket_state_internal_label": "ticket_state_internal_label",
+              "ticket_state_external_label": "ticket_state_external_label"
             }
           }
         },
         {
-          "path": "/tickets/string",
+          "path": "/tickets/id",
           "responseStatusCode": 200,
           "name": "Admin Not Found",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -37820,7 +37820,7 @@
                 "icon": "🐞",
                 "workspace_id": "ecahpwf5",
                 "ticket_type_attributes": {
-                  "type": "string",
+                  "type": "type",
                   "ticket_type_attributes": [
                     {
                       "type": "ticket_type_attribute",
@@ -37915,17 +37915,17 @@
                 "total_count": 2
               },
               "is_shared": true,
-              "ticket_state_internal_label": "string",
-              "ticket_state_external_label": "string"
+              "ticket_state_internal_label": "ticket_state_internal_label",
+              "ticket_state_external_label": "ticket_state_external_label"
             }
           }
         },
         {
-          "path": "/tickets/string",
+          "path": "/tickets/id",
           "responseStatusCode": 200,
           "name": "Assignee Not Found",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -37951,7 +37951,7 @@
                 "icon": "🐞",
                 "workspace_id": "ecahpwf5",
                 "ticket_type_attributes": {
-                  "type": "string",
+                  "type": "type",
                   "ticket_type_attributes": [
                     {
                       "type": "ticket_type_attribute",
@@ -38046,8 +38046,8 @@
                 "total_count": 2
               },
               "is_shared": true,
-              "ticket_state_internal_label": "string",
-              "ticket_state_external_label": "string"
+              "ticket_state_internal_label": "ticket_state_internal_label",
+              "ticket_state_external_label": "ticket_state_external_label"
             }
           }
         }
@@ -38318,7 +38318,7 @@
                     "icon": "🐞",
                     "workspace_id": "ecahpwf5",
                     "ticket_type_attributes": {
-                      "type": "string",
+                      "type": "type",
                       "ticket_type_attributes": [
                         {
                           "type": "ticket_type_attribute",
@@ -38413,8 +38413,8 @@
                     "total_count": 2
                   },
                   "is_shared": true,
-                  "ticket_state_internal_label": "string",
-                  "ticket_state_external_label": "string"
+                  "ticket_state_internal_label": "ticket_state_internal_label",
+                  "ticket_state_external_label": "ticket_state_external_label"
                 }
               ],
               "total_count": 12345,
@@ -38623,7 +38623,7 @@
           "responseStatusCode": 200,
           "name": "Successful",
           "queryParameters": {
-            "user_id": "string"
+            "user_id": "user_id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -38686,7 +38686,7 @@
           "path": "/visitors",
           "responseStatusCode": 200,
           "queryParameters": {
-            "user_id": "string"
+            "user_id": "user_id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -38778,7 +38778,7 @@
               "social_profiles": {
                 "type": "social_profile.list",
                 "social_profiles": [
-                  "string"
+                  "social_profiles"
                 ]
               },
               "owner_id": "5169261",
@@ -38798,7 +38798,7 @@
               "segments": {
                 "type": "segment.list",
                 "segments": [
-                  "string"
+                  "segments"
                 ]
               },
               "custom_attributes": {},
@@ -39151,7 +39151,7 @@
               "social_profiles": {
                 "type": "social_profile.list",
                 "social_profiles": [
-                  "string"
+                  "social_profiles"
                 ]
               },
               "owner_id": "5169261",
@@ -39171,7 +39171,7 @@
               "segments": {
                 "type": "segment.list",
                 "segments": [
-                  "string"
+                  "segments"
                 ]
               },
               "custom_attributes": {},
@@ -39279,7 +39279,7 @@
               "social_profiles": {
                 "type": "social_profile.list",
                 "social_profiles": [
-                  "string"
+                  "social_profiles"
                 ]
               },
               "owner_id": "5169261",
@@ -39299,7 +39299,7 @@
               "segments": {
                 "type": "segment.list",
                 "segments": [
-                  "string"
+                  "segments"
                 ]
               },
               "custom_attributes": {},

--- a/packages/parsers/src/openapi/__test__/__snapshots__/only-include-referenced-schemas.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/only-include-referenced-schemas.json
@@ -28575,7 +28575,15 @@
           ]
         }
       ],
-      "examples": [],
+      "examples": [
+        {
+          "path": "/events",
+          "responseStatusCode": 202,
+          "headers": {
+            "Intercom-Version": "2.11"
+          }
+        }
+      ],
       "protocol": {
         "type": "rest"
       }
@@ -28716,7 +28724,15 @@
           ]
         }
       ],
-      "examples": [],
+      "examples": [
+        {
+          "path": "/events/summaries",
+          "responseStatusCode": 200,
+          "headers": {
+            "Intercom-Version": "2.11"
+          }
+        }
+      ],
       "protocol": {
         "type": "rest"
       }
@@ -29276,7 +29292,18 @@
         }
       ],
       "errors": [],
-      "examples": [],
+      "examples": [
+        {
+          "path": "/download/content/data/string",
+          "responseStatusCode": 200,
+          "pathParameters": {
+            "job_identifier": "string"
+          },
+          "headers": {
+            "Intercom-Version": "2.11"
+          }
+        }
+      ],
       "protocol": {
         "type": "rest"
       }
@@ -33809,7 +33836,18 @@
           ]
         }
       ],
-      "examples": [],
+      "examples": [
+        {
+          "path": "/tags/123",
+          "responseStatusCode": 200,
+          "pathParameters": {
+            "id": "123"
+          },
+          "headers": {
+            "Intercom-Version": "2.11"
+          }
+        }
+      ],
       "protocol": {
         "type": "rest"
       }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/openapi-filter.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/openapi-filter.json
@@ -11197,7 +11197,7 @@
           "responseStatusCode": 200,
           "name": "Successful",
           "queryParameters": {
-            "scroll_param": "string"
+            "scroll_param": "scroll_param"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -11241,7 +11241,7 @@
           "path": "/companies/scroll",
           "responseStatusCode": 200,
           "queryParameters": {
-            "scroll_param": "string"
+            "scroll_param": "scroll_param"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -11917,11 +11917,11 @@
       ],
       "examples": [
         {
-          "path": "/contacts/string/companies",
+          "path": "/contacts/id/companies",
           "responseStatusCode": 200,
           "name": "Successful",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -11984,11 +11984,11 @@
           }
         },
         {
-          "path": "/contacts/string/companies",
+          "path": "/contacts/id/companies",
           "responseStatusCode": 200,
           "name": "Bad Request",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -12049,11 +12049,11 @@
           }
         },
         {
-          "path": "/contacts/string/companies",
+          "path": "/contacts/id/companies",
           "responseStatusCode": 200,
           "name": "Company Not Found",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -12713,7 +12713,7 @@
                   "id": "17495962",
                   "created_at": 1674589321,
                   "contact": {
-                    "type": "string",
+                    "type": "type",
                     "id": "214656d0c743eafcfde7f248"
                   },
                   "author": {
@@ -13016,7 +13016,7 @@
               "id": "17495962",
               "created_at": 1674589321,
               "contact": {
-                "type": "string",
+                "type": "type",
                 "id": "214656d0c743eafcfde7f248"
               },
               "author": {
@@ -13070,7 +13070,7 @@
               "id": "17495962",
               "created_at": 1674589321,
               "contact": {
-                "type": "string",
+                "type": "type",
                 "id": "214656d0c743eafcfde7f248"
               },
               "author": {
@@ -13124,7 +13124,7 @@
               "id": "17495962",
               "created_at": 1674589321,
               "contact": {
-                "type": "string",
+                "type": "type",
                 "id": "214656d0c743eafcfde7f248"
               },
               "author": {
@@ -16205,11 +16205,11 @@
       ],
       "examples": [
         {
-          "path": "/contacts/string",
+          "path": "/contacts/id",
           "responseStatusCode": 200,
           "name": "Successful",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -16225,10 +16225,10 @@
           }
         },
         {
-          "path": "/contacts/string",
+          "path": "/contacts/id",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -18729,7 +18729,7 @@
           "name": "Successful",
           "queryParameters": {
             "per_page": 20,
-            "starting_after": "string"
+            "starting_after": "starting_after"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -18816,7 +18816,7 @@
           "responseStatusCode": 200,
           "queryParameters": {
             "per_page": 20,
-            "starting_after": "string"
+            "starting_after": "starting_after"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -26501,7 +26501,7 @@
                 "icon": "🐞",
                 "workspace_id": "ecahpwf5",
                 "ticket_type_attributes": {
-                  "type": "string",
+                  "type": "type",
                   "ticket_type_attributes": [
                     {
                       "type": "ticket_type_attribute",
@@ -26596,8 +26596,8 @@
                 "total_count": 2
               },
               "is_shared": true,
-              "ticket_state_internal_label": "string",
-              "ticket_state_external_label": "string"
+              "ticket_state_internal_label": "ticket_state_internal_label",
+              "ticket_state_external_label": "ticket_state_external_label"
             }
           }
         },
@@ -26632,7 +26632,7 @@
                 "icon": "🐞",
                 "workspace_id": "ecahpwf5",
                 "ticket_type_attributes": {
-                  "type": "string",
+                  "type": "type",
                   "ticket_type_attributes": [
                     {
                       "type": "ticket_type_attribute",
@@ -26727,8 +26727,8 @@
                 "total_count": 2
               },
               "is_shared": true,
-              "ticket_state_internal_label": "string",
-              "ticket_state_external_label": "string"
+              "ticket_state_internal_label": "ticket_state_internal_label",
+              "ticket_state_external_label": "ticket_state_external_label"
             }
           }
         }
@@ -28388,9 +28388,9 @@
           "name": "Successful Response",
           "queryParameters": {
             "filter": {
-              "user_id": "string"
+              "user_id": "user_id"
             },
-            "type": "string",
+            "type": "type",
             "summary": false
           },
           "headers": {
@@ -28415,9 +28415,9 @@
           "responseStatusCode": 200,
           "queryParameters": {
             "filter": {
-              "user_id": "string"
+              "user_id": "user_id"
             },
-            "type": "string",
+            "type": "type",
             "summary": false
           },
           "headers": {
@@ -28992,11 +28992,11 @@
       "errors": [],
       "examples": [
         {
-          "path": "/export/content/data/string",
+          "path": "/export/content/data/job_identifier",
           "responseStatusCode": 200,
           "name": "Successful",
           "pathParameters": {
-            "job_identifier": "string"
+            "job_identifier": "job_identifier"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -29012,10 +29012,10 @@
           }
         },
         {
-          "path": "/export/content/data/string",
+          "path": "/export/content/data/job_identifier",
           "responseStatusCode": 200,
           "pathParameters": {
-            "job_identifier": "string"
+            "job_identifier": "job_identifier"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -29141,11 +29141,11 @@
       "errors": [],
       "examples": [
         {
-          "path": "/export/cancel/string",
+          "path": "/export/cancel/job_identifier",
           "responseStatusCode": 200,
           "name": "Successful",
           "pathParameters": {
-            "job_identifier": "string"
+            "job_identifier": "job_identifier"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -29161,10 +29161,10 @@
           }
         },
         {
-          "path": "/export/cancel/string",
+          "path": "/export/cancel/job_identifier",
           "responseStatusCode": 200,
           "pathParameters": {
-            "job_identifier": "string"
+            "job_identifier": "job_identifier"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -29294,10 +29294,10 @@
       "errors": [],
       "examples": [
         {
-          "path": "/download/content/data/string",
+          "path": "/download/content/data/job_identifier",
           "responseStatusCode": 200,
           "pathParameters": {
-            "job_identifier": "string"
+            "job_identifier": "job_identifier"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -31939,7 +31939,7 @@
               "id": "17495962",
               "created_at": 1674589321,
               "contact": {
-                "type": "string",
+                "type": "type",
                 "id": "214656d0c743eafcfde7f248"
               },
               "author": {
@@ -34433,11 +34433,11 @@
       ],
       "examples": [
         {
-          "path": "/ticket_types/string/attributes",
+          "path": "/ticket_types/ticket_type_id/attributes",
           "responseStatusCode": 200,
           "name": "Ticket Type Attribute Created",
           "pathParameters": {
-            "ticket_type_id": "string"
+            "ticket_type_id": "ticket_type_id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -34656,12 +34656,12 @@
       ],
       "examples": [
         {
-          "path": "/ticket_types/string/attributes/string",
+          "path": "/ticket_types/ticket_type_id/attributes/id",
           "responseStatusCode": 200,
           "name": "Ticket Type Attribute Updated",
           "pathParameters": {
-            "ticket_type_id": "string",
-            "id": "string"
+            "ticket_type_id": "ticket_type_id",
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -34919,7 +34919,7 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "type": "string",
+              "type": "type",
               "ticket_types": [
                 {
                   "type": "ticket_type",
@@ -34930,7 +34930,7 @@
                   "icon": "🐞",
                   "workspace_id": "ecahpwf5",
                   "ticket_type_attributes": {
-                    "type": "string",
+                    "type": "type",
                     "ticket_type_attributes": [
                       {
                         "type": "ticket_type_attribute",
@@ -35117,7 +35117,7 @@
               "icon": "🐞",
               "workspace_id": "ecahpwf5",
               "ticket_type_attributes": {
-                "type": "string",
+                "type": "type",
                 "ticket_type_attributes": [
                   {
                     "type": "ticket_type_attribute",
@@ -35296,11 +35296,11 @@
       ],
       "examples": [
         {
-          "path": "/ticket_types/string",
+          "path": "/ticket_types/id",
           "responseStatusCode": 200,
           "name": "Ticket Type Found",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -35389,10 +35389,10 @@
           }
         },
         {
-          "path": "/ticket_types/string",
+          "path": "/ticket_types/id",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -35408,7 +35408,7 @@
               "icon": "🐞",
               "workspace_id": "ecahpwf5",
               "ticket_type_attributes": {
-                "type": "string",
+                "type": "type",
                 "ticket_type_attributes": [
                   {
                     "type": "ticket_type_attribute",
@@ -35599,11 +35599,11 @@
       ],
       "examples": [
         {
-          "path": "/ticket_types/string",
+          "path": "/ticket_types/id",
           "responseStatusCode": 200,
           "name": "Ticket Type Updated",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -35619,7 +35619,7 @@
               "icon": "🐞",
               "workspace_id": "ecahpwf5",
               "ticket_type_attributes": {
-                "type": "string",
+                "type": "type",
                 "ticket_type_attributes": [
                   {
                     "type": "ticket_type_attribute",
@@ -36990,7 +36990,7 @@
                 "icon": "🐞",
                 "workspace_id": "ecahpwf5",
                 "ticket_type_attributes": {
-                  "type": "string",
+                  "type": "type",
                   "ticket_type_attributes": [
                     {
                       "type": "ticket_type_attribute",
@@ -37085,8 +37085,8 @@
                 "total_count": 2
               },
               "is_shared": true,
-              "ticket_state_internal_label": "string",
-              "ticket_state_external_label": "string"
+              "ticket_state_internal_label": "ticket_state_internal_label",
+              "ticket_state_external_label": "ticket_state_external_label"
             }
           }
         }
@@ -37240,11 +37240,11 @@
       ],
       "examples": [
         {
-          "path": "/tickets/string",
+          "path": "/tickets/id",
           "responseStatusCode": 200,
           "name": "Ticket Found",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -37368,10 +37368,10 @@
           }
         },
         {
-          "path": "/tickets/string",
+          "path": "/tickets/id",
           "responseStatusCode": 200,
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -37397,7 +37397,7 @@
                 "icon": "🐞",
                 "workspace_id": "ecahpwf5",
                 "ticket_type_attributes": {
-                  "type": "string",
+                  "type": "type",
                   "ticket_type_attributes": [
                     {
                       "type": "ticket_type_attribute",
@@ -37492,8 +37492,8 @@
                 "total_count": 2
               },
               "is_shared": true,
-              "ticket_state_internal_label": "string",
-              "ticket_state_external_label": "string"
+              "ticket_state_internal_label": "ticket_state_internal_label",
+              "ticket_state_external_label": "ticket_state_external_label"
             }
           }
         }
@@ -37659,11 +37659,11 @@
       ],
       "examples": [
         {
-          "path": "/tickets/string",
+          "path": "/tickets/id",
           "responseStatusCode": 200,
           "name": "Successful Response",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -37689,7 +37689,7 @@
                 "icon": "🐞",
                 "workspace_id": "ecahpwf5",
                 "ticket_type_attributes": {
-                  "type": "string",
+                  "type": "type",
                   "ticket_type_attributes": [
                     {
                       "type": "ticket_type_attribute",
@@ -37784,17 +37784,17 @@
                 "total_count": 2
               },
               "is_shared": true,
-              "ticket_state_internal_label": "string",
-              "ticket_state_external_label": "string"
+              "ticket_state_internal_label": "ticket_state_internal_label",
+              "ticket_state_external_label": "ticket_state_external_label"
             }
           }
         },
         {
-          "path": "/tickets/string",
+          "path": "/tickets/id",
           "responseStatusCode": 200,
           "name": "Admin Not Found",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -37820,7 +37820,7 @@
                 "icon": "🐞",
                 "workspace_id": "ecahpwf5",
                 "ticket_type_attributes": {
-                  "type": "string",
+                  "type": "type",
                   "ticket_type_attributes": [
                     {
                       "type": "ticket_type_attribute",
@@ -37915,17 +37915,17 @@
                 "total_count": 2
               },
               "is_shared": true,
-              "ticket_state_internal_label": "string",
-              "ticket_state_external_label": "string"
+              "ticket_state_internal_label": "ticket_state_internal_label",
+              "ticket_state_external_label": "ticket_state_external_label"
             }
           }
         },
         {
-          "path": "/tickets/string",
+          "path": "/tickets/id",
           "responseStatusCode": 200,
           "name": "Assignee Not Found",
           "pathParameters": {
-            "id": "string"
+            "id": "id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -37951,7 +37951,7 @@
                 "icon": "🐞",
                 "workspace_id": "ecahpwf5",
                 "ticket_type_attributes": {
-                  "type": "string",
+                  "type": "type",
                   "ticket_type_attributes": [
                     {
                       "type": "ticket_type_attribute",
@@ -38046,8 +38046,8 @@
                 "total_count": 2
               },
               "is_shared": true,
-              "ticket_state_internal_label": "string",
-              "ticket_state_external_label": "string"
+              "ticket_state_internal_label": "ticket_state_internal_label",
+              "ticket_state_external_label": "ticket_state_external_label"
             }
           }
         }
@@ -38318,7 +38318,7 @@
                     "icon": "🐞",
                     "workspace_id": "ecahpwf5",
                     "ticket_type_attributes": {
-                      "type": "string",
+                      "type": "type",
                       "ticket_type_attributes": [
                         {
                           "type": "ticket_type_attribute",
@@ -38413,8 +38413,8 @@
                     "total_count": 2
                   },
                   "is_shared": true,
-                  "ticket_state_internal_label": "string",
-                  "ticket_state_external_label": "string"
+                  "ticket_state_internal_label": "ticket_state_internal_label",
+                  "ticket_state_external_label": "ticket_state_external_label"
                 }
               ],
               "total_count": 12345,
@@ -38623,7 +38623,7 @@
           "responseStatusCode": 200,
           "name": "Successful",
           "queryParameters": {
-            "user_id": "string"
+            "user_id": "user_id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -38686,7 +38686,7 @@
           "path": "/visitors",
           "responseStatusCode": 200,
           "queryParameters": {
-            "user_id": "string"
+            "user_id": "user_id"
           },
           "headers": {
             "Intercom-Version": "2.11"
@@ -38778,7 +38778,7 @@
               "social_profiles": {
                 "type": "social_profile.list",
                 "social_profiles": [
-                  "string"
+                  "social_profiles"
                 ]
               },
               "owner_id": "5169261",
@@ -38798,7 +38798,7 @@
               "segments": {
                 "type": "segment.list",
                 "segments": [
-                  "string"
+                  "segments"
                 ]
               },
               "custom_attributes": {},
@@ -39151,7 +39151,7 @@
               "social_profiles": {
                 "type": "social_profile.list",
                 "social_profiles": [
-                  "string"
+                  "social_profiles"
                 ]
               },
               "owner_id": "5169261",
@@ -39171,7 +39171,7 @@
               "segments": {
                 "type": "segment.list",
                 "segments": [
-                  "string"
+                  "segments"
                 ]
               },
               "custom_attributes": {},
@@ -39279,7 +39279,7 @@
               "social_profiles": {
                 "type": "social_profile.list",
                 "social_profiles": [
-                  "string"
+                  "social_profiles"
                 ]
               },
               "owner_id": "5169261",
@@ -39299,7 +39299,7 @@
               "segments": {
                 "type": "segment.list",
                 "segments": [
-                  "string"
+                  "segments"
                 ]
               },
               "custom_attributes": {},

--- a/packages/parsers/src/openapi/__test__/__snapshots__/openapi-filter.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/openapi-filter.json
@@ -28575,7 +28575,15 @@
           ]
         }
       ],
-      "examples": [],
+      "examples": [
+        {
+          "path": "/events",
+          "responseStatusCode": 202,
+          "headers": {
+            "Intercom-Version": "2.11"
+          }
+        }
+      ],
       "protocol": {
         "type": "rest"
       }
@@ -28716,7 +28724,15 @@
           ]
         }
       ],
-      "examples": [],
+      "examples": [
+        {
+          "path": "/events/summaries",
+          "responseStatusCode": 200,
+          "headers": {
+            "Intercom-Version": "2.11"
+          }
+        }
+      ],
       "protocol": {
         "type": "rest"
       }
@@ -29276,7 +29292,18 @@
         }
       ],
       "errors": [],
-      "examples": [],
+      "examples": [
+        {
+          "path": "/download/content/data/string",
+          "responseStatusCode": 200,
+          "pathParameters": {
+            "job_identifier": "string"
+          },
+          "headers": {
+            "Intercom-Version": "2.11"
+          }
+        }
+      ],
       "protocol": {
         "type": "rest"
       }
@@ -33809,7 +33836,18 @@
           ]
         }
       ],
-      "examples": [],
+      "examples": [
+        {
+          "path": "/tags/123",
+          "responseStatusCode": 200,
+          "pathParameters": {
+            "id": "123"
+          },
+          "headers": {
+            "Intercom-Version": "2.11"
+          }
+        }
+      ],
       "protocol": {
         "type": "rest"
       }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/content-type.txt
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/content-type.txt
@@ -9,7 +9,6 @@
       "content",
       "application/json",
       "examples",
-      "",
     ],
   },
 ]

--- a/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/uploadcare.txt
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/uploadcare.txt
@@ -79,20 +79,6 @@
       "content",
       "application/json",
       "examples",
-      "",
-    ],
-  },
-  {
-    "message": "Invalid example, expected object for json",
-    "path": [
-      "paths",
-      "/files/{uuid}/metadata/{key}/",
-      "get",
-      "responses",
-      "content",
-      "application/json",
-      "examples",
-      "",
     ],
   },
   {
@@ -105,7 +91,6 @@
       "content",
       "application/json",
       "examples",
-      "",
     ],
   },
   {
@@ -118,33 +103,6 @@
       "content",
       "application/json",
       "examples",
-      "",
-    ],
-  },
-  {
-    "message": "Invalid example, expected object for json",
-    "path": [
-      "paths",
-      "/files/{uuid}/metadata/{key}/",
-      "put",
-      "responses",
-      "content",
-      "application/json",
-      "examples",
-      "",
-    ],
-  },
-  {
-    "message": "Invalid example, expected object for json",
-    "path": [
-      "paths",
-      "/files/{uuid}/metadata/{key}/",
-      "put",
-      "responses",
-      "content",
-      "application/json",
-      "examples",
-      "",
     ],
   },
   {

--- a/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-global-headers.txt
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-global-headers.txt
@@ -9,7 +9,6 @@
       "content",
       "application/json",
       "examples",
-      "",
     ],
   },
   {

--- a/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-idempotency-headers.txt
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-idempotency-headers.txt
@@ -9,7 +9,6 @@
       "content",
       "application/json",
       "examples",
-      "",
     ],
   },
 ]

--- a/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-parameter-name.txt
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-parameter-name.txt
@@ -9,7 +9,6 @@
       "content",
       "application/json",
       "examples",
-      "",
     ],
   },
 ]

--- a/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-sdk-group-name-with-streaming.txt
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-sdk-group-name-with-streaming.txt
@@ -9,7 +9,6 @@
       "content",
       "application/json",
       "examples",
-      "",
     ],
   },
 ]

--- a/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-streaming-with-audiences.txt
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-streaming-with-audiences.txt
@@ -9,7 +9,6 @@
       "content",
       "application/json",
       "examples",
-      "",
     ],
   },
 ]

--- a/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-streaming-with-reference.txt
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-streaming-with-reference.txt
@@ -9,7 +9,6 @@
       "content",
       "application/json",
       "examples",
-      "",
     ],
   },
 ]

--- a/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-streaming-with-sse.txt
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-streaming-with-sse.txt
@@ -9,7 +9,6 @@
       "content",
       "application/json",
       "examples",
-      "",
     ],
   },
 ]

--- a/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-token-variable-name.txt
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-token-variable-name.txt
@@ -9,7 +9,6 @@
       "content",
       "application/json",
       "examples",
-      "",
     ],
   },
 ]

--- a/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-version.txt
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/pathing/errors/x-fern-version.txt
@@ -9,7 +9,6 @@
       "content",
       "application/json",
       "examples",
-      "",
     ],
   },
 ]

--- a/packages/parsers/src/openapi/__test__/__snapshots__/petstore.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/petstore.json
@@ -89,12 +89,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -114,12 +114,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -139,12 +139,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -164,12 +164,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -189,12 +189,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -214,12 +214,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -239,12 +239,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -264,12 +264,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -369,12 +369,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -394,12 +394,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -419,12 +419,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -444,12 +444,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -469,12 +469,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -494,12 +494,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -519,12 +519,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -544,12 +544,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -659,12 +659,12 @@
                     "name": "Dogs"
                   },
                   "photoUrls": [
-                    "string"
+                    "photoUrls"
                   ],
                   "tags": [
                     {
                       "id": 0,
-                      "name": "string"
+                      "name": "name"
                     }
                   ],
                   "status": "available"
@@ -696,12 +696,12 @@
                     "name": "Dogs"
                   },
                   "photoUrls": [
-                    "string"
+                    "photoUrls"
                   ],
                   "tags": [
                     {
                       "id": 0,
-                      "name": "string"
+                      "name": "name"
                     }
                   ],
                   "status": "available"
@@ -733,12 +733,12 @@
                     "name": "Dogs"
                   },
                   "photoUrls": [
-                    "string"
+                    "photoUrls"
                   ],
                   "tags": [
                     {
                       "id": 0,
-                      "name": "string"
+                      "name": "name"
                     }
                   ],
                   "status": "available"
@@ -770,12 +770,12 @@
                     "name": "Dogs"
                   },
                   "photoUrls": [
-                    "string"
+                    "photoUrls"
                   ],
                   "tags": [
                     {
                       "id": 0,
-                      "name": "string"
+                      "name": "name"
                     }
                   ],
                   "status": "available"
@@ -802,12 +802,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -830,12 +830,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -858,12 +858,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"
@@ -886,12 +886,12 @@
                 "name": "Dogs"
               },
               "photoUrls": [
-                "string"
+                "photoUrls"
               ],
               "tags": [
                 {
                   "id": 0,
-                  "name": "string"
+                  "name": "name"
                 }
               ],
               "status": "available"

--- a/packages/parsers/src/openapi/__test__/__snapshots__/query-params.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/query-params.json
@@ -224,11 +224,11 @@
           "responseStatusCode": 200,
           "queryParameters": {
             "filter": {
-              "name": "string",
+              "name": "name",
               "age": 0,
               "location": {
-                "city": "string",
-                "country": "string",
+                "city": "city",
+                "country": "country",
                 "coordinates": {
                   "latitude": 0,
                   "longitude": 0
@@ -238,14 +238,14 @@
             "sort": "asc",
             "limit": 0,
             "tags": [
-              "string"
+              "tags"
             ]
           },
           "responseBody": {
             "type": "json",
             "value": {
               "results": [
-                "string"
+                "results"
               ]
             }
           }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/readonly.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/readonly.json
@@ -49,18 +49,18 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string",
-              "name": "string",
-              "email": "string",
-              "createdAt": "string",
+              "id": "id",
+              "name": "name",
+              "email": "email",
+              "createdAt": "createdAt",
               "settings": {
-                "theme": "string",
+                "theme": "theme",
                 "notifications": false,
-                "lastModified": "string"
+                "lastModified": "lastModified"
               },
               "stats": {
                 "totalLogins": 0,
-                "lastLoginTime": "string",
+                "lastLoginTime": "lastLoginTime",
                 "accountStatus": "active"
               }
             }
@@ -124,26 +124,26 @@
       "errors": [],
       "examples": [
         {
-          "path": "/users/string",
+          "path": "/users/userId",
           "responseStatusCode": 200,
           "pathParameters": {
-            "userId": "string"
+            "userId": "userId"
           },
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string",
-              "name": "string",
-              "email": "string",
-              "createdAt": "string",
+              "id": "id",
+              "name": "name",
+              "email": "email",
+              "createdAt": "createdAt",
               "settings": {
-                "theme": "string",
+                "theme": "theme",
                 "notifications": false,
-                "lastModified": "string"
+                "lastModified": "lastModified"
               },
               "stats": {
                 "totalLogins": 0,
-                "lastLoginTime": "string",
+                "lastLoginTime": "lastLoginTime",
                 "accountStatus": "active"
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/streaming.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/streaming.json
@@ -69,7 +69,7 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string"
+              "id": "id"
             }
           }
         }
@@ -146,7 +146,7 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string"
+              "id": "id"
             }
           }
         }
@@ -223,7 +223,7 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "id": "string"
+              "id": "id"
             }
           }
         }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/uploadcare.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/uploadcare.json
@@ -350,14 +350,6 @@
                   "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
                 }
               }
-            },
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
             }
           ]
         },
@@ -1091,14 +1083,6 @@
                   "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
                 }
               }
-            },
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
             }
           ]
         },
@@ -1432,197 +1416,6 @@
               }
             ]
           }
-        },
-        {
-          "path": "/files/21975c81-7f57-4c7a-aef9-acfe28779f78/storage/",
-          "responseStatusCode": 200,
-          "pathParameters": {
-            "uuid": "test-uuid-replacement"
-          },
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "datetime_removed": null,
-              "datetime_stored": "2018-11-26T12:49:10.477888Z",
-              "datetime_uploaded": "2018-11-26T12:49:09.945335Z",
-              "variations": null,
-              "is_image": true,
-              "is_ready": true,
-              "mime_type": "image/jpeg",
-              "original_file_url": "https://ucarecdn.com/22240276-2f06-41f8-9411-755c8ce926ed/pineapple.jpg",
-              "original_filename": "pineapple.jpg",
-              "size": 642,
-              "url": "https://api.uploadcare.com/files/22240276-2f06-41f8-9411-755c8ce926ed/",
-              "uuid": "test-uuid-replacement",
-              "content_info": {
-                "mime": {
-                  "mime": "image/jpeg",
-                  "type": "image",
-                  "subtype": "jpeg"
-                },
-                "image": {
-                  "format": "JPEG",
-                  "width": 500,
-                  "height": 500,
-                  "sequence": false,
-                  "color_mode": "RGB",
-                  "orientation": 6,
-                  "geo_location": {
-                    "latitude": 55.62013611111111,
-                    "longitude": 37.66299166666666
-                  },
-                  "datetime_original": "2018-08-20T08:59:50",
-                  "dpi": [
-                    72,
-                    72
-                  ]
-                }
-              },
-              "metadata": {
-                "subsystem": "uploader",
-                "pet": "cat"
-              },
-              "appdata": {
-                "aws_rekognition_detect_labels": {
-                  "data": {
-                    "LabelModelVersion": "2.0",
-                    "Labels": [
-                      {
-                        "Confidence": 93.41645812988281,
-                        "Instances": [],
-                        "Name": "Home Decor",
-                        "Parents": []
-                      },
-                      {
-                        "Confidence": 70.75951385498047,
-                        "Instances": [],
-                        "Name": "Linen",
-                        "Parents": [
-                          {
-                            "Name": "Home Decor"
-                          }
-                        ]
-                      },
-                      {
-                        "Confidence": 64.7123794555664,
-                        "Instances": [],
-                        "Name": "Sunlight",
-                        "Parents": []
-                      },
-                      {
-                        "Confidence": 56.264793395996094,
-                        "Instances": [],
-                        "Name": "Flare",
-                        "Parents": [
-                          {
-                            "Name": "Light"
-                          }
-                        ]
-                      },
-                      {
-                        "Confidence": 50.47153854370117,
-                        "Instances": [],
-                        "Name": "Tree",
-                        "Parents": [
-                          {
-                            "Name": "Plant"
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "version": "2016-06-27",
-                  "datetime_created": "2021-09-21T11:25:31.259763Z",
-                  "datetime_updated": "2021-09-21T11:27:33.359763Z"
-                },
-                "aws_rekognition_detect_moderation_labels": {
-                  "data": {
-                    "ModerationModelVersion": "6.0",
-                    "ModerationLabels": [
-                      {
-                        "Confidence": 93.41645812988281,
-                        "Name": "Weapons",
-                        "ParentName": "Violence"
-                      }
-                    ]
-                  },
-                  "version": "2016-06-27",
-                  "datetime_created": "2023-02-21T11:25:31.259763Z",
-                  "datetime_updated": "2023-02-21T11:27:33.359763Z"
-                },
-                "remove_bg": {
-                  "data": {
-                    "foreground_type": "person"
-                  },
-                  "version": "1.0",
-                  "datetime_created": "2021-07-25T12:24:33.159663Z",
-                  "datetime_updated": "2021-07-25T12:24:33.159663Z"
-                },
-                "uc_clamav_virus_scan": {
-                  "data": {
-                    "infected": true,
-                    "infected_with": "Win.Test.EICAR_HDB-1"
-                  },
-                  "version": "0.104.2",
-                  "datetime_created": "2021-09-21T11:24:33.159663Z",
-                  "datetime_updated": "2021-09-21T11:24:33.159663Z"
-                }
-              }
-            }
-          },
-          "snippets": {
-            "javascript": [
-              {
-                "name": "JS",
-                "language": "JavaScript",
-                "code": "import {\n  storeFile,\n  UploadcareSimpleAuthSchema,\n} from '@uploadcare/rest-client';\n\nconst uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({\n  publicKey: 'YOUR_PUBLIC_KEY',\n  secretKey: 'YOUR_SECRET_KEY',\n});\n\nconst result = await storeFile(\n  {\n    uuid: '1bac376c-aa7e-4356-861b-dd2657b5bfd2',\n  },\n  { authSchema: uploadcareSimpleAuthSchema }\n)\n",
-                "generated": false
-              }
-            ],
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->file();\n$result = $api->storeFile('1bac376c-aa7e-4356-861b-dd2657b5bfd2');\necho \\sprintf('File %s is stored at %s', $result->getUuid(), $result->getDatetimeStored()->format(\\DateTimeInterface::ATOM));\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\nfile = uploadcare.file(\"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\nfile.store()\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\nuuid = '1bac376c-aa7e-4356-861b-dd2657b5bfd2'\nUploadcare::File.store(uuid)\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet file = try await uploadcare.storeFile(withUUID: \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\nprint(file)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nuploadcare.saveFile(\"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\n",
-                "generated": false
-              }
-            ]
-          }
         }
       ],
       "protocol": {
@@ -1743,14 +1536,6 @@
           },
           "name": "Bad Request",
           "examples": [
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
-            },
             {
               "responseBody": {
                 "type": "json",
@@ -2208,197 +1993,6 @@
               }
             ]
           }
-        },
-        {
-          "path": "/files/21975c81-7f57-4c7a-aef9-acfe28779f78/storage/",
-          "responseStatusCode": 200,
-          "pathParameters": {
-            "uuid": "test-uuid-replacement"
-          },
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "datetime_removed": null,
-              "datetime_stored": "2018-11-26T12:49:10.477888Z",
-              "datetime_uploaded": "2018-11-26T12:49:09.945335Z",
-              "variations": null,
-              "is_image": true,
-              "is_ready": true,
-              "mime_type": "image/jpeg",
-              "original_file_url": "https://ucarecdn.com/22240276-2f06-41f8-9411-755c8ce926ed/pineapple.jpg",
-              "original_filename": "pineapple.jpg",
-              "size": 642,
-              "url": "https://api.uploadcare.com/files/22240276-2f06-41f8-9411-755c8ce926ed/",
-              "uuid": "test-uuid-replacement",
-              "content_info": {
-                "mime": {
-                  "mime": "image/jpeg",
-                  "type": "image",
-                  "subtype": "jpeg"
-                },
-                "image": {
-                  "format": "JPEG",
-                  "width": 500,
-                  "height": 500,
-                  "sequence": false,
-                  "color_mode": "RGB",
-                  "orientation": 6,
-                  "geo_location": {
-                    "latitude": 55.62013611111111,
-                    "longitude": 37.66299166666666
-                  },
-                  "datetime_original": "2018-08-20T08:59:50",
-                  "dpi": [
-                    72,
-                    72
-                  ]
-                }
-              },
-              "metadata": {
-                "subsystem": "uploader",
-                "pet": "cat"
-              },
-              "appdata": {
-                "aws_rekognition_detect_labels": {
-                  "data": {
-                    "LabelModelVersion": "2.0",
-                    "Labels": [
-                      {
-                        "Confidence": 93.41645812988281,
-                        "Instances": [],
-                        "Name": "Home Decor",
-                        "Parents": []
-                      },
-                      {
-                        "Confidence": 70.75951385498047,
-                        "Instances": [],
-                        "Name": "Linen",
-                        "Parents": [
-                          {
-                            "Name": "Home Decor"
-                          }
-                        ]
-                      },
-                      {
-                        "Confidence": 64.7123794555664,
-                        "Instances": [],
-                        "Name": "Sunlight",
-                        "Parents": []
-                      },
-                      {
-                        "Confidence": 56.264793395996094,
-                        "Instances": [],
-                        "Name": "Flare",
-                        "Parents": [
-                          {
-                            "Name": "Light"
-                          }
-                        ]
-                      },
-                      {
-                        "Confidence": 50.47153854370117,
-                        "Instances": [],
-                        "Name": "Tree",
-                        "Parents": [
-                          {
-                            "Name": "Plant"
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "version": "2016-06-27",
-                  "datetime_created": "2021-09-21T11:25:31.259763Z",
-                  "datetime_updated": "2021-09-21T11:27:33.359763Z"
-                },
-                "aws_rekognition_detect_moderation_labels": {
-                  "data": {
-                    "ModerationModelVersion": "6.0",
-                    "ModerationLabels": [
-                      {
-                        "Confidence": 93.41645812988281,
-                        "Name": "Weapons",
-                        "ParentName": "Violence"
-                      }
-                    ]
-                  },
-                  "version": "2016-06-27",
-                  "datetime_created": "2023-02-21T11:25:31.259763Z",
-                  "datetime_updated": "2023-02-21T11:27:33.359763Z"
-                },
-                "remove_bg": {
-                  "data": {
-                    "foreground_type": "person"
-                  },
-                  "version": "1.0",
-                  "datetime_created": "2021-07-25T12:24:33.159663Z",
-                  "datetime_updated": "2021-07-25T12:24:33.159663Z"
-                },
-                "uc_clamav_virus_scan": {
-                  "data": {
-                    "infected": true,
-                    "infected_with": "Win.Test.EICAR_HDB-1"
-                  },
-                  "version": "0.104.2",
-                  "datetime_created": "2021-09-21T11:24:33.159663Z",
-                  "datetime_updated": "2021-09-21T11:24:33.159663Z"
-                }
-              }
-            }
-          },
-          "snippets": {
-            "javascript": [
-              {
-                "name": "JS",
-                "language": "JavaScript",
-                "code": "import {\n  deleteFile,\n  UploadcareSimpleAuthSchema,\n} from '@uploadcare/rest-client';\n\nconst uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({\n  publicKey: 'YOUR_PUBLIC_KEY',\n  secretKey: 'YOUR_SECRET_KEY',\n});\n\nconst result = await deleteFile(\n  {\n    uuid: '1bac376c-aa7e-4356-861b-dd2657b5bfd2',\n  },\n  { authSchema: uploadcareSimpleAuthSchema }\n)\n",
-                "generated": false
-              }
-            ],
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$fileInfo = (new Uploadcare\\Api($configuration))->file()->deleteFile('1bac376c-aa7e-4356-861b-dd2657b5bfd2');\necho \\sprintf('File \\'%s\\' deleted at \\'%s\\'', $fileInfo->getUuid(), $fileInfo->getDatetimeRemoved()->format(\\DateTimeInterface::ATOM));\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\nfile = uploadcare.file(\"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\nfile.delete()\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\nputs Uploadcare::File.delete('1bac376c-aa7e-4356-861b-dd2657b5bfd2')\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet file = try await uploadcare.deleteFile(withUUID: \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\nprint(file)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nuploadcare.deleteFile(fileId = \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\n",
-                "generated": false
-              }
-            ]
-          }
         }
       ],
       "protocol": {
@@ -2532,14 +2126,6 @@
           },
           "name": "Bad Request",
           "examples": [
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
-            },
             {
               "responseBody": {
                 "type": "json",
@@ -2945,200 +2531,6 @@
               "metadata": {
                 "subsystem": "tester",
                 "pet": "dog"
-              }
-            }
-          },
-          "snippets": {
-            "javascript": [
-              {
-                "name": "JS",
-                "language": "JavaScript",
-                "code": "import {\n  fileInfo,\n  UploadcareSimpleAuthSchema,\n} from '@uploadcare/rest-client';\n\nconst uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({\n  publicKey: 'YOUR_PUBLIC_KEY',\n  secretKey: 'YOUR_SECRET_KEY',\n});\n\nconst result = await fileInfo(\n  {\n    uuid: '1bac376c-aa7e-4356-861b-dd2657b5bfd2',\n  },\n  { authSchema: uploadcareSimpleAuthSchema }\n)\n",
-                "generated": false
-              }
-            ],
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->file();\n$fileInfo = $api->fileInfo('1bac376c-aa7e-4356-861b-dd2657b5bfd2');\necho \\sprintf('URL: %s, ID: %s, Mime type: %s', $fileInfo->getUrl(), $fileInfo->getUuid(), $fileInfo->getMimeType());\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\nfile = uploadcare.file(\"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\nprint(file.info)\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\nuuid = '1bac376c-aa7e-4356-861b-dd2657b5bfd2'\nputs Uploadcare::File.info(uuid).inspect\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet fileInfoQuery = FileInfoQuery().include(.appdata)\nlet file = try await uploadcare.fileInfo(withUUID: \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\", withQuery: fileInfoQuery)\nprint(file)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nval file = uploadcare.getFile(fileId = \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\nLog.d(\"TAG\", file.toString())\n",
-                "generated": false
-              }
-            ]
-          }
-        },
-        {
-          "path": "/files/03ccf9ab-f266-43fb-973d-a6529c55c2ae/",
-          "responseStatusCode": 200,
-          "pathParameters": {
-            "uuid": "test-uuid-replacement"
-          },
-          "queryParameters": {
-            "include": "appdata"
-          },
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "datetime_removed": null,
-              "datetime_stored": "2018-11-26T12:49:10.477888Z",
-              "datetime_uploaded": "2018-11-26T12:49:09.945335Z",
-              "variations": null,
-              "is_image": true,
-              "is_ready": true,
-              "mime_type": "image/jpeg",
-              "original_file_url": "https://ucarecdn.com/22240276-2f06-41f8-9411-755c8ce926ed/pineapple.jpg",
-              "original_filename": "pineapple.jpg",
-              "size": 642,
-              "url": "https://api.uploadcare.com/files/22240276-2f06-41f8-9411-755c8ce926ed/",
-              "uuid": "test-uuid-replacement",
-              "content_info": {
-                "mime": {
-                  "mime": "image/jpeg",
-                  "type": "image",
-                  "subtype": "jpeg"
-                },
-                "image": {
-                  "format": "JPEG",
-                  "width": 500,
-                  "height": 500,
-                  "sequence": false,
-                  "color_mode": "RGB",
-                  "orientation": 6,
-                  "geo_location": {
-                    "latitude": 55.62013611111111,
-                    "longitude": 37.66299166666666
-                  },
-                  "datetime_original": "2018-08-20T08:59:50",
-                  "dpi": [
-                    72,
-                    72
-                  ]
-                }
-              },
-              "metadata": {
-                "subsystem": "uploader",
-                "pet": "cat"
-              },
-              "appdata": {
-                "aws_rekognition_detect_labels": {
-                  "data": {
-                    "LabelModelVersion": "2.0",
-                    "Labels": [
-                      {
-                        "Confidence": 93.41645812988281,
-                        "Instances": [],
-                        "Name": "Home Decor",
-                        "Parents": []
-                      },
-                      {
-                        "Confidence": 70.75951385498047,
-                        "Instances": [],
-                        "Name": "Linen",
-                        "Parents": [
-                          {
-                            "Name": "Home Decor"
-                          }
-                        ]
-                      },
-                      {
-                        "Confidence": 64.7123794555664,
-                        "Instances": [],
-                        "Name": "Sunlight",
-                        "Parents": []
-                      },
-                      {
-                        "Confidence": 56.264793395996094,
-                        "Instances": [],
-                        "Name": "Flare",
-                        "Parents": [
-                          {
-                            "Name": "Light"
-                          }
-                        ]
-                      },
-                      {
-                        "Confidence": 50.47153854370117,
-                        "Instances": [],
-                        "Name": "Tree",
-                        "Parents": [
-                          {
-                            "Name": "Plant"
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "version": "2016-06-27",
-                  "datetime_created": "2021-09-21T11:25:31.259763Z",
-                  "datetime_updated": "2021-09-21T11:27:33.359763Z"
-                },
-                "aws_rekognition_detect_moderation_labels": {
-                  "data": {
-                    "ModerationModelVersion": "6.0",
-                    "ModerationLabels": [
-                      {
-                        "Confidence": 93.41645812988281,
-                        "Name": "Weapons",
-                        "ParentName": "Violence"
-                      }
-                    ]
-                  },
-                  "version": "2016-06-27",
-                  "datetime_created": "2023-02-21T11:25:31.259763Z",
-                  "datetime_updated": "2023-02-21T11:27:33.359763Z"
-                },
-                "remove_bg": {
-                  "data": {
-                    "foreground_type": "person"
-                  },
-                  "version": "1.0",
-                  "datetime_created": "2021-07-25T12:24:33.159663Z",
-                  "datetime_updated": "2021-07-25T12:24:33.159663Z"
-                },
-                "uc_clamav_virus_scan": {
-                  "data": {
-                    "infected": true,
-                    "infected_with": "Win.Test.EICAR_HDB-1"
-                  },
-                  "version": "0.104.2",
-                  "datetime_created": "2021-09-21T11:24:33.159663Z",
-                  "datetime_updated": "2021-09-21T11:24:33.159663Z"
-                }
               }
             }
           },
@@ -5346,14 +4738,6 @@
                   "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
                 }
               }
-            },
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
             }
           ]
         },
@@ -5705,14 +5089,6 @@
                   "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
                 }
               }
-            },
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
             }
           ]
         },
@@ -5988,14 +5364,6 @@
           },
           "name": "Bad Request",
           "examples": [
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
-            },
             {
               "responseBody": {
                 "type": "json",
@@ -6354,14 +5722,6 @@
                   "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
                 }
               }
-            },
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
             }
           ]
         },
@@ -6666,14 +6026,6 @@
           },
           "name": "Bad Request",
           "examples": [
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
-            },
             {
               "responseBody": {
                 "type": "json",
@@ -7033,14 +6385,6 @@
           },
           "name": "Bad Request",
           "examples": [
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
-            },
             {
               "responseBody": {
                 "type": "json",
@@ -7508,14 +6852,6 @@
                   "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
                 }
               }
-            },
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
             }
           ]
         },
@@ -7871,14 +7207,6 @@
                   "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
                 }
               }
-            },
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
             }
           ]
         },
@@ -7973,67 +7301,6 @@
                 "file_id": "test-uuid-replacement"
               },
               "status": "done"
-            }
-          },
-          "snippets": {
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->addons();\n$status = $api->checkRemoveBackground('request-id');\necho \\sprintf('Remove background status: %s', $status);\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\naddon_task_status = uploadcare.addons_api.status(request_id, AddonLabels.REMOVE_BG)\nprint(addon_task_status)\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\nrequest_id = '1bac376c-aa7e-4356-861b-dd2657b5bfd2'\nresult = Uploadcare::Addons.remove_bg_status(request_id)\nputs result.status\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet status = try await uploadcare.checkRemoveBGStatus(requestID: \"requestID\")\nprint(status)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nval addOn = RemoveBgAddOn(uploadcare)\nval status = addOn.check(requestId = \"d1fb31c6-ed34-4e21-bdc3-4f1485f58e21\")\nLog.d(\"TAG\", status.toString())\n",
-                "generated": false
-              }
-            ]
-          }
-        },
-        {
-          "path": "/addons/remove_bg/execute/status/",
-          "responseStatusCode": 200,
-          "queryParameters": {
-            "request_id": "string"
-          },
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "result": {
-                "file_id": "test-uuid-replacement"
-              },
-              "status": "in_progress"
             }
           },
           "snippets": {
@@ -8202,14 +7469,6 @@
                   "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
                 }
               }
-            },
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
             }
           ]
         },
@@ -8288,73 +7547,6 @@
         }
       ],
       "examples": [
-        {
-          "path": "/files/21975c81-7f57-4c7a-aef9-acfe28779f78/metadata/",
-          "responseStatusCode": 200,
-          "pathParameters": {
-            "uuid": "test-uuid-replacement"
-          },
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "subsystem": "uploader",
-              "pet": "cat"
-            }
-          },
-          "snippets": {
-            "javascript": [
-              {
-                "name": "JS",
-                "language": "JavaScript",
-                "code": "import {\n  getMetadata,\n  UploadcareSimpleAuthSchema,\n} from '@uploadcare/rest-client';\n\nconst uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({\n  publicKey: 'YOUR_PUBLIC_KEY',\n  secretKey: 'YOUR_SECRET_KEY',\n});\n\nconst result = await getMetadata(\n  {\n    uuid: '1bac376c-aa7e-4356-861b-dd2657b5bfd2',\n  },\n  { authSchema: uploadcareSimpleAuthSchema }\n)\n",
-                "generated": false
-              }
-            ],
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->file();\n$fileInfo = $api->fileInfo('1bac376c-aa7e-4356-861b-dd2657b5bfd2');\necho \\sprintf(\"File %s metadata:\\n\", $fileInfo->getUuid());\nforeach ($fileInfo->getMetadata() as $metaKey => $metaItem) {\n    echo \\sprintf(\"%s: %s\\n\", $metaKey, $metaItem);\n}\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\nvalue = uploadcare.metadata_api.get_all_metadata(\"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\nprint(value)\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\nuuid = '1bac376c-aa7e-4356-861b-dd2657b5bfd2'\nputs Uploadcare::FileMetadata.show(uuid, 'pet')\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet metadata = try await uploadcare.fileMetadata(withUUID: \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\nprint(metadata)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nval metadata = uploadcare.getFileMetadata(fileId = \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\nLog.d(\"TAG\", metadata.toString())\n",
-                "generated": false
-              }
-            ]
-          }
-        },
         {
           "path": "/files/21975c81-7f57-4c7a-aef9-acfe28779f78/metadata/",
           "responseStatusCode": 200,
@@ -8572,14 +7764,6 @@
                   "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
                 }
               }
-            },
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
             }
           ]
         },
@@ -8658,71 +7842,6 @@
         }
       ],
       "examples": [
-        {
-          "path": "/files/21975c81-7f57-4c7a-aef9-acfe28779f78/metadata/subsystem/",
-          "responseStatusCode": 200,
-          "pathParameters": {
-            "uuid": "test-uuid-replacement",
-            "key": "subsystem"
-          },
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": "uploader"
-          },
-          "snippets": {
-            "javascript": [
-              {
-                "name": "JS",
-                "language": "JavaScript",
-                "code": "import {\n  getMetadataValue,\n  UploadcareSimpleAuthSchema,\n} from '@uploadcare/rest-client';\n\nconst uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({\n  publicKey: 'YOUR_PUBLIC_KEY',\n  secretKey: 'YOUR_SECRET_KEY',\n});\n\nconst result = await getMetadataValue(\n  {\n    uuid: '1bac376c-aa7e-4356-861b-dd2657b5bfd2',\n    key: 'pet'\n  },\n  { authSchema: uploadcareSimpleAuthSchema }\n)\n",
-                "generated": false
-              }
-            ],
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->metadata();\n$metadata = $api->getMetadata('1bac376c-aa7e-4356-861b-dd2657b5bfd2');\necho \\sprintf('Value for key \\'pet\\' %s', $metadata['pet'] ?? 'does not exists');\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\nvalue = uploadcare.metadata_api.get_key(\"1bac376c-aa7e-4356-861b-dd2657b5bfd2\", \"pet\")\nprint(value)\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\nuuid = '1bac376c-aa7e-4356-861b-dd2657b5bfd2'\nputs Uploadcare::FileMetadata.index(uuid).inspect\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet value = try await uploadcare.fileMetadataValue(forKey: \"pet\", withUUID: \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\nprint(value)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nval value = uploadcare.getFileMetadataKeyValue(\n    fileId = \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\",\n    key = \"pet\"\n)\nLog.d(\"TAG\", value)\n",
-                "generated": false
-              }
-            ]
-          }
-        },
         {
           "path": "/files/21975c81-7f57-4c7a-aef9-acfe28779f78/metadata/subsystem/",
           "responseStatusCode": 200,
@@ -8950,14 +8069,6 @@
                   "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
                 }
               }
-            },
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
             }
           ]
         },
@@ -9039,136 +8150,6 @@
         {
           "path": "/files/21975c81-7f57-4c7a-aef9-acfe28779f78/metadata/subsystem/",
           "responseStatusCode": 200,
-          "pathParameters": {
-            "uuid": "test-uuid-replacement",
-            "key": "subsystem"
-          },
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": "uploader"
-          },
-          "snippets": {
-            "javascript": [
-              {
-                "name": "JS",
-                "language": "JavaScript",
-                "code": "import {\n  updateMetadata,\n  UploadcareSimpleAuthSchema,\n} from '@uploadcare/rest-client';\n\nconst uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({\n  publicKey: 'YOUR_PUBLIC_KEY',\n  secretKey: 'YOUR_SECRET_KEY',\n});\n\nconst result = await updateMetadata(\n  {\n    uuid: '1bac376c-aa7e-4356-861b-dd2657b5bfd2',\n    key: 'pet',\n    value: 'dog',\n  },\n  { authSchema: uploadcareSimpleAuthSchema }\n)\n",
-                "generated": false
-              }
-            ],
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->metadata();\n$result = $api->setKey('1bac376c-aa7e-4356-861b-dd2657b5bfd2', 'pet', 'dog');\necho \\sprintf('Metadata key \\'pet\\' is set to %s', $result['pet']);\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\nfile_uuid = '1bac376c-aa7e-4356-861b-dd2657b5bfd2'\nkey, value = \"pet\", \"dog\"\nuploadcare.metadata_api.update_or_create_key(file_uuid, key, value)\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\nuuid = '1bac376c-aa7e-4356-861b-dd2657b5bfd2'\nkey = 'pet'\nvalue = 'dog'\nUploadcare::FileMetadata.update(uuid, key, value)\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet response = try await uploadcare.updateFileMetadata(\n  withUUID: \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\", \n  key: \"pet\", \n  value: dog\n)\n print(response)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nval value = uploadcare.updateFileMetadataKeyValue(\n    fileId = \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\",\n    key = \"pet\",\n    value = \"dog\"\n)\nLog.d(\"TAG\", value)\n",
-                "generated": false
-              }
-            ]
-          }
-        },
-        {
-          "path": "/files/21975c81-7f57-4c7a-aef9-acfe28779f78/metadata/subsystem/",
-          "responseStatusCode": 200,
-          "pathParameters": {
-            "uuid": "test-uuid-replacement",
-            "key": "subsystem"
-          },
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": "uploader"
-          },
-          "snippets": {
-            "javascript": [
-              {
-                "name": "JS",
-                "language": "JavaScript",
-                "code": "import {\n  updateMetadata,\n  UploadcareSimpleAuthSchema,\n} from '@uploadcare/rest-client';\n\nconst uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({\n  publicKey: 'YOUR_PUBLIC_KEY',\n  secretKey: 'YOUR_SECRET_KEY',\n});\n\nconst result = await updateMetadata(\n  {\n    uuid: '1bac376c-aa7e-4356-861b-dd2657b5bfd2',\n    key: 'pet',\n    value: 'dog',\n  },\n  { authSchema: uploadcareSimpleAuthSchema }\n)\n",
-                "generated": false
-              }
-            ],
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->metadata();\n$result = $api->setKey('1bac376c-aa7e-4356-861b-dd2657b5bfd2', 'pet', 'dog');\necho \\sprintf('Metadata key \\'pet\\' is set to %s', $result['pet']);\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\nfile_uuid = '1bac376c-aa7e-4356-861b-dd2657b5bfd2'\nkey, value = \"pet\", \"dog\"\nuploadcare.metadata_api.update_or_create_key(file_uuid, key, value)\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\nuuid = '1bac376c-aa7e-4356-861b-dd2657b5bfd2'\nkey = 'pet'\nvalue = 'dog'\nUploadcare::FileMetadata.update(uuid, key, value)\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet response = try await uploadcare.updateFileMetadata(\n  withUUID: \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\", \n  key: \"pet\", \n  value: dog\n)\n print(response)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nval value = uploadcare.updateFileMetadataKeyValue(\n    fileId = \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\",\n    key = \"pet\",\n    value = \"dog\"\n)\nLog.d(\"TAG\", value)\n",
-                "generated": false
-              }
-            ]
-          }
-        },
-        {
-          "path": "/files/21975c81-7f57-4c7a-aef9-acfe28779f78/metadata/subsystem/",
-          "responseStatusCode": 201,
           "pathParameters": {
             "uuid": "test-uuid-replacement",
             "key": "subsystem"
@@ -9442,14 +8423,6 @@
                   "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
                 }
               }
-            },
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
             }
           ]
         },
@@ -9527,7 +8500,69 @@
           ]
         }
       ],
-      "examples": [],
+      "examples": [
+        {
+          "path": "/files/21975c81-7f57-4c7a-aef9-acfe28779f78/metadata/subsystem/",
+          "responseStatusCode": 204,
+          "pathParameters": {
+            "uuid": "test-uuid-replacement",
+            "key": "subsystem"
+          },
+          "headers": {
+            "Accept": "application/vnd.uploadcare-v0.7+json"
+          },
+          "snippets": {
+            "javascript": [
+              {
+                "name": "JS",
+                "language": "JavaScript",
+                "code": "import {\n  deleteMetadata,\n  UploadcareSimpleAuthSchema,\n} from '@uploadcare/rest-client';\n\nconst uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({\n  publicKey: 'YOUR_PUBLIC_KEY',\n  secretKey: 'YOUR_SECRET_KEY',\n});\n\nconst result = await deleteMetadata(\n  {\n    uuid: '1bac376c-aa7e-4356-861b-dd2657b5bfd2',\n    key: 'delete_key',\n  },\n  { authSchema: uploadcareSimpleAuthSchema }\n)\n",
+                "generated": false
+              }
+            ],
+            "php": [
+              {
+                "name": "PHP",
+                "language": "PHP",
+                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$metadataApi = (new Uploadcare\\Api($configuration))->metadata();\ntry {\n    $metadataApi->removeKey('1bac376c-aa7e-4356-861b-dd2657b5bfd2', 'pet');\n} catch (\\Throwable $e) {\n    echo \\sprintf('Error while key removing: %s', $e->getMessage());\n}\necho 'Key was successfully removed';\n",
+                "generated": false
+              }
+            ],
+            "python": [
+              {
+                "name": "Python",
+                "language": "Python",
+                "code": "from pyuploadcare import Uploadcare\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\nfile_uuid = '1bac376c-aa7e-4356-861b-dd2657b5bfd2'\nuploadcare.metadata_api.delete_key(file_uuid, mkey='pet')\n",
+                "generated": false
+              }
+            ],
+            "ruby": [
+              {
+                "name": "Ruby",
+                "language": "Ruby",
+                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\nputs Uploadcare::FileMetadata.delete('1bac376c-aa7e-4356-861b-dd2657b5bfd2', 'pet')\n",
+                "generated": false
+              }
+            ],
+            "swift": [
+              {
+                "name": "Swift",
+                "language": "Swift",
+                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\ntry await uploadcare.deleteFileMetadata(forKey: \"pet\",  withUUID: \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\n",
+                "generated": false
+              }
+            ],
+            "kotlin": [
+              {
+                "name": "Kotlin",
+                "language": "Kotlin",
+                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nuploadcare.deleteFileMetadataKey(fileId = \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\", key = \"pet\")\n",
+                "generated": false
+              }
+            ]
+          }
+        }
+      ],
       "protocol": {
         "type": "rest"
       }
@@ -9758,14 +8793,6 @@
           },
           "name": "Bad Request",
           "examples": [
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
-            },
             {
               "responseBody": {
                 "type": "json",
@@ -10168,14 +9195,6 @@
                   "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
                 }
               }
-            },
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
             }
           ]
         },
@@ -10505,14 +9524,6 @@
                   "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
                 }
               }
-            },
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
             }
           ]
         },
@@ -10655,7 +9666,68 @@
           ]
         }
       ],
-      "examples": [],
+      "examples": [
+        {
+          "path": "/groups/badfc9f7-f88f-4921-9cc0-22e2c08aa2da~12/",
+          "responseStatusCode": 204,
+          "pathParameters": {
+            "uuid": "badfc9f7-f88f-4921-9cc0-22e2c08aa2da~12"
+          },
+          "headers": {
+            "Accept": "application/vnd.uploadcare-v0.7+json"
+          },
+          "snippets": {
+            "javascript": [
+              {
+                "name": "JS",
+                "language": "JavaScript",
+                "code": "import {\n  deleteGroup,\n  UploadcareSimpleAuthSchema,\n} from '@uploadcare/rest-client';\n\nconst uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({\n  publicKey: 'YOUR_PUBLIC_KEY',\n  secretKey: 'YOUR_SECRET_KEY',\n});\n\nconst result = await deleteGroup(\n  {\n    uuid: 'c5bec8c7-d4b6-4921-9e55-6edb027546bc~1',\n  },\n  { authSchema: uploadcareSimpleAuthSchema }\n)\n",
+                "generated": false
+              }
+            ],
+            "php": [
+              {
+                "name": "PHP",
+                "language": "PHP",
+                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->group();\ntry {\n    $api->removeGroup('c5bec8c7-d4b6-4921-9e55-6edb027546bc~1');\n} catch (\\Throwable $e) {\n    echo \\sprintf('Error while group deletion: %s', $e->getMessage());\n}\necho 'Group successfully deleted';\n",
+                "generated": false
+              }
+            ],
+            "python": [
+              {
+                "name": "Python",
+                "language": "Python",
+                "code": "from pyuploadcare import Uploadcare\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\nfile_group = uploadcare.file_group(\"c5bec8c7-d4b6-4921-9e55-6edb027546bc~1\")\nfile_group.delete()\n",
+                "generated": false
+              }
+            ],
+            "ruby": [
+              {
+                "name": "Ruby",
+                "language": "Ruby",
+                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\nputs Uploadcare::Group.delete('c5bec8c7-d4b6-4921-9e55-6edb027546bc~1')\n",
+                "generated": false
+              }
+            ],
+            "swift": [
+              {
+                "name": "Swift",
+                "language": "Swift",
+                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\ntry await uploadcare.deleteGroup(withUUID: \"c5bec8c7-d4b6-4921-9e55-6edb027546bc~1\")\n",
+                "generated": false
+              }
+            ],
+            "kotlin": [
+              {
+                "name": "Kotlin",
+                "language": "Kotlin",
+                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nuploadcare.deleteGroup(groupId = \"c5bec8c7-d4b6-4921-9e55-6edb027546bc~1\")\n",
+                "generated": false
+              }
+            ]
+          }
+        }
+      ],
       "protocol": {
         "type": "rest"
       }
@@ -10743,14 +9815,6 @@
           },
           "name": "Bad Request",
           "examples": [
-            {
-              "responseBody": {
-                "type": "json",
-                "value": {
-                  "detail": "Simple authentication over HTTP is forbidden. Please, use HTTPS or signed requests instead."
-                }
-              }
-            },
             {
               "responseBody": {
                 "type": "json",
@@ -10868,64 +9932,6 @@
         }
       ],
       "examples": [
-        {
-          "path": "/project/",
-          "responseStatusCode": 200,
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "collaborators": [],
-              "name": "demo",
-              "pub_key": "YOUR_PUBLIC_KEY",
-              "autostore_enabled": true
-            }
-          },
-          "snippets": {
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->project();\n$projectInfo = $api->getProjectInfo();\necho \\sprintf(\"Project %s info:\\n\", $projectInfo->getName());\necho \\sprintf(\"Public key: %s\\n\", $projectInfo->getPubKey());\necho \\sprintf(\"Auto-store enabled: %s\\n\", $projectInfo->isAutostoreEnabled() ? 'yes' : 'no');\nforeach ($projectInfo->getCollaborators() as $email => $name) {\n    echo \\sprintf(\"%s: %s\\n\", $name, $email);\n}\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare, ProjectInfo\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\nproject_info = uploadcare.get_project_info()\nprint(project_info)\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\nproject_info = Uploadcare::Project.show\nputs project_info.inspect\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet project = try await uploadcare.getProjectInfo()\nprint(project)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nval project = uploadcare.getProject()\nLog.d(\"TAG\", project.toString())\n",
-                "generated": false
-              }
-            ]
-          }
-        },
         {
           "path": "/project/",
           "responseStatusCode": 200,
@@ -11585,77 +10591,6 @@
               }
             ]
           }
-        },
-        {
-          "path": "/webhooks/",
-          "responseStatusCode": 201,
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "id": 1,
-              "project": 13,
-              "created": "2016-04-27T11:49:54.948615Z",
-              "updated": "2016-04-27T12:04:57.819933Z",
-              "event": "file.infected",
-              "target_url": "http://example.com/hooks/receiver",
-              "is_active": true,
-              "signing_secret": "7kMVZivndx0ErgvhRKAr",
-              "version": "0.7"
-            }
-          },
-          "snippets": {
-            "javascript": [
-              {
-                "name": "JS",
-                "language": "JavaScript",
-                "code": "import {\n  createWebhook,\n  UploadcareSimpleAuthSchema,\n} from '@uploadcare/rest-client';\n\nconst uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({\n  publicKey: 'YOUR_PUBLIC_KEY',\n  secretKey: 'YOUR_SECRET_KEY',\n});\n\nconst result = await createWebhook(\n  {\n    targetUrl: 'https://yourwebhook.com',\n    event: 'file.uploaded',\n    isActive: true,\n  },\n  { authSchema: uploadcareSimpleAuthSchema }\n)\n",
-                "generated": false
-              }
-            ],
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->webhook();\n$result = $api->createWebhook('https://yourwebhook.com', true, 'sign-secret', 'file.uploaded');\necho \\sprintf('Webhook %s created', $result->getId());\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare, Webhook\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\nwebhook = uploadcare.webhooks_api.create(\n    {\n        \"event\": \"file.uploaded\",\n        \"target_url\": \"https://yourwebhook.com\",\n        \"is_active\": True,\n    }\n)\nprint(webhook)\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\noptions = {\n  target_url: 'https://yourwebhook.com',\n  event: 'file.uploaded',\n  is_active: true\n}\nUploadcare::Webhook.create(**options)\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet url = URL(string: \"https://yourwebhook.com\")!\nlet webhook = try await uploadcare.createWebhook(targetUrl: url,  event: .fileUploaded, isActive: true, signingSecret: \"sign-secret\")\nprint(webhook)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nval url = URI(\"https://yourwebhook.com\")\nval webhook = uploadcare.createWebhook(\n    targetUrl = url,\n    event = EventType.UPLOADED,\n    isActive = true,\n    signingSecret = \"sign-secret\"\n)\nLog.d(\"TAG\", webhook.toString())\n",
-                "generated": false
-              }
-            ]
-          }
         }
       ],
       "protocol": {
@@ -11972,80 +10907,6 @@
               }
             ]
           }
-        },
-        {
-          "path": "/webhooks/143/",
-          "responseStatusCode": 200,
-          "pathParameters": {
-            "id": 143
-          },
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "id": 1,
-              "project": 13,
-              "created": "2016-04-27T11:49:54.948615Z",
-              "updated": "2016-04-27T12:04:57.819933Z",
-              "event": "file.infected",
-              "target_url": "http://example.com/hooks/receiver",
-              "is_active": true,
-              "signing_secret": "7kMVZivndx0ErgvhRKAr",
-              "version": "0.7"
-            }
-          },
-          "snippets": {
-            "javascript": [
-              {
-                "name": "JS",
-                "language": "JavaScript",
-                "code": "import {\n  updateWebhook,\n  UploadcareSimpleAuthSchema,\n} from '@uploadcare/rest-client';\n\nconst uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({\n  publicKey: 'YOUR_PUBLIC_KEY',\n  secretKey: 'YOUR_SECRET_KEY',\n});\n\nconst result = await updateWebhook(\n  {\n    id: 1473151,\n    targetUrl: 'https://yourwebhook.com',\n    event: 'file.uploaded',\n    isActive: true,\n    signingSecret: 'webhook-secret',\n  },\n  { authSchema: uploadcareSimpleAuthSchema }\n)\n",
-                "generated": false
-              }
-            ],
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->webhook();\n$webhook = $api->updateWebhook(1473151, [\n    'target_url' => 'https://yourwebhook.com',\n    'event' => 'file.uploaded',\n    'is_active' => true,\n    'signing_secret' => 'webhook-secret',\n]);\n\\sprintf(\"Webhook with url %s is %s\\n\", $webhook->getTargetUrl(), $webhook->isActive() ? 'active' : 'not active');\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare, Webhook\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\nwebhook_id = 1473151\nwebhook = uploadcare.webhooks_api.update(webhook_id, {\"is_active\": False})\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\nwebhook_id = 1_473_151\noptions = {\n  target_url: 'https://yourwebhook.com',\n  event: 'file.uploaded',\n  is_active: true,\n  signing_secret: 'webhook-secret'\n}\nUploadcare::Webhook.update(webhook_id, options)\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet url = URL(string: \"https://yourwebhook.com\")!\nlet webhook = try await uploadcare.updateWebhook(id: 1473151, targetUrl: url, event: .fileInfoUpdated, isActive: true, signingSecret: \"webhook-secret\")\nprint(webhook)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nval url = URI(\"https://yourwebhook.com\")\nval webhook = uploadcare.updateWebhook(\n    webhookId = 1473151,\n    targetUrl = url,\n    event = EventType.UPLOADED,\n    isActive = true,\n    signingSecret = \"\",\n)\nLog.d(\"TAG\", webhook.toString())\n",
-                "generated": false
-              }
-            ]
-          }
         }
       ],
       "protocol": {
@@ -12281,7 +11142,65 @@
           ]
         }
       ],
-      "examples": [],
+      "examples": [
+        {
+          "path": "/webhooks/unsubscribe/",
+          "responseStatusCode": 204,
+          "headers": {
+            "Accept": "application/vnd.uploadcare-v0.7+json"
+          },
+          "snippets": {
+            "javascript": [
+              {
+                "name": "JS",
+                "language": "JavaScript",
+                "code": "import {\n  deleteWebhook,\n  UploadcareSimpleAuthSchema,\n} from '@uploadcare/rest-client';\n\nconst uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({\n  publicKey: 'YOUR_PUBLIC_KEY',\n  secretKey: 'YOUR_SECRET_KEY',\n});\n\nconst result = await deleteWebhook(\n  {\n    targetUrl: 'https://yourwebhook.com',\n  },\n  { authSchema: uploadcareSimpleAuthSchema }\n)\n",
+                "generated": false
+              }
+            ],
+            "php": [
+              {
+                "name": "PHP",
+                "language": "PHP",
+                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->webhook();\n$result = $api->deleteWebhook('https://yourwebhook.com');\necho $result ? 'Webhook has been deleted' : 'Webhook is not deleted, something went wrong';\n",
+                "generated": false
+              }
+            ],
+            "python": [
+              {
+                "name": "Python",
+                "language": "Python",
+                "code": "from pyuploadcare import Uploadcare, Webhook\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\nwebhook_id = 1473151\nuploadcare.delete_webhook(webhook_id)\n",
+                "generated": false
+              }
+            ],
+            "ruby": [
+              {
+                "name": "Ruby",
+                "language": "Ruby",
+                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\nputs Uploadcare::Webhook.delete('https://yourwebhook.com')\n",
+                "generated": false
+              }
+            ],
+            "swift": [
+              {
+                "name": "Swift",
+                "language": "Swift",
+                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet url = URL(string: \"https://yourwebhook.com\")!\ntry await uploadcare.deleteWebhook(forTargetUrl: url)\n",
+                "generated": false
+              }
+            ],
+            "kotlin": [
+              {
+                "name": "Kotlin",
+                "language": "Kotlin",
+                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nval url = URI(\"https://yourwebhook.com\")\nuploadcare.deleteWebhook(url)\n",
+                "generated": false
+              }
+            ]
+          }
+        }
+      ],
       "protocol": {
         "type": "rest"
       }
@@ -12710,36 +11629,6 @@
               }
             }
           }
-        },
-        {
-          "path": "/convert/document/86c91c35-58e1-41f7-9b23-2d7652cfcd17/",
-          "responseStatusCode": 200,
-          "pathParameters": {
-            "uuid": "test-uuid-replacement"
-          },
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "error": null,
-              "format": {
-                "name": "txt",
-                "conversion_formats": [
-                  {
-                    "name": "epub"
-                  },
-                  {
-                    "name": "pdf"
-                  }
-                ]
-              },
-              "converted_groups": {
-                "pdf": "49732da8-1530-470c-8743-998c4c634718~5"
-              }
-            }
-          }
         }
       ],
       "protocol": {
@@ -13071,75 +11960,6 @@
         }
       ],
       "examples": [
-        {
-          "path": "/convert/document/",
-          "responseStatusCode": 200,
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "problems": {
-                "test-uuid-replacement": "Bad path \"8ddbbb48-0927-4df7-afac-c6031668b01b\". Use UUID or CDN URL"
-              },
-              "result": [
-                {
-                  "original_source": "https://cdn.uploadcare.com/5ffa2545-ea40-4e71-a9e4-3a8e49b7b737/document/-/format/jpg/-/page/1/",
-                  "token": 445630631,
-                  "uuid": "test-uuid-replacement"
-                },
-                {
-                  "original_source": "88a51210-bd69-4411-bc72-a9952d9512cd/document/-/format/pdf/",
-                  "token": 445630637,
-                  "uuid": "test-uuid-replacement"
-                }
-              ]
-            }
-          },
-          "snippets": {
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\nuse Uploadcare\\Interfaces\\Conversion\\ConvertedItemInterface;\nuse Uploadcare\\Interfaces\\Response\\ResponseProblemInterface;\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->conversion();\n$request = new Uploadcare\\Conversion\\DocumentConversionRequest('pdf');\n$result = $api->convertDocument('1bac376c-aa7e-4356-861b-dd2657b5bfd2', $request);\nif ($result instanceof ConvertedItemInterface) {\n    echo \\sprintf('Conversion requested. Key is \\'%s\\'', $result->getToken());\n}\nif ($result instanceof ResponseProblemInterface) {\n    echo \\sprintf('Error in request: %s', $result->getReason());\n}\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\nfile = uploadcare.file('1bac376c-aa7e-4356-861b-dd2657b5bfd2')\ntransformation = DocumentTransformation().format(DocumentFormat.pdf)\nconverted_file = file.convert(transformation)\nprint(converted_file.info)\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\ndocument_params = { uuid: '1bac376c-aa7e-4356-861b-dd2657b5bfd2', format: :pdf }\noptions = { store: true }\nUploadcare::DocumentConverter.convert(document_params, options)\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet file = try await uploadcare.fileInfo(withUUID: \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\nlet settings = DocumentConversionJobSettings(forFile: file)\n  .format(.pdf)\n  \nlet response = try await uploadcare.convertDocumentsWithSettings([settings])\nprint(response)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nval conversionJob = DocumentConversionJob(fileId = \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\n    .apply { setFormat(DocumentFormat.PDF) }\nval converter = DocumentConverter(uploadcare, listOf(conversionJob))\nval response = converter.convertWithResultData()\nLog.d(\"TAG\", response.toString())\n",
-                "generated": false
-              }
-            ]
-          }
-        },
         {
           "path": "/convert/document/",
           "responseStatusCode": 200,
@@ -13658,76 +12478,6 @@
               }
             ]
           }
-        },
-        {
-          "path": "/convert/document/status/426339926/",
-          "responseStatusCode": 200,
-          "pathParameters": {
-            "token": 426339926
-          },
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "status": "processing",
-              "error": null,
-              "result": {
-                "uuid": "test-uuid-replacement"
-              }
-            }
-          },
-          "snippets": {
-            "javascript": [
-              {
-                "name": "JS",
-                "language": "JavaScript",
-                "code": "import {\n  conversionJobStatus,\n  ConversionType,\n  UploadcareSimpleAuthSchema,\n} from '@uploadcare/rest-client';\n\nconst uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({\n  publicKey: 'YOUR_PUBLIC_KEY',\n  secretKey: 'YOUR_SECRET_KEY',\n});\n\nconst result = await conversionJobStatus(\n  {\n    type: ConversionType.DOCUMENT,\n    token: 32921143\n  },\n  { authSchema: uploadcareSimpleAuthSchema }\n)\n",
-                "generated": false
-              }
-            ],
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->conversion();\n$status = $api->documentJobStatus(32921143);\necho \\sprintf('Conversion status: %s', $status->getError() ?? $status->getStatus());\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\ntoken = 32921143\ndocument_convert_status = uploadcare.document_convert_api.status(token)\nprint(document_convert_status.status)\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\ntoken = 32_921_143\nputs Uploadcare::DocumentConverter.status(token)\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet job = try await uploadcare.documentConversionJobStatus(token: 32921143)\nprint(job.statusString)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nval status = uploadcare.getDocumentConversionStatus(token = 32921143)\nLog.d(\"TAG\", status.toString())\n",
-                "generated": false
-              }
-            ]
-          }
         }
       ],
       "protocol": {
@@ -14072,77 +12822,6 @@
         }
       ],
       "examples": [
-        {
-          "path": "/convert/video/",
-          "responseStatusCode": 200,
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "problems": {
-                "test-uuid-replacement": "Bad path \"13cd56e2-f6d7-4c66-ab1b-ffd13cd6646d\". Use UUID or CDN URL"
-              },
-              "result": [
-                {
-                  "original_source": "d52d7136-a2e5-4338-9f45-affbf83b857d/video/-/format/ogg/-/quality/best/",
-                  "token": 445630631,
-                  "thumbnails_group_uuid": "575ed4e8-f4e8-4c14-a58b-1527b6d9ee46~1",
-                  "uuid": "test-uuid-replacement"
-                },
-                {
-                  "original_source": "500196bc-9da5-4aaf-8f3e-70a4ce86edae/video/",
-                  "token": 445630637,
-                  "thumbnails_group_uuid": "be3b4d5e-179d-460e-8a5d-69112ac86cbb~1",
-                  "uuid": "test-uuid-replacement"
-                }
-              ]
-            }
-          },
-          "snippets": {
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\nuse Uploadcare\\Interfaces\\Conversion\\ConvertedItemInterface;\nuse Uploadcare\\Interfaces\\Response\\ResponseProblemInterface;\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->conversion();\n$request = (new Uploadcare\\Conversion\\VideoEncodingRequest())\n    ->setHorizontalSize(1024)\n    ->setVerticalSize(768)\n    ->setResizeMode('preserve_ratio')\n    ->setTargetFormat('mp4');\n$result = $api->convertVideo('1bac376c-aa7e-4356-861b-dd2657b5bfd2', $request);\nif ($result instanceof ConvertedItemInterface) {\n    echo \\sprintf('Conversion requested. Key is \\'%s\\'', $result->getToken());\n}\nif ($result instanceof ResponseProblemInterface) {\n    echo \\sprintf('Error in request: %s', $result->getReason());\n}\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\ntransformation = (\n    VideoTransformation()\n    .format(VideoFormat.mp4)\n    .size(width=640, height=480, resize_mode=ResizeMode.add_padding)\n    .quality(Quality.lighter)\n    .cut(start_time=\"0:1.535\", length=\"0:10.0\")\n    .thumbs(10)\n)\n\npath = transformation.path('1bac376c-aa7e-4356-861b-dd2657b5bfd2')\nresponse = uploadcare.video_convert_api.convert([path])\nvideo_convert_info = response.result[0]\nconverted_file = uploadcare.file(video_convert_info.uuid)\nvideo_convert_status = uploadcare.video_convert_api.status(video_convert_info.token)\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\nvideo_params = {\n  uuid: '1bac376c-aa7e-4356-861b-dd2657b5bfd2',\n  format: :mp4,\n  quality: :lighter\n}\noptions = { store: true }\nUploadcare::VideoConverter.convert(video_params, options)\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet file = try await uploadcare.fileInfo(withUUID: \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\nlet settings = VideoConversionJobSettings(forFile: videoFile)\n  .format(.mp4)\n  .size(VideoSize(width: 640, height: 480))\n  .resizeMode(.addPadding)\n  .quality(.lighter)\n  .cut( VideoCut(startTime: \"0:0:5.000\", length: \"15\") )\n  .thumbs(10)\n\nlet response = try await uploadcare.convertVideosWithSettings([settings])\nprint(response)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nval conversionJob = VideoConversionJob(fileId = \"1bac376c-aa7e-4356-861b-dd2657b5bfd2\")\n    .apply {\n        setFormat(VideoFormat.MP4)\n        resize(width = 640, height = 480, resizeMode = VideoResizeMode.LETTERBOX)\n        quality(VideoQuality.LIGHTER)\n        cut(startTime = \"0:0:5.000\", length = \"15\")\n        thumbnails(10)\n    }\nval converter = VideoConverter(uploadcare, listOf(conversionJob))\nval response = converter.convertWithResultData()\nLog.d(\"TAG\", response.toString())\n",
-                "generated": false
-              }
-            ]
-          }
-        },
         {
           "path": "/convert/video/",
           "responseStatusCode": 200,
@@ -14607,77 +13286,6 @@
         }
       ],
       "examples": [
-        {
-          "path": "/convert/video/status/426339926/",
-          "responseStatusCode": 200,
-          "pathParameters": {
-            "token": 426339926
-          },
-          "headers": {
-            "Accept": "application/vnd.uploadcare-v0.7+json"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "status": "processing",
-              "error": null,
-              "result": {
-                "thumbnails_group_uuid": "575ed4e8-f4e8-4c14-a58b-1527b6d9ee46~1",
-                "uuid": "test-uuid-replacement"
-              }
-            }
-          },
-          "snippets": {
-            "javascript": [
-              {
-                "name": "JS",
-                "language": "JavaScript",
-                "code": "import {\n  conversionJobStatus,\n  ConversionType,\n  UploadcareSimpleAuthSchema,\n} from '@uploadcare/rest-client';\n\nconst uploadcareSimpleAuthSchema = new UploadcareSimpleAuthSchema({\n  publicKey: 'YOUR_PUBLIC_KEY',\n  secretKey: 'YOUR_SECRET_KEY',\n});\n\nconst result = await conversionJobStatus(\n  {\n    type: ConversionType.VIDEO,\n    token: 1201016744\n  },\n  { authSchema: uploadcareSimpleAuthSchema }\n)\n",
-                "generated": false
-              }
-            ],
-            "php": [
-              {
-                "name": "PHP",
-                "language": "PHP",
-                "code": "<?php\n$configuration = Uploadcare\\Configuration::create((string) $_ENV['UPLOADCARE_PUBLIC_KEY'], (string) $_ENV['UPLOADCARE_SECRET_KEY']);\n\n$api = (new Uploadcare\\Api($configuration))->conversion();\n$status = $api->videoJobStatus(1201016744);\necho \\sprintf('Conversion status: %s', $status->getError() ?? $status->getStatus());\n",
-                "generated": false
-              }
-            ],
-            "python": [
-              {
-                "name": "Python",
-                "language": "Python",
-                "code": "from pyuploadcare import Uploadcare\nuploadcare = Uploadcare(public_key='YOUR_PUBLIC_KEY', secret_key='YOUR_SECRET_KEY')\n\ntoken = 1201016744\nvideo_convert_status = uploadcare.video_convert_api.status(token)\nprint(video_convert_status.status)\n",
-                "generated": false
-              }
-            ],
-            "ruby": [
-              {
-                "name": "Ruby",
-                "language": "Ruby",
-                "code": "require 'uploadcare'\nUploadcare.config.public_key = 'YOUR_PUBLIC_KEY'\nUploadcare.config.secret_key = 'YOUR_SECRET_KEY'\n\ntoken = 1_201_016_744\nputs Uploadcare::VideoConverter.status(token)\n",
-                "generated": false
-              }
-            ],
-            "swift": [
-              {
-                "name": "Swift",
-                "language": "Swift",
-                "code": "import Uploadcare\n\nlet uploadcare = Uploadcare(withPublicKey: \"YOUR_PUBLIC_KEY\", secretKey: \"YOUR_SECRET_KEY\")\n\nlet job = try await uploadcare.videoConversionJobStatus(token: 1201016744)\nprint(job.statusString)\n",
-                "generated": false
-              }
-            ],
-            "kotlin": [
-              {
-                "name": "Kotlin",
-                "language": "Kotlin",
-                "code": "import com.uploadcare.android.library.api.UploadcareClient\n\nval uploadcare = UploadcareClient(publicKey = \"YOUR_PUBLIC_KEY\", secretKey = \"YOUR_SECRET_KEY\")\n\nval status = uploadcare.getVideoConversionStatus(token = 1201016744)\nLog.d(\"TAG\", status.toString())\n",
-                "generated": false
-              }
-            ]
-          }
-        },
         {
           "path": "/convert/video/status/426339926/",
           "responseStatusCode": 200,

--- a/packages/parsers/src/openapi/__test__/__snapshots__/uploadcare.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/uploadcare.json
@@ -4055,14 +4055,14 @@
               "result": {
                 "datetime_removed": "null",
                 "datetime_stored": "null",
-                "datetime_uploaded": "string",
+                "datetime_uploaded": "datetime_uploaded",
                 "is_image": true,
                 "is_ready": true,
                 "mime_type": "image/jpeg",
                 "original_file_url": "null",
                 "original_filename": "EU_4.jpg",
                 "size": 0,
-                "url": "string",
+                "url": "url",
                 "uuid": "test-uuid-replacement",
                 "metadata": {}
               }
@@ -5171,7 +5171,7 @@
           "path": "/addons/aws_rekognition_detect_labels/execute/status/",
           "responseStatusCode": 200,
           "queryParameters": {
-            "request_id": "string"
+            "request_id": "request_id"
           },
           "headers": {
             "Accept": "application/vnd.uploadcare-v0.7+json"
@@ -5804,7 +5804,7 @@
           "path": "/addons/aws_rekognition_detect_moderation_labels/execute/status/",
           "responseStatusCode": 200,
           "queryParameters": {
-            "request_id": "string"
+            "request_id": "request_id"
           },
           "headers": {
             "Accept": "application/vnd.uploadcare-v0.7+json"
@@ -6474,7 +6474,7 @@
           "path": "/addons/uc_clamav_virus_scan/execute/status/",
           "responseStatusCode": 200,
           "queryParameters": {
-            "request_id": "string"
+            "request_id": "request_id"
           },
           "headers": {
             "Accept": "application/vnd.uploadcare-v0.7+json"
@@ -7289,7 +7289,7 @@
           "path": "/addons/remove_bg/execute/status/",
           "responseStatusCode": 200,
           "queryParameters": {
-            "request_id": "string"
+            "request_id": "request_id"
           },
           "headers": {
             "Accept": "application/vnd.uploadcare-v0.7+json"
@@ -9353,11 +9353,11 @@
               "files": [
                 null
               ],
-              "id": "string",
-              "datetime_created": "string",
+              "id": "id",
+              "datetime_created": "datetime_created",
               "files_count": 0,
-              "cdn_url": "string",
-              "url": "string"
+              "cdn_url": "cdn_url",
+              "url": "url"
             }
           },
           "snippets": {
@@ -13560,7 +13560,7 @@
                 }
               }
             },
-            "file": "string"
+            "file": "file"
           }
         }
       ]
@@ -13760,7 +13760,7 @@
                 }
               }
             },
-            "file": "string"
+            "file": "file"
           }
         }
       ]
@@ -13960,7 +13960,7 @@
                 }
               }
             },
-            "file": "string"
+            "file": "file"
           }
         }
       ]
@@ -14160,7 +14160,7 @@
                 }
               }
             },
-            "file": "string"
+            "file": "file"
           }
         }
       ]
@@ -14360,7 +14360,7 @@
                 }
               }
             },
-            "file": "string",
+            "file": "file",
             "previous_values": {
               "appdata": {
                 "aws_rekognition_detect_labels": {
@@ -14421,8 +14421,8 @@
                       }
                     }
                   },
-                  "datetime_created": "string",
-                  "datetime_updated": "string"
+                  "datetime_created": "datetime_created",
+                  "datetime_updated": "datetime_updated"
                 },
                 "aws_rekognition_detect_moderation_labels": {
                   "version": "2016-06-27",
@@ -14445,25 +14445,25 @@
                       }
                     }
                   },
-                  "datetime_created": "string",
-                  "datetime_updated": "string"
+                  "datetime_created": "datetime_created",
+                  "datetime_updated": "datetime_updated"
                 },
                 "remove_bg": {
                   "version": "1.0",
                   "data": {
-                    "foreground_type": "string"
+                    "foreground_type": "foreground_type"
                   },
-                  "datetime_created": "string",
-                  "datetime_updated": "string"
+                  "datetime_created": "datetime_created",
+                  "datetime_updated": "datetime_updated"
                 },
                 "uc_clamav_virus_scan": {
                   "version": "0.104.2",
                   "data": {
                     "infected": false,
-                    "infected_with": "string"
+                    "infected_with": "infected_with"
                   },
-                  "datetime_created": "string",
-                  "datetime_updated": "string"
+                  "datetime_created": "datetime_created",
+                  "datetime_updated": "datetime_updated"
                 }
               },
               "metadata": {}

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-global-headers.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-global-headers.json
@@ -132,16 +132,16 @@
       "errors": [],
       "examples": [
         {
-          "path": "/user/string",
+          "path": "/user/userId",
           "responseStatusCode": 200,
           "pathParameters": {
-            "userId": "string"
+            "userId": "userId"
           },
           "headers": {
-            "my-api-key": "string",
-            "another_header": "string",
-            "x-api-key": "string",
-            "my-api-version": "string"
+            "my-api-key": "my-api-key",
+            "another_header": "another_header",
+            "x-api-key": "x-api-key",
+            "my-api-version": "my-api-version"
           },
           "responseBody": {
             "type": "json",

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-ignore.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-ignore.json
@@ -113,8 +113,8 @@
           "queryParameters": {
             "pageNumber": 0,
             "limit": 0,
-            "ignoredParam1": "string",
-            "ignoredParam2": "string"
+            "ignoredParam1": "ignoredParam1",
+            "ignoredParam2": "ignoredParam2"
           },
           "responseBody": {
             "type": "json",
@@ -124,9 +124,9 @@
               },
               "users": [
                 {
-                  "id": "string",
-                  "name": "string",
-                  "email": "string",
+                  "id": "id",
+                  "name": "name",
+                  "email": "email",
                   "age": 0
                 }
               ]

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-pagination.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-pagination.json
@@ -86,9 +86,9 @@
               },
               "users": [
                 {
-                  "id": "string",
-                  "name": "string",
-                  "email": "string",
+                  "id": "id",
+                  "name": "name",
+                  "email": "email",
                   "age": 0
                 }
               ]

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-parameter-name.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-parameter-name.json
@@ -84,16 +84,16 @@
       "errors": [],
       "examples": [
         {
-          "path": "/user/string",
+          "path": "/user/userId",
           "responseStatusCode": 200,
           "pathParameters": {
-            "userId": "string"
+            "userId": "userId"
           },
           "queryParameters": {
-            "foo": "string"
+            "foo": "foo"
           },
           "headers": {
-            "X-API-Version": "string"
+            "X-API-Version": "X-API-Version"
           },
           "responseBody": {
             "type": "json",

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-sdk-group-name-with-streaming.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-sdk-group-name-with-streaming.json
@@ -82,10 +82,10 @@
       "errors": [],
       "examples": [
         {
-          "path": "/user/string",
+          "path": "/user/userId",
           "responseStatusCode": 200,
           "pathParameters": {
-            "userId": "string"
+            "userId": "userId"
           },
           "responseBody": {
             "type": "json",

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-audiences.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-audiences.json
@@ -82,10 +82,10 @@
       "errors": [],
       "examples": [
         {
-          "path": "/user/string",
+          "path": "/user/userId",
           "responseStatusCode": 200,
           "pathParameters": {
-            "userId": "string"
+            "userId": "userId"
           },
           "responseBody": {
             "type": "json",

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-stream-condition.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-stream-condition.json
@@ -125,9 +125,9 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "chat_id": "string",
-              "turn_id": "string",
-              "answer": "string"
+              "chat_id": "chat_id",
+              "turn_id": "turn_id",
+              "answer": "answer"
             }
           }
         },
@@ -155,9 +155,9 @@
           "responseBody": {
             "type": "json",
             "value": {
-              "chat_id": "string",
-              "turn_id": "string",
-              "answer": "string"
+              "chat_id": "chat_id",
+              "turn_id": "turn_id",
+              "answer": "answer"
             }
           }
         },

--- a/packages/parsers/src/openapi/constants.ts
+++ b/packages/parsers/src/openapi/constants.ts
@@ -1,0 +1,3 @@
+export const APPLICATION_JSON_CONTENT_TYPE = "application/json";
+export const TEXT_EVENT_STREAM_CONTENT_TYPE = "text/event-stream";
+export const APPLICATION_OCTET_STREAM_CONTENT_TYPE = "application/octet-stream";


### PR DESCRIPTION
## Short description of the changes made

* Previously, no examples were being generated for empty responses, now we generate examples without `responseBody`
* Previously, examples were returning defaults for strings as "strings" if not found elsewhere, now we return property keys, if available

## What was the motivation & context behind this PR?

* Customer go lives

## How has this PR been tested?

* Snapshot tests
