### PR TITLE
chore(docs): rehash turbopuffer record id

### DIFF
--- a/packages/fern-docs/search-server/src/turbopuffer/records/create-base-record.ts
+++ b/packages/fern-docs/search-server/src/turbopuffer/records/create-base-record.ts
@@ -1,6 +1,7 @@
 import { FernNavigation } from "@fern-api/fdr-sdk";
 import { isNonNullish } from "@fern-api/ui-core-utils";
 import { addLeadingSlash } from "@fern-docs/utils";
+import { createHash } from "crypto";
 import { createRoleFacet } from "../../shared/roles/create-role-facet";
 import {
   flipAndOrToOrAnd,
@@ -71,7 +72,7 @@ export function createBaseRecord({
   );
 
   return {
-    id: node.id,
+    id: createHash("sha256").update(node.id).digest("hex"),
     attributes: {
       type,
       org_id,


### PR DESCRIPTION
## Short description of the changes made
Re 256 hash the turbopuffer record id. 

## What was the motivation & context behind this PR?
Limit max size of turbopuffer records. 

## How has this PR been tested?
N/A
