### PR TITLE
feat: Support GET webhooks OpenApi parser v2

### DIFF
--- a/fern/apis/fdr/definition/api/latest/webhook.yml
+++ b/fern/apis/fdr/definition/api/latest/webhook.yml
@@ -19,6 +19,7 @@ types:
       method: WebhookHttpMethod
       path: list<string>
       headers: optional<list<type.ObjectProperty>>
+      queryParameters: optional<list<type.ObjectProperty>>
       payloads: optional<list<WebhookPayload>>
       examples: optional<list<v1Read.ExampleWebhookPayload>>
 

--- a/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
+++ b/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
@@ -247,6 +247,7 @@ export class ApiDefinitionV1ToLatest {
       availability: undefined,
       method: v1.method,
       path: v1.path,
+      queryParameters: undefined,
       headers: this.migrateParameters(v1.headers),
       payloads: [payload],
       examples: v1.examples.map((example) => ({

--- a/packages/fdr-sdk/src/client/generated/api/resources/api/resources/latest/resources/webhook/types/WebhookDefinition.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/api/resources/latest/resources/webhook/types/WebhookDefinition.ts
@@ -14,6 +14,7 @@ export interface WebhookDefinition
     method: FernRegistry.api.latest.WebhookHttpMethod;
     path: string[];
     headers: FernRegistry.api.latest.ObjectProperty[] | undefined;
+    queryParameters: FernRegistry.api.latest.ObjectProperty[] | undefined;
     payloads: FernRegistry.api.latest.WebhookPayload[] | undefined;
     examples: FernRegistry.api.v1.read.ExampleWebhookPayload[] | undefined;
 }

--- a/packages/fdr-sdk/src/client/generated/api/resources/api/resources/v1/resources/register/client/Client.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/api/resources/v1/resources/register/client/Client.ts
@@ -658,6 +658,9 @@ export class Register {
      *                     headers: [{
      *                             "key": "value"
      *                         }],
+     *                     queryParameters: [{
+     *                             "key": "value"
+     *                         }],
      *                     payloads: [{
      *                             "key": "value"
      *                         }],

--- a/packages/fdr-sdk/src/client/generated/api/resources/api/resources/v1/resources/register/client/requests/RegisterApiDefinitionRequest.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/api/resources/v1/resources/register/client/requests/RegisterApiDefinitionRequest.ts
@@ -631,6 +631,9 @@ import * as FernRegistry from "../../../../../../../../index";
  *                     headers: [{
  *                             "key": "value"
  *                         }],
+ *                     queryParameters: [{
+ *                             "key": "value"
+ *                         }],
  *                     payloads: [{
  *                             "key": "value"
  *                         }],

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fern-api/docs-parsers",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern-platform.git",

--- a/packages/parsers/src/client/generated/api/resources/api/resources/latest/resources/webhook/types/WebhookDefinition.ts
+++ b/packages/parsers/src/client/generated/api/resources/api/resources/latest/resources/webhook/types/WebhookDefinition.ts
@@ -14,6 +14,7 @@ export interface WebhookDefinition
     method: FernRegistry.api.latest.WebhookHttpMethod;
     path: string[];
     headers: FernRegistry.api.latest.ObjectProperty[] | undefined;
+    queryParameters: FernRegistry.api.latest.ObjectProperty[] | undefined;
     payloads: FernRegistry.api.latest.WebhookPayload[] | undefined;
     examples: FernRegistry.api.v1.read.ExampleWebhookPayload[] | undefined;
 }

--- a/packages/parsers/src/openapi/3.1/auth/OAuth2SecuritySchemeConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/auth/OAuth2SecuritySchemeConverter.node.ts
@@ -79,6 +79,7 @@ export class OAuth2SecuritySchemeConverterNode extends BaseOpenApiV3_1ConverterN
       this.authorizationUrl,
       "POST",
       undefined,
+      undefined,
       undefined
     );
     if (endpointId == null) {

--- a/packages/parsers/src/openapi/3.1/guards/isWebhookDefinition.ts
+++ b/packages/parsers/src/openapi/3.1/guards/isWebhookDefinition.ts
@@ -5,5 +5,5 @@ export function isWebhookDefinition(
     | FernRegistry.api.latest.EndpointDefinition
     | FernRegistry.api.latest.WebhookDefinition
 ): definition is FernRegistry.api.latest.WebhookDefinition {
-  return "payloads" in definition && definition.payloads != null;
+  return "payloads" in definition;
 }

--- a/packages/parsers/src/openapi/3.1/paths/OperationObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/OperationObjectConverter.node.ts
@@ -320,7 +320,8 @@ export class OperationObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
       this.path,
       this.method,
       sdkMethodName.sdkMethodName,
-      this.input.operationId
+      this.input.operationId,
+      this.isWebhook
     );
 
     // TODO: figure out how to merge user specified examples with success response
@@ -440,6 +441,9 @@ export class OperationObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
         path:
           this.convertPathToPathParts()?.map((part) => part.value.toString()) ??
           [],
+        queryParameters: convertOperationObjectProperties(
+          this.queryParameters
+        )?.flat(),
         headers: convertOperationObjectProperties(this.requestHeaders)?.flat(),
         payloads: this.requests?.convertToWebhookPayload(),
         examples: [this.requests?.webhookExample()].filter(isNonNullish),

--- a/packages/parsers/src/openapi/__test__/__snapshots__/webhooks.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/webhooks.json
@@ -2,7 +2,67 @@
   "id": "test-uuid-replacement",
   "endpoints": {},
   "websockets": {},
-  "webhooks": {},
+  "webhooks": {
+    "webhook_.GetPet": {
+      "id": "webhook_.GetPet",
+      "operationId": "GetPet",
+      "method": "GET",
+      "path": [
+        "/",
+        "pet"
+      ],
+      "queryParameters": [
+        {
+          "key": "id",
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "optional",
+              "shape": {
+                "type": "alias",
+                "value": {
+                  "type": "primitive",
+                  "value": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "examples": []
+    },
+    "webhook_.CreatePet": {
+      "id": "webhook_.CreatePet",
+      "operationId": "CreatePet",
+      "method": "POST",
+      "path": [
+        "/",
+        "pet"
+      ],
+      "payloads": [
+        {
+          "shape": {
+            "type": "alias",
+            "value": {
+              "type": "id",
+              "id": "Pet"
+            }
+          }
+        }
+      ],
+      "examples": [
+        {
+          "payload": {
+            "id": 0,
+            "name": "name",
+            "tag": "tag"
+          }
+        }
+      ]
+    }
+  },
   "types": {
     "Pet": {
       "name": "Pet",

--- a/packages/parsers/src/openapi/__test__/fixtures/webhooks/openapi.yml
+++ b/packages/parsers/src/openapi/__test__/fixtures/webhooks/openapi.yml
@@ -4,6 +4,13 @@ info:
   version: 1.0.0
 webhooks:
   /pet:
+    get:
+      operationId: GetPet
+      parameters:
+        - name: id
+          in: query
+          schema:
+            type: integer
     post:
       operationId: CreatePet
       requestBody:

--- a/packages/parsers/src/openapi/utils/getEndpointId.ts
+++ b/packages/parsers/src/openapi/utils/getEndpointId.ts
@@ -5,7 +5,8 @@ export function getEndpointId(
   path: string | undefined,
   method: string | undefined,
   sdkMethodName: string | undefined,
-  operationId: string | undefined
+  operationId: string | undefined,
+  isWebhook: boolean | undefined
 ): string | undefined {
   if (path == null) {
     return undefined;
@@ -19,5 +20,5 @@ export function getEndpointId(
   if (endpointName == null) {
     return undefined;
   }
-  return `endpoint_${camelCase(namespace != null ? (typeof namespace === "string" ? namespace : namespace.join("_")) : "")}.${camelCase(sdkMethodName ?? "") || operationId || camelCase(endpointName)}`;
+  return `${isWebhook ? "webhook_" : "endpoint_"}${camelCase(namespace != null ? (typeof namespace === "string" ? namespace : namespace.join("_")) : "")}.${camelCase(sdkMethodName ?? "") || operationId || camelCase(endpointName)}`;
 }

--- a/servers/fdr/src/api/generated/api/resources/api/resources/latest/resources/webhook/types/WebhookDefinition.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/api/resources/latest/resources/webhook/types/WebhookDefinition.d.ts
@@ -9,6 +9,7 @@ export interface WebhookDefinition extends FernRegistry.api.latest.WithDescripti
     method: FernRegistry.api.latest.WebhookHttpMethod;
     path: string[];
     headers: FernRegistry.api.latest.ObjectProperty[] | undefined;
+    queryParameters: FernRegistry.api.latest.ObjectProperty[] | undefined;
     payloads: FernRegistry.api.latest.WebhookPayload[] | undefined;
     examples: FernRegistry.api.v1.read.ExampleWebhookPayload[] | undefined;
 }


### PR DESCRIPTION
## Short description of the changes made

* Enables GET endpoints on webhooks
* Adds query parameters to FDR shape, for use with UI to display query parameters

## What was the motivation & context behind this PR?

* Customer request

## How has this PR been tested?

* Snapshot tests
