### PR TITLE
fix: shorten turbopuffer record ids

### DIFF
--- a/packages/fern-docs/search-server/src/turbopuffer/records/create-base-record.ts
+++ b/packages/fern-docs/search-server/src/turbopuffer/records/create-base-record.ts
@@ -71,7 +71,7 @@ export function createBaseRecord({
   );
 
   return {
-    id: `${org_id}:${domain}:${node.id}`,
+    id: node.id,
     attributes: {
       type,
       org_id,


### PR DESCRIPTION
## Short description of the changes made
Turbopuffer record ids need to be less than 64 bytes and org id + domain are repetitive, since we create a namespace for each domain. 

## What was the motivation & context behind this PR?
Failing to index records for a customer. 

## How has this PR been tested?
Staging
