### PR TITLE
fix: v1 api supports exploded

### DIFF
--- a/fern/apis/fdr/definition/api/v1/read/type.yml
+++ b/fern/apis/fdr/definition/api/v1/read/type.yml
@@ -204,6 +204,7 @@ types:
     extends: ObjectProperty
     properties:
       contentType: optional<ContentType>
+      exploded: optional<boolean>
 
   FormDataFileProperty:
     union:

--- a/fern/apis/fdr/definition/api/v1/register/type.yml
+++ b/fern/apis/fdr/definition/api/v1/register/type.yml
@@ -207,6 +207,7 @@ types:
     extends: ObjectProperty
     properties:
       contentType: optional<ContentType>
+      exploded: optional<boolean>
 
   FormDataFileProperty:
     union:

--- a/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
+++ b/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
@@ -688,7 +688,7 @@ export class ApiDefinitionV1ToLatest {
           contentType: bodyProp.contentType,
           description: bodyProp.description,
           availability: bodyProp.availability,
-          exploded: undefined,
+          exploded: bodyProp.exploded,
           valueShape: {
             type: "alias",
             value: this.migrateTypeReference(bodyProp.valueType),

--- a/packages/fdr-sdk/src/client/generated/api/resources/api/resources/v1/resources/read/resources/type/types/FormDataBodyProperty.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/api/resources/v1/resources/read/resources/type/types/FormDataBodyProperty.ts
@@ -6,4 +6,5 @@ import * as FernRegistry from "../../../../../../../../../index";
 
 export interface FormDataBodyProperty extends FernRegistry.api.v1.read.ObjectProperty {
     contentType: FernRegistry.api.v1.read.ContentType | undefined;
+    exploded: boolean | undefined;
 }

--- a/packages/fdr-sdk/src/client/generated/api/resources/api/resources/v1/resources/register/resources/type/types/FormDataBodyProperty.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/api/resources/v1/resources/register/resources/type/types/FormDataBodyProperty.ts
@@ -6,4 +6,5 @@ import * as FernRegistry from "../../../../../../../../../index";
 
 export interface FormDataBodyProperty extends FernRegistry.api.v1.register.ObjectProperty {
     contentType: FernRegistry.api.v1.register.ContentType | undefined;
+    exploded: boolean | undefined;
 }

--- a/packages/parsers/src/client/generated/api/resources/api/resources/v1/resources/read/resources/type/types/FormDataBodyProperty.ts
+++ b/packages/parsers/src/client/generated/api/resources/api/resources/v1/resources/read/resources/type/types/FormDataBodyProperty.ts
@@ -6,4 +6,5 @@ import * as FernRegistry from "../../../../../../../../../index";
 
 export interface FormDataBodyProperty extends FernRegistry.api.v1.read.ObjectProperty {
     contentType: FernRegistry.api.v1.read.ContentType | undefined;
+    exploded: boolean | undefined;
 }

--- a/packages/parsers/src/client/generated/api/resources/api/resources/v1/resources/register/resources/type/types/FormDataBodyProperty.ts
+++ b/packages/parsers/src/client/generated/api/resources/api/resources/v1/resources/register/resources/type/types/FormDataBodyProperty.ts
@@ -6,4 +6,5 @@ import * as FernRegistry from "../../../../../../../../../index";
 
 export interface FormDataBodyProperty extends FernRegistry.api.v1.register.ObjectProperty {
     contentType: FernRegistry.api.v1.register.ContentType | undefined;
+    exploded: boolean | undefined;
 }

--- a/servers/fdr/src/api/generated/api/resources/api/resources/v1/resources/read/resources/type/types/FormDataBodyProperty.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/api/resources/v1/resources/read/resources/type/types/FormDataBodyProperty.d.ts
@@ -4,4 +4,5 @@
 import * as FernRegistry from "../../../../../../../../../index";
 export interface FormDataBodyProperty extends FernRegistry.api.v1.read.ObjectProperty {
     contentType: FernRegistry.api.v1.read.ContentType | undefined;
+    exploded: boolean | undefined;
 }

--- a/servers/fdr/src/api/generated/api/resources/api/resources/v1/resources/register/resources/type/types/FormDataBodyProperty.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/api/resources/v1/resources/register/resources/type/types/FormDataBodyProperty.d.ts
@@ -4,4 +4,5 @@
 import * as FernRegistry from "../../../../../../../../../index";
 export interface FormDataBodyProperty extends FernRegistry.api.v1.register.ObjectProperty {
     contentType: FernRegistry.api.v1.register.ContentType | undefined;
+    exploded: boolean | undefined;
 }


### PR DESCRIPTION
## Short description of the changes made
Pipe through exploded through legacy API for the legacy OpenAPI parser. 

## What was the motivation & context behind this PR?
Customer demand. 

## How has this PR been tested?
Snapshots. 
