### PR TITLE
chore: scale down initial fdr task nodes to 9

### DIFF
--- a/servers/fdr-deploy/bin/fdr-deploy.ts
+++ b/servers/fdr-deploy/bin/fdr-deploy.ts
@@ -50,7 +50,7 @@ async function main() {
           environmentType,
           environmentInfo,
           {
-            desiredTaskCount: 12,
+            desiredTaskCount: 9,
             maxTaskCount: 24,
             redis: true,
             memory: 4096,


### PR DESCRIPTION
## Short description of the changes made
B/c load with url now loads from s3, we should be able to scale down FDR. 

## What was the motivation & context behind this PR?
Save some cost. 

## How has this PR been tested?
N/A
