### PR TITLE
feat: resolve hrefs in markdown

### DIFF
--- a/packages/fern-docs/bundle/src/server/withResolvedDocsContent.ts
+++ b/packages/fern-docs/bundle/src/server/withResolvedDocsContent.ts
@@ -20,6 +20,7 @@ interface WithResolvedDocsContentOpts {
   edgeFlags: EdgeFlags;
   scope?: Record<string, unknown>;
   replaceSrc?: (src: string) => ImageData | undefined;
+  replaceHref?: (href: string) => string | undefined;
 }
 
 export async function withResolvedDocsContent({
@@ -30,6 +31,7 @@ export async function withResolvedDocsContent({
   edgeFlags,
   scope,
   replaceSrc,
+  replaceHref,
 }: WithResolvedDocsContentOpts): Promise<DocsContent | undefined> {
   const node = withPrunedNavigation(found.node, {
     visibleNodeIds: [found.node.id],
@@ -81,6 +83,8 @@ export async function withResolvedDocsContent({
 
       // inject the file url and dimensions for images and other embeddable files
       replaceSrc,
+      // resolve absolute pathed hrefs to the correct path (considers version and basepath)
+      replaceHref,
     },
     serializeMdx,
     domain,

--- a/packages/fern-docs/ui/src/mdx/bundlers/mdx-bundler.ts
+++ b/packages/fern-docs/ui/src/mdx/bundlers/mdx-bundler.ts
@@ -25,6 +25,7 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import remarkSmartypants from "remark-smartypants";
 import { rehypeFiles } from "../plugins/rehype-files";
+import { rehypeLinks } from "../plugins/rehype-links";
 import { rehypeExtractAsides } from "../plugins/rehypeExtractAsides";
 import { rehypeFernCode } from "../plugins/rehypeFernCode";
 import { rehypeFernComponents } from "../plugins/rehypeFernComponents";
@@ -50,6 +51,7 @@ async function serializeMdxImpl(
     filename,
     scope = {},
     replaceSrc,
+    replaceHref,
   }: FernSerializeMdxOptions = {}
 ): Promise<FernDocs.MarkdownText | undefined> {
   if (content == null) {
@@ -141,6 +143,7 @@ async function serializeMdxImpl(
         rehypeSqueezeParagraphs,
         rehypeMdxClassStyle,
         [rehypeFiles, { replaceSrc }],
+        [rehypeLinks, { replaceHref }],
         rehypeAcornErrorBoundary,
         rehypeSlug,
         rehypeKatex,

--- a/packages/fern-docs/ui/src/mdx/bundlers/next-mdx-remote.ts
+++ b/packages/fern-docs/ui/src/mdx/bundlers/next-mdx-remote.ts
@@ -22,6 +22,7 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import remarkSmartypants from "remark-smartypants";
 import { rehypeFiles } from "../plugins/rehype-files";
+import { rehypeLinks } from "../plugins/rehype-links";
 import { rehypeExtractAsides } from "../plugins/rehypeExtractAsides";
 import { rehypeFernCode } from "../plugins/rehypeFernCode";
 import { rehypeFernComponents } from "../plugins/rehypeFernComponents";
@@ -31,7 +32,7 @@ import type { FernSerializeMdxOptions } from "../types";
 type SerializeOptions = NonNullable<Parameters<typeof serialize>[1]>;
 
 function withDefaultMdxOptions(
-  { options = {}, replaceSrc }: FernSerializeMdxOptions = {},
+  { options = {}, replaceSrc, replaceHref }: FernSerializeMdxOptions = {},
   frontmatter: FernDocs.Frontmatter
 ): SerializeOptions["mdxOptions"] {
   const remarkRehypeOptions = {
@@ -60,6 +61,7 @@ function withDefaultMdxOptions(
     rehypeSqueezeParagraphs,
     rehypeMdxClassStyle,
     [rehypeFiles, { replaceSrc }],
+    [rehypeLinks, { replaceHref }],
     rehypeAcornErrorBoundary,
     rehypeSlug,
     rehypeKatex,

--- a/packages/fern-docs/ui/src/mdx/plugins/rehype-links.ts
+++ b/packages/fern-docs/ui/src/mdx/plugins/rehype-links.ts
@@ -7,7 +7,7 @@ import {
 } from "@fern-docs/mdx";
 
 export interface RehypeLinksOptions {
-  replaceHref?(href: string): string | undefined;
+  replaceHref?: (href: string) => string | undefined;
 }
 
 export function rehypeLinks({ replaceHref }: RehypeLinksOptions = {}): (

--- a/packages/fern-docs/ui/src/mdx/plugins/rehype-links.ts
+++ b/packages/fern-docs/ui/src/mdx/plugins/rehype-links.ts
@@ -1,0 +1,52 @@
+import {
+  isMdxJsxAttribute,
+  isMdxJsxElementHast,
+  mdxJsxAttributeToString,
+  visit,
+  type Hast,
+} from "@fern-docs/mdx";
+
+export interface RehypeLinksOptions {
+  replaceHref?(href: string): string | undefined;
+}
+
+export function rehypeLinks({ replaceHref }: RehypeLinksOptions = {}): (
+  ast: Hast.Root
+) => void {
+  return function (ast): void {
+    if (replaceHref == null) {
+      return;
+    }
+    visit(ast, (node) => {
+      if (node.type === "element" && node.tagName === "a") {
+        const href = node.properties.href;
+        if (typeof href !== "string") {
+          return;
+        }
+        const newHref = replaceHref(href);
+        if (newHref == null) {
+          return;
+        }
+        node.properties.href = newHref;
+      }
+
+      // TODO handle nested attributes and mdx expressions
+      if (isMdxJsxElementHast(node)) {
+        const attributes = node.attributes.filter(isMdxJsxAttribute);
+        const hrefAttribute = attributes.find((attr) => attr.name === "href");
+        if (hrefAttribute == null) {
+          return;
+        }
+        const href = mdxJsxAttributeToString(hrefAttribute);
+        if (!href) {
+          return;
+        }
+        const newHref = replaceHref(href);
+        if (newHref == null) {
+          return;
+        }
+        hrefAttribute.value = newHref;
+      }
+    });
+  };
+}

--- a/packages/fern-docs/ui/src/mdx/plugins/rehype-links.ts
+++ b/packages/fern-docs/ui/src/mdx/plugins/rehype-links.ts
@@ -13,7 +13,7 @@ export interface RehypeLinksOptions {
 export function rehypeLinks({ replaceHref }: RehypeLinksOptions = {}): (
   ast: Hast.Root
 ) => void {
-  return function (ast): void {
+  return (ast) => {
     if (replaceHref == null) {
       return;
     }

--- a/packages/fern-docs/ui/src/mdx/types.ts
+++ b/packages/fern-docs/ui/src/mdx/types.ts
@@ -1,6 +1,7 @@
 import type * as FernDocs from "@fern-api/fdr-sdk/docs";
 import type { Options } from "@mdx-js/esbuild";
 import { RehypeFilesOptions } from "./plugins/rehype-files";
+import { RehypeLinksOptions } from "./plugins/rehype-links";
 
 export type FernSerializeMdxOptions = {
   filename?: string;
@@ -10,6 +11,7 @@ export type FernSerializeMdxOptions = {
   files?: Record<string, string>;
   scope?: Record<string, unknown>;
   replaceSrc?: RehypeFilesOptions["replaceSrc"];
+  replaceHref?: RehypeLinksOptions["replaceHref"];
 };
 
 export type SerializeMdxFunc =


### PR DESCRIPTION
sometimes urls inside of markdown needs to be version-aware, so that when the same page is repeated in multiple versions, the docs writer can use an absolute path that works on all versions.

An example:
```mdx
[Link](/path/to/another/page)
```

and both the current page and the target page exists across multiple versions of the docs, then it will link you to the right version: `/version-a/path/to/another/page` and `/version-b/path/to/another/page` depending on which version you're currently viewing.