### PR TITLE
feat: search disabled config

### DIFF
--- a/packages/fern-docs/edge-config/src/getEdgeFlags.ts
+++ b/packages/fern-docs/edge-config/src/getEdgeFlags.ts
@@ -17,6 +17,7 @@ const EDGE_FLAGS = [
   "toc-default-enabled" as const,
   "snippet-template-enabled" as const,
   "http-snippets-enabled" as const,
+  "search-disabled" as const,
   "inline-feedback-enabled" as const,
   "dark-code-enabled" as const,
   "disable-proxy" as const,
@@ -74,6 +75,10 @@ export async function getEdgeFlags(domain: string): Promise<EdgeFlags> {
     const isSnippetTemplatesEnabled = checkDomainMatchesCustomers(
       domain,
       config["snippet-template-enabled"]
+    );
+    const isSearchDisabled = checkDomainMatchesCustomers(
+      domain,
+      config["search-disabled"]
     );
     const isHttpSnippetsEnabled = checkDomainMatchesCustomers(
       domain,
@@ -181,6 +186,7 @@ export async function getEdgeFlags(domain: string): Promise<EdgeFlags> {
       isTocDefaultEnabled,
       isSnippetTemplatesEnabled:
         isSnippetTemplatesEnabled || isDevelopment(domain),
+      isSearchDisabled,
       isHttpSnippetsEnabled,
       isInlineFeedbackEnabled,
       isDarkCodeEnabled,
@@ -216,6 +222,7 @@ export async function getEdgeFlags(domain: string): Promise<EdgeFlags> {
       isSeoDisabled: !isCustomDomain(domain),
       isTocDefaultEnabled: false,
       isSnippetTemplatesEnabled: isDevelopment(domain),
+      isSearchDisabled: false,
       isHttpSnippetsEnabled: false,
       isInlineFeedbackEnabled: isFern(domain),
       isDarkCodeEnabled: false,

--- a/packages/fern-docs/ui/src/services/useSearchService.ts
+++ b/packages/fern-docs/ui/src/services/useSearchService.ts
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import type { SearchConfig } from "@fern-docs/search-utils";
+import { useEdgeFlags } from "../atoms";
 import { useIsLocalPreview } from "../contexts/local-preview";
 import { useApiRouteSWR } from "../hooks/useApiRouteSWR";
 
@@ -24,8 +25,9 @@ export type SearchService = SearchService.Available | SearchService.Unavailable;
 
 export function useSearchConfig(): SearchConfig {
   const isLocalPreview = useIsLocalPreview();
+  const { isSearchDisabled } = useEdgeFlags();
 
-  if (isLocalPreview) {
+  if (isLocalPreview || isSearchDisabled) {
     return { isAvailable: false };
   }
 

--- a/packages/fern-docs/utils/src/flags.ts
+++ b/packages/fern-docs/utils/src/flags.ts
@@ -5,6 +5,7 @@ export interface EdgeFlags {
   isSeoDisabled: boolean;
   isTocDefaultEnabled: boolean;
   isSnippetTemplatesEnabled: boolean;
+  isSearchDisabled: boolean;
   isHttpSnippetsEnabled: boolean;
   isInlineFeedbackEnabled: boolean;
   isDarkCodeEnabled: boolean;
@@ -40,6 +41,7 @@ export const DEFAULT_EDGE_FLAGS: EdgeFlags = {
   isSeoDisabled: false,
   isTocDefaultEnabled: false,
   isSnippetTemplatesEnabled: false,
+  isSearchDisabled: false,
   isHttpSnippetsEnabled: false,
   isInlineFeedbackEnabled: false,
   isDarkCodeEnabled: false,


### PR DESCRIPTION
This PR hooks up a new Edge config to disable search. Makes it easier for customers like Deepgram to hijack search. 
