### PR TITLE
feat: override matching for code blocks

### DIFF
--- a/packages/fern-docs/syntax-highlighter/src/FernSyntaxHighlighter.tsx
+++ b/packages/fern-docs/syntax-highlighter/src/FernSyntaxHighlighter.tsx
@@ -21,6 +21,7 @@ export interface FernSyntaxHighlighterProps {
   viewportRef?: React.RefObject<ScrollToHandle>;
   maxLines?: number;
   wordWrap?: boolean;
+  matchLanguage?: string;
 }
 
 export const FernSyntaxHighlighter = forwardRef<
@@ -38,7 +39,7 @@ export const FernSyntaxHighlighter = forwardRef<
       return highlightTokens(highlighter, code, language);
     } catch (e) {
       // TODO: sentry
-      // eslint-disable-next-line no-console
+
       console.error("Error occurred while highlighting tokens", e);
       return createRawTokens(code, language);
     }

--- a/packages/fern-docs/ui/src/mdx/components/code/CodeGroup.tsx
+++ b/packages/fern-docs/ui/src/mdx/components/code/CodeGroup.tsx
@@ -35,15 +35,8 @@ export const CodeGroup: React.FC<React.PropsWithChildren<CodeGroup.Props>> = ({
   useEffect(() => {
     if (selectedLanguage) {
       const matchingTab = itemsRef.current.find((item) => {
-        if (item.matchLanguage) {
-          return (
-            ApiDefinition.cleanLanguage(item.matchLanguage) === selectedLanguage
-          );
-        }
-        return (
-          item.language &&
-          ApiDefinition.cleanLanguage(item.language) === selectedLanguage
-        );
+        const matchLanguage = item.matchLanguage || item.language;
+        return ApiDefinition.cleanLanguage(matchLanguage) === selectedLanguage;
       });
 
       if (matchingTab) {
@@ -51,12 +44,10 @@ export const CodeGroup: React.FC<React.PropsWithChildren<CodeGroup.Props>> = ({
         setSelectedTabIndex((prevIndex) => {
           const prevTab = itemsRef.current[prevIndex];
           if (prevTab) {
-            const currentMatch = prevTab.matchLanguage
-              ? ApiDefinition.cleanLanguage(prevTab.matchLanguage) ===
-                selectedLanguage
-              : prevTab.language &&
-                ApiDefinition.cleanLanguage(prevTab.language) ===
-                  selectedLanguage;
+            const prevMatchLanguage = prevTab.matchLanguage || prevTab.language;
+            const currentMatch =
+              ApiDefinition.cleanLanguage(prevMatchLanguage) ===
+              selectedLanguage;
             if (currentMatch) {
               return prevIndex;
             }
@@ -72,14 +63,12 @@ export const CodeGroup: React.FC<React.PropsWithChildren<CodeGroup.Props>> = ({
     setSelectedTabIndex(newIndex);
 
     const tab = itemsRef.current[newIndex];
-    const normalizedLanguage = tab?.matchLanguage
-      ? ApiDefinition.cleanLanguage(tab.matchLanguage)
-      : tab?.language
-        ? ApiDefinition.cleanLanguage(tab.language)
-        : undefined;
-
-    if (normalizedLanguage && normalizedLanguage !== selectedLanguage) {
-      setSelectedLanguage(normalizedLanguage);
+    if (tab) {
+      const matchLanguage = tab.matchLanguage || tab.language;
+      const normalizedLanguage = ApiDefinition.cleanLanguage(matchLanguage);
+      if (normalizedLanguage && normalizedLanguage !== selectedLanguage) {
+        setSelectedLanguage(normalizedLanguage);
+      }
     }
   };
 

--- a/packages/fern-docs/ui/src/mdx/components/code/CodeGroup.tsx
+++ b/packages/fern-docs/ui/src/mdx/components/code/CodeGroup.tsx
@@ -15,6 +15,7 @@ import { HorizontalOverflowMask } from "../../../components/HorizontalOverflowMa
 export declare namespace CodeGroup {
   export interface Item extends FernSyntaxHighlighterProps {
     title?: string;
+    matchLanguage?: string;
   }
 
   export interface Props {
@@ -34,19 +35,31 @@ export const CodeGroup: React.FC<React.PropsWithChildren<CodeGroup.Props>> = ({
   useEffect(() => {
     if (selectedLanguage) {
       const matchingTab = itemsRef.current.find((item) => {
-        const normalizedLanguage = ApiDefinition.cleanLanguage(item.language);
-        return item.language && normalizedLanguage === selectedLanguage;
+        if (item.matchLanguage) {
+          return (
+            ApiDefinition.cleanLanguage(item.matchLanguage) === selectedLanguage
+          );
+        }
+        return (
+          item.language &&
+          ApiDefinition.cleanLanguage(item.language) === selectedLanguage
+        );
       });
 
       if (matchingTab) {
         const newIndex = itemsRef.current.indexOf(matchingTab);
         setSelectedTabIndex((prevIndex) => {
           const prevTab = itemsRef.current[prevIndex];
-          if (
-            prevTab?.language &&
-            ApiDefinition.cleanLanguage(prevTab.language) === selectedLanguage
-          ) {
-            return prevIndex;
+          if (prevTab) {
+            const currentMatch = prevTab.matchLanguage
+              ? ApiDefinition.cleanLanguage(prevTab.matchLanguage) ===
+                selectedLanguage
+              : prevTab.language &&
+                ApiDefinition.cleanLanguage(prevTab.language) ===
+                  selectedLanguage;
+            if (currentMatch) {
+              return prevIndex;
+            }
           }
           return newIndex;
         });
@@ -59,9 +72,11 @@ export const CodeGroup: React.FC<React.PropsWithChildren<CodeGroup.Props>> = ({
     setSelectedTabIndex(newIndex);
 
     const tab = itemsRef.current[newIndex];
-    const normalizedLanguage = tab?.language
-      ? ApiDefinition.cleanLanguage(tab.language)
-      : undefined;
+    const normalizedLanguage = tab?.matchLanguage
+      ? ApiDefinition.cleanLanguage(tab.matchLanguage)
+      : tab?.language
+        ? ApiDefinition.cleanLanguage(tab.language)
+        : undefined;
 
     if (normalizedLanguage && normalizedLanguage !== selectedLanguage) {
       setSelectedLanguage(normalizedLanguage);

--- a/packages/fern-docs/ui/src/mdx/plugins/rehypeFernCode.ts
+++ b/packages/fern-docs/ui/src/mdx/plugins/rehypeFernCode.ts
@@ -285,7 +285,7 @@ export function parseBlockMetaString(
   }
 
   const matchLanguage = meta.match(
-    /matchLanguage=(?:"((?:[^"\\]|\\.)*?)"|'((?:[^'\\]|\\.)*?)')/
+    /for=(?:"((?:[^"\\]|\\.)*?)"|'((?:[^'\\]|\\.)*?)')/
   );
   const match = matchLanguage?.[1] ?? matchLanguage?.[2];
   meta = meta.replace(matchLanguage?.[0] ?? "", "");

--- a/packages/fern-docs/ui/src/mdx/plugins/rehypeFernCode.ts
+++ b/packages/fern-docs/ui/src/mdx/plugins/rehypeFernCode.ts
@@ -95,6 +95,7 @@ export function rehypeFernCode(): (tree: Hast.Root) => void {
             highlightStyle: meta.focused ? "focus" : "highlight",
             maxLines: meta.maxLines,
             wordWrap: meta.wordWrap,
+            matchLanguage: meta.matchLanguage,
           };
           if (meta.title == null) {
             parent?.children.splice(index, 1, {
@@ -133,6 +134,7 @@ interface CodeBlockItem {
   maxLines: number | undefined;
   title: string | undefined;
   wordWrap: boolean | undefined;
+  matchLanguage: string | undefined;
 }
 
 function visitCodeBlockNodes(nodeToVisit: MdxJsxElementHast) {
@@ -163,6 +165,7 @@ function visitCodeBlockNodes(nodeToVisit: MdxJsxElementHast) {
                     ? title.value.value
                     : undefined),
               wordWrap: meta.wordWrap,
+              matchLanguage: meta.matchLanguage,
             });
           }
         }
@@ -187,6 +190,7 @@ function visitCodeBlockNodes(nodeToVisit: MdxJsxElementHast) {
           maxLines: meta.maxLines,
           title: meta.title,
           wordWrap: meta.wordWrap,
+          matchLanguage: meta.matchLanguage,
         });
       }
     }
@@ -221,6 +225,7 @@ interface FernCodeMeta {
   focused?: boolean;
   wordWrap?: boolean;
   highlights: number[];
+  matchLanguage: string | undefined;
 }
 
 function maybeParseInt(str: string | null | undefined): number | undefined {
@@ -279,6 +284,12 @@ export function parseBlockMetaString(
     meta = meta.replace(wordWrap[0], "");
   }
 
+  const matchLanguage = meta.match(
+    /matchLanguage=(?:"((?:[^"\\]|\\.)*?)"|'((?:[^'\\]|\\.)*?)')/
+  );
+  const match = matchLanguage?.[1] ?? matchLanguage?.[2];
+  meta = meta.replace(matchLanguage?.[0] ?? "", "");
+
   const [highlights, strippedMeta] = parseHighlightedLineNumbers(meta);
   meta = strippedMeta;
 
@@ -306,6 +317,7 @@ export function parseBlockMetaString(
     focused: focused != null,
     wordWrap: wordWrap != null,
     highlights,
+    matchLanguage: match,
   };
 }
 


### PR DESCRIPTION
This PR introduces the ability to override the matching language for CodeBlocks:

https://github.com/user-attachments/assets/0249529a-c270-4d33-9d98-2a4930ef2b06

Usage is as follows:
````md
<CodeGroup>
```bash NPM matchLanguage="typescript"
npm install fern-api
```
```bash PyPI matchLanguage="python"
pypi install fern
```
</CodeGroup>
````