### PR TITLE
chore: ai chat code copy

### DIFF
--- a/packages/fern-docs/components/src/FernButton.scss
+++ b/packages/fern-docs/components/src/FernButton.scss
@@ -430,6 +430,12 @@
     }
   }
 
+  #fern-search-desktop-command {
+    .fern-copy-button {
+      top: 0.1rem !important;
+    }
+  }
+
   .fern-copy-button {
     @apply size-fit backdrop-blur;
   }

--- a/packages/fern-docs/search-ui/src/components/desktop/desktop-ask-ai.tsx
+++ b/packages/fern-docs/search-ui/src/components/desktop/desktop-ask-ai.tsx
@@ -643,12 +643,6 @@ const AskAICommandItems = memo<{
                     message.assistant?.id ?? message.user?.id
                   }
                   value={message.assistant?.id ?? message.user?.id}
-                  onSelect={() => {
-                    const content = message.assistant?.content;
-                    if (content) {
-                      void navigator.clipboard.writeText(content);
-                    }
-                  }}
                   asChild
                   scrollLogicalPosition="start"
                 >

--- a/packages/fern-docs/syntax-highlighter/src/CodeBlockWithClipboardButton.tsx
+++ b/packages/fern-docs/syntax-highlighter/src/CodeBlockWithClipboardButton.tsx
@@ -20,8 +20,8 @@ export const CodeBlockWithClipboardButton: React.FC<
       {children}
       <CopyToClipboardButton
         className={cn(
-          "absolute z-20",
-          "z-10 opacity-0 backdrop-blur transition group-hover/cb-container:opacity-100",
+          "fern-copy-button absolute z-20",
+          "opacity-0 backdrop-blur transition group-hover/cb-container:opacity-100",
           "right-3 top-2"
         )}
         content={code}


### PR DESCRIPTION
This PR updates the display and functionality of the copy code button. 
1. Disables copying the entire chat response on click
2. Code blocks now only copy code when copy button is clicked
3. Copy button is centered within code blocks

https://github.com/user-attachments/assets/abcae4f9-d4c7-4604-9101-8c10322b1a81


