### PR TITLE
fix: add language fallback for examples

### DIFF
--- a/packages/fern-docs/ui/src/api-reference/endpoints/useExampleSelection.ts
+++ b/packages/fern-docs/ui/src/api-reference/endpoints/useExampleSelection.ts
@@ -49,8 +49,11 @@ export function useExampleSelection(
           responseIndex: undefined,
         };
       }
+      console.log("language: ", language);
       const allExamples = Object.values(
-        examplesByLanguageKeyAndStatusCode[language] ?? {}
+        examplesByLanguageKeyAndStatusCode[language] ??
+          examplesByLanguageKeyAndStatusCode.curl ??
+          {}
       )
         .flatMap((e) => Object.values(e))
         .flat();

--- a/packages/fern-docs/ui/src/api-reference/endpoints/useExampleSelection.ts
+++ b/packages/fern-docs/ui/src/api-reference/endpoints/useExampleSelection.ts
@@ -49,7 +49,6 @@ export function useExampleSelection(
           responseIndex: undefined,
         };
       }
-      console.log("language: ", language);
       const allExamples = Object.values(
         examplesByLanguageKeyAndStatusCode[language] ??
           examplesByLanguageKeyAndStatusCode.curl ??


### PR DESCRIPTION
This PR adds a language fallback for example selection. If no example matches the currently selected language, always attempt to find a `curl` example before returning no examples. 

Fixes a bug reported by the Murf team.

