### PR TITLE
chore: handle 204 content types in playground

### DIFF
--- a/packages/fern-docs/ui/src/playground/endpoint/PlaygroundResponseCard.tsx
+++ b/packages/fern-docs/ui/src/playground/endpoint/PlaygroundResponseCard.tsx
@@ -141,6 +141,8 @@ export function PlaygroundResponseCard({
               title="PDF preview"
               allowFullScreen
             />
+          ) : response.response.status === 204 ? (
+            <PlaygroundResponsePreview response={response} />
           ) : (
             <FernErrorTag
               component="PlaygroundEndpointContent"


### PR DESCRIPTION
## Short description of the changes made
204 responses are not handled safely in the API plagyround. 

## What was the motivation & context behind this PR?
Customer reported issue. 

## How has this PR been tested?
Local preview
