### PR TITLE
fix: Fix endpoint and subpackage ids for better ergonomics with Nav Converter in CLI and objects

### DIFF
--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fern-api/docs-parsers",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern-platform.git",

--- a/packages/parsers/src/openapi/3.1/auth/OAuth2SecuritySchemeConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/auth/OAuth2SecuritySchemeConverter.node.ts
@@ -77,14 +77,14 @@ export class OAuth2SecuritySchemeConverterNode extends BaseOpenApiV3_1ConverterN
     }
 
     // TODO: revisit this -- this is not correct
-    const endpointId = getEndpointId(
-      undefined,
-      this.authorizationUrl,
-      "POST",
-      undefined,
-      undefined,
-      undefined
-    );
+    const endpointId = getEndpointId({
+      namespace: undefined,
+      path: this.authorizationUrl,
+      method: "POST",
+      sdkMethodName: undefined,
+      operationId: undefined,
+      isWebhook: undefined,
+    });
     if (endpointId == null) {
       return undefined;
     }

--- a/packages/parsers/src/openapi/3.1/extensions/XFernGlobalHeadersConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/extensions/XFernGlobalHeadersConverter.node.ts
@@ -54,6 +54,7 @@ export class XFernGlobalHeadersConverterNode extends BaseOpenApiV3_1ConverterNod
           context: this.context,
           accessPath: this.accessPath,
           pathId: this.pathId,
+          parameterName: headerName,
         }),
       ];
     });

--- a/packages/parsers/src/openapi/3.1/extensions/XFernGroupNameConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/extensions/XFernGroupNameConverter.node.ts
@@ -1,3 +1,4 @@
+import { camelCase } from "es-toolkit";
 import { FernRegistry } from "../../../client/generated";
 import {
   BaseOpenApiV3_1ConverterNode,
@@ -42,6 +43,8 @@ export class XFernGroupNameConverterNode extends BaseOpenApiV3_1ConverterNode<
       subpackagePath = [this.groupName];
     }
 
-    return subpackagePath.map((path) => FernRegistry.api.v1.SubpackageId(path));
+    return subpackagePath.map((path) =>
+      FernRegistry.api.v1.SubpackageId(camelCase(path))
+    );
   }
 }

--- a/packages/parsers/src/openapi/3.1/extensions/__test__/XFernGroupNameConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/extensions/__test__/XFernGroupNameConverter.node.test.ts
@@ -34,7 +34,7 @@ describe("XFernGroupNameConverterNode", () => {
         accessPath: [],
         pathId: "",
       });
-      expect(converter.convert()).toEqual(["test-group"]);
+      expect(converter.convert()).toEqual(["testGroup"]);
     });
 
     it("returns undefined when groupName is not set", () => {

--- a/packages/parsers/src/openapi/3.1/paths/OperationObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/OperationObjectConverter.node.ts
@@ -21,6 +21,7 @@ import { XFernGroupNameConverterNode } from "../extensions/XFernGroupNameConvert
 import { XFernSdkMethodNameConverterNode } from "../extensions/XFernSdkMethodNameConverter.node";
 import { XFernWebhookConverterNode } from "../extensions/XFernWebhookConverter.node";
 import { RedocExampleConverterNode } from "../extensions/examples/RedocExampleConverter.node";
+import { X_FERN_GROUP_NAME } from "../extensions/fernExtension.consts";
 import { isReferenceObject } from "../guards/isReferenceObject";
 import { ExampleObjectConverterNode } from "./ExampleObjectConverter.node";
 import { ServerObjectConverterNode } from "./ServerObjectConverter.node";
@@ -313,12 +314,12 @@ export class OperationObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
     ) {
       // TODO: review if tags multiplex endpoint definitions, or if there should
       // be some cascading behavior
-      this.namespaces = this.input.tags.slice(0, 1).map((tag) => {
+      this.namespaces = this.input.tags.slice(0, 1).map((tag, index) => {
         const newNamespaceNode = new XFernGroupNameConverterNode({
-          input: { "x-fern-group-name": tag },
+          input: { [X_FERN_GROUP_NAME]: tag },
           context: this.context,
           accessPath: this.accessPath,
-          pathId: "x-fern-group-name",
+          pathId: ["tags", `${index}`],
         });
         return newNamespaceNode;
       });

--- a/packages/parsers/src/openapi/3.1/paths/OperationObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/OperationObjectConverter.node.ts
@@ -334,14 +334,14 @@ export class OperationObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
 
     this.endpointIds = this.namespaces
       .map((namespace) =>
-        getEndpointId(
-          maybeSingleValueToArray(namespace?.groupName),
-          this.path,
-          this.method,
-          sdkMethodName.sdkMethodName,
-          this.input.operationId,
-          this.isWebhook
-        )
+        getEndpointId({
+          namespace: maybeSingleValueToArray(namespace?.groupName),
+          path: this.path,
+          method: this.method,
+          sdkMethodName: sdkMethodName.sdkMethodName,
+          operationId: this.input.operationId,
+          isWebhook: this.isWebhook,
+        })
       )
       .filter(isNonNullish);
 

--- a/packages/parsers/src/openapi/3.1/paths/PathItemObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/PathItemObjectConverter.node.ts
@@ -135,11 +135,11 @@ export class PathItemObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
       )[]
     | undefined {
     return [
-      this.get?.convert(),
-      this.post?.convert(),
-      this.put?.convert(),
-      this.patch?.convert(),
-      this.delete?.convert(),
+      ...(this.get?.convert() ?? []),
+      ...(this.post?.convert() ?? []),
+      ...(this.put?.convert() ?? []),
+      ...(this.patch?.convert() ?? []),
+      ...(this.delete?.convert() ?? []),
     ].filter(isNonNullish);
   }
 }

--- a/packages/parsers/src/openapi/3.1/paths/PathItemObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/PathItemObjectConverter.node.ts
@@ -11,6 +11,14 @@ import { XFernBasePathConverterNode } from "../extensions/XFernBasePathConverter
 import { OperationObjectConverterNode } from "./OperationObjectConverter.node";
 import { ServerObjectConverterNode } from "./ServerObjectConverter.node";
 
+type ConstructorArgs =
+  BaseOpenApiV3_1ConverterNodeConstructorArgs<OpenAPIV3_1.PathItemObject> & {
+    servers: ServerObjectConverterNode[] | undefined;
+    globalAuth: SecurityRequirementObjectConverterNode | undefined;
+    basePath: XFernBasePathConverterNode | undefined;
+    isWebhook: boolean | undefined;
+  };
+
 export class PathItemObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
   OpenAPIV3_1.PathItemObject,
   (
@@ -26,21 +34,15 @@ export class PathItemObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
   delete: OperationObjectConverterNode | undefined;
   path: string | undefined;
 
-  constructor(
-    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<OpenAPIV3_1.PathItemObject>,
-    protected servers: ServerObjectConverterNode[] | undefined,
-    protected globalAuth: SecurityRequirementObjectConverterNode | undefined,
-    protected basePath: XFernBasePathConverterNode | undefined,
-    protected isWebhook: boolean | undefined
-  ) {
+  constructor(args: ConstructorArgs) {
     super(args);
-    this.safeParse();
+    this.safeParse(args);
   }
 
-  parse(): void {
+  parse({ servers, globalAuth, basePath, isWebhook }: ConstructorArgs): void {
     this.description = this.input.description;
-    this.servers = coalesceServers(
-      this.servers,
+    const coalescedServers = coalesceServers(
+      servers,
       this.input.servers,
       this.context,
       this.accessPath
@@ -50,81 +52,74 @@ export class PathItemObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
       : this.pathId;
 
     if (this.input.get != null) {
-      this.get = new OperationObjectConverterNode(
-        {
-          input: this.input.get,
-          context: this.context,
-          accessPath: this.accessPath,
-          pathId: "get",
-        },
-        this.servers,
-        this.globalAuth,
+      this.get = new OperationObjectConverterNode({
+        input: this.input.get,
+        context: this.context,
+        accessPath: this.accessPath,
+        pathId: "get",
+        servers: coalescedServers,
+        globalAuth,
         path,
-        "GET",
-        this.basePath,
-        this.isWebhook
-      );
+        method: "GET",
+        basePath,
+        isWebhook,
+      });
     }
     if (this.input.post != null) {
-      this.post = new OperationObjectConverterNode(
-        {
-          input: this.input.post,
-          context: this.context,
-          accessPath: this.accessPath,
-          pathId: "post",
-        },
-        this.servers,
-        this.globalAuth,
+      this.post = new OperationObjectConverterNode({
+        input: this.input.post,
+        context: this.context,
+        accessPath: this.accessPath,
+        pathId: "post",
+        servers: coalescedServers,
+        globalAuth,
         path,
-        "POST",
-        this.basePath,
-        this.isWebhook
-      );
+        method: "POST",
+        basePath,
+        isWebhook,
+      });
     }
     if (this.input.put != null) {
-      this.put = new OperationObjectConverterNode(
-        {
-          input: this.input.put,
-          context: this.context,
-          accessPath: this.accessPath,
-          pathId: "put",
-        },
-        this.servers,
-        this.globalAuth,
+      this.put = new OperationObjectConverterNode({
+        input: this.input.put,
+        context: this.context,
+        accessPath: this.accessPath,
+        pathId: "put",
+        servers: coalescedServers,
+        globalAuth,
         path,
-        "PUT",
-        this.basePath
-      );
+        method: "PUT",
+        basePath,
+        isWebhook: false,
+      });
     }
     if (this.input.patch != null) {
-      this.patch = new OperationObjectConverterNode(
-        {
-          input: this.input.patch,
-          context: this.context,
-          accessPath: this.accessPath,
-          pathId: "patch",
-        },
-        this.servers,
-        this.globalAuth,
+      this.patch = new OperationObjectConverterNode({
+        input: this.input.patch,
+        context: this.context,
+        accessPath: this.accessPath,
+        pathId: "patch",
+        servers: coalescedServers,
+        globalAuth,
         path,
-        "PATCH",
-        this.basePath
-      );
+        method: "PATCH",
+        basePath,
+        isWebhook: false,
+      });
     }
     if (this.input.delete != null) {
-      this.delete = new OperationObjectConverterNode(
-        {
-          input: this.input.delete,
-          context: this.context,
-          accessPath: this.accessPath,
-          pathId: "delete",
-        },
-        this.servers,
-        this.globalAuth,
+      this.delete = new OperationObjectConverterNode({
+        input: this.input.delete,
+        context: this.context,
+        accessPath: this.accessPath,
+        pathId: "delete",
+        servers: coalescedServers,
+        globalAuth,
         path,
-        "DELETE",
-        this.basePath
-      );
+        method: "DELETE",
+        basePath,
+        isWebhook: false,
+      });
     }
   }
 

--- a/packages/parsers/src/openapi/3.1/paths/PathsObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/PathsObjectConverter.node.ts
@@ -23,6 +23,13 @@ export declare namespace PathsObjectConverterNode {
       FernRegistry.api.latest.WebhookDefinition
     >;
   }
+
+  export interface ConstructorArgs
+    extends BaseOpenApiV3_1ConverterNodeConstructorArgs<OpenAPIV3_1.PathsObject> {
+    servers: ServerObjectConverterNode[] | undefined;
+    globalAuth: SecurityRequirementObjectConverterNode | undefined;
+    basePath: XFernBasePathConverterNode | undefined;
+  }
 }
 
 export class PathsObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
@@ -31,41 +38,36 @@ export class PathsObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
 > {
   paths: PathItemObjectConverterNode[] | undefined;
 
-  constructor(
-    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<OpenAPIV3_1.PathsObject>,
-    protected readonly servers: ServerObjectConverterNode[] | undefined,
-    protected readonly globalAuth:
-      | SecurityRequirementObjectConverterNode
-      | undefined,
-    protected readonly basePath: XFernBasePathConverterNode | undefined
-  ) {
+  constructor(args: PathsObjectConverterNode.ConstructorArgs) {
     super(args);
-    this.safeParse();
+    this.safeParse(args);
   }
 
-  parse(): void {
+  parse({
+    servers,
+    globalAuth,
+    basePath,
+  }: PathsObjectConverterNode.ConstructorArgs): void {
     this.paths = Object.entries(this.input)
       .map(([path, pathItem]) => {
         if (pathItem == null) {
           return undefined;
         }
-        return new PathItemObjectConverterNode(
-          {
-            input: pathItem,
-            context: this.context,
-            accessPath: this.accessPath,
-            pathId: path,
-          },
-          coalesceServers(
-            this.servers,
+        return new PathItemObjectConverterNode({
+          input: pathItem,
+          context: this.context,
+          accessPath: this.accessPath,
+          pathId: path,
+          servers: coalesceServers(
+            servers,
             pathItem.servers,
             this.context,
             this.accessPath
           ),
-          this.globalAuth,
-          this.basePath,
-          undefined
-        );
+          globalAuth,
+          basePath,
+          isWebhook: undefined,
+        });
       })
       .filter(isNonNullish);
   }

--- a/packages/parsers/src/openapi/3.1/paths/WebhooksObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/WebhooksObjectConverter.node.ts
@@ -13,27 +13,33 @@ import { isWebhookDefinition } from "../guards/isWebhookDefinition";
 import { PathItemObjectConverterNode } from "./PathItemObjectConverter.node";
 import { ServerObjectConverterNode } from "./ServerObjectConverter.node";
 
+export declare namespace WebhooksObjectConverterNode {
+  export interface ConstructorArgs
+    extends BaseOpenApiV3_1ConverterNodeConstructorArgs<
+      OpenAPIV3_1.Document["webhooks"]
+    > {
+    servers: ServerObjectConverterNode[] | undefined;
+    globalAuth: SecurityRequirementObjectConverterNode | undefined;
+    basePath: XFernBasePathConverterNode | undefined;
+  }
+}
+
 export class WebhooksObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
   OpenAPIV3_1.Document["webhooks"],
   FernRegistry.api.latest.ApiDefinition["webhooks"]
 > {
   webhooks: PathItemObjectConverterNode[] | undefined;
 
-  constructor(
-    args: BaseOpenApiV3_1ConverterNodeConstructorArgs<
-      OpenAPIV3_1.Document["webhooks"]
-    >,
-    protected readonly basePath: XFernBasePathConverterNode | undefined,
-    protected readonly servers: ServerObjectConverterNode[] | undefined,
-    protected readonly globalAuth:
-      | SecurityRequirementObjectConverterNode
-      | undefined
-  ) {
+  constructor(args: WebhooksObjectConverterNode.ConstructorArgs) {
     super(args);
-    this.safeParse();
+    this.safeParse(args);
   }
 
-  parse(): void {
+  parse({
+    servers,
+    globalAuth,
+    basePath,
+  }: WebhooksObjectConverterNode.ConstructorArgs): void {
     this.webhooks = Object.entries(this.input ?? {})
       .map(([operation, operationItem]) => {
         const resolvedOperationItem = resolveWebhookReference(
@@ -43,18 +49,16 @@ export class WebhooksObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
         if (resolvedOperationItem == null) {
           return undefined;
         }
-        return new PathItemObjectConverterNode(
-          {
-            input: resolvedOperationItem,
-            context: this.context,
-            accessPath: this.accessPath,
-            pathId: operation,
-          },
-          this.servers,
-          this.globalAuth,
-          this.basePath,
-          true
-        );
+        return new PathItemObjectConverterNode({
+          input: resolvedOperationItem,
+          context: this.context,
+          accessPath: this.accessPath,
+          pathId: operation,
+          servers,
+          globalAuth,
+          basePath,
+          isWebhook: true,
+        });
       })
       .filter(isNonNullish);
   }

--- a/packages/parsers/src/openapi/3.1/paths/__test__/OperationObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/OperationObjectConverter.node.test.ts
@@ -35,7 +35,7 @@ describe("OperationObjectConverterNode", () => {
 
       const result = node.convert();
 
-      expect(result).toEqual({
+      expect(result).toEqual([{
         auth: undefined,
         availability: undefined,
         defaultEnvironment: undefined,
@@ -99,7 +99,7 @@ describe("OperationObjectConverterNode", () => {
         responseHeaders: undefined,
         responses: undefined,
         snippetTemplates: undefined,
-      });
+      }]);
     });
 
     it("should handle undefined path", () => {

--- a/packages/parsers/src/openapi/3.1/paths/__test__/OperationObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/OperationObjectConverter.node.test.ts
@@ -35,71 +35,73 @@ describe("OperationObjectConverterNode", () => {
 
       const result = node.convert();
 
-      expect(result).toEqual([{
-        auth: undefined,
-        availability: undefined,
-        defaultEnvironment: undefined,
-        description: "Get a pet",
-        displayName: undefined,
-        environments: [],
-        errors: undefined,
-        examples: [
-          {
-            path: "/pets/petId",
-            responseStatusCode: 200,
-            pathParameters: {
-              petId: "petId",
-            },
-          },
-        ],
-        id: "endpoint_.getPetsPetId",
-        method: "GET",
-        namespace: undefined,
-        operationId: undefined,
-        path: [
-          { type: "literal", value: "/" },
-          { type: "literal", value: "pets" },
-          { type: "literal", value: "/" },
-          { type: "pathParameter", value: FernRegistry.PropertyKey("petId") },
-        ],
-        pathParameters: [
-          {
-            availability: undefined,
-            description: undefined,
-            key: FernRegistry.PropertyKey("petId"),
-            valueShape: {
-              type: "alias",
-              value: {
-                default: undefined,
-                shape: {
-                  type: "alias",
-                  value: {
-                    type: "primitive",
-                    value: {
-                      default: undefined,
-                      format: undefined,
-                      maxLength: undefined,
-                      minLength: undefined,
-                      regex: undefined,
-                      type: "string",
-                    },
-                  },
-                },
-                type: "optional",
+      expect(result).toEqual([
+        {
+          auth: undefined,
+          availability: undefined,
+          defaultEnvironment: undefined,
+          description: "Get a pet",
+          displayName: undefined,
+          environments: [],
+          errors: undefined,
+          examples: [
+            {
+              path: "/pets/petId",
+              responseStatusCode: 200,
+              pathParameters: {
+                petId: "petId",
               },
             },
+          ],
+          id: "endpoint_.getPetsPetId",
+          method: "GET",
+          namespace: undefined,
+          operationId: undefined,
+          path: [
+            { type: "literal", value: "/" },
+            { type: "literal", value: "pets" },
+            { type: "literal", value: "/" },
+            { type: "pathParameter", value: FernRegistry.PropertyKey("petId") },
+          ],
+          pathParameters: [
+            {
+              availability: undefined,
+              description: undefined,
+              key: FernRegistry.PropertyKey("petId"),
+              valueShape: {
+                type: "alias",
+                value: {
+                  default: undefined,
+                  shape: {
+                    type: "alias",
+                    value: {
+                      type: "primitive",
+                      value: {
+                        default: undefined,
+                        format: undefined,
+                        maxLength: undefined,
+                        minLength: undefined,
+                        regex: undefined,
+                        type: "string",
+                      },
+                    },
+                  },
+                  type: "optional",
+                },
+              },
+            },
+          ],
+          protocol: {
+            type: "rest",
           },
-        ],
-        protocol: {
-          type: "rest",
+          queryParameters: undefined,
+          requestHeaders: undefined,
+          requests: undefined,
+          responseHeaders: undefined,
+          responses: undefined,
+          snippetTemplates: undefined,
         },
-        queryParameters: undefined,
-        requestHeaders: undefined,
-        requests: undefined,
-        responseHeaders: undefined,
-        responses: undefined,
-        snippetTemplates: undefined,
-      }]);
+      ]);
     });
 
     it("should handle undefined path", () => {

--- a/packages/parsers/src/openapi/3.1/paths/__test__/OperationObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/OperationObjectConverter.node.test.ts
@@ -19,19 +19,18 @@ describe("OperationObjectConverterNode", () => {
         ],
       };
 
-      const node = new OperationObjectConverterNode(
-        {
-          input,
-          context: mockContext,
-          accessPath: [],
-          pathId: "test",
-        },
-        undefined,
-        undefined,
-        "/pets/{petId}",
-        "GET",
-        undefined
-      );
+      const node = new OperationObjectConverterNode({
+        input,
+        context: mockContext,
+        accessPath: [],
+        pathId: "test",
+        path: "/pets/{petId}",
+        method: "GET",
+        servers: undefined,
+        globalAuth: undefined,
+        basePath: undefined,
+        isWebhook: undefined,
+      });
 
       const result = node.convert();
 
@@ -110,20 +109,18 @@ describe("OperationObjectConverterNode", () => {
       };
 
       const path = undefined as unknown as string;
-      const node = new OperationObjectConverterNode(
-        {
-          input,
-          context: mockContext,
-          accessPath: [],
-          pathId: "test",
-        },
-        undefined,
-        undefined,
+      const node = new OperationObjectConverterNode({
+        input,
+        context: mockContext,
+        accessPath: [],
+        pathId: "test",
+        method: "GET",
         path,
-        "GET",
-        undefined,
-        undefined
-      );
+        servers: undefined,
+        globalAuth: undefined,
+        basePath: undefined,
+        isWebhook: undefined,
+      });
 
       const result = node.convert();
       expect(result).toBeUndefined();
@@ -132,19 +129,18 @@ describe("OperationObjectConverterNode", () => {
 
   describe("convertPathToPathParts", () => {
     it("should convert path with parameters", () => {
-      const node = new OperationObjectConverterNode(
-        {
-          input: {},
-          context: mockContext,
-          accessPath: [],
-          pathId: "test",
-        },
-        undefined,
-        undefined,
-        "/users/{userId}/posts/{postId}",
-        "GET",
-        undefined
-      );
+      const node = new OperationObjectConverterNode({
+        input: {},
+        context: mockContext,
+        accessPath: [],
+        pathId: "test",
+        path: "/users/{userId}/posts/{postId}",
+        method: "GET",
+        servers: undefined,
+        globalAuth: undefined,
+        basePath: undefined,
+        isWebhook: undefined,
+      });
 
       const result = node.convertPathToPathParts();
 

--- a/packages/parsers/src/openapi/3.1/paths/__test__/PathItemObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/PathItemObjectConverter.node.test.ts
@@ -34,18 +34,16 @@ describe("PathItemObjectConverterNode", () => {
         },
       };
 
-      const node = new PathItemObjectConverterNode(
-        {
-          input,
-          context: mockContext,
-          accessPath: [],
-          pathId: "/pets/{petId}",
-        },
-        undefined,
-        undefined,
-        undefined,
-        undefined
-      );
+      const node = new PathItemObjectConverterNode({
+        input,
+        context: mockContext,
+        accessPath: [],
+        pathId: "/pets/{petId}",
+        servers: undefined,
+        globalAuth: undefined,
+        basePath: undefined,
+        isWebhook: undefined,
+      });
 
       const result = node.convert();
 
@@ -182,18 +180,16 @@ describe("PathItemObjectConverterNode", () => {
         description: "Empty path",
       };
 
-      const node = new PathItemObjectConverterNode(
-        {
-          input,
-          context: mockContext,
-          accessPath: [],
-          pathId: "/empty",
-        },
-        undefined,
-        undefined,
-        undefined,
-        undefined
-      );
+      const node = new PathItemObjectConverterNode({
+        input,
+        context: mockContext,
+        accessPath: [],
+        pathId: "/empty",
+        servers: undefined,
+        globalAuth: undefined,
+        basePath: undefined,
+        isWebhook: undefined,
+      });
 
       const result = node.convert();
       expect(result).toEqual([]);
@@ -216,18 +212,16 @@ describe("PathItemObjectConverterNode", () => {
         },
       };
 
-      const node = new PathItemObjectConverterNode(
-        {
-          input,
-          context: mockContext,
-          accessPath: [],
-          pathId: "/test",
-        },
-        undefined,
-        undefined,
-        undefined,
-        undefined
-      );
+      const node = new PathItemObjectConverterNode({
+        input,
+        context: mockContext,
+        accessPath: [],
+        pathId: "/test",
+        servers: undefined,
+        globalAuth: undefined,
+        basePath: undefined,
+        isWebhook: undefined,
+      });
 
       const result = node.convert();
       expect(result).toHaveLength(1);

--- a/packages/parsers/src/openapi/3.1/paths/__test__/PathsObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/PathsObjectConverter.node.test.ts
@@ -37,17 +37,15 @@ describe("PathsObjectConverterNode", () => {
         },
       };
 
-      const node = new PathsObjectConverterNode(
-        {
-          input,
-          context: mockContext,
-          accessPath: [],
-          pathId: "test",
-        },
-        undefined,
-        undefined,
-        undefined
-      );
+      const node = new PathsObjectConverterNode({
+        input,
+        context: mockContext,
+        accessPath: [],
+        pathId: "test",
+        servers: undefined,
+        globalAuth: undefined,
+        basePath: undefined,
+      });
 
       const result = node.convert() ?? { endpoints: {} };
 
@@ -65,17 +63,15 @@ describe("PathsObjectConverterNode", () => {
     it("should handle empty paths object", () => {
       const input: OpenAPIV3_1.PathsObject = {};
 
-      const node = new PathsObjectConverterNode(
-        {
-          input,
-          context: mockContext,
-          accessPath: [],
-          pathId: "test",
-        },
-        undefined,
-        undefined,
-        undefined
-      );
+      const node = new PathsObjectConverterNode({
+        input,
+        context: mockContext,
+        accessPath: [],
+        pathId: "test",
+        servers: undefined,
+        globalAuth: undefined,
+        basePath: undefined,
+      });
 
       const result = node.convert();
       expect(result).toEqual({
@@ -89,17 +85,15 @@ describe("PathsObjectConverterNode", () => {
         "/test": undefined,
       };
 
-      const node = new PathsObjectConverterNode(
-        {
-          input,
-          context: mockContext,
-          accessPath: [],
-          pathId: "test",
-        },
-        undefined,
-        undefined,
-        undefined
-      );
+      const node = new PathsObjectConverterNode({
+        input,
+        context: mockContext,
+        accessPath: [],
+        pathId: "test",
+        servers: undefined,
+        globalAuth: undefined,
+        basePath: undefined,
+      });
 
       const result = node.convert();
       expect(result).toEqual({
@@ -127,17 +121,15 @@ describe("PathsObjectConverterNode", () => {
         },
       };
 
-      const node = new PathsObjectConverterNode(
-        {
-          input,
-          context: mockContext,
-          accessPath: [],
-          pathId: "test",
-        },
-        undefined,
-        undefined,
-        undefined
-      );
+      const node = new PathsObjectConverterNode({
+        input,
+        context: mockContext,
+        accessPath: [],
+        pathId: "test",
+        servers: undefined,
+        globalAuth: undefined,
+        basePath: undefined,
+      });
 
       const result = node.convert() ?? { endpoints: {} };
       expect(result).toBeDefined();

--- a/packages/parsers/src/openapi/3.1/paths/__test__/parameters/ParameterBaseObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/parameters/ParameterBaseObjectConverter.node.test.ts
@@ -24,6 +24,7 @@ describe("ParameterBaseObjectConverterNode", () => {
       context: mockContext,
       accessPath: [],
       pathId: "test",
+      parameterName: undefined,
     });
 
     expect(converter.schema).toBeDefined();
@@ -48,6 +49,7 @@ describe("ParameterBaseObjectConverterNode", () => {
       context: mockContext,
       accessPath: [],
       pathId: "test",
+      parameterName: undefined,
     });
 
     expect(converter.schema).toBeDefined();
@@ -67,6 +69,7 @@ describe("ParameterBaseObjectConverterNode", () => {
       context: mockContext,
       accessPath: [],
       pathId: "test",
+      parameterName: undefined,
     }).convert();
 
     expect(converted).toEqual({
@@ -94,6 +97,7 @@ describe("ParameterBaseObjectConverterNode", () => {
       context: mockContext,
       accessPath: [],
       pathId: "test",
+      parameterName: undefined,
     });
 
     const result = converter.convert();

--- a/packages/parsers/src/openapi/3.1/paths/__test__/request/ExampleObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/request/ExampleObjectConverter.node.test.ts
@@ -195,6 +195,7 @@ describe("ExampleObjectConverterNode", () => {
             "application/json",
             undefined,
             "testpath",
+            undefined,
             200,
             [],
             undefined

--- a/packages/parsers/src/openapi/3.1/paths/__test__/request/MultipartFormDataPropertySchemaConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/request/MultipartFormDataPropertySchemaConverter.node.test.ts
@@ -18,6 +18,8 @@ describe("MultipartFormDataPropertySchemaConverterNode", () => {
       accessPath: [],
       pathId: "test",
       seenSchemas: new Set(),
+      nullable: undefined,
+      schemaName: undefined,
     });
 
     expect(converter.multipartType).toBe("file");
@@ -40,6 +42,8 @@ describe("MultipartFormDataPropertySchemaConverterNode", () => {
       accessPath: [],
       pathId: "test",
       seenSchemas: new Set(),
+      nullable: undefined,
+      schemaName: undefined,
     });
 
     expect(converter.multipartType).toBe("files");
@@ -58,6 +62,8 @@ describe("MultipartFormDataPropertySchemaConverterNode", () => {
       accessPath: [],
       pathId: "test",
       seenSchemas: new Set(),
+      nullable: undefined,
+      schemaName: undefined,
     });
 
     expect(converter.multipartType).toBe("property");
@@ -84,6 +90,8 @@ describe("MultipartFormDataPropertySchemaConverterNode", () => {
       accessPath: [],
       pathId: "test",
       seenSchemas: new Set(),
+      nullable: undefined,
+      schemaName: undefined,
     });
 
     expect(converter.multipartType).toBe("file");
@@ -104,6 +112,8 @@ describe("MultipartFormDataPropertySchemaConverterNode", () => {
       accessPath: [],
       pathId: "test",
       seenSchemas: new Set(),
+      nullable: undefined,
+      schemaName: undefined,
     });
 
     expect(converter.multipartType).toBeUndefined();
@@ -124,6 +134,8 @@ describe("MultipartFormDataPropertySchemaConverterNode", () => {
       accessPath: [],
       pathId: "test",
       seenSchemas: new Set(),
+      nullable: undefined,
+      schemaName: undefined,
     });
 
     const result = converter.convert();

--- a/packages/parsers/src/openapi/3.1/paths/__test__/request/RequestBodyObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/request/RequestBodyObjectConverter.node.test.ts
@@ -24,6 +24,8 @@ describe("RequestBodyObjectConverterNode", () => {
       context: mockContext,
       accessPath: [],
       pathId: "test",
+      method: undefined,
+      path: undefined,
     });
 
     expect(converter.requestBodiesByContentType).toBeDefined();
@@ -48,6 +50,8 @@ describe("RequestBodyObjectConverterNode", () => {
       context: mockContext,
       accessPath: [],
       pathId: "test",
+      method: undefined,
+      path: undefined,
     });
 
     expect(converter.requestBodiesByContentType).toBeDefined();
@@ -73,6 +77,8 @@ describe("RequestBodyObjectConverterNode", () => {
       context: mockContext,
       accessPath: [],
       pathId: "test",
+      method: undefined,
+      path: undefined,
     });
 
     expect(
@@ -100,6 +106,8 @@ describe("RequestBodyObjectConverterNode", () => {
       context: mockContext,
       accessPath: [],
       pathId: "test",
+      method: undefined,
+      path: undefined,
     });
 
     const result = converter.convert();
@@ -115,9 +123,15 @@ describe("RequestBodyObjectConverterNode", () => {
             valueShape: {
               type: "alias",
               value: {
-                type: "primitive",
-                value: {
-                  type: "string",
+                type: "optional",
+                shape: {
+                  type: "alias",
+                  value: {
+                    type: "primitive",
+                    value: {
+                      type: "string",
+                    },
+                  },
                 },
               },
             },
@@ -135,6 +149,8 @@ describe("RequestBodyObjectConverterNode", () => {
       context: mockContext,
       accessPath: [],
       pathId: "test",
+      method: undefined,
+      path: undefined,
     });
 
     expect(converter.requestBodiesByContentType).toBeUndefined();

--- a/packages/parsers/src/openapi/3.1/paths/__test__/request/RequestMediaTypeObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/request/RequestMediaTypeObjectConverter.node.test.ts
@@ -15,15 +15,15 @@ describe("RequestMediaTypeObjectConverterNode", () => {
       },
     };
 
-    const converter = new RequestMediaTypeObjectConverterNode(
-      {
-        input,
-        context: mockContext,
-        accessPath: [],
-        pathId: "test",
-      },
-      "application/json"
-    );
+    const converter = new RequestMediaTypeObjectConverterNode({
+      input,
+      context: mockContext,
+      accessPath: [],
+      pathId: "test",
+      contentType: "application/json",
+      method: undefined,
+      path: undefined,
+    });
 
     expect(converter.contentType).toBe("json");
     expect(converter.schema).toBeDefined();
@@ -36,15 +36,15 @@ describe("RequestMediaTypeObjectConverterNode", () => {
       },
     };
 
-    const converter = new RequestMediaTypeObjectConverterNode(
-      {
-        input,
-        context: mockContext,
-        accessPath: [],
-        pathId: "test",
-      },
-      "application/octet-stream"
-    );
+    const converter = new RequestMediaTypeObjectConverterNode({
+      input,
+      context: mockContext,
+      accessPath: [],
+      pathId: "test",
+      contentType: "application/octet-stream",
+      method: undefined,
+      path: undefined,
+    });
 
     expect(converter.contentType).toBe("bytes");
     expect(converter.isOptional).toBe(true);
@@ -64,15 +64,15 @@ describe("RequestMediaTypeObjectConverterNode", () => {
       },
     };
 
-    const converter = new RequestMediaTypeObjectConverterNode(
-      {
-        input,
-        context: mockContext,
-        accessPath: [],
-        pathId: "test",
-      },
-      "multipart/form-data"
-    );
+    const converter = new RequestMediaTypeObjectConverterNode({
+      input,
+      context: mockContext,
+      accessPath: [],
+      pathId: "test",
+      contentType: "multipart/form-data",
+      method: undefined,
+      path: undefined,
+    });
 
     expect(converter.contentType).toBe("form-data");
     expect(converter.fields).toBeDefined();
@@ -91,15 +91,15 @@ describe("RequestMediaTypeObjectConverterNode", () => {
       Pet: { type: "object" },
     };
 
-    const converter = new RequestMediaTypeObjectConverterNode(
-      {
-        input,
-        context: mockContext,
-        accessPath: [],
-        pathId: "test",
-      },
-      "application/json"
-    );
+    const converter = new RequestMediaTypeObjectConverterNode({
+      input,
+      context: mockContext,
+      accessPath: [],
+      pathId: "test",
+      contentType: "application/json",
+      method: undefined,
+      path: undefined,
+    });
 
     expect(converter.schema).toBeDefined();
   });
@@ -111,15 +111,15 @@ describe("RequestMediaTypeObjectConverterNode", () => {
       },
     };
 
-    const converter = new RequestMediaTypeObjectConverterNode(
-      {
-        input,
-        context: mockContext,
-        accessPath: [],
-        pathId: "test",
-      },
-      "application/xml"
-    );
+    const converter = new RequestMediaTypeObjectConverterNode({
+      input,
+      context: mockContext,
+      accessPath: [],
+      pathId: "test",
+      contentType: "application/xml",
+      method: undefined,
+      path: undefined,
+    });
 
     expect(converter.contentType).toBeUndefined();
     expect(mockContext.errors.warning).toHaveBeenCalled();

--- a/packages/parsers/src/openapi/3.1/paths/__test__/response/ResponseMediaTypeObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/response/ResponseMediaTypeObjectConverter.node.test.ts
@@ -26,6 +26,7 @@ describe("ResponseMediaTypeObjectConverterNode", () => {
       "application/json",
       undefined,
       "test",
+      undefined,
       200,
       [],
       {}
@@ -54,6 +55,7 @@ describe("ResponseMediaTypeObjectConverterNode", () => {
       "application/octet-stream",
       undefined,
       "test",
+      undefined,
       200,
       [],
       {}
@@ -83,6 +85,7 @@ describe("ResponseMediaTypeObjectConverterNode", () => {
       "application/json",
       "json",
       "test",
+      undefined,
       200,
       [],
       {}
@@ -106,6 +109,7 @@ describe("ResponseMediaTypeObjectConverterNode", () => {
       "text/event-stream",
       "sse",
       "test",
+      undefined,
       200,
       [],
       {}
@@ -128,6 +132,7 @@ describe("ResponseMediaTypeObjectConverterNode", () => {
       "application/json",
       undefined,
       "test",
+      undefined,
       200,
       [],
       {}
@@ -166,6 +171,7 @@ describe("ResponseMediaTypeObjectConverterNode", () => {
       "application/json",
       undefined,
       "test",
+      undefined,
       200,
       [],
       {}

--- a/packages/parsers/src/openapi/3.1/paths/__test__/response/ResponseObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/response/ResponseObjectConverter.node.test.ts
@@ -28,6 +28,7 @@ describe("ResponseObjectConverterNode", () => {
         pathId: "test",
       },
       "test",
+      undefined,
       200,
       [],
       {}
@@ -58,6 +59,7 @@ describe("ResponseObjectConverterNode", () => {
         pathId: "test",
       },
       "test",
+      undefined,
       200,
       [],
       {}
@@ -94,6 +96,7 @@ describe("ResponseObjectConverterNode", () => {
         pathId: "test",
       },
       "test",
+      undefined,
       200,
       [],
       {}
@@ -116,6 +119,7 @@ describe("ResponseObjectConverterNode", () => {
         pathId: "test",
       },
       "test",
+      undefined,
       200,
       [],
       {}
@@ -156,6 +160,7 @@ describe("ResponseObjectConverterNode", () => {
         pathId: "test",
       },
       "test",
+      undefined,
       200,
       [],
       {}

--- a/packages/parsers/src/openapi/3.1/paths/__test__/response/ResponsesObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/response/ResponsesObjectConverter.node.test.ts
@@ -30,6 +30,7 @@ describe("ResponsesObjectConverterNode", () => {
         pathId: "test",
       },
       "test",
+      undefined,
       [],
       {}
     );
@@ -65,6 +66,7 @@ describe("ResponsesObjectConverterNode", () => {
         pathId: "test",
       },
       "testpath",
+      undefined,
       [],
       {}
     );
@@ -104,6 +106,7 @@ describe("ResponsesObjectConverterNode", () => {
         pathId: "test",
       },
       "test",
+      undefined,
       [],
       {}
     );
@@ -137,6 +140,7 @@ describe("ResponsesObjectConverterNode", () => {
         pathId: "test",
       },
       "test",
+      undefined,
       [],
       {}
     );
@@ -156,6 +160,7 @@ describe("ResponsesObjectConverterNode", () => {
         pathId: "test",
       },
       "test",
+      undefined,
       [],
       {}
     );

--- a/packages/parsers/src/openapi/3.1/paths/parameters/ParameterBaseObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/parameters/ParameterBaseObjectConverter.node.ts
@@ -40,13 +40,13 @@ export class ParameterBaseObjectConverterNode extends BaseOpenApiV3_1ConverterNo
   constructor(
     args: BaseOpenApiV3_1ConverterNodeConstructorArgs<
       OpenAPIV3_1.ParameterBaseObject | OpenAPIV3_1.ReferenceObject
-    >
+    > & { parameterName: string | undefined }
   ) {
     super(args);
-    this.safeParse();
+    this.safeParse(args.parameterName);
   }
 
-  parse(): void {
+  parse(parameterName: string): void {
     this.description = this.input.description;
 
     let schema:
@@ -79,6 +79,8 @@ export class ParameterBaseObjectConverterNode extends BaseOpenApiV3_1ConverterNo
       accessPath: this.accessPath,
       pathId: "schema",
       seenSchemas: new Set(),
+      nullable: undefined,
+      schemaName: parameterName,
     });
 
     // TODO: support multiple examples

--- a/packages/parsers/src/openapi/3.1/paths/request/MultipartFormDataPropertySchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/request/MultipartFormDataPropertySchemaConverter.node.ts
@@ -17,7 +17,10 @@ export class MultipartFormDataPropertySchemaConverterNode extends SchemaConverte
   contentType: string | undefined;
 
   constructor(
-    args: BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs<OpenAPIV3_1.SchemaObject>
+    args: BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs<OpenAPIV3_1.SchemaObject> & {
+      nullable: boolean | undefined;
+      schemaName: string | undefined;
+    }
   ) {
     super(args);
     this.safeParse();

--- a/packages/parsers/src/openapi/3.1/paths/request/RequestBodyObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/request/RequestBodyObjectConverter.node.ts
@@ -22,15 +22,13 @@ export class RequestBodyObjectConverterNode extends BaseOpenApiV3_1ConverterNode
   constructor(
     args: BaseOpenApiV3_1ConverterNodeConstructorArgs<
       OpenAPIV3_1.RequestBodyObject | OpenAPIV3_1.ReferenceObject
-    >,
-    protected method: HttpMethod,
-    protected path: string
+    > & { method: HttpMethod; path: string }
   ) {
     super(args);
-    this.safeParse();
+    this.safeParse(args);
   }
 
-  parse(): void {
+  parse({ method, path }: { method: HttpMethod; path: string }): void {
     const requestBody = resolveRequestReference(
       this.input,
       this.context.document
@@ -48,17 +46,15 @@ export class RequestBodyObjectConverterNode extends BaseOpenApiV3_1ConverterNode
       ([contentType, contentTypeObject]) => {
         this.requestBodiesByContentType ??= {};
         this.requestBodiesByContentType[contentType] =
-          new RequestMediaTypeObjectConverterNode(
-            {
-              input: contentTypeObject,
-              context: this.context,
-              accessPath: this.accessPath,
-              pathId: "content",
-            },
+          new RequestMediaTypeObjectConverterNode({
+            input: contentTypeObject,
+            context: this.context,
+            accessPath: this.accessPath,
+            pathId: "content",
             contentType,
-            this.method,
-            this.path
-          );
+            method,
+            path,
+          });
       }
     );
   }

--- a/packages/parsers/src/openapi/3.1/paths/response/ResponseMediaTypeObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/response/ResponseMediaTypeObjectConverter.node.ts
@@ -364,6 +364,8 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
             accessPath: this.accessPath,
             pathId: "type",
             seenSchemas: new Set(),
+            nullable: undefined,
+            schemaName: "Response Body",
           });
         }
       } else if (mediaType?.isOctetStream()) {
@@ -388,6 +390,8 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
             accessPath: this.accessPath,
             pathId: this.pathId,
             seenSchemas: new Set(),
+            nullable: undefined,
+            schemaName: "Response Body",
           });
         }
       }

--- a/packages/parsers/src/openapi/3.1/paths/response/ResponseObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/response/ResponseObjectConverter.node.ts
@@ -59,6 +59,7 @@ export class ResponseObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
         context: this.context,
         accessPath: this.accessPath,
         pathId: "headers",
+        parameterName: headerName,
       });
     });
 

--- a/packages/parsers/src/openapi/3.1/paths/response/ResponsesObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/response/ResponsesObjectConverter.node.ts
@@ -48,6 +48,10 @@ export class ResponsesObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
   parse(): void {
     const defaultResponse = this.input.default;
     Object.entries(this.input).forEach(([statusCode, response]) => {
+      if (statusCode === "default") {
+        return;
+      }
+
       if (parseInt(statusCode) >= 400) {
         this.errorsByStatusCode ??= {};
         this.errorsByStatusCode[statusCode] = new ResponseObjectConverterNode(
@@ -71,10 +75,7 @@ export class ResponsesObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
         this.responsesByStatusCode[statusCode] =
           new ResponseObjectConverterNode(
             {
-              input: {
-                ...defaultResponse,
-                ...response,
-              },
+              input: response,
               context: this.context,
               accessPath: this.accessPath,
               pathId: "responses",

--- a/packages/parsers/src/openapi/3.1/schemas/ArrayConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/ArrayConverter.node.ts
@@ -23,11 +23,15 @@ export class ArrayConverterNode extends BaseOpenApiV3_1ConverterNodeWithTracking
   ArrayConverterNode.Output[] | undefined
 > {
   item: SchemaConverterNode | undefined;
+  schemaName: string | undefined;
 
   constructor(
-    args: BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs<ArrayConverterNode.Input>
+    args: BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs<ArrayConverterNode.Input> & {
+      schemaName: string | undefined;
+    }
   ) {
     super(args);
+    this.schemaName = args.schemaName;
     this.safeParse();
   }
 
@@ -38,6 +42,8 @@ export class ArrayConverterNode extends BaseOpenApiV3_1ConverterNodeWithTracking
       accessPath: this.accessPath,
       pathId: "items",
       seenSchemas: this.seenSchemas,
+      nullable: undefined,
+      schemaName: this.schemaName,
     });
 
     if (this.input.items == null) {

--- a/packages/parsers/src/openapi/3.1/schemas/ComponentsConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/ComponentsConverter.node.ts
@@ -55,6 +55,8 @@ export class ComponentsConverterNode extends BaseOpenApiV3_1ConverterNode<
               accessPath: this.accessPath,
               pathId: key,
               seenSchemas: new Set(),
+              nullable: undefined,
+              schemaName: key,
             }),
           ];
         })

--- a/packages/parsers/src/openapi/3.1/schemas/MixedSchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/MixedSchemaConverter.node.ts
@@ -25,11 +25,15 @@ export class MixedSchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTr
 > {
   typeNodes: SchemaConverterNode[] | undefined;
   nullable: boolean | undefined;
+  schemaName: string | undefined;
 
   constructor(
-    args: BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs<MixedSchemaConverterNode.Input>
+    args: BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs<MixedSchemaConverterNode.Input> & {
+      schemaName: string | undefined;
+    }
   ) {
     super(args);
+    this.schemaName = args.schemaName;
     this.parse();
   }
 
@@ -45,6 +49,8 @@ export class MixedSchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTr
             accessPath: this.accessPath,
             pathId: this.pathId,
             seenSchemas: this.seenSchemas,
+            nullable: this.nullable,
+            schemaName: this.schemaName,
           });
         }
         return undefined;

--- a/packages/parsers/src/openapi/3.1/schemas/ReferenceConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/ReferenceConverter.node.ts
@@ -16,16 +16,27 @@ export class ReferenceConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrac
   OpenAPIV3_1.ReferenceObject,
   FernRegistry.api.latest.TypeShape.Alias
 > {
+  description: string | undefined;
+  availability: AvailabilityConverterNode | undefined;
+
   schemaId: string | undefined;
   maybeEnumConverterNode: EnumConverterNode | undefined;
+  nullable: boolean | undefined;
+  schemaName: string | undefined;
 
   constructor(
-    args: BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs<OpenAPIV3_1.ReferenceObject>,
-    protected nullable: boolean | undefined,
-    public description: string | undefined,
-    public availability: AvailabilityConverterNode | undefined
+    args: BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs<OpenAPIV3_1.ReferenceObject> & {
+      nullable: boolean | undefined;
+      schemaName: string | undefined;
+      description: string | undefined;
+      availability: AvailabilityConverterNode | undefined;
+    }
   ) {
     super(args);
+    this.nullable = args.nullable;
+    this.schemaName = args.schemaName;
+    this.description = args.description;
+    this.availability = args.availability;
     this.safeParse();
   }
 
@@ -87,6 +98,7 @@ export class ReferenceConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrac
       pathId: this.schemaId ?? "",
       seenSchemas: this.seenSchemas,
       nullable: this.nullable,
+      schemaName: this.schemaName,
     }).example(exampleArgs);
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
@@ -61,15 +61,17 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
   name: string | undefined;
   examples: unknown | undefined;
   availability: AvailabilityConverterNode | undefined;
-  nullable?: boolean | undefined;
+  nullable: boolean | undefined;
+  schemaName: string | undefined;
 
   constructor(
     args: BaseOpenApiV3_1ConverterNodeWithTrackingConstructorArgs<
       OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject
-    > & { nullable?: boolean | undefined }
+    > & { nullable: boolean | undefined; schemaName: string | undefined }
   ) {
     super(args);
     this.nullable = args.nullable;
+    this.schemaName = args.schemaName;
     this.safeParse();
   }
 
@@ -106,18 +108,17 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
       }
       this.seenSchemas.add(refPath);
 
-      this.typeShapeNode = new ReferenceConverterNode(
-        {
-          input: this.input,
-          context: this.context,
-          accessPath: this.accessPath,
-          pathId: refPath,
-          seenSchemas: this.seenSchemas,
-        },
-        this.nullable,
-        this.description,
-        this.availability
-      );
+      this.typeShapeNode = new ReferenceConverterNode({
+        input: this.input,
+        context: this.context,
+        accessPath: this.accessPath,
+        pathId: refPath,
+        seenSchemas: this.seenSchemas,
+        nullable: this.nullable,
+        schemaName: this.schemaName,
+        description: this.description,
+        availability: this.availability,
+      });
     } else {
       // If the object is not a reference object, then it is a schema object, gather all appropriate variables
       this.name = this.input.title;
@@ -136,6 +137,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
           accessPath: this.accessPath,
           pathId: this.pathId,
           seenSchemas: this.seenSchemas,
+          schemaName: this.schemaName,
         });
       } else if (
         isNonArraySchema(this.input) &&
@@ -147,6 +149,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
           accessPath: this.accessPath,
           pathId: this.pathId,
           seenSchemas: this.seenSchemas,
+          schemaName: this.schemaName,
         });
         // here, isObjectSchema also supports null type
       } else if (isObjectSchema(this.input) && this.input.allOf != null) {
@@ -157,6 +160,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
           accessPath: this.accessPath,
           pathId: this.pathId,
           seenSchemas: this.seenSchemas,
+          schemaName: this.schemaName,
         });
       } else if (isNonArraySchema(this.input) && this.input.enum != null) {
         this.typeShapeNode = new EnumConverterNode({
@@ -178,6 +182,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
                 accessPath: this.accessPath,
                 pathId: this.pathId,
                 seenSchemas: this.seenSchemas,
+                schemaName: this.schemaName,
               });
             }
             break;
@@ -189,6 +194,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
                 accessPath: this.accessPath,
                 pathId: this.pathId,
                 seenSchemas: this.seenSchemas,
+                schemaName: this.schemaName,
               });
             }
             break;
@@ -268,6 +274,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
             pathId: this.pathId,
             seenSchemas: this.seenSchemas,
             nullable: true,
+            schemaName: this.schemaName,
           });
         }
       } else if (this.input.properties != null) {
@@ -277,6 +284,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
           accessPath: this.accessPath,
           pathId: this.pathId,
           seenSchemas: this.seenSchemas,
+          schemaName: this.schemaName,
         });
       }
     }

--- a/packages/parsers/src/openapi/3.1/schemas/__test__/ArrayConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/__test__/ArrayConverter.node.test.ts
@@ -22,6 +22,7 @@ describe("ArrayConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       expect(node.item?.typeShapeNode).toBeInstanceOf(StringConverterNode);
     });
@@ -36,6 +37,7 @@ describe("ArrayConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       expect(mockContext.errors.error).toHaveBeenCalledWith({
         message:
@@ -57,6 +59,7 @@ describe("ArrayConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       const converted = node.convert();
       expect(converted).toEqual([
@@ -89,6 +92,7 @@ describe("ArrayConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       const converted = node.convert();
       expect(converted).toEqual([

--- a/packages/parsers/src/openapi/3.1/schemas/__test__/MixedSchemaConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/__test__/MixedSchemaConverter.node.test.ts
@@ -22,6 +22,7 @@ describe("MixedSchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
 
       expect(node.nullable).toBe(true);
@@ -40,6 +41,7 @@ describe("MixedSchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
 
       expect(node.nullable).toBeUndefined();
@@ -60,6 +62,7 @@ describe("MixedSchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
 
       const result = node.convert()[0];
@@ -82,6 +85,7 @@ describe("MixedSchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
 
       const result = node.convert()[0];
@@ -100,6 +104,7 @@ describe("MixedSchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
 
       node.typeNodes = undefined;

--- a/packages/parsers/src/openapi/3.1/schemas/__test__/ObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/__test__/ObjectConverter.node.test.ts
@@ -20,6 +20,7 @@ describe("ObjectConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       expect(node.extends).toEqual([]);
       expect(node.properties).toEqual({});
@@ -40,6 +41,7 @@ describe("ObjectConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       expect(Object.keys(node.properties ?? {})).toEqual(["name", "age"]);
       expect(node.properties?.name).toBeInstanceOf(SchemaConverterNode);
@@ -61,12 +63,32 @@ describe("ObjectConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       expect(node.extraProperties).toBeDefined();
-      const converted = node.convert()[0]?.extraProperties;
+      const maybeConverted = node.convert()[0];
+      const converted =
+        maybeConverted?.type === "object"
+          ? maybeConverted?.extraProperties
+          : undefined;
       expect(converted).toEqual({
-        type: "unknown",
-        displayName: "TestObject",
+        type: "map",
+        keyShape: {
+          type: "alias",
+          value: {
+            type: "primitive",
+            value: {
+              type: "string",
+            },
+          },
+        },
+        valueShape: {
+          type: "alias",
+          value: {
+            type: "unknown",
+            displayName: "TestObject",
+          },
+        },
       });
     });
 
@@ -81,6 +103,7 @@ describe("ObjectConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       expect(node.extraProperties).toBeUndefined();
     });
@@ -96,6 +119,7 @@ describe("ObjectConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       expect(node.extraProperties).toBeInstanceOf(SchemaConverterNode);
     });
@@ -115,6 +139,7 @@ describe("ObjectConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       const converted = node.convert();
       expect(converted).toEqual([
@@ -146,6 +171,7 @@ describe("ObjectConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       const converted = node.convert();
       expect(converted).toEqual([

--- a/packages/parsers/src/openapi/3.1/schemas/__test__/OneOfConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/__test__/OneOfConverter.node.test.ts
@@ -36,6 +36,7 @@ describe("OneOfConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       expect(node.discriminated).toBe(false);
       expect(node.undiscriminatedMapping?.length).toBe(2);
@@ -58,6 +59,7 @@ describe("OneOfConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       expect(node.discriminated).toBe(true);
       expect(node.discriminant).toBe("type");
@@ -83,6 +85,7 @@ describe("OneOfConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       const result = node.convert()[0];
       expect(result?.type).toBe("discriminatedUnion");
@@ -93,8 +96,16 @@ describe("OneOfConverterNode", () => {
       const input: OpenAPIV3_1.NonArraySchemaObject = {
         type: "object",
         oneOf: [
-          { type: "object", properties: { a: { type: "string" } } },
-          { type: "object", properties: { b: { type: "string" } } },
+          {
+            type: "object",
+            properties: { a: { type: "string" } },
+            required: ["a"],
+          },
+          {
+            type: "object",
+            properties: { b: { type: "string" } },
+            required: ["b"],
+          },
         ],
       };
       const node = new OneOfConverterNode({
@@ -103,6 +114,7 @@ describe("OneOfConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       const result = node.convert()[0];
       expect(result?.type).toBe("undiscriminatedUnion");
@@ -110,6 +122,7 @@ describe("OneOfConverterNode", () => {
         type: "undiscriminatedUnion",
         variants: [
           {
+            displayName: "Variant 1",
             shape: {
               type: "object",
               extends: [],
@@ -130,6 +143,7 @@ describe("OneOfConverterNode", () => {
             },
           },
           {
+            displayName: "Variant 2",
             shape: {
               type: "object",
               extends: [],
@@ -163,6 +177,7 @@ describe("OneOfConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
       });
       const result = node.convert();
       expect(result).toBeUndefined();

--- a/packages/parsers/src/openapi/3.1/schemas/__test__/ReferenceConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/__test__/ReferenceConverter.node.test.ts
@@ -20,6 +20,10 @@ describe("ReferenceConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
+        description: undefined,
+        availability: undefined,
       });
       expect(node.schemaId).toBe("Pet");
     });
@@ -34,6 +38,10 @@ describe("ReferenceConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        schemaName: undefined,
+        nullable: undefined,
+        description: undefined,
+        availability: undefined,
       });
       expect(node.schemaId).toBeUndefined();
       expect(mockContext.errors.error).toHaveBeenCalledWith({
@@ -54,6 +62,10 @@ describe("ReferenceConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
+        description: undefined,
+        availability: undefined,
       });
       expect(node.convert()).toEqual({
         type: "alias",
@@ -75,6 +87,10 @@ describe("ReferenceConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
+        description: undefined,
+        availability: undefined,
       });
       expect(node.convert()).toBeUndefined();
     });

--- a/packages/parsers/src/openapi/3.1/schemas/__test__/SchemaConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/__test__/SchemaConverter.node.test.ts
@@ -22,6 +22,8 @@ describe("SchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
       });
       expect(node.typeShapeNode).toBeInstanceOf(ReferenceConverterNode);
     });
@@ -39,6 +41,8 @@ describe("SchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
       });
       expect(node.typeShapeNode).toBeInstanceOf(ObjectConverterNode);
     });
@@ -53,6 +57,8 @@ describe("SchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
       });
       expect(node.typeShapeNode).toBeDefined();
     });
@@ -67,6 +73,8 @@ describe("SchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
       });
       expect(node.typeShapeNode).toBeDefined();
     });
@@ -81,6 +89,8 @@ describe("SchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
       });
       expect(node.typeShapeNode).toBeDefined();
     });
@@ -95,6 +105,8 @@ describe("SchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
       });
       expect(node.typeShapeNode).toBeDefined();
     });
@@ -112,6 +124,8 @@ describe("SchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
       });
       expect(node.typeShapeNode).toBeDefined();
     });
@@ -127,6 +141,8 @@ describe("SchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
       });
       expect(node.typeShapeNode).toBeDefined();
     });
@@ -141,6 +157,8 @@ describe("SchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
       });
       expect(node.typeShapeNode).toBeDefined();
     });
@@ -158,6 +176,8 @@ describe("SchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
       });
       expect(node.typeShapeNode).toBeDefined();
     });
@@ -173,6 +193,8 @@ describe("SchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
       });
       expect(node.description).toBe("test description");
     });
@@ -189,6 +211,8 @@ describe("SchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
       });
       const result = node.convert();
       expect(result).toEqual({
@@ -213,6 +237,8 @@ describe("SchemaConverterNode", () => {
         accessPath: [],
         pathId: "test",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
       });
       expect(node.convert()).toEqual({
         type: "alias",
@@ -235,6 +261,7 @@ describe("SchemaConverterNode", () => {
         pathId: "test",
         seenSchemas: new Set(),
         nullable: true,
+        schemaName: undefined,
       });
       expect(node.nullable).toBe(false);
     });
@@ -250,6 +277,7 @@ describe("SchemaConverterNode", () => {
         pathId: "test",
         seenSchemas: new Set(),
         nullable: true,
+        schemaName: undefined,
       });
       expect(node.nullable).toBe(true);
     });

--- a/packages/parsers/src/openapi/__test__/__snapshots__/anyOf.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/anyOf.json
@@ -79,13 +79,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -108,13 +114,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/application-json.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/application-json.json
@@ -106,9 +106,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -118,9 +124,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/availability.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/availability.json
@@ -368,9 +368,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -381,9 +387,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 }
@@ -455,9 +467,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 }
@@ -523,9 +541,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 }
@@ -597,9 +621,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -610,9 +640,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -631,9 +667,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -652,9 +694,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/cohere.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/cohere.json
@@ -1719,7 +1719,7 @@
       "id": "endpoint_v2.chat",
       "description": "Generates a text response to a user message and streams it down, token by token. To learn how to use the Chat API with streaming follow our [Text Generation guides](https://docs.cohere.com/v2/docs/chat-api).\n\nFollow the [Migration Guide](https://docs.cohere.com/v2/docs/migrating-v1-to-v2) for instructions on moving from API v1 to API v2.\n",
       "namespace": [
-        "v2"
+        "subpackage_v2"
       ],
       "displayName": "Chat with the model",
       "operationId": "chatv2",
@@ -8493,7 +8493,7 @@
       "id": "endpoint_v2.embed",
       "description": "This endpoint returns text embeddings. An embedding is a list of floating point numbers that captures semantic information about the text that it represents.\n\nEmbeddings can be used to create text classifiers as well as empower semantic search. To learn more about embeddings, see the embedding page.\n\nIf you want to learn more how to use the embedding model, have a look at the [Semantic Search Guide](https://docs.cohere.com/docs/semantic-search).",
       "namespace": [
-        "v2"
+        "subpackage_v2"
       ],
       "displayName": "Embed",
       "operationId": "embedv2",
@@ -12360,7 +12360,7 @@
       "id": "endpoint_embedJobs.list",
       "description": "The list embed job endpoint allows users to view all embed jobs history for that specific user.",
       "namespace": [
-        "embed-jobs"
+        "subpackage_embedJobs"
       ],
       "displayName": "List Embed Jobs",
       "operationId": "list-embed-jobs",
@@ -12934,7 +12934,7 @@
       "id": "endpoint_embedJobs.create",
       "description": "This API launches an async Embed job for a [Dataset](https://docs.cohere.com/docs/datasets) of type `embed-input`. The result of a completed embed job is new Dataset of type `embed-output`, which contains the original text entries and the corresponding embeddings.",
       "namespace": [
-        "embed-jobs"
+        "subpackage_embedJobs"
       ],
       "displayName": "Create an Embed Job",
       "operationId": "create-embed-job",
@@ -13522,7 +13522,7 @@
       "id": "endpoint_embedJobs.get",
       "description": "This API retrieves the details about an embed job started by the same user.",
       "namespace": [
-        "embed-jobs"
+        "subpackage_embedJobs"
       ],
       "displayName": "Fetch an Embed Job",
       "operationId": "get-embed-job",
@@ -14118,7 +14118,7 @@
       "id": "endpoint_embedJobs.cancel",
       "description": "This API allows users to cancel an active embed job. Once invoked, the embedding process will be terminated, and users will be charged for the embeddings processed up to the cancellation point. It's important to note that partial results will not be available to users after cancellation.",
       "namespace": [
-        "embed-jobs"
+        "subpackage_embedJobs"
       ],
       "displayName": "Cancel an Embed Job",
       "operationId": "cancel-embed-job",
@@ -15517,7 +15517,7 @@
       "id": "endpoint_v2.rerank",
       "description": "This endpoint takes in a query and a list of texts and produces an ordered array with each text assigned a relevance score.",
       "namespace": [
-        "v2"
+        "subpackage_v2"
       ],
       "displayName": "Rerank",
       "operationId": "rerankv2",
@@ -17172,7 +17172,7 @@
       "id": "endpoint_datasets.list",
       "description": "List datasets that have been created.",
       "namespace": [
-        "datasets"
+        "subpackage_datasets"
       ],
       "displayName": "List Datasets",
       "operationId": "list-datasets",
@@ -17894,7 +17894,7 @@
       "id": "endpoint_datasets.create",
       "description": "Create a dataset by uploading a file. See ['Dataset Creation'](https://docs.cohere.com/docs/datasets#dataset-creation) for more information.",
       "namespace": [
-        "datasets"
+        "subpackage_datasets"
       ],
       "displayName": "Create a Dataset",
       "operationId": "create-dataset",
@@ -18605,7 +18605,7 @@
       "id": "endpoint_datasets.getUsage",
       "description": "View the dataset storage usage for your Organization. Each Organization can have up to 10GB of storage across all their users.",
       "namespace": [
-        "datasets"
+        "subpackage_datasets"
       ],
       "displayName": "Get Dataset Usage",
       "operationId": "get-dataset-usage",
@@ -19146,7 +19146,7 @@
       "id": "endpoint_datasets.get",
       "description": "Retrieve a dataset by ID. See ['Datasets'](https://docs.cohere.com/docs/datasets) for more information.",
       "namespace": [
-        "datasets"
+        "subpackage_datasets"
       ],
       "displayName": "Get a Dataset",
       "operationId": "get-dataset",
@@ -19772,7 +19772,7 @@
       "id": "endpoint_datasets.delete",
       "description": "Delete a dataset by ID. Datasets are automatically deleted after 30 days, but they can also be deleted manually.",
       "namespace": [
-        "datasets"
+        "subpackage_datasets"
       ],
       "displayName": "Delete a Dataset",
       "operationId": "delete-dataset",
@@ -22351,7 +22351,7 @@
       "id": "endpoint_connectors.list",
       "description": "Returns a list of connectors ordered by descending creation date (newer first). See ['Managing your Connector'](https://docs.cohere.com/docs/managing-your-connector) for more information.",
       "namespace": [
-        "connectors"
+        "subpackage_connectors"
       ],
       "displayName": "List Connectors",
       "operationId": "list-connectors",
@@ -22939,7 +22939,7 @@
       "id": "endpoint_connectors.create",
       "description": "Creates a new connector. The connector is tested during registration and will cancel registration when the test is unsuccessful. See ['Creating and Deploying a Connector'](https://docs.cohere.com/v1/docs/creating-and-deploying-a-connector) for more information.",
       "namespace": [
-        "connectors"
+        "subpackage_connectors"
       ],
       "displayName": "Create a Connector",
       "operationId": "create-connector",
@@ -23518,7 +23518,7 @@
       "id": "endpoint_connectors.get",
       "description": "Retrieve a connector by ID. See ['Connectors'](https://docs.cohere.com/docs/connectors) for more information.",
       "namespace": [
-        "connectors"
+        "subpackage_connectors"
       ],
       "displayName": "Get a Connector",
       "operationId": "get-connector",
@@ -24087,7 +24087,7 @@
       "id": "endpoint_connectors.update",
       "description": "Update a connector by ID. Omitted fields will not be updated. See ['Managing your Connector'](https://docs.cohere.com/docs/managing-your-connector) for more information.",
       "namespace": [
-        "connectors"
+        "subpackage_connectors"
       ],
       "displayName": "Update a Connector",
       "operationId": "update-connector",
@@ -24691,7 +24691,7 @@
       "id": "endpoint_connectors.delete",
       "description": "Delete a connector by ID. See ['Connectors'](https://docs.cohere.com/docs/connectors) for more information.",
       "namespace": [
-        "connectors"
+        "subpackage_connectors"
       ],
       "displayName": "Delete a Connector",
       "operationId": "delete-connector",
@@ -25236,7 +25236,7 @@
       "id": "endpoint_connectors.oAuthAuthorize",
       "description": "Authorize the connector with the given ID for the connector oauth app.  See ['Connector Authentication'](https://docs.cohere.com/docs/connector-authentication) for more information.",
       "namespace": [
-        "connectors"
+        "subpackage_connectors"
       ],
       "displayName": "Authorize with oAuth",
       "operationId": "oAuthAuthorize-connector",
@@ -25820,7 +25820,7 @@
       "id": "endpoint_models.get",
       "description": "Returns the details of a model, provided its name.",
       "namespace": [
-        "models"
+        "subpackage_models"
       ],
       "displayName": "Get a Model",
       "operationId": "get-model",
@@ -26348,7 +26348,7 @@
       "id": "endpoint_models.list",
       "description": "Returns a list of models available for use. The list contains models from Cohere as well as your fine-tuned models.",
       "namespace": [
-        "models"
+        "subpackage_models"
       ],
       "displayName": "List Models",
       "operationId": "list-models",
@@ -27456,7 +27456,7 @@
     "endpoint_finetuning.ListFinetunedModels": {
       "id": "endpoint_finetuning.ListFinetunedModels",
       "namespace": [
-        "finetuning"
+        "subpackage_finetuning"
       ],
       "displayName": "Lists fine-tuned models.",
       "operationId": "ListFinetunedModels",
@@ -27837,7 +27837,7 @@
     "endpoint_finetuning.CreateFinetunedModel": {
       "id": "endpoint_finetuning.CreateFinetunedModel",
       "namespace": [
-        "finetuning"
+        "subpackage_finetuning"
       ],
       "displayName": "Trains and deploys a fine-tuned model.",
       "operationId": "CreateFinetunedModel",
@@ -28172,7 +28172,7 @@
     "endpoint_finetuning.GetFinetunedModel": {
       "id": "endpoint_finetuning.GetFinetunedModel",
       "namespace": [
-        "finetuning"
+        "subpackage_finetuning"
       ],
       "displayName": "Returns a fine-tuned model by ID.",
       "operationId": "GetFinetunedModel",
@@ -28499,7 +28499,7 @@
     "endpoint_finetuning.UpdateFinetunedModel": {
       "id": "endpoint_finetuning.UpdateFinetunedModel",
       "namespace": [
-        "finetuning"
+        "subpackage_finetuning"
       ],
       "displayName": "Updates a fine-tuned model.",
       "operationId": "UpdateFinetunedModel",
@@ -29044,7 +29044,7 @@
     "endpoint_finetuning.DeleteFinetunedModel": {
       "id": "endpoint_finetuning.DeleteFinetunedModel",
       "namespace": [
-        "finetuning"
+        "subpackage_finetuning"
       ],
       "displayName": "Deletes a fine-tuned model.",
       "operationId": "DeleteFinetunedModel",
@@ -29344,7 +29344,7 @@
     "endpoint_finetuning.ListEvents": {
       "id": "endpoint_finetuning.ListEvents",
       "namespace": [
-        "finetuning"
+        "subpackage_finetuning"
       ],
       "displayName": "Retrieves the chronology of statuses the fine-tuned model has been through.",
       "operationId": "ListEvents",
@@ -29734,7 +29734,7 @@
     "endpoint_finetuning.ListTrainingStepMetrics": {
       "id": "endpoint_finetuning.ListTrainingStepMetrics",
       "namespace": [
-        "finetuning"
+        "subpackage_finetuning"
       ],
       "displayName": "Retrieves metrics measured during the training of a fine-tuned model.",
       "operationId": "ListTrainingStepMetrics",
@@ -41120,35 +41120,35 @@
     }
   },
   "subpackages": {
-    "v2": {
-      "id": "v2",
+    "subpackage_v2": {
+      "id": "subpackage_v2",
       "name": "v2",
-      "displayName": "v2"
+      "displayName": "V2"
     },
-    "embedJobs": {
-      "id": "embedJobs",
-      "name": "embed-jobs",
-      "displayName": "embed-jobs"
+    "subpackage_embedJobs": {
+      "id": "subpackage_embedJobs",
+      "name": "embedJobs",
+      "displayName": "Embed Jobs"
     },
-    "datasets": {
-      "id": "datasets",
+    "subpackage_datasets": {
+      "id": "subpackage_datasets",
       "name": "datasets",
-      "displayName": "datasets"
+      "displayName": "Datasets"
     },
-    "connectors": {
-      "id": "connectors",
+    "subpackage_connectors": {
+      "id": "subpackage_connectors",
       "name": "connectors",
-      "displayName": "connectors"
+      "displayName": "Connectors"
     },
-    "models": {
-      "id": "models",
+    "subpackage_models": {
+      "id": "subpackage_models",
       "name": "models",
-      "displayName": "models"
+      "displayName": "Models"
     },
-    "finetuning": {
-      "id": "finetuning",
+    "subpackage_finetuning": {
+      "id": "subpackage_finetuning",
       "name": "finetuning",
-      "displayName": "finetuning"
+      "displayName": "Finetuning"
     }
   },
   "auths": {

--- a/packages/parsers/src/openapi/__test__/__snapshots__/cohere.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/cohere.json
@@ -628,9 +628,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -660,9 +666,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -692,9 +704,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -724,9 +742,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -756,9 +780,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -788,9 +818,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -820,9 +856,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -852,9 +894,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -884,9 +932,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -916,9 +970,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -948,9 +1008,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -980,9 +1046,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -1719,7 +1791,7 @@
       "id": "endpoint_v2.chat",
       "description": "Generates a text response to a user message and streams it down, token by token. To learn how to use the Chat API with streaming follow our [Text Generation guides](https://docs.cohere.com/v2/docs/chat-api).\n\nFollow the [Migration Guide](https://docs.cohere.com/v2/docs/migrating-v1-to-v2) for instructions on moving from API v1 to API v2.\n",
       "namespace": [
-        "subpackage_v2"
+        "v2"
       ],
       "displayName": "Chat with the model",
       "operationId": "chatv2",
@@ -2160,9 +2232,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -2192,9 +2270,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -2224,9 +2308,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -2256,9 +2346,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -2288,9 +2384,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -2320,9 +2422,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -2352,9 +2460,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -2384,9 +2498,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -2416,9 +2536,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -2448,9 +2574,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -2480,9 +2612,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -2512,9 +2650,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -3609,9 +3753,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -3641,9 +3791,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -3673,9 +3829,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -3705,9 +3867,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -3737,9 +3905,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -3769,9 +3943,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -3801,9 +3981,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -3833,9 +4019,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -3865,9 +4057,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -3897,9 +4095,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -3929,9 +4133,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -3961,9 +4171,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -4739,13 +4955,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -4758,13 +4980,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -4777,9 +5005,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -4790,8 +5024,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "EmbedInputType"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "EmbedInputType"
+                      }
+                    }
                   }
                 }
               },
@@ -4800,12 +5040,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "EmbeddingType"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "EmbeddingType"
+                          }
+                        }
                       }
                     }
                   }
@@ -4815,19 +5061,26 @@
               {
                 "key": "truncate",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "NONE"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "NONE"
+                        },
+                        {
+                          "value": "START"
+                        },
+                        {
+                          "value": "END"
+                        }
+                      ],
+                      "default": "END"
                     },
-                    {
-                      "value": "START"
-                    },
-                    {
-                      "value": "END"
-                    }
-                  ],
-                  "default": "END"
+                    "default": "END"
+                  }
                 },
                 "description": "One of `NONE|START|END` to specify how the API will handle inputs longer than the maximum token length.\n\nPassing `START` will discard the start of the input. `END` will discard the end of the input. In both cases, input is discarded until the remaining input is exactly the maximum input token length for the model.\n\nIf `NONE` is selected, when the input exceeds the maximum input token length an error will be returned."
               }
@@ -4860,9 +5113,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -4892,9 +5151,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -4924,9 +5189,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -4956,9 +5227,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -4988,9 +5265,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -5020,9 +5303,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -5052,9 +5341,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -5084,9 +5379,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -5116,9 +5417,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -5148,9 +5455,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -5180,9 +5493,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -5212,9 +5531,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -8493,7 +8818,7 @@
       "id": "endpoint_v2.embed",
       "description": "This endpoint returns text embeddings. An embedding is a list of floating point numbers that captures semantic information about the text that it represents.\n\nEmbeddings can be used to create text classifiers as well as empower semantic search. To learn more about embeddings, see the embedding page.\n\nIf you want to learn more how to use the embedding model, have a look at the [Semantic Search Guide](https://docs.cohere.com/docs/semantic-search).",
       "namespace": [
-        "subpackage_v2"
+        "v2"
       ],
       "displayName": "Embed",
       "operationId": "embedv2",
@@ -8720,9 +9045,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -8752,9 +9083,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -8784,9 +9121,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -8816,9 +9159,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -8848,9 +9197,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -8880,9 +9235,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -8912,9 +9273,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -8944,9 +9311,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -8976,9 +9349,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -9008,9 +9387,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -9040,9 +9425,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -9072,9 +9463,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -12360,7 +12757,7 @@
       "id": "endpoint_embedJobs.list",
       "description": "The list embed job endpoint allows users to view all embed jobs history for that specific user.",
       "namespace": [
-        "subpackage_embedJobs"
+        "embedJobs"
       ],
       "displayName": "List Embed Jobs",
       "operationId": "list-embed-jobs",
@@ -12460,9 +12857,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -12492,9 +12895,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -12524,9 +12933,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -12556,9 +12971,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -12588,9 +13009,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -12620,9 +13047,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -12652,9 +13085,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -12684,9 +13123,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -12716,9 +13161,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -12748,9 +13199,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -12780,9 +13237,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -12812,9 +13275,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -12934,7 +13403,7 @@
       "id": "endpoint_embedJobs.create",
       "description": "This API launches an async Embed job for a [Dataset](https://docs.cohere.com/docs/datasets) of type `embed-input`. The result of a completed embed job is new Dataset of type `embed-output`, which contains the original text entries and the corresponding embeddings.",
       "namespace": [
-        "subpackage_embedJobs"
+        "embedJobs"
       ],
       "displayName": "Create an Embed Job",
       "operationId": "create-embed-job",
@@ -13046,9 +13515,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13078,9 +13553,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13110,9 +13591,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13142,9 +13629,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13174,9 +13667,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13206,9 +13705,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13238,9 +13743,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13270,9 +13781,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13302,9 +13819,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13334,9 +13857,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13366,9 +13895,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13398,9 +13933,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13522,7 +14063,7 @@
       "id": "endpoint_embedJobs.get",
       "description": "This API retrieves the details about an embed job started by the same user.",
       "namespace": [
-        "subpackage_embedJobs"
+        "embedJobs"
       ],
       "displayName": "Fetch an Embed Job",
       "operationId": "get-embed-job",
@@ -13645,9 +14186,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13677,9 +14224,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13709,9 +14262,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13741,9 +14300,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13773,9 +14338,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13805,9 +14376,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13837,9 +14414,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13869,9 +14452,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13901,9 +14490,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13933,9 +14528,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13965,9 +14566,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -13997,9 +14604,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -14118,7 +14731,7 @@
       "id": "endpoint_embedJobs.cancel",
       "description": "This API allows users to cancel an active embed job. Once invoked, the embedding process will be terminated, and users will be charged for the embeddings processed up to the cancellation point. It's important to note that partial results will not be available to users after cancellation.",
       "namespace": [
-        "subpackage_embedJobs"
+        "embedJobs"
       ],
       "displayName": "Cancel an Embed Job",
       "operationId": "cancel-embed-job",
@@ -14245,9 +14858,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -14277,9 +14896,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -14309,9 +14934,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -14341,9 +14972,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -14373,9 +15010,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -14405,9 +15048,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -14437,9 +15086,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -14469,9 +15124,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -14501,9 +15162,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -14533,9 +15200,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -14565,9 +15238,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -14597,9 +15276,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15028,9 +15713,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15060,9 +15751,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15092,9 +15789,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15124,9 +15827,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15156,9 +15865,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15188,9 +15903,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15220,9 +15941,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15252,9 +15979,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15284,9 +16017,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15316,9 +16055,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15348,9 +16093,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15380,9 +16131,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15517,7 +16274,7 @@
       "id": "endpoint_v2.rerank",
       "description": "This endpoint takes in a query and a list of texts and produces an ordered array with each text assigned a relevance score.",
       "namespace": [
-        "subpackage_v2"
+        "v2"
       ],
       "displayName": "Rerank",
       "operationId": "rerankv2",
@@ -15766,9 +16523,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15798,9 +16561,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15830,9 +16599,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15862,9 +16637,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15894,9 +16675,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15926,9 +16713,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15958,9 +16751,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -15990,9 +16789,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16022,9 +16827,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16054,9 +16865,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16086,9 +16903,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16118,9 +16941,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16568,9 +17397,43 @@
                         {
                           "key": "labels",
                           "valueShape": {
-                            "type": "object",
-                            "extends": [],
-                            "properties": []
+                            "type": "alias",
+                            "value": {
+                              "type": "map",
+                              "keyShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "valueShape": {
+                                "type": "object",
+                                "extends": [],
+                                "properties": [
+                                  {
+                                    "key": "confidence",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "primitive",
+                                            "value": {
+                                              "type": "double"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
                           },
                           "description": "A map containing each label and its confidence score according to the classifier. All the confidence scores add up to 1 for single-label classification. For multi-label classification the label confidences are independent of each other, so they don't have to sum up to 1."
                         },
@@ -16627,9 +17490,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16659,9 +17528,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16691,9 +17566,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16723,9 +17604,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16755,9 +17642,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16787,9 +17680,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16819,9 +17718,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16851,9 +17756,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16883,9 +17794,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16915,9 +17832,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16947,9 +17870,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -16979,9 +17908,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17172,7 +18107,7 @@
       "id": "endpoint_datasets.list",
       "description": "List datasets that have been created.",
       "namespace": [
-        "subpackage_datasets"
+        "datasets"
       ],
       "displayName": "List Datasets",
       "operationId": "list-datasets",
@@ -17352,12 +18287,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "Dataset"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "Dataset"
+                          }
+                        }
                       }
                     }
                   }
@@ -17380,9 +18321,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17412,9 +18359,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17444,9 +18397,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17476,9 +18435,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17508,9 +18473,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17540,9 +18511,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17572,9 +18549,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17604,9 +18587,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17636,9 +18625,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17668,9 +18663,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17700,9 +18701,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17732,9 +18739,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -17894,7 +18907,7 @@
       "id": "endpoint_datasets.create",
       "description": "Create a dataset by uploading a file. See ['Dataset Creation'](https://docs.cohere.com/docs/datasets#dataset-creation) for more information.",
       "namespace": [
-        "subpackage_datasets"
+        "datasets"
       ],
       "displayName": "Create a Dataset",
       "operationId": "create-dataset",
@@ -18134,9 +19147,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -18159,9 +19178,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18191,9 +19216,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18223,9 +19254,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18255,9 +19292,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18287,9 +19330,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18319,9 +19368,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18351,9 +19406,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18383,9 +19444,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18415,9 +19482,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18447,9 +19520,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18479,9 +19558,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18511,9 +19596,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18605,7 +19696,7 @@
       "id": "endpoint_datasets.getUsage",
       "description": "View the dataset storage usage for your Organization. Each Organization can have up to 10GB of storage across all their users.",
       "namespace": [
-        "subpackage_datasets"
+        "datasets"
       ],
       "displayName": "Get Dataset Usage",
       "operationId": "get-dataset-usage",
@@ -18679,9 +19770,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -18704,9 +19801,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18736,9 +19839,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18768,9 +19877,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18800,9 +19915,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18832,9 +19953,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18864,9 +19991,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18896,9 +20029,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18928,9 +20067,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18960,9 +20105,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -18992,9 +20143,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19024,9 +20181,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19056,9 +20219,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19146,7 +20315,7 @@
       "id": "endpoint_datasets.get",
       "description": "Retrieve a dataset by ID. See ['Datasets'](https://docs.cohere.com/docs/datasets) for more information.",
       "namespace": [
-        "subpackage_datasets"
+        "datasets"
       ],
       "displayName": "Get a Dataset",
       "operationId": "get-dataset",
@@ -19257,9 +20426,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19289,9 +20464,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19321,9 +20502,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19353,9 +20540,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19385,9 +20578,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19417,9 +20616,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19449,9 +20654,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19481,9 +20692,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19513,9 +20730,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19545,9 +20768,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19577,9 +20806,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19609,9 +20844,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19772,7 +21013,7 @@
       "id": "endpoint_datasets.delete",
       "description": "Delete a dataset by ID. Datasets are automatically deleted after 30 days, but they can also be deleted manually.",
       "namespace": [
-        "subpackage_datasets"
+        "datasets"
       ],
       "displayName": "Delete a Dataset",
       "operationId": "delete-dataset",
@@ -19872,9 +21113,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19904,9 +21151,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19936,9 +21189,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -19968,9 +21227,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20000,9 +21265,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20032,9 +21303,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20064,9 +21341,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20096,9 +21379,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20128,9 +21417,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20160,9 +21455,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20192,9 +21493,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20224,9 +21531,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20552,9 +21865,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -20565,9 +21884,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -20578,8 +21903,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ApiMeta"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ApiMeta"
+                      }
+                    }
                   }
                 }
               }
@@ -20600,9 +21931,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20632,9 +21969,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20664,9 +22007,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20696,9 +22045,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20728,9 +22083,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20760,9 +22121,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20792,9 +22159,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20824,9 +22197,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20856,9 +22235,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20888,9 +22273,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20920,9 +22311,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -20952,9 +22349,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21246,9 +22649,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21278,9 +22687,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21310,9 +22725,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21342,9 +22763,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21374,9 +22801,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21406,9 +22839,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21438,9 +22877,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21470,9 +22915,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21502,9 +22953,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21534,9 +22991,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21566,9 +23029,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21598,9 +23067,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21890,9 +23365,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21922,9 +23403,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21954,9 +23441,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -21986,9 +23479,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22018,9 +23517,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22050,9 +23555,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22082,9 +23593,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22114,9 +23631,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22146,9 +23669,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22178,9 +23707,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22210,9 +23745,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22242,9 +23783,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22351,7 +23898,7 @@
       "id": "endpoint_connectors.list",
       "description": "Returns a list of connectors ordered by descending creation date (newer first). See ['Managing your Connector'](https://docs.cohere.com/docs/managing-your-connector) for more information.",
       "namespace": [
-        "subpackage_connectors"
+        "connectors"
       ],
       "displayName": "List Connectors",
       "operationId": "list-connectors",
@@ -22472,9 +24019,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22504,9 +24057,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22536,9 +24095,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22568,9 +24133,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22600,9 +24171,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22632,9 +24209,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22664,9 +24247,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22696,9 +24285,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22728,9 +24323,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22760,9 +24361,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22792,9 +24399,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22824,9 +24437,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -22939,7 +24558,7 @@
       "id": "endpoint_connectors.create",
       "description": "Creates a new connector. The connector is tested during registration and will cancel registration when the test is unsuccessful. See ['Creating and Deploying a Connector'](https://docs.cohere.com/v1/docs/creating-and-deploying-a-connector) for more information.",
       "namespace": [
-        "subpackage_connectors"
+        "connectors"
       ],
       "displayName": "Create a Connector",
       "operationId": "create-connector",
@@ -23030,9 +24649,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23062,9 +24687,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23094,9 +24725,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23126,9 +24763,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23158,9 +24801,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23190,9 +24839,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23222,9 +24877,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23254,9 +24915,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23286,9 +24953,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23318,9 +24991,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23350,9 +25029,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23382,9 +25067,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23518,7 +25209,7 @@
       "id": "endpoint_connectors.get",
       "description": "Retrieve a connector by ID. See ['Connectors'](https://docs.cohere.com/docs/connectors) for more information.",
       "namespace": [
-        "subpackage_connectors"
+        "connectors"
       ],
       "displayName": "Get a Connector",
       "operationId": "get-connector",
@@ -23620,9 +25311,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23652,9 +25349,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23684,9 +25387,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23716,9 +25425,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23748,9 +25463,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23780,9 +25501,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23812,9 +25539,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23844,9 +25577,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23876,9 +25615,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23908,9 +25653,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23940,9 +25691,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -23972,9 +25729,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24087,7 +25850,7 @@
       "id": "endpoint_connectors.update",
       "description": "Update a connector by ID. Omitted fields will not be updated. See ['Managing your Connector'](https://docs.cohere.com/docs/managing-your-connector) for more information.",
       "namespace": [
-        "subpackage_connectors"
+        "connectors"
       ],
       "displayName": "Update a Connector",
       "operationId": "update-connector",
@@ -24201,9 +25964,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24233,9 +26002,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24265,9 +26040,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24297,9 +26078,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24329,9 +26116,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24361,9 +26154,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24393,9 +26192,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24425,9 +26230,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24457,9 +26268,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24489,9 +26306,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24521,9 +26344,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24553,9 +26382,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24691,7 +26526,7 @@
       "id": "endpoint_connectors.delete",
       "description": "Delete a connector by ID. See ['Connectors'](https://docs.cohere.com/docs/connectors) for more information.",
       "namespace": [
-        "subpackage_connectors"
+        "connectors"
       ],
       "displayName": "Delete a Connector",
       "operationId": "delete-connector",
@@ -24793,9 +26628,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24825,9 +26666,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24857,9 +26704,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24889,9 +26742,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24921,9 +26780,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24953,9 +26818,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -24985,9 +26856,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25017,9 +26894,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25049,9 +26932,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25081,9 +26970,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25113,9 +27008,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25145,9 +27046,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25236,7 +27143,7 @@
       "id": "endpoint_connectors.oAuthAuthorize",
       "description": "Authorize the connector with the given ID for the connector oauth app.  See ['Connector Authentication'](https://docs.cohere.com/docs/connector-authentication) for more information.",
       "namespace": [
-        "subpackage_connectors"
+        "connectors"
       ],
       "displayName": "Authorize with oAuth",
       "operationId": "oAuthAuthorize-connector",
@@ -25375,9 +27282,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25407,9 +27320,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25439,9 +27358,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25471,9 +27396,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25503,9 +27434,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25535,9 +27472,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25567,9 +27510,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25599,9 +27548,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25631,9 +27586,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25663,9 +27624,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25695,9 +27662,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25727,9 +27700,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25820,7 +27799,7 @@
       "id": "endpoint_models.get",
       "description": "Returns the details of a model, provided its name.",
       "namespace": [
-        "subpackage_models"
+        "models"
       ],
       "displayName": "Get a Model",
       "operationId": "get-model",
@@ -25942,9 +27921,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -25974,9 +27959,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26006,9 +27997,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26038,9 +28035,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26070,9 +28073,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26102,9 +28111,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26134,9 +28149,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26166,9 +28187,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26198,9 +28225,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26230,9 +28263,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26262,9 +28301,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26294,9 +28339,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26348,7 +28399,7 @@
       "id": "endpoint_models.list",
       "description": "Returns a list of models available for use. The list contains models from Cohere as well as your fine-tuned models.",
       "namespace": [
-        "subpackage_models"
+        "models"
       ],
       "displayName": "List Models",
       "operationId": "list-models",
@@ -26482,9 +28533,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26514,9 +28571,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26546,9 +28609,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26578,9 +28647,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26610,9 +28685,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26642,9 +28723,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26674,9 +28761,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26706,9 +28799,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26738,9 +28837,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26770,9 +28875,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26802,9 +28913,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -26834,9 +28951,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -27061,9 +29184,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -27093,9 +29222,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -27125,9 +29260,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -27157,9 +29298,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -27189,9 +29336,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -27221,9 +29374,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -27253,9 +29412,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -27285,9 +29450,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -27317,9 +29488,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -27349,9 +29526,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -27381,9 +29564,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -27413,9 +29602,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -27456,7 +29651,7 @@
     "endpoint_finetuning.ListFinetunedModels": {
       "id": "endpoint_finetuning.ListFinetunedModels",
       "namespace": [
-        "subpackage_finetuning"
+        "finetuning"
       ],
       "displayName": "Lists fine-tuned models.",
       "operationId": "ListFinetunedModels",
@@ -27837,7 +30032,7 @@
     "endpoint_finetuning.CreateFinetunedModel": {
       "id": "endpoint_finetuning.CreateFinetunedModel",
       "namespace": [
-        "subpackage_finetuning"
+        "finetuning"
       ],
       "displayName": "Trains and deploys a fine-tuned model.",
       "operationId": "CreateFinetunedModel",
@@ -28172,7 +30367,7 @@
     "endpoint_finetuning.GetFinetunedModel": {
       "id": "endpoint_finetuning.GetFinetunedModel",
       "namespace": [
-        "subpackage_finetuning"
+        "finetuning"
       ],
       "displayName": "Returns a fine-tuned model by ID.",
       "operationId": "GetFinetunedModel",
@@ -28499,7 +30694,7 @@
     "endpoint_finetuning.UpdateFinetunedModel": {
       "id": "endpoint_finetuning.UpdateFinetunedModel",
       "namespace": [
-        "subpackage_finetuning"
+        "finetuning"
       ],
       "displayName": "Updates a fine-tuned model.",
       "operationId": "UpdateFinetunedModel",
@@ -29044,7 +31239,7 @@
     "endpoint_finetuning.DeleteFinetunedModel": {
       "id": "endpoint_finetuning.DeleteFinetunedModel",
       "namespace": [
-        "subpackage_finetuning"
+        "finetuning"
       ],
       "displayName": "Deletes a fine-tuned model.",
       "operationId": "DeleteFinetunedModel",
@@ -29344,7 +31539,7 @@
     "endpoint_finetuning.ListEvents": {
       "id": "endpoint_finetuning.ListEvents",
       "namespace": [
-        "subpackage_finetuning"
+        "finetuning"
       ],
       "displayName": "Retrieves the chronology of statuses the fine-tuned model has been through.",
       "operationId": "ListEvents",
@@ -29734,7 +31929,7 @@
     "endpoint_finetuning.ListTrainingStepMetrics": {
       "id": "endpoint_finetuning.ListTrainingStepMetrics",
       "namespace": [
-        "subpackage_finetuning"
+        "finetuning"
       ],
       "displayName": "Retrieves metrics measured during the training of a fine-tuned model.",
       "operationId": "ListTrainingStepMetrics",
@@ -30594,9 +32789,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30604,9 +32805,24 @@
           }
         ],
         "extraProperties": {
-          "type": "primitive",
-          "value": {
-            "type": "string"
+          "type": "map",
+          "keyShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "valueShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -30651,9 +32867,77 @@
               "value": {
                 "type": "optional",
                 "shape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": []
+                  "type": "alias",
+                  "value": {
+                    "type": "map",
+                    "keyShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "valueShape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "description",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The description of the parameter.\n"
+                        },
+                        {
+                          "key": "type",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "description": "The type of the parameter. Must be a valid Python type.\n"
+                        },
+                        {
+                          "key": "required",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "boolean",
+                                    "default": false
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "Denotes whether the parameter is always present (required) or not. Defaults to not required.\n"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             },
@@ -31054,167 +33338,227 @@
           {
             "key": "api_version",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "version",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                {
-                  "key": "is_deprecated",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "optional",
-                      "shape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "version",
+                      "valueShape": {
                         "type": "alias",
                         "value": {
                           "type": "primitive",
                           "value": {
-                            "type": "boolean"
+                            "type": "string"
                           }
                         }
                       }
-                    }
-                  }
-                },
-                {
-                  "key": "is_experimental",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "optional",
-                      "shape": {
+                    },
+                    {
+                      "key": "is_deprecated",
+                      "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "boolean"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "boolean"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "key": "is_experimental",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "boolean"
+                              }
+                            }
                           }
                         }
                       }
                     }
-                  }
+                  ]
                 }
-              ]
+              }
             }
           },
           {
             "key": "billed_units",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "images",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "double"
-                      }
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "images",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "double"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of billed images.\n"
+                    },
+                    {
+                      "key": "input_tokens",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "double"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of billed input tokens.\n"
+                    },
+                    {
+                      "key": "output_tokens",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "double"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of billed output tokens.\n"
+                    },
+                    {
+                      "key": "search_units",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "double"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of billed search units.\n"
+                    },
+                    {
+                      "key": "classifications",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "double"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of billed classifications units.\n"
                     }
-                  },
-                  "description": "The number of billed images.\n"
-                },
-                {
-                  "key": "input_tokens",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "double"
-                      }
-                    }
-                  },
-                  "description": "The number of billed input tokens.\n"
-                },
-                {
-                  "key": "output_tokens",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "double"
-                      }
-                    }
-                  },
-                  "description": "The number of billed output tokens.\n"
-                },
-                {
-                  "key": "search_units",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "double"
-                      }
-                    }
-                  },
-                  "description": "The number of billed search units.\n"
-                },
-                {
-                  "key": "classifications",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "double"
-                      }
-                    }
-                  },
-                  "description": "The number of billed classifications units.\n"
+                  ]
                 }
-              ]
+              }
             }
           },
           {
             "key": "tokens",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "input_tokens",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "double"
-                      }
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "input_tokens",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "double"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of tokens used as input to the model.\n"
+                    },
+                    {
+                      "key": "output_tokens",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "double"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of tokens produced by the model.\n"
                     }
-                  },
-                  "description": "The number of tokens used as input to the model.\n"
-                },
-                {
-                  "key": "output_tokens",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "double"
-                      }
-                    }
-                  },
-                  "description": "The number of tokens produced by the model.\n"
+                  ]
                 }
-              ]
+              }
             }
           },
           {
@@ -31222,13 +33566,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31538,10 +33888,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid",
-                  "minLength": 1
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid",
+                      "minLength": 1
+                    }
+                  }
                 }
               }
             },
@@ -31563,12 +33919,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ChatSearchQuery"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ChatSearchQuery"
+                      }
+                    }
                   }
                 }
               }
@@ -31591,12 +33953,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ChatSearchResult"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ChatSearchResult"
+                      }
+                    }
                   }
                 }
               }
@@ -31608,12 +33976,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ChatDocument"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ChatDocument"
+                      }
+                    }
                   }
                 }
               }
@@ -31636,10 +34010,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "minLength": 1
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
                 }
               }
             },
@@ -31661,12 +34041,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ChatCitation"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ChatCitation"
+                      }
+                    }
                   }
                 }
               }
@@ -31689,9 +34075,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -31702,12 +34094,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ToolCall"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ToolCall"
+                      }
+                    }
                   }
                 }
               }
@@ -31727,24 +34125,30 @@
           {
             "key": "finish_reason",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "COMPLETE"
-                },
-                {
-                  "value": "ERROR_LIMIT"
-                },
-                {
-                  "value": "MAX_TOKENS"
-                },
-                {
-                  "value": "ERROR"
-                },
-                {
-                  "value": "ERROR_TOXIC"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "COMPLETE"
+                    },
+                    {
+                      "value": "ERROR_LIMIT"
+                    },
+                    {
+                      "value": "MAX_TOKENS"
+                    },
+                    {
+                      "value": "ERROR"
+                    },
+                    {
+                      "value": "ERROR_TOXIC"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "- `COMPLETE` - the model sent back a finished reply\n- `ERROR_LIMIT` - the reply was cut off because the model reached the maximum number of tokens for its context length\n- `MAX_TOKENS` - the reply was cut off because the model reached the maximum number of tokens specified by the max_tokens parameter\n- `ERROR` - something went wrong when generating the reply\n- `ERROR_TOXIC` - the model generated a reply that was deemed toxic\n"
           },
@@ -31753,8 +34157,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "NonStreamedChatResponse"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "NonStreamedChatResponse"
+                  }
+                }
               }
             },
             "description": "The consolidated response from the model. Contains the generated reply and all the other information streamed back in the previous events.\n"
@@ -31773,9 +34183,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -31786,9 +34202,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -31799,9 +34221,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -31812,9 +34240,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -31837,8 +34271,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ToolCallDelta"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ToolCallDelta"
+                  }
+                }
               }
             }
           },
@@ -31847,9 +34287,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -31870,9 +34316,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -31899,10 +34351,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "uuid",
-                      "minLength": 1
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "uuid",
+                          "minLength": 1
+                        }
+                      }
                     }
                   }
                 },
@@ -31923,12 +34381,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "ChatSearchQuery"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "ChatSearchQuery"
+                          }
+                        }
                       }
                     }
                   }
@@ -31950,12 +34414,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "ChatSearchResult"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "ChatSearchResult"
+                          }
+                        }
                       }
                     }
                   }
@@ -31967,12 +34437,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "ChatDocument"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "ChatDocument"
+                          }
+                        }
                       }
                     }
                   }
@@ -31994,10 +34470,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "minLength": 1
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
                     }
                   }
                 },
@@ -32018,12 +34500,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "ChatCitation"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "ChatCitation"
+                          }
+                        }
                       }
                     }
                   }
@@ -32045,9 +34533,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -32058,12 +34552,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "ToolCall"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "ToolCall"
+                          }
+                        }
                       }
                     }
                   }
@@ -32082,24 +34582,30 @@
               {
                 "key": "finish_reason",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "COMPLETE"
-                    },
-                    {
-                      "value": "ERROR_LIMIT"
-                    },
-                    {
-                      "value": "MAX_TOKENS"
-                    },
-                    {
-                      "value": "ERROR"
-                    },
-                    {
-                      "value": "ERROR_TOXIC"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "COMPLETE"
+                        },
+                        {
+                          "value": "ERROR_LIMIT"
+                        },
+                        {
+                          "value": "MAX_TOKENS"
+                        },
+                        {
+                          "value": "ERROR"
+                        },
+                        {
+                          "value": "ERROR_TOXIC"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "- `COMPLETE` - the model sent back a finished reply\n- `ERROR_LIMIT` - the reply was cut off because the model reached the maximum number of tokens for its context length\n- `MAX_TOKENS` - the reply was cut off because the model reached the maximum number of tokens specified by the max_tokens parameter\n- `ERROR` - something went wrong when generating the reply\n- `ERROR_TOXIC` - the model generated a reply that was deemed toxic\n"
               },
@@ -32108,8 +34614,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "NonStreamedChatResponse"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "NonStreamedChatResponse"
+                      }
+                    }
                   }
                 },
                 "description": "The consolidated response from the model. Contains the generated reply and all the other information streamed back in the previous events.\n"
@@ -32129,8 +34641,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ToolCallDelta"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ToolCallDelta"
+                      }
+                    }
                   }
                 }
               },
@@ -32139,9 +34657,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -32161,9 +34685,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -32316,9 +34846,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -32326,45 +34862,69 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "function"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "function"
+                    }
+                  ]
                 }
-              ]
+              }
             }
           },
           {
             "key": "function",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "name",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "name",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "key": "arguments",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
                       }
                     }
-                  }
-                },
-                {
-                  "key": "arguments",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -32382,9 +34942,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32393,9 +34959,15 @@
           {
             "key": "tool_output",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": []
+                }
+              }
             }
           }
         ]
@@ -32412,9 +34984,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32423,9 +35001,15 @@
           {
             "key": "document",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": []
+                }
+              }
             }
           }
         ]
@@ -32449,9 +35033,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -32460,9 +35050,15 @@
               {
                 "key": "tool_output",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": []
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": []
+                    }
+                  }
                 }
               }
             ]
@@ -32479,9 +35075,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -32490,9 +35092,15 @@
               {
                 "key": "document",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": []
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": []
+                    }
+                  }
                 }
               }
             ]
@@ -32512,9 +35120,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -32525,9 +35139,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -32538,9 +35158,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32551,12 +35177,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Source"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Source"
+                      }
+                    }
                   }
                 }
               }
@@ -33434,56 +36066,86 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "function"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "function"
+                    }
+                  ]
                 }
-              ]
+              }
             }
           },
           {
             "key": "function",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "name",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "name",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The name of the function."
+                    },
+                    {
+                      "key": "description",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The description of the function."
+                    },
+                    {
+                      "key": "parameters",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "object",
+                            "extends": [],
+                            "properties": []
+                          }
+                        }
+                      },
+                      "description": "The parameters of the function as a JSON schema."
                     }
-                  },
-                  "description": "The name of the function."
-                },
-                {
-                  "key": "description",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "description": "The description of the function."
-                },
-                {
-                  "key": "parameters",
-                  "valueShape": {
-                    "type": "object",
-                    "extends": [],
-                    "properties": []
-                  },
-                  "description": "The parameters of the function as a JSON schema."
+                  ]
                 }
-              ]
+              }
             },
             "description": "The function to be executed."
           }
@@ -33499,18 +36161,24 @@
           {
             "key": "mode",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "FAST"
-                },
-                {
-                  "value": "ACCURATE"
-                },
-                {
-                  "value": "OFF"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "FAST"
+                    },
+                    {
+                      "value": "ACCURATE"
+                    },
+                    {
+                      "value": "OFF"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Defaults to `\"accurate\"`.\nDictates the approach taken to generating citations as part of the RAG flow by allowing the user to specify whether they want `\"accurate\"` results, `\"fast\"` results or no results.\n"
           }
@@ -33817,97 +36485,145 @@
           {
             "key": "billed_units",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "input_tokens",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "double"
-                      }
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "input_tokens",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "double"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of billed input tokens.\n"
+                    },
+                    {
+                      "key": "output_tokens",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "double"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of billed output tokens.\n"
+                    },
+                    {
+                      "key": "search_units",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "double"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of billed search units.\n"
+                    },
+                    {
+                      "key": "classifications",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "double"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of billed classifications units.\n"
                     }
-                  },
-                  "description": "The number of billed input tokens.\n"
-                },
-                {
-                  "key": "output_tokens",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "double"
-                      }
-                    }
-                  },
-                  "description": "The number of billed output tokens.\n"
-                },
-                {
-                  "key": "search_units",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "double"
-                      }
-                    }
-                  },
-                  "description": "The number of billed search units.\n"
-                },
-                {
-                  "key": "classifications",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "double"
-                      }
-                    }
-                  },
-                  "description": "The number of billed classifications units.\n"
+                  ]
                 }
-              ]
+              }
             }
           },
           {
             "key": "tokens",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "input_tokens",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "double"
-                      }
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "input_tokens",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "double"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of tokens used as input to the model.\n"
+                    },
+                    {
+                      "key": "output_tokens",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "double"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of tokens produced by the model.\n"
                     }
-                  },
-                  "description": "The number of tokens used as input to the model.\n"
-                },
-                {
-                  "key": "output_tokens",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "double"
-                      }
-                    }
-                  },
-                  "description": "The number of tokens produced by the model.\n"
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -34129,9 +36845,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -34140,31 +36862,49 @@
           {
             "key": "delta",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "message",
-                  "valueShape": {
-                    "type": "object",
-                    "extends": [],
-                    "properties": [
-                      {
-                        "key": "role",
-                        "valueShape": {
-                          "type": "enum",
-                          "values": [
-                            {
-                              "value": "assistant"
-                            }
-                          ]
-                        },
-                        "description": "The role of the message."
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "message",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "object",
+                            "extends": [],
+                            "properties": [
+                              {
+                                "key": "role",
+                                "valueShape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "optional",
+                                    "shape": {
+                                      "type": "enum",
+                                      "values": [
+                                        {
+                                          "value": "assistant"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                "description": "The role of the message."
+                              }
+                            ]
+                          }
+                        }
                       }
-                    ]
-                  }
+                    }
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -34184,9 +36924,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -34194,51 +36940,81 @@
           {
             "key": "delta",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "message",
-                  "valueShape": {
-                    "type": "object",
-                    "extends": [],
-                    "properties": [
-                      {
-                        "key": "content",
-                        "valueShape": {
-                          "type": "object",
-                          "extends": [],
-                          "properties": [
-                            {
-                              "key": "text",
-                              "valueShape": {
-                                "type": "alias",
-                                "value": {
-                                  "type": "primitive",
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "message",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "object",
+                            "extends": [],
+                            "properties": [
+                              {
+                                "key": "content",
+                                "valueShape": {
+                                  "type": "alias",
                                   "value": {
-                                    "type": "string"
+                                    "type": "optional",
+                                    "shape": {
+                                      "type": "object",
+                                      "extends": [],
+                                      "properties": [
+                                        {
+                                          "key": "text",
+                                          "valueShape": {
+                                            "type": "alias",
+                                            "value": {
+                                              "type": "optional",
+                                              "shape": {
+                                                "type": "alias",
+                                                "value": {
+                                                  "type": "primitive",
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "key": "type",
+                                          "valueShape": {
+                                            "type": "alias",
+                                            "value": {
+                                              "type": "optional",
+                                              "shape": {
+                                                "type": "enum",
+                                                "values": [
+                                                  {
+                                                    "value": "text"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
                                   }
                                 }
                               }
-                            },
-                            {
-                              "key": "type",
-                              "valueShape": {
-                                "type": "enum",
-                                "values": [
-                                  {
-                                    "value": "text"
-                                  }
-                                ]
-                              }
-                            }
-                          ]
+                            ]
+                          }
                         }
                       }
-                    ]
-                  }
+                    }
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -34258,9 +37034,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -34268,40 +37050,64 @@
           {
             "key": "delta",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "message",
-                  "valueShape": {
-                    "type": "object",
-                    "extends": [],
-                    "properties": [
-                      {
-                        "key": "content",
-                        "valueShape": {
-                          "type": "object",
-                          "extends": [],
-                          "properties": [
-                            {
-                              "key": "text",
-                              "valueShape": {
-                                "type": "alias",
-                                "value": {
-                                  "type": "primitive",
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "message",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "object",
+                            "extends": [],
+                            "properties": [
+                              {
+                                "key": "content",
+                                "valueShape": {
+                                  "type": "alias",
                                   "value": {
-                                    "type": "string"
+                                    "type": "optional",
+                                    "shape": {
+                                      "type": "object",
+                                      "extends": [],
+                                      "properties": [
+                                        {
+                                          "key": "text",
+                                          "valueShape": {
+                                            "type": "alias",
+                                            "value": {
+                                              "type": "optional",
+                                              "shape": {
+                                                "type": "alias",
+                                                "value": {
+                                                  "type": "primitive",
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
                                   }
                                 }
                               }
-                            }
-                          ]
+                            ]
+                          }
                         }
                       }
-                    ]
-                  }
+                    }
+                  ]
                 }
-              ]
+              }
             }
           },
           {
@@ -34309,8 +37115,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "LogprobItem"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "LogprobItem"
+                  }
+                }
               }
             }
           }
@@ -34331,9 +37143,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -34353,22 +37171,34 @@
           {
             "key": "delta",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "tool_plan",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "tool_plan",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
                       }
                     }
-                  }
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -34388,9 +37218,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -34398,75 +37234,117 @@
           {
             "key": "delta",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "tool_call",
-                  "valueShape": {
-                    "type": "object",
-                    "extends": [],
-                    "properties": [
-                      {
-                        "key": "id",
-                        "valueShape": {
-                          "type": "alias",
-                          "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
-                            }
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "tool_call",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "object",
+                            "extends": [],
+                            "properties": [
+                              {
+                                "key": "id",
+                                "valueShape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "optional",
+                                    "shape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "primitive",
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "key": "type",
+                                "valueShape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "optional",
+                                    "shape": {
+                                      "type": "enum",
+                                      "values": [
+                                        {
+                                          "value": "function"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "key": "function",
+                                "valueShape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "optional",
+                                    "shape": {
+                                      "type": "object",
+                                      "extends": [],
+                                      "properties": [
+                                        {
+                                          "key": "name",
+                                          "valueShape": {
+                                            "type": "alias",
+                                            "value": {
+                                              "type": "optional",
+                                              "shape": {
+                                                "type": "alias",
+                                                "value": {
+                                                  "type": "primitive",
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "key": "arguments",
+                                          "valueShape": {
+                                            "type": "alias",
+                                            "value": {
+                                              "type": "optional",
+                                              "shape": {
+                                                "type": "alias",
+                                                "value": {
+                                                  "type": "primitive",
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            ]
                           }
                         }
-                      },
-                      {
-                        "key": "type",
-                        "valueShape": {
-                          "type": "enum",
-                          "values": [
-                            {
-                              "value": "function"
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": "function",
-                        "valueShape": {
-                          "type": "object",
-                          "extends": [],
-                          "properties": [
-                            {
-                              "key": "name",
-                              "valueShape": {
-                                "type": "alias",
-                                "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "key": "arguments",
-                              "valueShape": {
-                                "type": "alias",
-                                "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            }
-                          ]
-                        }
                       }
-                    ]
-                  }
+                    }
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -34486,9 +37364,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -34496,40 +37380,64 @@
           {
             "key": "delta",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "tool_call",
-                  "valueShape": {
-                    "type": "object",
-                    "extends": [],
-                    "properties": [
-                      {
-                        "key": "function",
-                        "valueShape": {
-                          "type": "object",
-                          "extends": [],
-                          "properties": [
-                            {
-                              "key": "arguments",
-                              "valueShape": {
-                                "type": "alias",
-                                "value": {
-                                  "type": "primitive",
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "tool_call",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "object",
+                            "extends": [],
+                            "properties": [
+                              {
+                                "key": "function",
+                                "valueShape": {
+                                  "type": "alias",
                                   "value": {
-                                    "type": "string"
+                                    "type": "optional",
+                                    "shape": {
+                                      "type": "object",
+                                      "extends": [],
+                                      "properties": [
+                                        {
+                                          "key": "arguments",
+                                          "valueShape": {
+                                            "type": "alias",
+                                            "value": {
+                                              "type": "optional",
+                                              "shape": {
+                                                "type": "alias",
+                                                "value": {
+                                                  "type": "primitive",
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
                                   }
                                 }
                               }
-                            }
-                          ]
+                            ]
+                          }
                         }
                       }
-                    ]
-                  }
+                    }
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -34549,9 +37457,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -34573,9 +37487,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -34583,29 +37503,47 @@
           {
             "key": "delta",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "message",
-                  "valueShape": {
-                    "type": "object",
-                    "extends": [],
-                    "properties": [
-                      {
-                        "key": "citations",
-                        "valueShape": {
-                          "type": "alias",
-                          "value": {
-                            "type": "id",
-                            "id": "Citation"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "message",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "object",
+                            "extends": [],
+                            "properties": [
+                              {
+                                "key": "citations",
+                                "valueShape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "optional",
+                                    "shape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "id",
+                                        "id": "Citation"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ]
                           }
                         }
                       }
-                    ]
-                  }
+                    }
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -34625,9 +37563,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -34649,9 +37593,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -34659,30 +37609,48 @@
           {
             "key": "delta",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "finish_reason",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "id",
-                      "id": "ChatFinishReason"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "finish_reason",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "ChatFinishReason"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "key": "usage",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "Usage"
+                            }
+                          }
+                        }
+                      }
                     }
-                  }
-                },
-                {
-                  "key": "usage",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "id",
-                      "id": "Usage"
-                    }
-                  }
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -34709,9 +37677,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -34720,31 +37694,49 @@
               {
                 "key": "delta",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "message",
-                      "valueShape": {
-                        "type": "object",
-                        "extends": [],
-                        "properties": [
-                          {
-                            "key": "role",
-                            "valueShape": {
-                              "type": "enum",
-                              "values": [
-                                {
-                                  "value": "assistant"
-                                }
-                              ]
-                            },
-                            "description": "The role of the message."
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "message",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "object",
+                                "extends": [],
+                                "properties": [
+                                  {
+                                    "key": "role",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "enum",
+                                          "values": [
+                                            {
+                                              "value": "assistant"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "description": "The role of the message."
+                                  }
+                                ]
+                              }
+                            }
                           }
-                        ]
-                      }
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             ]
@@ -34763,9 +37755,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -34773,51 +37771,81 @@
               {
                 "key": "delta",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "message",
-                      "valueShape": {
-                        "type": "object",
-                        "extends": [],
-                        "properties": [
-                          {
-                            "key": "content",
-                            "valueShape": {
-                              "type": "object",
-                              "extends": [],
-                              "properties": [
-                                {
-                                  "key": "text",
-                                  "valueShape": {
-                                    "type": "alias",
-                                    "value": {
-                                      "type": "primitive",
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "message",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "object",
+                                "extends": [],
+                                "properties": [
+                                  {
+                                    "key": "content",
+                                    "valueShape": {
+                                      "type": "alias",
                                       "value": {
-                                        "type": "string"
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "object",
+                                          "extends": [],
+                                          "properties": [
+                                            {
+                                              "key": "text",
+                                              "valueShape": {
+                                                "type": "alias",
+                                                "value": {
+                                                  "type": "optional",
+                                                  "shape": {
+                                                    "type": "alias",
+                                                    "value": {
+                                                      "type": "primitive",
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "key": "type",
+                                              "valueShape": {
+                                                "type": "alias",
+                                                "value": {
+                                                  "type": "optional",
+                                                  "shape": {
+                                                    "type": "enum",
+                                                    "values": [
+                                                      {
+                                                        "value": "text"
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
                                       }
                                     }
                                   }
-                                },
-                                {
-                                  "key": "type",
-                                  "valueShape": {
-                                    "type": "enum",
-                                    "values": [
-                                      {
-                                        "value": "text"
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
+                                ]
+                              }
                             }
                           }
-                        ]
-                      }
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             ]
@@ -34836,9 +37864,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -34846,40 +37880,64 @@
               {
                 "key": "delta",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "message",
-                      "valueShape": {
-                        "type": "object",
-                        "extends": [],
-                        "properties": [
-                          {
-                            "key": "content",
-                            "valueShape": {
-                              "type": "object",
-                              "extends": [],
-                              "properties": [
-                                {
-                                  "key": "text",
-                                  "valueShape": {
-                                    "type": "alias",
-                                    "value": {
-                                      "type": "primitive",
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "message",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "object",
+                                "extends": [],
+                                "properties": [
+                                  {
+                                    "key": "content",
+                                    "valueShape": {
+                                      "type": "alias",
                                       "value": {
-                                        "type": "string"
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "object",
+                                          "extends": [],
+                                          "properties": [
+                                            {
+                                              "key": "text",
+                                              "valueShape": {
+                                                "type": "alias",
+                                                "value": {
+                                                  "type": "optional",
+                                                  "shape": {
+                                                    "type": "alias",
+                                                    "value": {
+                                                      "type": "primitive",
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
                                       }
                                     }
                                   }
-                                }
-                              ]
+                                ]
+                              }
                             }
                           }
-                        ]
-                      }
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
@@ -34887,8 +37945,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "LogprobItem"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "LogprobItem"
+                      }
+                    }
                   }
                 }
               }
@@ -34908,9 +37972,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -34929,22 +37999,34 @@
               {
                 "key": "delta",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "tool_plan",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "tool_plan",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
                           }
                         }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             ]
@@ -34963,9 +38045,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -34973,75 +38061,117 @@
               {
                 "key": "delta",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "tool_call",
-                      "valueShape": {
-                        "type": "object",
-                        "extends": [],
-                        "properties": [
-                          {
-                            "key": "id",
-                            "valueShape": {
-                              "type": "alias",
-                              "value": {
-                                "type": "primitive",
-                                "value": {
-                                  "type": "string"
-                                }
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "tool_call",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "object",
+                                "extends": [],
+                                "properties": [
+                                  {
+                                    "key": "id",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "primitive",
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": "type",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "enum",
+                                          "values": [
+                                            {
+                                              "value": "function"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": "function",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "object",
+                                          "extends": [],
+                                          "properties": [
+                                            {
+                                              "key": "name",
+                                              "valueShape": {
+                                                "type": "alias",
+                                                "value": {
+                                                  "type": "optional",
+                                                  "shape": {
+                                                    "type": "alias",
+                                                    "value": {
+                                                      "type": "primitive",
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "key": "arguments",
+                                              "valueShape": {
+                                                "type": "alias",
+                                                "value": {
+                                                  "type": "optional",
+                                                  "shape": {
+                                                    "type": "alias",
+                                                    "value": {
+                                                      "type": "primitive",
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
-                          },
-                          {
-                            "key": "type",
-                            "valueShape": {
-                              "type": "enum",
-                              "values": [
-                                {
-                                  "value": "function"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "key": "function",
-                            "valueShape": {
-                              "type": "object",
-                              "extends": [],
-                              "properties": [
-                                {
-                                  "key": "name",
-                                  "valueShape": {
-                                    "type": "alias",
-                                    "value": {
-                                      "type": "primitive",
-                                      "value": {
-                                        "type": "string"
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "key": "arguments",
-                                  "valueShape": {
-                                    "type": "alias",
-                                    "value": {
-                                      "type": "primitive",
-                                      "value": {
-                                        "type": "string"
-                                      }
-                                    }
-                                  }
-                                }
-                              ]
-                            }
                           }
-                        ]
-                      }
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             ]
@@ -35060,9 +38190,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -35070,40 +38206,64 @@
               {
                 "key": "delta",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "tool_call",
-                      "valueShape": {
-                        "type": "object",
-                        "extends": [],
-                        "properties": [
-                          {
-                            "key": "function",
-                            "valueShape": {
-                              "type": "object",
-                              "extends": [],
-                              "properties": [
-                                {
-                                  "key": "arguments",
-                                  "valueShape": {
-                                    "type": "alias",
-                                    "value": {
-                                      "type": "primitive",
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "tool_call",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "object",
+                                "extends": [],
+                                "properties": [
+                                  {
+                                    "key": "function",
+                                    "valueShape": {
+                                      "type": "alias",
                                       "value": {
-                                        "type": "string"
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "object",
+                                          "extends": [],
+                                          "properties": [
+                                            {
+                                              "key": "arguments",
+                                              "valueShape": {
+                                                "type": "alias",
+                                                "value": {
+                                                  "type": "optional",
+                                                  "shape": {
+                                                    "type": "alias",
+                                                    "value": {
+                                                      "type": "primitive",
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
                                       }
                                     }
                                   }
-                                }
-                              ]
+                                ]
+                              }
                             }
                           }
-                        ]
-                      }
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             ]
@@ -35122,9 +38282,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -35145,9 +38311,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -35155,29 +38327,47 @@
               {
                 "key": "delta",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "message",
-                      "valueShape": {
-                        "type": "object",
-                        "extends": [],
-                        "properties": [
-                          {
-                            "key": "citations",
-                            "valueShape": {
-                              "type": "alias",
-                              "value": {
-                                "type": "id",
-                                "id": "Citation"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "message",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "object",
+                                "extends": [],
+                                "properties": [
+                                  {
+                                    "key": "citations",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "id",
+                                            "id": "Citation"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                ]
                               }
                             }
                           }
-                        ]
-                      }
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             ]
@@ -35196,9 +38386,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -35219,9 +38415,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -35229,30 +38431,48 @@
               {
                 "key": "delta",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "finish_reason",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "id",
-                          "id": "ChatFinishReason"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "finish_reason",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "id",
+                                  "id": "ChatFinishReason"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "key": "usage",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "id",
+                                  "id": "Usage"
+                                }
+                              }
+                            }
+                          }
                         }
-                      }
-                    },
-                    {
-                      "key": "usage",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "id",
-                          "id": "Usage"
-                        }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             ]
@@ -35270,9 +38490,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -35511,9 +38737,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -35524,9 +38756,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -35537,9 +38775,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -35623,189 +38867,8 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          {
-            "key": "finish_reason",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "id",
-                "id": "FinishReason"
-              }
-            }
-          },
-          {
-            "key": "response",
-            "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "id",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                {
-                  "key": "prompt",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "optional",
-                      "shape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                {
-                  "key": "generations",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "optional",
-                      "shape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "list",
-                          "itemShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "id",
-                              "id": "SingleGenerationInStream"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "GenerateStreamError": {
-      "name": "GenerateStreamError",
-      "shape": {
-        "type": "object",
-        "extends": [
-          "GenerateStreamEvent"
-        ],
-        "properties": [
-          {
-            "key": "index",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
-                }
-              }
-            },
-            "description": "Refers to the nth generation. Only present when `num_generations` is greater than zero."
-          },
-          {
-            "key": "is_finished",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          {
-            "key": "finish_reason",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "id",
-                "id": "FinishReason"
-              }
-            }
-          },
-          {
-            "key": "err",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "Error message"
-          }
-        ]
-      }
-    },
-    "GenerateStreamedResponse": {
-      "name": "GenerateStreamedResponse",
-      "shape": {
-        "type": "discriminatedUnion",
-        "discriminant": "event_type",
-        "variants": [
-          {
-            "discriminantValue": "text-generation",
-            "displayName": "Text Generation",
-            "type": "object",
-            "extends": [
-              "GenerateStreamEvent"
-            ],
-            "properties": [
-              {
-                "key": "text",
-                "valueShape": {
-                  "type": "alias",
-                  "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "description": "A segment of text of the generation."
-              },
-              {
-                "key": "index",
-                "valueShape": {
-                  "type": "alias",
-                  "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
-                    }
-                  }
-                },
-                "description": "Refers to the nth generation. Only present when `num_generations` is greater than zero, and only when text responses are being streamed."
-              },
-              {
-                "key": "is_finished",
-                "valueShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
                     "type": "primitive",
@@ -35815,41 +38878,31 @@
                   }
                 }
               }
-            ]
+            }
           },
           {
-            "discriminantValue": "stream-end",
-            "displayName": "Stream End",
-            "type": "object",
-            "extends": [
-              "GenerateStreamEvent"
-            ],
-            "properties": [
-              {
-                "key": "is_finished",
-                "valueShape": {
-                  "type": "alias",
-                  "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              },
-              {
-                "key": "finish_reason",
-                "valueShape": {
+            "key": "finish_reason",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
                     "type": "id",
                     "id": "FinishReason"
                   }
                 }
-              },
-              {
-                "key": "response",
-                "valueShape": {
+              }
+            }
+          },
+          {
+            "key": "response",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
                   "type": "object",
                   "extends": [],
                   "properties": [
@@ -35908,6 +38961,275 @@
                   ]
                 }
               }
+            }
+          }
+        ]
+      }
+    },
+    "GenerateStreamError": {
+      "name": "GenerateStreamError",
+      "shape": {
+        "type": "object",
+        "extends": [
+          "GenerateStreamEvent"
+        ],
+        "properties": [
+          {
+            "key": "index",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Refers to the nth generation. Only present when `num_generations` is greater than zero."
+          },
+          {
+            "key": "is_finished",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "key": "finish_reason",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "FinishReason"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "key": "err",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Error message"
+          }
+        ]
+      }
+    },
+    "GenerateStreamedResponse": {
+      "name": "GenerateStreamedResponse",
+      "shape": {
+        "type": "discriminatedUnion",
+        "discriminant": "event_type",
+        "variants": [
+          {
+            "discriminantValue": "text-generation",
+            "displayName": "Text Generation",
+            "type": "object",
+            "extends": [
+              "GenerateStreamEvent"
+            ],
+            "properties": [
+              {
+                "key": "text",
+                "valueShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "description": "A segment of text of the generation."
+              },
+              {
+                "key": "index",
+                "valueShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                },
+                "description": "Refers to the nth generation. Only present when `num_generations` is greater than zero, and only when text responses are being streamed."
+              },
+              {
+                "key": "is_finished",
+                "valueShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "discriminantValue": "stream-end",
+            "displayName": "Stream End",
+            "type": "object",
+            "extends": [
+              "GenerateStreamEvent"
+            ],
+            "properties": [
+              {
+                "key": "is_finished",
+                "valueShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "key": "finish_reason",
+                "valueShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "FinishReason"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "key": "response",
+                "valueShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "id",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "key": "prompt",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "key": "generations",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "list",
+                                  "itemShape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "id",
+                                      "id": "SingleGenerationInStream"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
             ]
           },
           {
@@ -35923,9 +39245,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -35936,9 +39264,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 }
@@ -35948,8 +39282,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "FinishReason"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "FinishReason"
+                      }
+                    }
                   }
                 }
               },
@@ -35958,9 +39298,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -36253,17 +39599,23 @@
                   "valueShape": {
                     "type": "alias",
                     "value": {
-                      "type": "list",
-                      "itemShape": {
+                      "type": "optional",
+                      "shape": {
                         "type": "alias",
                         "value": {
                           "type": "list",
                           "itemShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "double"
+                              "type": "list",
+                              "itemShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "double"
+                                  }
+                                }
                               }
                             }
                           }
@@ -36278,17 +39630,23 @@
                   "valueShape": {
                     "type": "alias",
                     "value": {
-                      "type": "list",
-                      "itemShape": {
+                      "type": "optional",
+                      "shape": {
                         "type": "alias",
                         "value": {
                           "type": "list",
                           "itemShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "list",
+                              "itemShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           }
@@ -36303,17 +39661,23 @@
                   "valueShape": {
                     "type": "alias",
                     "value": {
-                      "type": "list",
-                      "itemShape": {
+                      "type": "optional",
+                      "shape": {
                         "type": "alias",
                         "value": {
                           "type": "list",
                           "itemShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "list",
+                              "itemShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           }
@@ -36328,17 +39692,23 @@
                   "valueShape": {
                     "type": "alias",
                     "value": {
-                      "type": "list",
-                      "itemShape": {
+                      "type": "optional",
+                      "shape": {
                         "type": "alias",
                         "value": {
                           "type": "list",
                           "itemShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "list",
+                              "itemShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           }
@@ -36353,17 +39723,23 @@
                   "valueShape": {
                     "type": "alias",
                     "value": {
-                      "type": "list",
-                      "itemShape": {
+                      "type": "optional",
+                      "shape": {
                         "type": "alias",
                         "value": {
                           "type": "list",
                           "itemShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "list",
+                              "itemShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           }
@@ -36603,12 +39979,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "EmbedJob"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "EmbedJob"
+                      }
+                    }
                   }
                 }
               }
@@ -36798,9 +40180,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -36810,9 +40198,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -37046,9 +40440,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -37058,9 +40458,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -37079,9 +40485,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37092,9 +40504,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37105,9 +40523,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37118,9 +40542,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37131,9 +40561,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37144,9 +40580,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37166,9 +40608,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37179,9 +40627,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37192,9 +40646,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37214,9 +40674,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37227,9 +40693,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37240,13 +40712,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -37268,12 +40746,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "LabelMetric"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "LabelMetric"
+                      }
+                    }
                   }
                 }
               }
@@ -37293,9 +40777,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37306,9 +40796,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37319,9 +40815,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37332,9 +40834,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37345,9 +40853,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37358,9 +40872,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -37371,8 +40891,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "RerankerDataMetrics"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "RerankerDataMetrics"
+                  }
+                }
               }
             }
           },
@@ -37381,8 +40907,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ChatDataMetrics"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ChatDataMetrics"
+                  }
+                }
               }
             }
           },
@@ -37391,8 +40923,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ClassifyDataMetrics"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ClassifyDataMetrics"
+                  }
+                }
               }
             }
           }
@@ -37410,8 +40948,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "FinetuneDatasetMetrics"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "FinetuneDatasetMetrics"
+                  }
+                }
               }
             }
           }
@@ -38409,9 +41953,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38422,9 +41972,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38435,13 +41991,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -38454,8 +42016,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "CreateConnectorOAuth"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "CreateConnectorOAuth"
+                  }
+                }
               }
             },
             "description": "The OAuth 2.0 configuration for the connector. Cannot be specified if service_auth is specified."
@@ -38465,10 +42033,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean",
-                  "default": true
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean",
+                      "default": true
+                    }
+                  }
                 }
               }
             }
@@ -38478,10 +42052,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean",
-                  "default": false
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean",
+                      "default": false
+                    }
+                  }
                 }
               }
             }
@@ -38491,8 +42071,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "CreateConnectorServiceAuth"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "CreateConnectorServiceAuth"
+                  }
+                }
               }
             },
             "description": "The service to service authentication configuration for the connector. Cannot be specified if oauth is specified."
@@ -38530,9 +42116,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38730,9 +42322,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -38743,9 +42341,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38756,9 +42360,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -38866,20 +42476,8 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          {
-            "key": "keywords",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
                     "type": "primitive",
@@ -38892,13 +42490,43 @@
             }
           },
           {
+            "key": "keywords",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
             "key": "description",
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -38908,9 +42536,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -38920,13 +42554,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -39425,24 +43065,30 @@
           {
             "key": "status",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "unknown"
-                },
-                {
-                  "value": "processing"
-                },
-                {
-                  "value": "failed"
-                },
-                {
-                  "value": "complete"
-                },
-                {
-                  "value": "queued"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "unknown"
+                    },
+                    {
+                      "value": "processing"
+                    },
+                    {
+                      "value": "failed"
+                    },
+                    {
+                      "value": "complete"
+                    },
+                    {
+                      "value": "queued"
+                    }
+                  ]
                 }
-              ]
+              }
             }
           },
           {
@@ -39450,12 +43096,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Cluster"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Cluster"
+                      }
+                    }
                   }
                 }
               }
@@ -39466,9 +43118,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -39478,9 +43136,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -39490,9 +43154,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -39500,17 +43170,29 @@
           {
             "key": "input_tracking_metrics",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": []
+                }
+              }
             }
           },
           {
             "key": "output_tracking_metrics",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": []
+                }
+              }
             }
           }
         ]
@@ -39579,9 +43261,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39592,12 +43280,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "CompatibleEndpoint"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "CompatibleEndpoint"
+                      }
+                    }
                   }
                 }
               }
@@ -39609,9 +43303,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -39622,9 +43322,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -39635,9 +43341,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39648,12 +43360,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "CompatibleEndpoint"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "CompatibleEndpoint"
+                      }
+                    }
                   }
                 }
               }
@@ -39869,9 +43587,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39882,9 +43606,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -39895,9 +43625,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39908,9 +43644,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39921,9 +43663,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             },
@@ -39934,9 +43682,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39947,9 +43701,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39960,11 +43720,17 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "LoraTargetModules",
-                "default": {
-                  "type": "enum",
-                  "value": "LORA_TARGET_MODULES_UNSPECIFIED"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "LoraTargetModules",
+                    "default": {
+                      "type": "enum",
+                      "value": "LORA_TARGET_MODULES_UNSPECIFIED"
+                    }
+                  }
                 }
               }
             },
@@ -40352,12 +44118,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "FinetunedModel"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "FinetunedModel"
+                      }
+                    }
                   }
                 }
               }
@@ -40369,9 +44141,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40382,9 +44160,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -40405,9 +44189,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40428,8 +44218,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "FinetunedModel"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "FinetunedModel"
+                  }
+                }
               }
             },
             "description": "Information about the fine-tuned model."
@@ -40449,8 +44245,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "FinetunedModel"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "FinetunedModel"
+                  }
+                }
               }
             },
             "description": "Information about the fine-tuned model."
@@ -40479,8 +44281,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "FinetunedModel"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "FinetunedModel"
+                  }
+                }
               }
             },
             "description": "Information about the fine-tuned model."
@@ -40500,9 +44308,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40513,11 +44327,17 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Status",
-                "default": {
-                  "type": "enum",
-                  "value": "STATUS_UNSPECIFIED"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Status",
+                    "default": {
+                      "type": "enum",
+                      "value": "STATUS_UNSPECIFIED"
+                    }
+                  }
                 }
               }
             },
@@ -40528,9 +44348,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "datetime"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "datetime"
+                    }
+                  }
                 }
               }
             },
@@ -40551,12 +44377,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Event"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Event"
+                      }
+                    }
                   }
                 }
               }
@@ -40568,9 +44400,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40581,9 +44419,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -40604,9 +44448,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "datetime"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "datetime"
+                    }
+                  }
                 }
               }
             },
@@ -40617,9 +44467,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -40630,22 +44486,28 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "map",
-                "keyShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "valueShape": {
-                  "type": "alias",
-                  "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "map",
+                    "keyShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "valueShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 }
@@ -40668,12 +44530,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "TrainingStepMetrics"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "TrainingStepMetrics"
+                      }
+                    }
                   }
                 }
               }
@@ -40685,9 +44553,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40931,17 +44805,23 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "list",
-                          "itemShape": {
+                          "type": "optional",
+                          "shape": {
                             "type": "alias",
                             "value": {
                               "type": "list",
                               "itemShape": {
                                 "type": "alias",
                                 "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "double"
+                                  "type": "list",
+                                  "itemShape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "double"
+                                      }
+                                    }
                                   }
                                 }
                               }
@@ -40956,17 +44836,23 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "list",
-                          "itemShape": {
+                          "type": "optional",
+                          "shape": {
                             "type": "alias",
                             "value": {
                               "type": "list",
                               "itemShape": {
                                 "type": "alias",
                                 "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "integer"
+                                  "type": "list",
+                                  "itemShape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
                                   }
                                 }
                               }
@@ -40981,17 +44867,23 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "list",
-                          "itemShape": {
+                          "type": "optional",
+                          "shape": {
                             "type": "alias",
                             "value": {
                               "type": "list",
                               "itemShape": {
                                 "type": "alias",
                                 "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "integer"
+                                  "type": "list",
+                                  "itemShape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
                                   }
                                 }
                               }
@@ -41006,17 +44898,23 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "list",
-                          "itemShape": {
+                          "type": "optional",
+                          "shape": {
                             "type": "alias",
                             "value": {
                               "type": "list",
                               "itemShape": {
                                 "type": "alias",
                                 "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "integer"
+                                  "type": "list",
+                                  "itemShape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
                                   }
                                 }
                               }
@@ -41031,17 +44929,23 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "list",
-                          "itemShape": {
+                          "type": "optional",
+                          "shape": {
                             "type": "alias",
                             "value": {
                               "type": "list",
                               "itemShape": {
                                 "type": "alias",
                                 "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "integer"
+                                  "type": "list",
+                                  "itemShape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
                                   }
                                 }
                               }
@@ -41120,33 +45024,33 @@
     }
   },
   "subpackages": {
-    "subpackage_v2": {
-      "id": "subpackage_v2",
+    "v2": {
+      "id": "v2",
       "name": "v2",
       "displayName": "V2"
     },
-    "subpackage_embedJobs": {
-      "id": "subpackage_embedJobs",
+    "embedJobs": {
+      "id": "embedJobs",
       "name": "embedJobs",
       "displayName": "Embed Jobs"
     },
-    "subpackage_datasets": {
-      "id": "subpackage_datasets",
+    "datasets": {
+      "id": "datasets",
       "name": "datasets",
       "displayName": "Datasets"
     },
-    "subpackage_connectors": {
-      "id": "subpackage_connectors",
+    "connectors": {
+      "id": "connectors",
       "name": "connectors",
       "displayName": "Connectors"
     },
-    "subpackage_models": {
-      "id": "subpackage_models",
+    "models": {
+      "id": "models",
       "name": "models",
       "displayName": "Models"
     },
-    "subpackage_finetuning": {
-      "id": "subpackage_finetuning",
+    "finetuning": {
+      "id": "finetuning",
       "name": "finetuning",
       "displayName": "Finetuning"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/deeptune.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/deeptune.json
@@ -5,7 +5,7 @@
       "id": "endpoint_textToSpeech.generate",
       "description": "API that converts text into lifelike speech with best-in-class latency & uses the most advanced AI audio model ever. Create voiceovers for your videos, audiobooks, or create AI chatbots for free.",
       "namespace": [
-        "text_to_speech"
+        "subpackage_textToSpeech"
       ],
       "displayName": "Text to Speech",
       "operationId": "textToSpeech",
@@ -90,7 +90,7 @@
       "id": "endpoint_textToSpeech.generateFromPrompt",
       "description": "If you prefer to manage voices on your own, you can use your own audio file as a reference for the voice clone.x",
       "namespace": [
-        "text_to_speech"
+        "subpackage_textToSpeech"
       ],
       "displayName": "Text to Speech (via prompt audio)",
       "operationId": "textToSpeechFromPrompt",
@@ -183,7 +183,7 @@
       "id": "endpoint_voices.list",
       "description": "Retrieve all voices associated with the current workspace.",
       "namespace": [
-        "voices"
+        "subpackage_voices"
       ],
       "displayName": "List voices in workspace",
       "operationId": "listVoices",
@@ -252,7 +252,7 @@
       "id": "endpoint_voices.create",
       "description": "Create a new voice with a name, optional description, and audio file.",
       "namespace": [
-        "voices"
+        "subpackage_voices"
       ],
       "displayName": "Create a cloned voice",
       "operationId": "createVoice",
@@ -348,7 +348,7 @@
       "id": "endpoint_voices.get",
       "description": "Retrieve a specific voice by its ID.",
       "namespace": [
-        "voices"
+        "subpackage_voices"
       ],
       "displayName": "Get an existing voice",
       "operationId": "getVoiceById",
@@ -441,7 +441,7 @@
       "id": "endpoint_voices.update",
       "description": "Update an existing voice with new name, description, or audio file.",
       "namespace": [
-        "voices"
+        "subpackage_voices"
       ],
       "displayName": "Update an existing voice",
       "operationId": "updateVoice",
@@ -563,7 +563,7 @@
       "id": "endpoint_voices.delete",
       "description": "Delete an existing voice by its ID.",
       "namespace": [
-        "voices"
+        "subpackage_voices"
       ],
       "displayName": "Delete a voice",
       "operationId": "deleteVoice",
@@ -1056,15 +1056,15 @@
     }
   },
   "subpackages": {
-    "textToSpeech": {
-      "id": "textToSpeech",
-      "name": "text_to_speech",
-      "displayName": "text_to_speech"
+    "subpackage_textToSpeech": {
+      "id": "subpackage_textToSpeech",
+      "name": "textToSpeech",
+      "displayName": "Text to Speech"
     },
-    "voices": {
-      "id": "voices",
+    "subpackage_voices": {
+      "id": "subpackage_voices",
       "name": "voices",
-      "displayName": "voices"
+      "displayName": "Voices"
     }
   },
   "auths": {

--- a/packages/parsers/src/openapi/__test__/__snapshots__/deeptune.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/deeptune.json
@@ -5,7 +5,7 @@
       "id": "endpoint_textToSpeech.generate",
       "description": "API that converts text into lifelike speech with best-in-class latency & uses the most advanced AI audio model ever. Create voiceovers for your videos, audiobooks, or create AI chatbots for free.",
       "namespace": [
-        "subpackage_textToSpeech"
+        "textToSpeech"
       ],
       "displayName": "Text to Speech",
       "operationId": "textToSpeech",
@@ -90,7 +90,7 @@
       "id": "endpoint_textToSpeech.generateFromPrompt",
       "description": "If you prefer to manage voices on your own, you can use your own audio file as a reference for the voice clone.x",
       "namespace": [
-        "subpackage_textToSpeech"
+        "textToSpeech"
       ],
       "displayName": "Text to Speech (via prompt audio)",
       "operationId": "textToSpeechFromPrompt",
@@ -183,7 +183,7 @@
       "id": "endpoint_voices.list",
       "description": "Retrieve all voices associated with the current workspace.",
       "namespace": [
-        "subpackage_voices"
+        "voices"
       ],
       "displayName": "List voices in workspace",
       "operationId": "listVoices",
@@ -252,7 +252,7 @@
       "id": "endpoint_voices.create",
       "description": "Create a new voice with a name, optional description, and audio file.",
       "namespace": [
-        "subpackage_voices"
+        "voices"
       ],
       "displayName": "Create a cloned voice",
       "operationId": "createVoice",
@@ -348,7 +348,7 @@
       "id": "endpoint_voices.get",
       "description": "Retrieve a specific voice by its ID.",
       "namespace": [
-        "subpackage_voices"
+        "voices"
       ],
       "displayName": "Get an existing voice",
       "operationId": "getVoiceById",
@@ -441,7 +441,7 @@
       "id": "endpoint_voices.update",
       "description": "Update an existing voice with new name, description, or audio file.",
       "namespace": [
-        "subpackage_voices"
+        "voices"
       ],
       "displayName": "Update an existing voice",
       "operationId": "updateVoice",
@@ -563,7 +563,7 @@
       "id": "endpoint_voices.delete",
       "description": "Delete an existing voice by its ID.",
       "namespace": [
-        "subpackage_voices"
+        "voices"
       ],
       "displayName": "Delete a voice",
       "operationId": "deleteVoice",
@@ -1007,9 +1007,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -1020,9 +1026,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "base64"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "base64"
+                    }
+                  }
                 }
               }
             },
@@ -1033,9 +1045,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -1056,13 +1074,13 @@
     }
   },
   "subpackages": {
-    "subpackage_textToSpeech": {
-      "id": "subpackage_textToSpeech",
+    "textToSpeech": {
+      "id": "textToSpeech",
       "name": "textToSpeech",
       "displayName": "Text to Speech"
     },
-    "subpackage_voices": {
-      "id": "subpackage_voices",
+    "voices": {
+      "id": "voices",
       "name": "voices",
       "displayName": "Voices"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/default-content.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/default-content.json
@@ -1,11 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_generativelanguage.GenerateContent": {
-      "id": "endpoint_generativelanguage.GenerateContent",
-      "namespace": [
-        "generativelanguage"
-      ],
+    "endpoint_.GenerateContent": {
+      "id": "endpoint_.GenerateContent",
       "operationId": "GenerateContent",
       "method": "POST",
       "path": [
@@ -98,12 +95,6 @@
       }
     }
   },
-  "subpackages": {
-    "generativelanguage": {
-      "id": "generativelanguage",
-      "name": "generativelanguage",
-      "displayName": "generativelanguage"
-    }
-  },
+  "subpackages": {},
   "auths": {}
 }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/default-content.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/default-content.json
@@ -4,7 +4,7 @@
     "endpoint_generativelanguage.GenerateContent": {
       "id": "endpoint_generativelanguage.GenerateContent",
       "namespace": [
-        "subpackage_generativelanguage"
+        "generativelanguage"
       ],
       "operationId": "GenerateContent",
       "method": "POST",
@@ -39,35 +39,9 @@
           }
         }
       ],
-      "responses": [
-        {
-          "statusCode": null,
-          "body": {
-            "type": "alias",
-            "value": {
-              "type": "id",
-              "id": "GenerateContentResponse"
-            }
-          },
-          "description": "Successful operation"
-        }
-      ],
+      "responses": [],
       "errors": [],
-      "examples": [
-        {
-          "path": "/generateContent",
-          "responseStatusCode": null,
-          "pathParameters": {
-            "model": "model"
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "bar": "bar"
-            }
-          }
-        }
-      ],
+      "examples": [],
       "protocol": {
         "type": "rest"
       }
@@ -87,9 +61,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -99,8 +79,8 @@
     }
   },
   "subpackages": {
-    "subpackage_generativelanguage": {
-      "id": "subpackage_generativelanguage",
+    "generativelanguage": {
+      "id": "generativelanguage",
       "name": "generativelanguage",
       "displayName": "Generativelanguage"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/default-content.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/default-content.json
@@ -1,8 +1,11 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.GenerateContent": {
-      "id": "endpoint_.GenerateContent",
+    "endpoint_generativelanguage.GenerateContent": {
+      "id": "endpoint_generativelanguage.GenerateContent",
+      "namespace": [
+        "subpackage_generativelanguage"
+      ],
       "operationId": "GenerateContent",
       "method": "POST",
       "path": [
@@ -95,6 +98,12 @@
       }
     }
   },
-  "subpackages": {},
+  "subpackages": {
+    "subpackage_generativelanguage": {
+      "id": "subpackage_generativelanguage",
+      "name": "generativelanguage",
+      "displayName": "Generativelanguage"
+    }
+  },
   "auths": {}
 }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/defaults.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/defaults.json
@@ -162,10 +162,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean",
-                      "default": true
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean",
+                          "default": true
+                        }
+                      }
                     }
                   }
                 }
@@ -175,10 +181,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean",
-                      "default": "true"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean",
+                          "default": "true"
+                        }
+                      }
                     }
                   }
                 }
@@ -188,10 +200,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "default": "defaultValue"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "default": "defaultValue"
+                        }
+                      }
                     }
                   }
                 }
@@ -201,10 +219,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double",
-                      "default": 3.14
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double",
+                          "default": 3.14
+                        }
+                      }
                     }
                   }
                 }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/discriminated-union-value-title.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/discriminated-union-value-title.json
@@ -79,13 +79,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -108,13 +114,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 }
@@ -144,13 +156,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -172,13 +190,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "double"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "double"
+                            }
+                          }
                         }
                       }
                     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/enum-casing.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/enum-casing.json
@@ -61,15 +61,21 @@
           {
             "key": "status",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "success"
-                },
-                {
-                  "value": "failure"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "success"
+                    },
+                    {
+                      "value": "failure"
+                    }
+                  ]
                 }
-              ]
+              }
             }
           },
           {
@@ -77,9 +83,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -89,22 +101,28 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "map",
-                "keyShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "valueShape": {
-                  "type": "alias",
-                  "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "map",
+                    "keyShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "valueShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/example-depth.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/example-depth.json
@@ -62,9 +62,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -75,8 +81,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "TreeNode"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "TreeNode"
+                  }
+                }
               }
             },
             "description": "Child nodes of this tree node"
@@ -86,8 +98,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "TreeNode"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "TreeNode"
+                  }
+                }
               }
             },
             "description": "Child nodes of this tree node"

--- a/packages/parsers/src/openapi/__test__/__snapshots__/examples.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/examples.json
@@ -720,9 +720,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/float.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/float.json
@@ -80,9 +80,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             }
@@ -102,9 +108,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             }
@@ -114,9 +126,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/inline-path-parameters.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/inline-path-parameters.json
@@ -144,13 +144,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -192,7 +198,7 @@
       "id": "endpoint_organizations.Search",
       "description": "",
       "namespace": [
-        "subpackage_organizations"
+        "organizations"
       ],
       "displayName": "Search an organization",
       "operationId": "Search",
@@ -248,15 +254,21 @@
               {
                 "key": "access",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "private"
-                    },
-                    {
-                      "value": "public"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "private"
+                        },
+                        {
+                          "value": "public"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "Access level"
               }
@@ -276,13 +288,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -327,8 +345,8 @@
   "webhooks": {},
   "types": {},
   "subpackages": {
-    "subpackage_organizations": {
-      "id": "subpackage_organizations",
+    "organizations": {
+      "id": "organizations",
       "name": "organizations",
       "displayName": "Organizations"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/inline-path-parameters.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/inline-path-parameters.json
@@ -188,9 +188,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.Search": {
-      "id": "endpoint_.Search",
+    "endpoint_organizations.Search": {
+      "id": "endpoint_organizations.Search",
       "description": "",
+      "namespace": [
+        "subpackage_organizations"
+      ],
       "displayName": "Search an organization",
       "operationId": "Search",
       "method": "POST",
@@ -323,6 +326,12 @@
   "websockets": {},
   "webhooks": {},
   "types": {},
-  "subpackages": {},
+  "subpackages": {
+    "subpackage_organizations": {
+      "id": "subpackage_organizations",
+      "name": "organizations",
+      "displayName": "Organizations"
+    }
+  },
   "auths": {}
 }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/inline-path-parameters.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/inline-path-parameters.json
@@ -188,12 +188,9 @@
         "type": "rest"
       }
     },
-    "endpoint_organizations.Search": {
-      "id": "endpoint_organizations.Search",
+    "endpoint_.Search": {
+      "id": "endpoint_.Search",
       "description": "",
-      "namespace": [
-        "Organizations"
-      ],
       "displayName": "Search an organization",
       "operationId": "Search",
       "method": "POST",
@@ -326,12 +323,6 @@
   "websockets": {},
   "webhooks": {},
   "types": {},
-  "subpackages": {
-    "organizations": {
-      "id": "organizations",
-      "name": "Organizations",
-      "displayName": "Organizations"
-    }
-  },
+  "subpackages": {},
   "auths": {}
 }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/inline-schema-reference.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/inline-schema-reference.json
@@ -55,9 +55,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -67,9 +73,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -88,9 +100,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -100,9 +118,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -136,6 +160,7 @@
             }
           },
           {
+            "displayName": "Response Body 3",
             "shape": {
               "type": "object",
               "extends": [],
@@ -145,9 +170,15 @@
                   "valueShape": {
                     "type": "alias",
                     "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
+                      "type": "optional",
+                      "shape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "primitive",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/json-string.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/json-string.json
@@ -15,9 +15,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }
@@ -27,9 +33,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/multi-url-generators-yml.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/multi-url-generators-yml.json
@@ -205,9 +205,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -217,9 +223,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -229,9 +241,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -241,9 +259,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "datetime"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "datetime"
+                    }
+                  }
                 }
               }
             }
@@ -262,9 +286,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -274,9 +304,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -286,9 +322,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/non-alphanumeric-characters.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/non-alphanumeric-characters.json
@@ -78,8 +78,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "DocumentIDSeparators"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "DocumentIDSeparators"
+                  }
+                }
               }
             }
           }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/nullable.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/nullable.json
@@ -298,9 +298,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -310,9 +316,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -322,12 +334,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "UserSettings"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "UserSettings"
+                      }
+                    }
                   }
                 }
               }
@@ -347,19 +365,7 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          {
-            "key": "email",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
@@ -373,16 +379,46 @@
             }
           },
           {
+            "key": "email",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
             "key": "settings",
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "UserSettings"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "UserSettings"
+                      }
+                    }
                   }
                 }
               }
@@ -402,9 +438,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -414,9 +456,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -426,9 +474,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -438,13 +492,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "datetime"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "datetime"
+                        }
+                      }
                     }
                   }
                 }
@@ -456,12 +516,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "UserSettings"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "UserSettings"
+                      }
+                    }
                   }
                 }
               }
@@ -472,12 +538,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "UserStats"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "UserStats"
+                      }
+                    }
                   }
                 }
               }
@@ -497,9 +569,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -509,9 +587,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -521,13 +605,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "datetime"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "datetime"
+                        }
+                      }
                     }
                   }
                 }
@@ -548,13 +638,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -566,13 +662,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "datetime"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "datetime"
+                        }
+                      }
                     }
                   }
                 }
@@ -584,20 +686,26 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "active"
-                    },
-                    {
-                      "value": "suspended"
-                    },
-                    {
-                      "value": "deleted"
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "active"
+                        },
+                        {
+                          "value": "suspended"
+                        },
+                        {
+                          "value": "deleted"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/oauth.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/oauth.json
@@ -5,7 +5,7 @@
       "id": "endpoint_auth.getToken",
       "description": "Exchange credentials or refresh token for an access token",
       "namespace": [
-        "subpackage_auth"
+        "auth"
       ],
       "displayName": "Request an access token",
       "method": "POST",
@@ -158,9 +158,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -170,9 +176,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -182,9 +194,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -195,9 +213,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -243,8 +267,8 @@
   "webhooks": {},
   "types": {},
   "subpackages": {
-    "subpackage_auth": {
-      "id": "subpackage_auth",
+    "auth": {
+      "id": "auth",
       "name": "auth",
       "displayName": "Auth"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/oauth.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/oauth.json
@@ -5,7 +5,7 @@
       "id": "endpoint_auth.getToken",
       "description": "Exchange credentials or refresh token for an access token",
       "namespace": [
-        "auth"
+        "subpackage_auth"
       ],
       "displayName": "Request an access token",
       "method": "POST",
@@ -243,10 +243,10 @@
   "webhooks": {},
   "types": {},
   "subpackages": {
-    "auth": {
-      "id": "auth",
+    "subpackage_auth": {
+      "id": "subpackage_auth",
       "name": "auth",
-      "displayName": "auth"
+      "displayName": "Auth"
     }
   },
   "auths": {}

--- a/packages/parsers/src/openapi/__test__/__snapshots__/only-include-referenced-schemas.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/only-include-referenced-schemas.json
@@ -1,12 +1,9 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_admins.identifyAdmin": {
-      "id": "endpoint_admins.identifyAdmin",
+    "endpoint_.identifyAdmin": {
+      "id": "endpoint_.identifyAdmin",
       "description": "\nYou can view the currently authorised admin along with the embedded app object (a \"workspace\" in legacy terminology).\n\n> 🚧 Single Sign On\n>\n> If you are building a custom \"Log in with Intercom\" flow for your site, and you call the `/me` endpoint to identify the logged-in user, you should not accept any sign-ins from users with unverified email addresses as it poses a potential impersonation security risk.\n",
-      "namespace": [
-        "Admins"
-      ],
       "displayName": "Identify an admin",
       "operationId": "identifyAdmin",
       "method": "GET",
@@ -110,12 +107,9 @@
         "type": "rest"
       }
     },
-    "endpoint_admins.setAwayAdmin": {
-      "id": "endpoint_admins.setAwayAdmin",
+    "endpoint_.setAwayAdmin": {
+      "id": "endpoint_.setAwayAdmin",
       "description": "You can set an Admin as away for the Inbox.",
-      "namespace": [
-        "Admins"
-      ],
       "displayName": "Set an admin to away",
       "operationId": "setAwayAdmin",
       "method": "PUT",
@@ -404,12 +398,9 @@
         "type": "rest"
       }
     },
-    "endpoint_admins.listActivityLogs": {
-      "id": "endpoint_admins.listActivityLogs",
+    "endpoint_.listActivityLogs": {
+      "id": "endpoint_.listActivityLogs",
       "description": "You can get a log of activities by all admins in an app.",
-      "namespace": [
-        "Admins"
-      ],
       "displayName": "List all activity logs",
       "operationId": "listActivityLogs",
       "method": "GET",
@@ -615,12 +606,9 @@
         "type": "rest"
       }
     },
-    "endpoint_admins.listAdmins": {
-      "id": "endpoint_admins.listAdmins",
+    "endpoint_.listAdmins": {
+      "id": "endpoint_.listAdmins",
       "description": "You can fetch a list of admins for a given workspace.",
-      "namespace": [
-        "Admins"
-      ],
       "displayName": "List all admins",
       "operationId": "listAdmins",
       "method": "GET",
@@ -748,12 +736,9 @@
         "type": "rest"
       }
     },
-    "endpoint_admins.retrieveAdmin": {
-      "id": "endpoint_admins.retrieveAdmin",
+    "endpoint_.retrieveAdmin": {
+      "id": "endpoint_.retrieveAdmin",
       "description": "You can retrieve the details of a single admin.",
-      "namespace": [
-        "Admins"
-      ],
       "displayName": "Retrieve an admin",
       "operationId": "retrieveAdmin",
       "method": "GET",
@@ -932,12 +917,9 @@
         "type": "rest"
       }
     },
-    "endpoint_articles.listArticles": {
-      "id": "endpoint_articles.listArticles",
+    "endpoint_.listArticles": {
+      "id": "endpoint_.listArticles",
       "description": "You can fetch a list of all articles by making a GET request to `https://api.intercom.io/articles`.\n\n> 📘 How are the articles sorted and ordered?\n>\n> Articles will be returned in descending order on the `updated_at` attribute. This means if you need to iterate through results then we'll show the most recently updated articles first.\n",
-      "namespace": [
-        "Articles"
-      ],
       "displayName": "List all articles",
       "operationId": "listArticles",
       "method": "GET",
@@ -1078,12 +1060,9 @@
         "type": "rest"
       }
     },
-    "endpoint_articles.createArticle": {
-      "id": "endpoint_articles.createArticle",
+    "endpoint_.createArticle": {
+      "id": "endpoint_.createArticle",
       "description": "You can create a new article by making a POST request to `https://api.intercom.io/articles`.",
-      "namespace": [
-        "Articles"
-      ],
       "displayName": "Create an article",
       "operationId": "createArticle",
       "method": "POST",
@@ -1326,12 +1305,9 @@
         "type": "rest"
       }
     },
-    "endpoint_articles.retrieveArticle": {
-      "id": "endpoint_articles.retrieveArticle",
+    "endpoint_.retrieveArticle": {
+      "id": "endpoint_.retrieveArticle",
       "description": "You can fetch the details of a single article by making a GET request to `https://api.intercom.io/articles/<id>`.",
-      "namespace": [
-        "Articles"
-      ],
       "displayName": "Retrieve an article",
       "operationId": "retrieveArticle",
       "method": "GET",
@@ -1525,12 +1501,9 @@
         "type": "rest"
       }
     },
-    "endpoint_articles.updateArticle": {
-      "id": "endpoint_articles.updateArticle",
+    "endpoint_.updateArticle": {
+      "id": "endpoint_.updateArticle",
       "description": "You can update the details of a single article by making a PUT request to `https://api.intercom.io/articles/<id>`.",
-      "namespace": [
-        "Articles"
-      ],
       "displayName": "Update an article",
       "operationId": "updateArticle",
       "method": "PUT",
@@ -2200,12 +2173,9 @@
         "type": "rest"
       }
     },
-    "endpoint_articles.deleteArticle": {
-      "id": "endpoint_articles.deleteArticle",
+    "endpoint_.deleteArticle": {
+      "id": "endpoint_.deleteArticle",
       "description": "You can delete a single article by making a DELETE request to `https://api.intercom.io/articles/<id>`.",
-      "namespace": [
-        "Articles"
-      ],
       "displayName": "Delete an article",
       "operationId": "deleteArticle",
       "method": "DELETE",
@@ -2379,12 +2349,9 @@
         "type": "rest"
       }
     },
-    "endpoint_articles.searchArticles": {
-      "id": "endpoint_articles.searchArticles",
+    "endpoint_.searchArticles": {
+      "id": "endpoint_.searchArticles",
       "description": "You can search for articles by making a GET request to `https://api.intercom.io/articles/search`.",
-      "namespace": [
-        "Articles"
-      ],
       "displayName": "Search for articles",
       "operationId": "searchArticles",
       "method": "GET",
@@ -2614,12 +2581,9 @@
         "type": "rest"
       }
     },
-    "endpoint_helpCenter.listAllCollections": {
-      "id": "endpoint_helpCenter.listAllCollections",
+    "endpoint_.listAllCollections": {
+      "id": "endpoint_.listAllCollections",
       "description": "You can fetch a list of all collections by making a GET request to `https://api.intercom.io/help_center/collections`.\n\nCollections will be returned in descending order on the `updated_at` attribute. This means if you need to iterate through results then we'll show the most recently updated collections first.\n",
-      "namespace": [
-        "Help Center"
-      ],
       "displayName": "List all collections",
       "operationId": "listAllCollections",
       "method": "GET",
@@ -2778,12 +2742,9 @@
         "type": "rest"
       }
     },
-    "endpoint_helpCenter.createCollection": {
-      "id": "endpoint_helpCenter.createCollection",
+    "endpoint_.createCollection": {
+      "id": "endpoint_.createCollection",
       "description": "You can create a new collection by making a POST request to `https://api.intercom.io/help_center/collections.`",
-      "namespace": [
-        "Help Center"
-      ],
       "displayName": "Create a collection",
       "operationId": "createCollection",
       "method": "POST",
@@ -2992,12 +2953,9 @@
         "type": "rest"
       }
     },
-    "endpoint_helpCenter.retrieveCollection": {
-      "id": "endpoint_helpCenter.retrieveCollection",
+    "endpoint_.retrieveCollection": {
+      "id": "endpoint_.retrieveCollection",
       "description": "You can fetch the details of a single collection by making a GET request to `https://api.intercom.io/help_center/collections/<id>`.",
-      "namespace": [
-        "Help Center"
-      ],
       "displayName": "Retrieve a collection",
       "operationId": "retrieveCollection",
       "method": "GET",
@@ -3187,12 +3145,9 @@
         "type": "rest"
       }
     },
-    "endpoint_helpCenter.updateCollection": {
-      "id": "endpoint_helpCenter.updateCollection",
+    "endpoint_.updateCollection": {
+      "id": "endpoint_.updateCollection",
       "description": "You can update the details of a single collection by making a PUT request to `https://api.intercom.io/collections/<id>`.",
-      "namespace": [
-        "Help Center"
-      ],
       "displayName": "Update a collection",
       "operationId": "updateCollection",
       "method": "PUT",
@@ -3619,12 +3574,9 @@
         "type": "rest"
       }
     },
-    "endpoint_helpCenter.deleteCollection": {
-      "id": "endpoint_helpCenter.deleteCollection",
+    "endpoint_.deleteCollection": {
+      "id": "endpoint_.deleteCollection",
       "description": "You can delete a single collection by making a DELETE request to `https://api.intercom.io/collections/<id>`.",
-      "namespace": [
-        "Help Center"
-      ],
       "displayName": "Delete a collection",
       "operationId": "deleteCollection",
       "method": "DELETE",
@@ -3806,12 +3758,9 @@
         "type": "rest"
       }
     },
-    "endpoint_helpCenter.retrieveHelpCenter": {
-      "id": "endpoint_helpCenter.retrieveHelpCenter",
+    "endpoint_.retrieveHelpCenter": {
+      "id": "endpoint_.retrieveHelpCenter",
       "description": "You can fetch the details of a single Help Center by making a GET request to `https://api.intercom.io/help_center/help_center/<id>`.",
-      "namespace": [
-        "Help Center"
-      ],
       "displayName": "Retrieve a Help Center",
       "operationId": "retrieveHelpCenter",
       "method": "GET",
@@ -3997,12 +3946,9 @@
         "type": "rest"
       }
     },
-    "endpoint_helpCenter.listHelpCenters": {
-      "id": "endpoint_helpCenter.listHelpCenters",
+    "endpoint_.listHelpCenters": {
+      "id": "endpoint_.listHelpCenters",
       "description": "You can list all Help Centers by making a GET request to `https://api.intercom.io/help_center/help_centers`.",
-      "namespace": [
-        "Help Center"
-      ],
       "displayName": "List all Help Centers",
       "operationId": "listHelpCenters",
       "method": "GET",
@@ -4127,12 +4073,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.retrieveCompany": {
-      "id": "endpoint_companies.retrieveCompany",
+    "endpoint_.retrieveCompany": {
+      "id": "endpoint_.retrieveCompany",
       "description": "You can fetch a single company by passing in `company_id` or `name`.\n\n  `https://api.intercom.io/companies?name={name}`\n\n  `https://api.intercom.io/companies?company_id={company_id}`\n\nYou can fetch all companies and filter by `segment_id` or `tag_id` as a query parameter.\n\n  `https://api.intercom.io/companies?tag_id={tag_id}`\n\n  `https://api.intercom.io/companies?segment_id={segment_id}`\n",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "Retrieve companies",
       "operationId": "retrieveCompany",
       "method": "GET",
@@ -4427,12 +4370,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.createOrUpdateCompany": {
-      "id": "endpoint_companies.createOrUpdateCompany",
+    "endpoint_.createOrUpdateCompany": {
+      "id": "endpoint_.createOrUpdateCompany",
       "description": "You can create or update a company.\n\nCompanies will be only visible in Intercom when there is at least one associated user.\n\nCompanies are looked up via `company_id` in a `POST` request, if not found via `company_id`, the new company will be created, if found, that company will be updated.\n\n{% admonition type=\"attention\" name=\"Using `company_id`\" %}\n  You can set a unique `company_id` value when creating a company. However, it is not possible to update `company_id`. Be sure to set a unique value once upon creation of the company.\n{% /admonition %}\n",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "Create or Update a company",
       "operationId": "createOrUpdateCompany",
       "method": "POST",
@@ -4659,12 +4599,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.RetrieveACompanyById": {
-      "id": "endpoint_companies.RetrieveACompanyById",
+    "endpoint_.RetrieveACompanyById": {
+      "id": "endpoint_.RetrieveACompanyById",
       "description": "You can fetch a single company.",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "Retrieve a company by ID",
       "operationId": "RetrieveACompanyById",
       "method": "GET",
@@ -4856,12 +4793,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.UpdateCompany": {
-      "id": "endpoint_companies.UpdateCompany",
+    "endpoint_.UpdateCompany": {
+      "id": "endpoint_.UpdateCompany",
       "description": "You can update a single company using the Intercom provisioned `id`.\n\n{% admonition type=\"attention\" name=\"Using `company_id`\" %}\n  When updating a company it is not possible to update `company_id`. This can only be set once upon creation of the company.\n{% /admonition %}\n",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "Update a company",
       "operationId": "UpdateCompany",
       "method": "PUT",
@@ -5053,12 +4987,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.deleteCompany": {
-      "id": "endpoint_companies.deleteCompany",
+    "endpoint_.deleteCompany": {
+      "id": "endpoint_.deleteCompany",
       "description": "You can delete a single company.",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "Delete a company",
       "operationId": "deleteCompany",
       "method": "DELETE",
@@ -5232,13 +5163,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companiesContacts.ListAttachedContacts": {
-      "id": "endpoint_companiesContacts.ListAttachedContacts",
+    "endpoint_.ListAttachedContacts": {
+      "id": "endpoint_.ListAttachedContacts",
       "description": "You can fetch a list of all contacts that belong to a company.",
-      "namespace": [
-        "Companies",
-        "Contacts"
-      ],
       "displayName": "List attached contacts",
       "operationId": "ListAttachedContacts",
       "method": "GET",
@@ -5426,12 +5353,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.ListAttachedSegmentsForCompanies": {
-      "id": "endpoint_companies.ListAttachedSegmentsForCompanies",
+    "endpoint_.ListAttachedSegmentsForCompanies": {
+      "id": "endpoint_.ListAttachedSegmentsForCompanies",
       "description": "You can fetch a list of all segments that belong to a company.",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "List attached segments for companies",
       "operationId": "ListAttachedSegmentsForCompanies",
       "method": "GET",
@@ -5612,12 +5536,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.listAllCompanies": {
-      "id": "endpoint_companies.listAllCompanies",
+    "endpoint_.listAllCompanies": {
+      "id": "endpoint_.listAllCompanies",
       "description": "You can list companies. The company list is sorted by the `last_request_at` field and by default is ordered descending, most recently requested first.\n\nNote that the API does not include companies who have no associated users in list responses.\n\nWhen using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "List all companies",
       "operationId": "listAllCompanies",
       "method": "POST",
@@ -5833,12 +5754,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.scrollOverAllCompanies": {
-      "id": "endpoint_companies.scrollOverAllCompanies",
+    "endpoint_.scrollOverAllCompanies": {
+      "id": "endpoint_.scrollOverAllCompanies",
       "description": "      The `list all companies` functionality does not work well for huge datasets, and can result in errors and performance problems when paging deeply. The Scroll API provides an efficient mechanism for iterating over all companies in a dataset.\n\n- Each app can only have 1 scroll open at a time. You'll get an error message if you try to have more than one open per app.\n- If the scroll isn't used for 1 minute, it expires and calls with that scroll param will fail\n- If the end of the scroll is reached, \"companies\" will be empty and the scroll parameter will expire\n\n{% admonition type=\"info\" name=\"Scroll Parameter\" %}\n  You can get the first page of companies by simply sending a GET request to the scroll endpoint.\n  For subsequent requests you will need to use the scroll parameter from the response.\n{% /admonition %}\n{% admonition type=\"danger\" name=\"Scroll network timeouts\" %}\n  Since scroll is often used on large datasets network errors such as timeouts can be encountered. When this occurs you will see a HTTP 500 error with the following message:\n  \"Request failed due to an internal network error. Please restart the scroll operation.\"\n  If this happens, you will need to restart your scroll query: It is not possible to continue from a specific point when using scroll.\n{% /admonition %}\n",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "Scroll over all companies",
       "operationId": "scrollOverAllCompanies",
       "method": "GET",
@@ -6011,13 +5929,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contactsCompanies.listCompaniesForAContact": {
-      "id": "endpoint_contactsCompanies.listCompaniesForAContact",
+    "endpoint_.listCompaniesForAContact": {
+      "id": "endpoint_.listCompaniesForAContact",
       "description": "You can fetch a list of companies that are associated to a contact.",
-      "namespace": [
-        "Contacts",
-        "Companies"
-      ],
       "displayName": "List attached companies for contact",
       "operationId": "listCompaniesForAContact",
       "method": "GET",
@@ -6231,13 +6145,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companiesContacts.attachContactToACompany": {
-      "id": "endpoint_companiesContacts.attachContactToACompany",
+    "endpoint_.attachContactToACompany": {
+      "id": "endpoint_.attachContactToACompany",
       "description": "You can attach a company to a single contact.",
-      "namespace": [
-        "Companies",
-        "Contacts"
-      ],
       "displayName": "Attach a Contact to a Company",
       "operationId": "attachContactToACompany",
       "method": "POST",
@@ -6575,13 +6485,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companiesContacts.detachContactFromACompany": {
-      "id": "endpoint_companiesContacts.detachContactFromACompany",
+    "endpoint_.detachContactFromACompany": {
+      "id": "endpoint_.detachContactFromACompany",
       "description": "You can detach a company from a single contact.",
-      "namespace": [
-        "Companies",
-        "Contacts"
-      ],
       "displayName": "Detach a contact from a company",
       "operationId": "detachContactFromACompany",
       "method": "DELETE",
@@ -6819,13 +6725,9 @@
         "type": "rest"
       }
     },
-    "endpoint_notesContacts.listNotes": {
-      "id": "endpoint_notesContacts.listNotes",
+    "endpoint_.listNotes": {
+      "id": "endpoint_.listNotes",
       "description": "You can fetch a list of notes that are associated to a contact.",
-      "namespace": [
-        "Notes",
-        "Contacts"
-      ],
       "displayName": "List all notes",
       "operationId": "listNotes",
       "method": "GET",
@@ -7039,13 +6941,9 @@
         "type": "rest"
       }
     },
-    "endpoint_notesContacts.createNote": {
-      "id": "endpoint_notesContacts.createNote",
+    "endpoint_.createNote": {
+      "id": "endpoint_.createNote",
       "description": "You can add a note to a single contact.",
-      "namespace": [
-        "Notes",
-        "Contacts"
-      ],
       "displayName": "Create a note",
       "operationId": "createNote",
       "method": "POST",
@@ -7370,13 +7268,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contactsSegments.listSegmentsForAContact": {
-      "id": "endpoint_contactsSegments.listSegmentsForAContact",
+    "endpoint_.listSegmentsForAContact": {
+      "id": "endpoint_.listSegmentsForAContact",
       "description": "You can fetch a list of segments that are associated to a contact.",
-      "namespace": [
-        "Contacts",
-        "Segments"
-      ],
       "displayName": "List attached segments for contact",
       "operationId": "listSegmentsForAContact",
       "method": "GET",
@@ -7566,13 +7460,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contactsSubscriptionTypes.listSubscriptionsForAContact": {
-      "id": "endpoint_contactsSubscriptionTypes.listSubscriptionsForAContact",
+    "endpoint_.listSubscriptionsForAContact": {
+      "id": "endpoint_.listSubscriptionsForAContact",
       "description": "You can fetch a list of subscription types that are attached to a contact. These can be subscriptions that a user has 'opted-in' to or has 'opted-out' from, depending on the subscription type.\nThis will return a list of Subscription Type objects that the contact is associated with.\n\nThe data property will show a combined list of:\n\n  1.Opt-out subscription types that the user has opted-out from.\n  2.Opt-in subscription types that the user has opted-in to receiving.\n",
-      "namespace": [
-        "Contacts",
-        "Subscription Types"
-      ],
       "displayName": "List subscriptions for a contact",
       "operationId": "listSubscriptionsForAContact",
       "method": "GET",
@@ -7796,13 +7686,9 @@
         "type": "rest"
       }
     },
-    "endpoint_subscriptionTypesContacts.attachSubscriptionTypeToContact": {
-      "id": "endpoint_subscriptionTypesContacts.attachSubscriptionTypeToContact",
+    "endpoint_.attachSubscriptionTypeToContact": {
+      "id": "endpoint_.attachSubscriptionTypeToContact",
       "description": "You can add a specific subscription to a contact. In Intercom, we have two different subscription types based on user consent - opt-out and opt-in:\n\n  1.Attaching a contact to an opt-out subscription type will opt that user out from receiving messages related to that subscription type.\n\n  2.Attaching a contact to an opt-in subscription type will opt that user in to receiving messages related to that subscription type.\n\nThis will return a subscription type model for the subscription type that was added to the contact.\n",
-      "namespace": [
-        "Subscription Types",
-        "Contacts"
-      ],
       "displayName": "Add subscription to a contact",
       "operationId": "attachSubscriptionTypeToContact",
       "method": "POST",
@@ -8138,13 +8024,9 @@
         "type": "rest"
       }
     },
-    "endpoint_subscriptionTypesContacts.detachSubscriptionTypeToContact": {
-      "id": "endpoint_subscriptionTypesContacts.detachSubscriptionTypeToContact",
+    "endpoint_.detachSubscriptionTypeToContact": {
+      "id": "endpoint_.detachSubscriptionTypeToContact",
       "description": "You can remove a specific subscription from a contact. This will return a subscription type model for the subscription type that was removed from the contact.",
-      "namespace": [
-        "Subscription Types",
-        "Contacts"
-      ],
       "displayName": "Remove subscription from a contact",
       "operationId": "detachSubscriptionTypeToContact",
       "method": "DELETE",
@@ -8380,13 +8262,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contactsTags.listTagsForAContact": {
-      "id": "endpoint_contactsTags.listTagsForAContact",
+    "endpoint_.listTagsForAContact": {
+      "id": "endpoint_.listTagsForAContact",
       "description": "You can fetch a list of all tags that are attached to a specific contact.",
-      "namespace": [
-        "Contacts",
-        "Tags"
-      ],
       "displayName": "List tags attached to a contact",
       "operationId": "listTagsForAContact",
       "method": "GET",
@@ -8573,13 +8451,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tagsContacts.attachTagToContact": {
-      "id": "endpoint_tagsContacts.attachTagToContact",
+    "endpoint_.attachTagToContact": {
+      "id": "endpoint_.attachTagToContact",
       "description": "You can tag a specific contact. This will return a tag object for the tag that was added to the contact.",
-      "namespace": [
-        "Tags",
-        "Contacts"
-      ],
       "displayName": "Add tag to a contact",
       "operationId": "attachTagToContact",
       "method": "POST",
@@ -8861,13 +8735,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tagsContacts.detachTagFromContact": {
-      "id": "endpoint_tagsContacts.detachTagFromContact",
+    "endpoint_.detachTagFromContact": {
+      "id": "endpoint_.detachTagFromContact",
       "description": "You can remove tag from a specific contact. This will return a tag object for the tag that was removed from the contact.",
-      "namespace": [
-        "Tags",
-        "Contacts"
-      ],
       "displayName": "Remove tag from a contact",
       "operationId": "detachTagFromContact",
       "method": "DELETE",
@@ -9087,12 +8957,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.ShowContact": {
-      "id": "endpoint_contacts.ShowContact",
+    "endpoint_.ShowContact": {
+      "id": "endpoint_.ShowContact",
       "description": "You can fetch the details of a single contact.",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Get a contact",
       "operationId": "ShowContact",
       "method": "GET",
@@ -9325,12 +9192,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.UpdateContact": {
-      "id": "endpoint_contacts.UpdateContact",
+    "endpoint_.UpdateContact": {
+      "id": "endpoint_.UpdateContact",
       "description": "You can update an existing contact (ie. user or lead).",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Update a contact",
       "operationId": "UpdateContact",
       "method": "PUT",
@@ -9582,12 +9446,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.DeleteContact": {
-      "id": "endpoint_contacts.DeleteContact",
+    "endpoint_.DeleteContact": {
+      "id": "endpoint_.DeleteContact",
       "description": "You can delete a single contact.",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Delete a contact",
       "operationId": "DeleteContact",
       "method": "DELETE",
@@ -9732,12 +9593,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.MergeContact": {
-      "id": "endpoint_contacts.MergeContact",
+    "endpoint_.MergeContact": {
+      "id": "endpoint_.MergeContact",
       "description": "You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Merge a lead and a user",
       "operationId": "MergeContact",
       "method": "POST",
@@ -9971,12 +9829,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.SearchContacts": {
-      "id": "endpoint_contacts.SearchContacts",
+    "endpoint_.SearchContacts": {
+      "id": "endpoint_.SearchContacts",
       "description": "You can search for multiple contacts by the value of their attributes in order to fetch exactly who you want.\n\nTo search for contacts, you need to send a `POST` request to `https://api.intercom.io/contacts/search`.\n\nThis will accept a query object in the body which will define your filters in order to search for contacts.\n\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `50` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n### Contact Creation Delay\n\nIf a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiple's there can be:\n* There's a limit of max 2 nested filters\n* There's a limit of max 15 filters for each AND or OR group\n\n### Searching for Timestamp Fields\n\nAll timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second.\nFor example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM). The search results will then include Contacts created from January 2nd, 2020 12:00 AM onwards.\nIf you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM).\nThis behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.\n\n### Accepted Fields\n\nMost key listed as part of the Contacts Model are searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foorbar\"`).\n\n| Field                              | Type                           |\n| ---------------------------------- | ------------------------------ |\n| id                                 | String                         |\n| role                               | String<br>Accepts user or lead |\n| name                               | String                         |\n| avatar                             | String                         |\n| owner_id                           | Integer                        |\n| email                              | String                         |\n| email_domain                       | String                         |\n| phone                              | String                         |\n| formatted_phone                    | String                         |\n| external_id                        | String                         |\n| created_at                         | Date (UNIX Timestamp)          |\n| signed_up_at                       | Date (UNIX Timestamp)          |\n| updated_at                         | Date (UNIX Timestamp)          |\n| last_seen_at                       | Date (UNIX Timestamp)          |\n| last_contacted_at                  | Date (UNIX Timestamp)          |\n| last_replied_at                    | Date (UNIX Timestamp)          |\n| last_email_opened_at               | Date (UNIX Timestamp)          |\n| last_email_clicked_at              | Date (UNIX Timestamp)          |\n| language_override                  | String                         |\n| browser                            | String                         |\n| browser_language                   | String                         |\n| os                                 | String                         |\n| location.country                   | String                         |\n| location.region                    | String                         |\n| location.city                      | String                         |\n| unsubscribed_from_emails           | Boolean                        |\n| marked_email_as_spam               | Boolean                        |\n| has_hard_bounced                   | Boolean                        |\n| ios_last_seen_at                   | Date (UNIX Timestamp)          |\n| ios_app_version                    | String                         |\n| ios_device                         | String                         |\n| ios_app_device                     | String                         |\n| ios_os_version                     | String                         |\n| ios_app_name                       | String                         |\n| ios_sdk_version                    | String                         |\n| android_last_seen_at               | Date (UNIX Timestamp)          |\n| android_app_version                | String                         |\n| android_device                     | String                         |\n| android_app_name                   | String                         |\n| andoid_sdk_version                 | String                         |\n| segment_id                         | String                         |\n| tag_id                             | String                         |\n| custom_attributes.{attribute_name} | String                         |\n\n### Accepted Operators\n\n{% admonition type=\"attention\" name=\"Searching based on `created_at`\" %}\n  You cannot use the `<=` or `>=` operators to search by `created_at`.\n{% /admonition %}\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                      | Description                                                      |\n| :------- | :------------------------------- | :--------------------------------------------------------------- |\n| =        | All                              | Equals                                                           |\n| !=       | All                              | Doesn't Equal                                                    |\n| IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |\n| NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |\n| >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |\n| <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |\n| ~        | String                           | Contains                                                         |\n| !~       | String                           | Doesn't Contain                                                  |\n| ^        | String                           | Starts With                                                      |\n| $        | String                           | Ends With                                                        |\n",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Search contacts",
       "operationId": "SearchContacts",
       "method": "POST",
@@ -10138,12 +9993,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.ListContacts": {
-      "id": "endpoint_contacts.ListContacts",
+    "endpoint_.ListContacts": {
+      "id": "endpoint_.ListContacts",
       "description": "You can fetch a list of all contacts (ie. users or leads) in your workspace.\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `50` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "List all contacts",
       "operationId": "ListContacts",
       "method": "GET",
@@ -10267,12 +10119,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.CreateContact": {
-      "id": "endpoint_contacts.CreateContact",
+    "endpoint_.CreateContact": {
+      "id": "endpoint_.CreateContact",
       "description": "You can create a new contact (ie. user or lead).",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Create contact",
       "operationId": "CreateContact",
       "method": "POST",
@@ -10497,12 +10346,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.ArchiveContact": {
-      "id": "endpoint_contacts.ArchiveContact",
+    "endpoint_.ArchiveContact": {
+      "id": "endpoint_.ArchiveContact",
       "description": "You can archive a single contact.",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Archive contact",
       "operationId": "ArchiveContact",
       "method": "POST",
@@ -10624,12 +10470,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.UnarchiveContact": {
-      "id": "endpoint_contacts.UnarchiveContact",
+    "endpoint_.UnarchiveContact": {
+      "id": "endpoint_.UnarchiveContact",
       "description": "You can unarchive a single contact.",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Unarchive contact",
       "operationId": "UnarchiveContact",
       "method": "POST",
@@ -10751,13 +10594,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tagsConversations.attachTagToConversation": {
-      "id": "endpoint_tagsConversations.attachTagToConversation",
+    "endpoint_.attachTagToConversation": {
+      "id": "endpoint_.attachTagToConversation",
       "description": "You can tag a specific conversation. This will return a tag object for the tag that was added to the conversation.",
-      "namespace": [
-        "Tags",
-        "Conversations"
-      ],
       "displayName": "Add tag to a conversation",
       "operationId": "attachTagToConversation",
       "method": "POST",
@@ -11011,13 +10850,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tagsConversations.detachTagFromConversation": {
-      "id": "endpoint_tagsConversations.detachTagFromConversation",
+    "endpoint_.detachTagFromConversation": {
+      "id": "endpoint_.detachTagFromConversation",
       "description": "You can remove tag from a specific conversation. This will return a tag object for the tag that was removed from the conversation.",
-      "namespace": [
-        "Tags",
-        "Conversations"
-      ],
       "displayName": "Remove tag from a conversation",
       "operationId": "detachTagFromConversation",
       "method": "DELETE",
@@ -11323,12 +11158,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.listConversations": {
-      "id": "endpoint_conversations.listConversations",
+    "endpoint_.listConversations": {
+      "id": "endpoint_.listConversations",
       "description": "You can fetch a list of all conversations.\n\nYou can optionally request the result page size and the cursor to start after to fetch the result.\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "List all conversations",
       "operationId": "listConversations",
       "method": "GET",
@@ -11586,12 +11418,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.createConversation": {
-      "id": "endpoint_conversations.createConversation",
+    "endpoint_.createConversation": {
+      "id": "endpoint_.createConversation",
       "description": "You can create a conversation that has been initiated by a contact (ie. user or lead).\nThe conversation can be an in-app message only.\n\n{% admonition type=\"info\" name=\"Sending for visitors\" %}\nYou can also send a message from a visitor by specifying their `user_id` or `id` value in the `from` field, along with a `type` field value of `contact`.\nThis visitor will be automatically converted to a contact with a lead role once the conversation is created.\n{% /admonition %}\n\nThis will return the Message model that has been created.\n\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Creates a conversation",
       "operationId": "createConversation",
       "method": "POST",
@@ -11820,12 +11649,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.retrieveConversation": {
-      "id": "endpoint_conversations.retrieveConversation",
+    "endpoint_.retrieveConversation": {
+      "id": "endpoint_.retrieveConversation",
       "description": "\nYou can fetch the details of a single conversation.\n\nThis will return a single Conversation model with all its conversation parts.\n\n{% admonition type=\"warning\" name=\"Hard limit of 500 parts\" %}\nThe maximum number of conversation parts that can be returned via the API is 500. If you have more than that we will return the 500 most recent conversation parts.\n{% /admonition %}\n\nFor AI agent conversation metadata, please note that you need to have the agent enabled in your workspace, which is a [paid feature](https://www.intercom.com/help/en/articles/8205718-fin-resolutions#h_97f8c2e671).\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Retrieve a conversation",
       "operationId": "retrieveConversation",
       "method": "GET",
@@ -12111,12 +11937,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.updateConversation": {
-      "id": "endpoint_conversations.updateConversation",
+    "endpoint_.updateConversation": {
+      "id": "endpoint_.updateConversation",
       "description": "\nYou can update an existing conversation.\n\n{% admonition type=\"info\" name=\"Replying and other actions\" %}\nIf you want to reply to a coveration or take an action such as assign, unassign, open, close or snooze, take a look at the reply and manage endpoints.\n{% /admonition %}\n\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Update a conversation",
       "operationId": "updateConversation",
       "method": "PUT",
@@ -12595,12 +12418,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.searchConversations": {
-      "id": "endpoint_conversations.searchConversations",
+    "endpoint_.searchConversations": {
+      "id": "endpoint_.searchConversations",
       "description": "You can search for multiple conversations by the value of their attributes in order to fetch exactly which ones you want.\n\nTo search for conversations, you need to send a `POST` request to `https://api.intercom.io/conversations/search`.\n\nThis will accept a query object in the body which will define your filters in order to search for conversations.\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `20` results per page and maximum is `150`.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiple's there can be:\n- There's a limit of max 2 nested filters\n- There's a limit of max 15 filters for each AND or OR group\n\n### Accepted Fields\n\nMost keys listed as part of the The conversation model is searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foorbar\"`).\n\n| Field                                     | Type                                                                                                                                                   |\n| :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- |\n| id                                        | String                                                                                                                                                 |\n| created_at                                | Date (UNIX timestamp)                                                                                                                                  |\n| updated_at                                | Date (UNIX timestamp)                                                                                                                                  |\n| source.type                               | String<br>Accepted fields are `conversation`, `email`, `facebook`, `instagram`, `phone_call`, `phone_switch`, `push`, `sms`, `twitter` and `whatsapp`. |\n| source.id                                 | String                                                                                                                                                 |\n| source.delivered_as                       | String                                                                                                                                                 |\n| source.subject                            | String                                                                                                                                                 |\n| source.body                               | String                                                                                                                                                 |\n| source.author.id                          | String                                                                                                                                                 |\n| source.author.type                        | String                                                                                                                                                 |\n| source.author.name                        | String                                                                                                                                                 |\n| source.author.email                       | String                                                                                                                                                 |\n| source.url                                | String                                                                                                                                                 |\n| contact_ids                               | String                                                                                                                                                 |\n| teammate_ids                              | String                                                                                                                                                 |\n| admin_assignee_id                         | String                                                                                                                                                 |\n| team_assignee_id                          | String                                                                                                                                                 |\n| channel_initiated                         | String                                                                                                                                                 |\n| open                                      | Boolean                                                                                                                                                |\n| read                                      | Boolean                                                                                                                                                |\n| state                                     | String                                                                                                                                                 |\n| waiting_since                             | Date (UNIX timestamp)                                                                                                                                  |\n| snoozed_until                             | Date (UNIX timestamp)                                                                                                                                  |\n| tag_ids                                   | String                                                                                                                                                 |\n| priority                                  | String                                                                                                                                                 |\n| statistics.time_to_assignment             | Integer                                                                                                                                                |\n| statistics.time_to_admin_reply            | Integer                                                                                                                                                |\n| statistics.time_to_first_close            | Integer                                                                                                                                                |\n| statistics.time_to_last_close             | Integer                                                                                                                                                |\n| statistics.median_time_to_reply           | Integer                                                                                                                                                |\n| statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_assignment_at            | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_close_at                 | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_assignment_at             | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_close_at                  | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_closed_by_id              | String                                                                                                                                                 |\n| statistics.count_reopens                  | Integer                                                                                                                                                |\n| statistics.count_assignments              | Integer                                                                                                                                                |\n| statistics.count_conversation_parts       | Integer                                                                                                                                                |\n| conversation_rating.requested_at          | Date (UNIX timestamp)                                                                                                                                  |\n| conversation_rating.replied_at            | Date (UNIX timestamp)                                                                                                                                  |\n| conversation_rating.score                 | Integer                                                                                                                                                |\n| conversation_rating.remark                | String                                                                                                                                                 |\n| conversation_rating.contact_id            | String                                                                                                                                                 |\n| conversation_rating.admin_d               | String                                                                                                                                                 |\n| ai_agent_participated                     | Boolean                                                                                                                                                |\n| ai_agent.resolution_state                 | String                                                                                                                                                 |\n| ai_agent.last_answer_type                 | String                                                                                                                                                 |\n| ai_agent.rating                           | Integer                                                                                                                                                |\n| ai_agent.rating_remark                    | String                                                                                                                                                 |\n| ai_agent.source_type                      | String                                                                                                                                                 |\n| ai_agent.source_title                     | String                                                                                                                                                 |\n\n### Accepted Operators\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type  (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                    | Description                                                  |\n| :------- | :----------------------------- | :----------------------------------------------------------- |\n| =        | All                            | Equals                                                       |\n| !=       | All                            | Doesn't Equal                                                |\n| IN       | All                            | In  Shortcut for `OR` queries  Values most be in Array       |\n| NIN      | All                            | Not In  Shortcut for `OR !` queries  Values must be in Array |\n| >        | Integer  Date (UNIX Timestamp) | Greater (or equal) than                                      |\n| <       | Integer  Date (UNIX Timestamp) | Lower (or equal) than                                        |\n| ~        | String                         | Contains                                                     |\n| !~       | String                         | Doesn't Contain                                              |\n| ^        | String                         | Starts With                                                  |\n| $        | String                         | Ends With                                                    |\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Search conversations",
       "operationId": "searchConversations",
       "method": "POST",
@@ -12793,12 +12613,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.replyConversation": {
-      "id": "endpoint_conversations.replyConversation",
+    "endpoint_.replyConversation": {
+      "id": "endpoint_.replyConversation",
       "description": "You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Reply to a conversation",
       "operationId": "replyConversation",
       "method": "POST",
@@ -13442,12 +13259,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.manageConversation": {
-      "id": "endpoint_conversations.manageConversation",
+    "endpoint_.manageConversation": {
+      "id": "endpoint_.manageConversation",
       "description": "For managing conversations you can:\n- Close a conversation\n- Snooze a conversation to reopen on a future date\n- Open a conversation which is `snoozed` or `closed`\n- Assign a conversation to an admin and/or team.\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Manage a conversation",
       "operationId": "manageConversation",
       "method": "POST",
@@ -14188,12 +14002,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.autoAssignConversation": {
-      "id": "endpoint_conversations.autoAssignConversation",
+    "endpoint_.autoAssignConversation": {
+      "id": "endpoint_.autoAssignConversation",
       "description": "You can let a conversation be automatically assigned following assignment rules.\n{% admonition type=\"attention\" name=\"When using workflows\" %}\nIt is not possible to use this endpoint with Workflows.\n{% /admonition %}\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Run Assignment Rules on a conversation",
       "operationId": "autoAssignConversation",
       "method": "POST",
@@ -14489,12 +14300,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.attachContactToConversation": {
-      "id": "endpoint_conversations.attachContactToConversation",
+    "endpoint_.attachContactToConversation": {
+      "id": "endpoint_.attachContactToConversation",
       "description": "You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.\n\n{% admonition type=\"attention\" name=\"Contacts without an email\" %}\nIf you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.\n{% /admonition %}\n\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Attach a contact to a conversation",
       "operationId": "attachContactToConversation",
       "method": "POST",
@@ -14758,12 +14566,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.detachContactFromConversation": {
-      "id": "endpoint_conversations.detachContactFromConversation",
+    "endpoint_.detachContactFromConversation": {
+      "id": "endpoint_.detachContactFromConversation",
       "description": "You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.\n\n{% admonition type=\"attention\" name=\"Contacts without an email\" %}\nIf you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.\n{% /admonition %}\n\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Detach a contact from a group conversation",
       "operationId": "detachContactFromConversation",
       "method": "DELETE",
@@ -15154,12 +14959,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.redactConversation": {
-      "id": "endpoint_conversations.redactConversation",
+    "endpoint_.redactConversation": {
+      "id": "endpoint_.redactConversation",
       "description": "You can redact a conversation part or the source message of a conversation (as seen in the source object).\n\n{% admonition type=\"info\" name=\"Redacting parts and messages\" %}\nIf you are redacting a conversation part, it must have a `body`. If you are redacting a source message, it must have been created by a contact. We will return a `conversation_part_not_redactable` error if these criteria are not met.\n{% /admonition %}\n\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Redact a conversation part",
       "operationId": "redactConversation",
       "method": "POST",
@@ -15526,12 +15328,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.convertConversationToTicket": {
-      "id": "endpoint_conversations.convertConversationToTicket",
+    "endpoint_.convertConversationToTicket": {
+      "id": "endpoint_.convertConversationToTicket",
       "description": "You can convert a conversation to a ticket.",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Convert a conversation to a ticket",
       "operationId": "convertConversationToTicket",
       "method": "POST",
@@ -15918,12 +15717,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataAttributes.lisDataAttributes": {
-      "id": "endpoint_dataAttributes.lisDataAttributes",
+    "endpoint_.lisDataAttributes": {
+      "id": "endpoint_.lisDataAttributes",
       "description": "You can fetch a list of all data attributes belonging to a workspace for contacts, companies or conversations.",
-      "namespace": [
-        "Data Attributes"
-      ],
       "displayName": "List all data attributes",
       "operationId": "lisDataAttributes",
       "method": "GET",
@@ -16328,12 +16124,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataAttributes.createDataAttribute": {
-      "id": "endpoint_dataAttributes.createDataAttribute",
+    "endpoint_.createDataAttribute": {
+      "id": "endpoint_.createDataAttribute",
       "description": "You can create a data attributes for a `contact` or a `company`.",
-      "namespace": [
-        "Data Attributes"
-      ],
       "displayName": "Create a data attribute",
       "operationId": "createDataAttribute",
       "method": "POST",
@@ -16746,12 +16539,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataAttributes.updateDataAttribute": {
-      "id": "endpoint_dataAttributes.updateDataAttribute",
+    "endpoint_.updateDataAttribute": {
+      "id": "endpoint_.updateDataAttribute",
       "description": "\nYou can update a data attribute.\n\n> 🚧 Updating the data type is not possible\n>\n> It is currently a dangerous action to execute changing a data attribute's type via the API. You will need to update the type via the UI instead.\n",
-      "namespace": [
-        "Data Attributes"
-      ],
       "displayName": "Update a data attribute",
       "operationId": "updateDataAttribute",
       "method": "PUT",
@@ -17160,12 +16950,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataEvents.lisDataEvents": {
-      "id": "endpoint_dataEvents.lisDataEvents",
+    "endpoint_.lisDataEvents": {
+      "id": "endpoint_.lisDataEvents",
       "description": "\n> 🚧\n>\n> Please note that you can only 'list' events that are less than 90 days old. Event counts and summaries will still include your events older than 90 days but you cannot 'list' these events individually if they are older than 90 days\n\nThe events belonging to a customer can be listed by sending a GET request to `https://api.intercom.io/events` with a user or lead identifier along with a `type` parameter. The identifier parameter can be one of `user_id`, `email` or `intercom_user_id`. The `type` parameter value must be `user`.\n\n- `https://api.intercom.io/events?type=user&user_id={user_id}`\n- `https://api.intercom.io/events?type=user&email={email}`\n- `https://api.intercom.io/events?type=user&intercom_user_id={id}` (this call can be used to list leads)\n\nThe `email` parameter value should be [url encoded](http://en.wikipedia.org/wiki/Percent-encoding) when sending.\n\nYou can optionally define the result page size as well with the `per_page` parameter.\n",
-      "namespace": [
-        "Data Events"
-      ],
       "displayName": "List all data events",
       "operationId": "lisDataEvents",
       "method": "GET",
@@ -17399,12 +17186,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataEvents.createDataEvent": {
-      "id": "endpoint_dataEvents.createDataEvent",
+    "endpoint_.createDataEvent": {
+      "id": "endpoint_.createDataEvent",
       "description": "\nYou will need an Access Token that has write permissions to send Events. Once you have a key you can submit events via POST to the Events resource, which is located at https://api.intercom.io/events, or you can send events using one of the client libraries. When working with the HTTP API directly a client should send the event with a `Content-Type` of `application/json`.\n\nWhen using the JavaScript API, [adding the code to your app](http://docs.intercom.io/configuring-Intercom/tracking-user-events-in-your-app) makes the Events API available. Once added, you can submit an event using the `trackEvent` method. This will associate the event with the Lead or currently logged-in user or logged-out visitor/lead and send it to Intercom. The final parameter is a map that can be used to send optional metadata about the event.\n\nWith the Ruby client you pass a hash describing the event to `Intercom::Event.create`, or call the `track_user` method directly on the current user object (e.g. `user.track_event`).\n\n**NB: For the JSON object types, please note that we do not currently support nested JSON structure.**\n\n| Type            | Description                                                                                                                                                                                                     | Example                                                                           |\n| :-------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |\n| String          | The value is a JSON String                                                                                                                                                                                      | `\"source\":\"desktop\"`                                                              |\n| Number          | The value is a JSON Number                                                                                                                                                                                      | `\"load\": 3.67`                                                                    |\n| Date            | The key ends with the String `_date` and the value is a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time), assumed to be in the [UTC](http://en.wikipedia.org/wiki/Coordinated_Universal_Time) timezone. | `\"contact_date\": 1392036272`                                                      |\n| Link            | The value is a HTTP or HTTPS URI.                                                                                                                                                                               | `\"article\": \"https://example.org/ab1de.html\"`                                     |\n| Rich Link       | The value is a JSON object that contains `url` and `value` keys.                                                                                                                                                | `\"article\": {\"url\": \"https://example.org/ab1de.html\", \"value\":\"the dude abides\"}` |\n| Monetary Amount | The value is a JSON object that contains `amount` and `currency` keys. The `amount` key is a positive integer representing the amount in cents. The price in the example to the right denotes €349.99.          | `\"price\": {\"amount\": 34999, \"currency\": \"eur\"}`                                   |\n\n**Lead Events**\n\nWhen submitting events for Leads, you will need to specify the Lead's `id`.\n\n**Metadata behaviour**\n\n- We currently limit the number of tracked metadata keys to 10 per event. Once the quota is reached, we ignore any further keys we receive. The first 10 metadata keys are determined by the order in which they are sent in with the event.\n- It is not possible to change the metadata keys once the event has been sent. A new event will need to be created with the new keys and you can archive the old one.\n- There might be up to 24 hrs delay when you send a new metadata for an existing event.\n\n**Event de-duplication**\n\nThe API may detect and ignore duplicate events. Each event is uniquely identified as a combination of the following data - the Workspace identifier, the Contact external identifier, the Data Event name and the Data Event created time. As a result, it is **strongly recommended** to send a second granularity Unix timestamp in the `created_at` field.\n\nDuplicated events are responded to using the normal `202 Accepted` code - an error is not thrown, however repeat requests will be counted against any rate limit that is in place.\n\n### HTTP API Responses\n\n- Successful responses to submitted events return `202 Accepted` with an empty body.\n- Unauthorised access will be rejected with a `401 Unauthorized` or `403 Forbidden` response code.\n- Events sent about users that cannot be found will return a `404 Not Found`.\n- Event lists containing duplicate events will have those duplicates ignored.\n- Server errors will return a `500` response code and may contain an error message in the body.\n\n",
-      "namespace": [
-        "Data Events"
-      ],
       "displayName": "Submit a data event",
       "operationId": "createDataEvent",
       "method": "POST",
@@ -17521,12 +17305,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataEvents.dataEventSummaries": {
-      "id": "endpoint_dataEvents.dataEventSummaries",
+    "endpoint_.dataEventSummaries": {
+      "id": "endpoint_.dataEventSummaries",
       "description": "Create event summaries for a user. Event summaries are used to track the number of times an event has occurred, the first time it occurred and the last time it occurred.\n\n",
-      "namespace": [
-        "Data Events"
-      ],
       "displayName": "Create event summaries",
       "operationId": "dataEventSummaries",
       "method": "POST",
@@ -17663,12 +17444,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataExport.createDataExport": {
-      "id": "endpoint_dataExport.createDataExport",
+    "endpoint_.createDataExport": {
+      "id": "endpoint_.createDataExport",
       "description": "To create your export job, you need to send a `POST` request to the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe only parameters you need to provide are the range of dates that you want exported.\n\n>🚧 Limit of one active job\n>\n> You can only have one active job per workspace. You will receive a HTTP status code of 429 with the message Exceeded rate limit of 1 pending message data export jobs if you attempt to create a second concurrent job.\n\n>❗️ Updated_at not included\n>\n> It should be noted that the timeframe only includes messages sent during the time period and not messages that were only updated during this period. For example, if a message was updated yesterday but sent two days ago, you would need to set the created_at_after date before the message was sent to include that in your retrieval job.\n\n>📘 Date ranges are inclusive\n>\n> Requesting data for 2018-06-01 until 2018-06-30 will get all data for those days including those specified - e.g. 2018-06-01 00:00:00 until 2018-06-30 23:59:99.\n",
-      "namespace": [
-        "Data Export"
-      ],
       "displayName": "Create content data export",
       "operationId": "createDataExport",
       "method": "POST",
@@ -17791,12 +17569,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataExport.getDataExport": {
-      "id": "endpoint_dataExport.getDataExport",
+    "endpoint_.getDataExport": {
+      "id": "endpoint_.getDataExport",
       "description": "You can view the status of your job by sending a `GET` request to the URL\n`https://api.intercom.io/export/content/data/{job_identifier}` - the `{job_identifier}` is the value returned in the response when you first created the export job. More on it can be seen in the Export Job Model.\n\n> 🚧 Jobs expire after two days\n> All jobs that have completed processing (and are thus available to download from the provided URL) will have an expiry limit of two days from when the export ob completed. After this, the data will no longer be available.\n",
-      "namespace": [
-        "Data Export"
-      ],
       "displayName": "Show content data export",
       "operationId": "getDataExport",
       "method": "GET",
@@ -17926,12 +17701,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataExport.cancelDataExport": {
-      "id": "endpoint_dataExport.cancelDataExport",
+    "endpoint_.cancelDataExport": {
+      "id": "endpoint_.cancelDataExport",
       "description": "You can cancel your job",
-      "namespace": [
-        "Data Export"
-      ],
       "displayName": "Cancel content data export",
       "operationId": "cancelDataExport",
       "method": "POST",
@@ -18053,12 +17825,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataExport.downloadDataExport": {
-      "id": "endpoint_dataExport.downloadDataExport",
+    "endpoint_.downloadDataExport": {
+      "id": "endpoint_.downloadDataExport",
       "description": "When a job has a status of complete, and thus a filled download_url, you can download your data by hitting that provided URL, formatted like so: https://api.intercom.io/download/content/data/xyz1234.\n\nYour exported message data will be streamed continuously back down to you in a gzipped CSV format.\n\n> 📘 Octet header required\n>\n> You will have to specify the header Accept: `application/octet-stream` when hitting this endpoint.\n",
-      "namespace": [
-        "Data Export"
-      ],
       "displayName": "Download content data export",
       "operationId": "downloadDataExport",
       "method": "GET",
@@ -18174,12 +17943,9 @@
         "type": "rest"
       }
     },
-    "endpoint_messages.createMessage": {
-      "id": "endpoint_messages.createMessage",
+    "endpoint_.createMessage": {
+      "id": "endpoint_.createMessage",
       "description": "You can create a message that has been initiated by an admin. The conversation can be either an in-app message or an email.\n\n> 🚧 Sending for visitors\n>\n> There can be a short delay between when a contact is created and when a contact becomes available to be messaged through the API. A 404 Not Found error will be returned in this case.\n\nThis will return the Message model that has been created.\n\n> 🚧 Retrieving Associated Conversations\n>\n> As this is a message, there will be no conversation present until the contact responds. Once they do, you will have to search for a contact's conversations with the id of the message.\n",
-      "namespace": [
-        "Messages"
-      ],
       "displayName": "Create a message",
       "operationId": "createMessage",
       "method": "POST",
@@ -18614,12 +18380,9 @@
         "type": "rest"
       }
     },
-    "endpoint_news.listNewsItems": {
-      "id": "endpoint_news.listNewsItems",
+    "endpoint_.listNewsItems": {
+      "id": "endpoint_.listNewsItems",
       "description": "You can fetch a list of all news items",
-      "namespace": [
-        "News"
-      ],
       "displayName": "List all news items",
       "operationId": "listNewsItems",
       "method": "GET",
@@ -18794,12 +18557,9 @@
         "type": "rest"
       }
     },
-    "endpoint_news.createNewsItem": {
-      "id": "endpoint_news.createNewsItem",
+    "endpoint_.createNewsItem": {
+      "id": "endpoint_.createNewsItem",
       "description": "You can create a news item",
-      "namespace": [
-        "News"
-      ],
       "displayName": "Create a news item",
       "operationId": "createNewsItem",
       "method": "POST",
@@ -18985,12 +18745,9 @@
         "type": "rest"
       }
     },
-    "endpoint_news.retrieveNewsItem": {
-      "id": "endpoint_news.retrieveNewsItem",
+    "endpoint_.retrieveNewsItem": {
+      "id": "endpoint_.retrieveNewsItem",
       "description": "You can fetch the details of a single news item.",
-      "namespace": [
-        "News"
-      ],
       "displayName": "Retrieve a news item",
       "operationId": "retrieveNewsItem",
       "method": "GET",
@@ -19193,11 +18950,8 @@
         "type": "rest"
       }
     },
-    "endpoint_news.updateNewsItem": {
-      "id": "endpoint_news.updateNewsItem",
-      "namespace": [
-        "News"
-      ],
+    "endpoint_.updateNewsItem": {
+      "id": "endpoint_.updateNewsItem",
       "displayName": "Update a news item",
       "operationId": "updateNewsItem",
       "method": "PUT",
@@ -19465,12 +19219,9 @@
         "type": "rest"
       }
     },
-    "endpoint_news.deleteNewsItem": {
-      "id": "endpoint_news.deleteNewsItem",
+    "endpoint_.deleteNewsItem": {
+      "id": "endpoint_.deleteNewsItem",
       "description": "You can delete a single news item.",
-      "namespace": [
-        "News"
-      ],
       "displayName": "Delete a news item",
       "operationId": "deleteNewsItem",
       "method": "DELETE",
@@ -19652,12 +19403,9 @@
         "type": "rest"
       }
     },
-    "endpoint_news.listLiveNewsfeedItems": {
-      "id": "endpoint_news.listLiveNewsfeedItems",
+    "endpoint_.listLiveNewsfeedItems": {
+      "id": "endpoint_.listLiveNewsfeedItems",
       "description": "You can fetch a list of all news items that are live on a given newsfeed",
-      "namespace": [
-        "News"
-      ],
       "displayName": "List all live newsfeed items",
       "operationId": "listLiveNewsfeedItems",
       "method": "GET",
@@ -19823,12 +19571,9 @@
         "type": "rest"
       }
     },
-    "endpoint_news.listNewsfeeds": {
-      "id": "endpoint_news.listNewsfeeds",
+    "endpoint_.listNewsfeeds": {
+      "id": "endpoint_.listNewsfeeds",
       "description": "You can fetch a list of all newsfeeds",
-      "namespace": [
-        "News"
-      ],
       "displayName": "List all newsfeeds",
       "operationId": "listNewsfeeds",
       "method": "GET",
@@ -19975,12 +19720,9 @@
         "type": "rest"
       }
     },
-    "endpoint_news.retrieveNewsfeed": {
-      "id": "endpoint_news.retrieveNewsfeed",
+    "endpoint_.retrieveNewsfeed": {
+      "id": "endpoint_.retrieveNewsfeed",
       "description": "You can fetch the details of a single newsfeed",
-      "namespace": [
-        "News"
-      ],
       "displayName": "Retrieve a newsfeed",
       "operationId": "retrieveNewsfeed",
       "method": "GET",
@@ -20134,12 +19876,9 @@
         "type": "rest"
       }
     },
-    "endpoint_notes.retrieveNote": {
-      "id": "endpoint_notes.retrieveNote",
+    "endpoint_.retrieveNote": {
+      "id": "endpoint_.retrieveNote",
       "description": "You can fetch the details of a single note.",
-      "namespace": [
-        "Notes"
-      ],
       "displayName": "Retrieve a note",
       "operationId": "retrieveNote",
       "method": "GET",
@@ -20326,12 +20065,9 @@
         "type": "rest"
       }
     },
-    "endpoint_segments.listSegments": {
-      "id": "endpoint_segments.listSegments",
+    "endpoint_.listSegments": {
+      "id": "endpoint_.listSegments",
       "description": "You can fetch a list of all segments.",
-      "namespace": [
-        "Segments"
-      ],
       "displayName": "List all segments",
       "operationId": "listSegments",
       "method": "GET",
@@ -20486,12 +20222,9 @@
         "type": "rest"
       }
     },
-    "endpoint_segments.retrieveSegment": {
-      "id": "endpoint_segments.retrieveSegment",
+    "endpoint_.retrieveSegment": {
+      "id": "endpoint_.retrieveSegment",
       "description": "You can fetch the details of a single segment.",
-      "namespace": [
-        "Segments"
-      ],
       "displayName": "Retrieve a segment",
       "operationId": "retrieveSegment",
       "method": "GET",
@@ -20668,12 +20401,9 @@
         "type": "rest"
       }
     },
-    "endpoint_subscriptionTypes.listSubscriptionTypes": {
-      "id": "endpoint_subscriptionTypes.listSubscriptionTypes",
+    "endpoint_.listSubscriptionTypes": {
+      "id": "endpoint_.listSubscriptionTypes",
       "description": "You can list all subscription types. A list of subscription type objects will be returned.",
-      "namespace": [
-        "Subscription Types"
-      ],
       "displayName": "List subscription types",
       "operationId": "listSubscriptionTypes",
       "method": "GET",
@@ -20812,12 +20542,9 @@
         "type": "rest"
       }
     },
-    "endpoint_switch.createPhoneSwitch": {
-      "id": "endpoint_switch.createPhoneSwitch",
+    "endpoint_.createPhoneSwitch": {
+      "id": "endpoint_.createPhoneSwitch",
       "description": "You can use the API to deflect phone calls to the Intercom Messenger.\nCalling this endpoint will send an SMS with a link to the Messenger to the phone number specified.\n\nIf custom attributes are specified, they will be added to the user or lead's custom data attributes.\n",
-      "namespace": [
-        "Switch"
-      ],
       "displayName": "Create a phone Switch",
       "operationId": "createPhoneSwitch",
       "method": "POST",
@@ -21022,12 +20749,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tags.listTags": {
-      "id": "endpoint_tags.listTags",
+    "endpoint_.listTags": {
+      "id": "endpoint_.listTags",
       "description": "You can fetch a list of all tags for a given workspace.\n\n",
-      "namespace": [
-        "Tags"
-      ],
       "displayName": "List all tags",
       "operationId": "listTags",
       "method": "GET",
@@ -21150,12 +20874,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tags.createTag": {
-      "id": "endpoint_tags.createTag",
+    "endpoint_.createTag": {
+      "id": "endpoint_.createTag",
       "description": "You can use this endpoint to perform the following operations:\n\n  **1. Create a new tag:** You can create a new tag by passing in the tag name as specified in \"Create or Update Tag Request Payload\" described below.\n\n  **2. Update an existing tag:** You can update an existing tag by passing the id of the tag as specified in \"Create or Update Tag Request Payload\" described below.\n\n  **3. Tag Companies:** You can tag single company or a list of companies. You can tag a company by passing in the tag name and the company details as specified in \"Tag Company Request Payload\" described below. Also, if the tag doesn't exist then a new one will be created automatically.\n\n  **4. Untag Companies:** You can untag a single company or a list of companies. You can untag a company by passing in the tag id and the company details as specified in \"Untag Company Request Payload\" described below.\n\n  **5. Tag Multiple Users:** You can tag a list of users. You can tag the users by passing in the tag name and the user details as specified in \"Tag Users Request Payload\" described below.\n\nEach operation will return a tag object.\n",
-      "namespace": [
-        "Tags"
-      ],
       "displayName": "Create or update a tag, Tag or untag companies, Tag contacts",
       "operationId": "createTag",
       "method": "POST",
@@ -21434,12 +21155,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tags.findTag": {
-      "id": "endpoint_tags.findTag",
+    "endpoint_.findTag": {
+      "id": "endpoint_.findTag",
       "description": "You can fetch the details of tags that are on the workspace by their id.\nThis will return a tag object.\n",
-      "namespace": [
-        "Tags"
-      ],
       "displayName": "Find a specific tag",
       "operationId": "findTag",
       "method": "GET",
@@ -21613,12 +21331,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tags.deleteTag": {
-      "id": "endpoint_tags.deleteTag",
+    "endpoint_.deleteTag": {
+      "id": "endpoint_.deleteTag",
       "description": "You can delete the details of tags that are on the workspace by passing in the id.",
-      "namespace": [
-        "Tags"
-      ],
       "displayName": "Delete tag",
       "operationId": "deleteTag",
       "method": "DELETE",
@@ -21809,12 +21524,9 @@
         "type": "rest"
       }
     },
-    "endpoint_teams.listTeams": {
-      "id": "endpoint_teams.listTeams",
+    "endpoint_.listTeams": {
+      "id": "endpoint_.listTeams",
       "description": "This will return a list of team objects for the App.",
-      "namespace": [
-        "Teams"
-      ],
       "displayName": "List all teams",
       "operationId": "listTeams",
       "method": "GET",
@@ -21931,12 +21643,9 @@
         "type": "rest"
       }
     },
-    "endpoint_teams.retrieveTeam": {
-      "id": "endpoint_teams.retrieveTeam",
+    "endpoint_.retrieveTeam": {
+      "id": "endpoint_.retrieveTeam",
       "description": "You can fetch the details of a single team, containing an array of admins that belong to this team.",
-      "namespace": [
-        "Teams"
-      ],
       "displayName": "Retrieve a team",
       "operationId": "retrieveTeam",
       "method": "GET",
@@ -22111,12 +21820,9 @@
         "type": "rest"
       }
     },
-    "endpoint_ticketTypeAttributes.createTicketTypeAttribute": {
-      "id": "endpoint_ticketTypeAttributes.createTicketTypeAttribute",
+    "endpoint_.createTicketTypeAttribute": {
+      "id": "endpoint_.createTicketTypeAttribute",
       "description": "You can create a new attribute for a ticket type.",
-      "namespace": [
-        "Ticket Type Attributes"
-      ],
       "displayName": "Create a new attribute for a ticket type",
       "operationId": "createTicketTypeAttribute",
       "method": "POST",
@@ -22305,12 +22011,9 @@
         "type": "rest"
       }
     },
-    "endpoint_ticketTypeAttributes.updateTicketTypeAttribute": {
-      "id": "endpoint_ticketTypeAttributes.updateTicketTypeAttribute",
+    "endpoint_.updateTicketTypeAttribute": {
+      "id": "endpoint_.updateTicketTypeAttribute",
       "description": "You can update an existing attribute for a ticket type.",
-      "namespace": [
-        "Ticket Type Attributes"
-      ],
       "displayName": "Update an existing attribute for a ticket type",
       "operationId": "updateTicketTypeAttribute",
       "method": "PUT",
@@ -22515,12 +22218,9 @@
         "type": "rest"
       }
     },
-    "endpoint_ticketTypes.listTicketTypes": {
-      "id": "endpoint_ticketTypes.listTicketTypes",
+    "endpoint_.listTicketTypes": {
+      "id": "endpoint_.listTicketTypes",
       "description": "You can get a list of all ticket types for a workspace.",
-      "namespace": [
-        "Ticket Types"
-      ],
       "displayName": "List all ticket types",
       "operationId": "listTicketTypes",
       "method": "GET",
@@ -22717,12 +22417,9 @@
         "type": "rest"
       }
     },
-    "endpoint_ticketTypes.createTicketType": {
-      "id": "endpoint_ticketTypes.createTicketType",
+    "endpoint_.createTicketType": {
+      "id": "endpoint_.createTicketType",
       "description": "You can create a new ticket type.\n> 📘 Creating ticket types.\n>\n> Every ticket type will be created with two default attributes: _default_title_ and _default_description_.\n> For the `icon` propery, use an emoji from [Twemoji Cheatsheet](https://twemoji-cheatsheet.vercel.app/)\n",
-      "namespace": [
-        "Ticket Types"
-      ],
       "displayName": "Create a ticket type",
       "operationId": "createTicketType",
       "method": "POST",
@@ -22916,12 +22613,9 @@
         "type": "rest"
       }
     },
-    "endpoint_ticketTypes.getTicketType": {
-      "id": "endpoint_ticketTypes.getTicketType",
+    "endpoint_.getTicketType": {
+      "id": "endpoint_.getTicketType",
       "description": "You can fetch the details of a single ticket type.",
-      "namespace": [
-        "Ticket Types"
-      ],
       "displayName": "Retrieve a ticket type",
       "operationId": "getTicketType",
       "method": "GET",
@@ -23139,12 +22833,9 @@
         "type": "rest"
       }
     },
-    "endpoint_ticketTypes.updateTicketType": {
-      "id": "endpoint_ticketTypes.updateTicketType",
+    "endpoint_.updateTicketType": {
+      "id": "endpoint_.updateTicketType",
       "description": "\nYou can update a ticket type.\n\n> 📘 Updating a ticket type.\n>\n> For the `icon` propery, use an emoji from [Twemoji Cheatsheet](https://twemoji-cheatsheet.vercel.app/)\n",
-      "namespace": [
-        "Ticket Types"
-      ],
       "displayName": "Update a ticket type",
       "operationId": "updateTicketType",
       "method": "PUT",
@@ -23380,12 +23071,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tickets.replyTicket": {
-      "id": "endpoint_tickets.replyTicket",
+    "endpoint_.replyTicket": {
+      "id": "endpoint_.replyTicket",
       "description": "You can reply to a ticket with a message from an admin or on behalf of a contact, or with a note for admins.",
-      "namespace": [
-        "Tickets"
-      ],
       "displayName": "Reply to a ticket",
       "operationId": "replyTicket",
       "method": "POST",
@@ -23742,13 +23430,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tagsTickets.attachTagToTicket": {
-      "id": "endpoint_tagsTickets.attachTagToTicket",
+    "endpoint_.attachTagToTicket": {
+      "id": "endpoint_.attachTagToTicket",
       "description": "You can tag a specific ticket. This will return a tag object for the tag that was added to the ticket.",
-      "namespace": [
-        "Tags",
-        "Tickets"
-      ],
       "displayName": "Add tag to a ticket",
       "operationId": "attachTagToTicket",
       "method": "POST",
@@ -24002,13 +23686,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tagsTickets.detachTagFromTicket": {
-      "id": "endpoint_tagsTickets.detachTagFromTicket",
+    "endpoint_.detachTagFromTicket": {
+      "id": "endpoint_.detachTagFromTicket",
       "description": "You can remove tag from a specific ticket. This will return a tag object for the tag that was removed from the ticket.",
-      "namespace": [
-        "Tags",
-        "Tickets"
-      ],
       "displayName": "Remove tag from a ticket",
       "operationId": "detachTagFromTicket",
       "method": "DELETE",
@@ -24314,12 +23994,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tickets.createTicket": {
-      "id": "endpoint_tickets.createTicket",
+    "endpoint_.createTicket": {
+      "id": "endpoint_.createTicket",
       "description": "You can create a new ticket.",
-      "namespace": [
-        "Tickets"
-      ],
       "displayName": "Create a ticket",
       "operationId": "createTicket",
       "method": "POST",
@@ -24573,12 +24250,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tickets.getTicket": {
-      "id": "endpoint_tickets.getTicket",
+    "endpoint_.getTicket": {
+      "id": "endpoint_.getTicket",
       "description": "You can fetch the details of a single ticket.",
-      "namespace": [
-        "Tickets"
-      ],
       "displayName": "Retrieve a ticket",
       "operationId": "getTicket",
       "method": "GET",
@@ -24831,12 +24505,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tickets.updateTicket": {
-      "id": "endpoint_tickets.updateTicket",
+    "endpoint_.updateTicket": {
+      "id": "endpoint_.updateTicket",
       "description": "You can update a ticket.",
-      "namespace": [
-        "Tickets"
-      ],
       "displayName": "Update a ticket",
       "operationId": "updateTicket",
       "method": "PUT",
@@ -25641,12 +25312,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tickets.searchTickets": {
-      "id": "endpoint_tickets.searchTickets",
+    "endpoint_.searchTickets": {
+      "id": "endpoint_.searchTickets",
       "description": "You can search for multiple tickets by the value of their attributes in order to fetch exactly which ones you want.\n\nTo search for tickets, you send a `POST` request to `https://api.intercom.io/tickets/search`.\n\nThis will accept a query object in the body which will define your filters.\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiples there can be:\n- There's a limit of max 2 nested filters\n- There's a limit of max 15 filters for each AND or OR group\n\n### Accepted Fields\n\nMost keys listed as part of the Ticket model are searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foobar\"`).\n\n| Field                                     | Type                                                                                     |\n| :---------------------------------------- | :--------------------------------------------------------------------------------------- |\n| id                                        | String                                                                                   |\n| created_at                                | Date (UNIX timestamp)                                                                    |\n| updated_at                                | Date (UNIX timestamp)                                                                    |\n| _default_title_                           | String                                                                                   |\n| _default_description_                     | String                                                                                   |\n| category                                  | String                                                                                   |\n| ticket_type_id                            | String                                                                                   |\n| contact_ids                               | String                                                                                   |\n| teammate_ids                              | String                                                                                   |\n| admin_assignee_id                         | String                                                                                   |\n| team_assignee_id                          | String                                                                                   |\n| open                                      | Boolean                                                                                  |\n| state                                     | String                                                                                   |\n| snoozed_until                             | Date (UNIX timestamp)                                                                    |\n| ticket_attribute.{id}                     | String or Boolean or Date (UNIX timestamp) or Float or Integer                           |\n\n### Accepted Operators\n\n{% admonition type=\"info\" name=\"Searching based on `created_at`\" %}\n  You may use the `<=` or `>=` operators to search by `created_at`.\n{% /admonition %}\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type  (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                    | Description                                                  |\n| :------- | :----------------------------- | :----------------------------------------------------------- |\n| =        | All                            | Equals                                                       |\n| !=       | All                            | Doesn't Equal                                                |\n| IN       | All                            | In  Shortcut for `OR` queries  Values most be in Array       |\n| NIN      | All                            | Not In  Shortcut for `OR !` queries  Values must be in Array |\n| >        | Integer  Date (UNIX Timestamp) | Greater (or equal) than                                      |\n| <       | Integer  Date (UNIX Timestamp) | Lower (or equal) than                                        |\n| ~        | String                         | Contains                                                     |\n| !~       | String                         | Doesn't Contain                                              |\n| ^        | String                         | Starts With                                                  |\n| $        | String                         | Ends With                                                    |\n",
-      "namespace": [
-        "Tickets"
-      ],
       "displayName": "Search tickets",
       "operationId": "searchTickets",
       "method": "POST",
@@ -25892,12 +25560,9 @@
         "type": "rest"
       }
     },
-    "endpoint_visitors.retrieveVisitorWithUserId": {
-      "id": "endpoint_visitors.retrieveVisitorWithUserId",
+    "endpoint_.retrieveVisitorWithUserId": {
+      "id": "endpoint_.retrieveVisitorWithUserId",
       "description": "You can fetch the details of a single visitor.",
-      "namespace": [
-        "Visitors"
-      ],
       "displayName": "Retrieve a visitor with User ID",
       "operationId": "retrieveVisitorWithUserId",
       "method": "GET",
@@ -26108,12 +25773,9 @@
         "type": "rest"
       }
     },
-    "endpoint_visitors.updateVisitor": {
-      "id": "endpoint_visitors.updateVisitor",
+    "endpoint_.updateVisitor": {
+      "id": "endpoint_.updateVisitor",
       "description": "Sending a PUT request to `/visitors` will result in an update of an existing Visitor.\n\n**Option 1.** You can update a visitor by passing in the `user_id` of the visitor in the Request body.\n\n**Option 2.** You can update a visitor by passing in the `id` of the visitor in the Request body.\n",
-      "namespace": [
-        "Visitors"
-      ],
       "displayName": "Update a visitor",
       "operationId": "updateVisitor",
       "method": "PUT",
@@ -26457,12 +26119,9 @@
         "type": "rest"
       }
     },
-    "endpoint_visitors.convertVisitor": {
-      "id": "endpoint_visitors.convertVisitor",
+    "endpoint_.convertVisitor": {
+      "id": "endpoint_.convertVisitor",
       "description": "You can merge a Visitor to a Contact of role type `lead` or `user`.\n\n> 📘 What happens upon a visitor being converted?\n>\n> If the User exists, then the Visitor will be merged into it, the Visitor deleted and the User returned. If the User does not exist, the Visitor will be converted to a User, with the User identifiers replacing it's Visitor identifiers.\n",
-      "namespace": [
-        "Visitors"
-      ],
       "displayName": "Convert a visitor",
       "operationId": "convertVisitor",
       "method": "POST",
@@ -44209,113 +43868,7 @@
       }
     }
   },
-  "subpackages": {
-    "admins": {
-      "id": "admins",
-      "name": "Admins",
-      "displayName": "Admins"
-    },
-    "articles": {
-      "id": "articles",
-      "name": "Articles",
-      "displayName": "Articles"
-    },
-    "helpCenter": {
-      "id": "helpCenter",
-      "name": "Help Center",
-      "displayName": "Help Center"
-    },
-    "companies": {
-      "id": "companies",
-      "name": "Companies",
-      "displayName": "Companies"
-    },
-    "contacts": {
-      "id": "contacts",
-      "name": "Contacts",
-      "displayName": "Contacts"
-    },
-    "notes": {
-      "id": "notes",
-      "name": "Notes",
-      "displayName": "Notes"
-    },
-    "segments": {
-      "id": "segments",
-      "name": "Segments",
-      "displayName": "Segments"
-    },
-    "subscriptionTypes": {
-      "id": "subscriptionTypes",
-      "name": "Subscription Types",
-      "displayName": "Subscription Types"
-    },
-    "tags": {
-      "id": "tags",
-      "name": "Tags",
-      "displayName": "Tags"
-    },
-    "conversations": {
-      "id": "conversations",
-      "name": "Conversations",
-      "displayName": "Conversations"
-    },
-    "dataAttributes": {
-      "id": "dataAttributes",
-      "name": "Data Attributes",
-      "displayName": "Data Attributes"
-    },
-    "dataEvents": {
-      "id": "dataEvents",
-      "name": "Data Events",
-      "displayName": "Data Events"
-    },
-    "dataExport": {
-      "id": "dataExport",
-      "name": "Data Export",
-      "displayName": "Data Export"
-    },
-    "messages": {
-      "id": "messages",
-      "name": "Messages",
-      "displayName": "Messages"
-    },
-    "news": {
-      "id": "news",
-      "name": "News",
-      "displayName": "News"
-    },
-    "switch": {
-      "id": "switch",
-      "name": "Switch",
-      "displayName": "Switch"
-    },
-    "teams": {
-      "id": "teams",
-      "name": "Teams",
-      "displayName": "Teams"
-    },
-    "ticketTypeAttributes": {
-      "id": "ticketTypeAttributes",
-      "name": "Ticket Type Attributes",
-      "displayName": "Ticket Type Attributes"
-    },
-    "ticketTypes": {
-      "id": "ticketTypes",
-      "name": "Ticket Types",
-      "displayName": "Ticket Types"
-    },
-    "tickets": {
-      "id": "tickets",
-      "name": "Tickets",
-      "displayName": "Tickets"
-    },
-    "visitors": {
-      "id": "visitors",
-      "name": "Visitors",
-      "displayName": "Visitors"
-    }
-  },
+  "subpackages": {},
   "auths": {
     "bearerAuth": {
       "type": "bearerAuth"

--- a/packages/parsers/src/openapi/__test__/__snapshots__/only-include-referenced-schemas.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/only-include-referenced-schemas.json
@@ -1,9 +1,12 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.identifyAdmin": {
-      "id": "endpoint_.identifyAdmin",
+    "endpoint_admins.identifyAdmin": {
+      "id": "endpoint_admins.identifyAdmin",
       "description": "\nYou can view the currently authorised admin along with the embedded app object (a \"workspace\" in legacy terminology).\n\n> 🚧 Single Sign On\n>\n> If you are building a custom \"Log in with Intercom\" flow for your site, and you call the `/me` endpoint to identify the logged-in user, you should not accept any sign-ins from users with unverified email addresses as it poses a potential impersonation security risk.\n",
+      "namespace": [
+        "subpackage_admins"
+      ],
       "displayName": "Identify an admin",
       "operationId": "identifyAdmin",
       "method": "GET",
@@ -107,9 +110,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.setAwayAdmin": {
-      "id": "endpoint_.setAwayAdmin",
+    "endpoint_admins.setAwayAdmin": {
+      "id": "endpoint_admins.setAwayAdmin",
       "description": "You can set an Admin as away for the Inbox.",
+      "namespace": [
+        "subpackage_admins"
+      ],
       "displayName": "Set an admin to away",
       "operationId": "setAwayAdmin",
       "method": "PUT",
@@ -398,9 +404,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listActivityLogs": {
-      "id": "endpoint_.listActivityLogs",
+    "endpoint_admins.listActivityLogs": {
+      "id": "endpoint_admins.listActivityLogs",
       "description": "You can get a log of activities by all admins in an app.",
+      "namespace": [
+        "subpackage_admins"
+      ],
       "displayName": "List all activity logs",
       "operationId": "listActivityLogs",
       "method": "GET",
@@ -606,9 +615,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listAdmins": {
-      "id": "endpoint_.listAdmins",
+    "endpoint_admins.listAdmins": {
+      "id": "endpoint_admins.listAdmins",
       "description": "You can fetch a list of admins for a given workspace.",
+      "namespace": [
+        "subpackage_admins"
+      ],
       "displayName": "List all admins",
       "operationId": "listAdmins",
       "method": "GET",
@@ -736,9 +748,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveAdmin": {
-      "id": "endpoint_.retrieveAdmin",
+    "endpoint_admins.retrieveAdmin": {
+      "id": "endpoint_admins.retrieveAdmin",
       "description": "You can retrieve the details of a single admin.",
+      "namespace": [
+        "subpackage_admins"
+      ],
       "displayName": "Retrieve an admin",
       "operationId": "retrieveAdmin",
       "method": "GET",
@@ -917,9 +932,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listArticles": {
-      "id": "endpoint_.listArticles",
+    "endpoint_articles.listArticles": {
+      "id": "endpoint_articles.listArticles",
       "description": "You can fetch a list of all articles by making a GET request to `https://api.intercom.io/articles`.\n\n> 📘 How are the articles sorted and ordered?\n>\n> Articles will be returned in descending order on the `updated_at` attribute. This means if you need to iterate through results then we'll show the most recently updated articles first.\n",
+      "namespace": [
+        "subpackage_articles"
+      ],
       "displayName": "List all articles",
       "operationId": "listArticles",
       "method": "GET",
@@ -1060,9 +1078,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createArticle": {
-      "id": "endpoint_.createArticle",
+    "endpoint_articles.createArticle": {
+      "id": "endpoint_articles.createArticle",
       "description": "You can create a new article by making a POST request to `https://api.intercom.io/articles`.",
+      "namespace": [
+        "subpackage_articles"
+      ],
       "displayName": "Create an article",
       "operationId": "createArticle",
       "method": "POST",
@@ -1305,9 +1326,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveArticle": {
-      "id": "endpoint_.retrieveArticle",
+    "endpoint_articles.retrieveArticle": {
+      "id": "endpoint_articles.retrieveArticle",
       "description": "You can fetch the details of a single article by making a GET request to `https://api.intercom.io/articles/<id>`.",
+      "namespace": [
+        "subpackage_articles"
+      ],
       "displayName": "Retrieve an article",
       "operationId": "retrieveArticle",
       "method": "GET",
@@ -1501,9 +1525,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateArticle": {
-      "id": "endpoint_.updateArticle",
+    "endpoint_articles.updateArticle": {
+      "id": "endpoint_articles.updateArticle",
       "description": "You can update the details of a single article by making a PUT request to `https://api.intercom.io/articles/<id>`.",
+      "namespace": [
+        "subpackage_articles"
+      ],
       "displayName": "Update an article",
       "operationId": "updateArticle",
       "method": "PUT",
@@ -2173,9 +2200,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.deleteArticle": {
-      "id": "endpoint_.deleteArticle",
+    "endpoint_articles.deleteArticle": {
+      "id": "endpoint_articles.deleteArticle",
       "description": "You can delete a single article by making a DELETE request to `https://api.intercom.io/articles/<id>`.",
+      "namespace": [
+        "subpackage_articles"
+      ],
       "displayName": "Delete an article",
       "operationId": "deleteArticle",
       "method": "DELETE",
@@ -2349,9 +2379,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.searchArticles": {
-      "id": "endpoint_.searchArticles",
+    "endpoint_articles.searchArticles": {
+      "id": "endpoint_articles.searchArticles",
       "description": "You can search for articles by making a GET request to `https://api.intercom.io/articles/search`.",
+      "namespace": [
+        "subpackage_articles"
+      ],
       "displayName": "Search for articles",
       "operationId": "searchArticles",
       "method": "GET",
@@ -2581,9 +2614,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listAllCollections": {
-      "id": "endpoint_.listAllCollections",
+    "endpoint_helpCenter.listAllCollections": {
+      "id": "endpoint_helpCenter.listAllCollections",
       "description": "You can fetch a list of all collections by making a GET request to `https://api.intercom.io/help_center/collections`.\n\nCollections will be returned in descending order on the `updated_at` attribute. This means if you need to iterate through results then we'll show the most recently updated collections first.\n",
+      "namespace": [
+        "subpackage_helpCenter"
+      ],
       "displayName": "List all collections",
       "operationId": "listAllCollections",
       "method": "GET",
@@ -2742,9 +2778,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createCollection": {
-      "id": "endpoint_.createCollection",
+    "endpoint_helpCenter.createCollection": {
+      "id": "endpoint_helpCenter.createCollection",
       "description": "You can create a new collection by making a POST request to `https://api.intercom.io/help_center/collections.`",
+      "namespace": [
+        "subpackage_helpCenter"
+      ],
       "displayName": "Create a collection",
       "operationId": "createCollection",
       "method": "POST",
@@ -2953,9 +2992,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveCollection": {
-      "id": "endpoint_.retrieveCollection",
+    "endpoint_helpCenter.retrieveCollection": {
+      "id": "endpoint_helpCenter.retrieveCollection",
       "description": "You can fetch the details of a single collection by making a GET request to `https://api.intercom.io/help_center/collections/<id>`.",
+      "namespace": [
+        "subpackage_helpCenter"
+      ],
       "displayName": "Retrieve a collection",
       "operationId": "retrieveCollection",
       "method": "GET",
@@ -3145,9 +3187,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateCollection": {
-      "id": "endpoint_.updateCollection",
+    "endpoint_helpCenter.updateCollection": {
+      "id": "endpoint_helpCenter.updateCollection",
       "description": "You can update the details of a single collection by making a PUT request to `https://api.intercom.io/collections/<id>`.",
+      "namespace": [
+        "subpackage_helpCenter"
+      ],
       "displayName": "Update a collection",
       "operationId": "updateCollection",
       "method": "PUT",
@@ -3574,9 +3619,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.deleteCollection": {
-      "id": "endpoint_.deleteCollection",
+    "endpoint_helpCenter.deleteCollection": {
+      "id": "endpoint_helpCenter.deleteCollection",
       "description": "You can delete a single collection by making a DELETE request to `https://api.intercom.io/collections/<id>`.",
+      "namespace": [
+        "subpackage_helpCenter"
+      ],
       "displayName": "Delete a collection",
       "operationId": "deleteCollection",
       "method": "DELETE",
@@ -3758,9 +3806,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveHelpCenter": {
-      "id": "endpoint_.retrieveHelpCenter",
+    "endpoint_helpCenter.retrieveHelpCenter": {
+      "id": "endpoint_helpCenter.retrieveHelpCenter",
       "description": "You can fetch the details of a single Help Center by making a GET request to `https://api.intercom.io/help_center/help_center/<id>`.",
+      "namespace": [
+        "subpackage_helpCenter"
+      ],
       "displayName": "Retrieve a Help Center",
       "operationId": "retrieveHelpCenter",
       "method": "GET",
@@ -3946,9 +3997,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listHelpCenters": {
-      "id": "endpoint_.listHelpCenters",
+    "endpoint_helpCenter.listHelpCenters": {
+      "id": "endpoint_helpCenter.listHelpCenters",
       "description": "You can list all Help Centers by making a GET request to `https://api.intercom.io/help_center/help_centers`.",
+      "namespace": [
+        "subpackage_helpCenter"
+      ],
       "displayName": "List all Help Centers",
       "operationId": "listHelpCenters",
       "method": "GET",
@@ -4073,9 +4127,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveCompany": {
-      "id": "endpoint_.retrieveCompany",
+    "endpoint_companies.retrieveCompany": {
+      "id": "endpoint_companies.retrieveCompany",
       "description": "You can fetch a single company by passing in `company_id` or `name`.\n\n  `https://api.intercom.io/companies?name={name}`\n\n  `https://api.intercom.io/companies?company_id={company_id}`\n\nYou can fetch all companies and filter by `segment_id` or `tag_id` as a query parameter.\n\n  `https://api.intercom.io/companies?tag_id={tag_id}`\n\n  `https://api.intercom.io/companies?segment_id={segment_id}`\n",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Retrieve companies",
       "operationId": "retrieveCompany",
       "method": "GET",
@@ -4370,9 +4427,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createOrUpdateCompany": {
-      "id": "endpoint_.createOrUpdateCompany",
+    "endpoint_companies.createOrUpdateCompany": {
+      "id": "endpoint_companies.createOrUpdateCompany",
       "description": "You can create or update a company.\n\nCompanies will be only visible in Intercom when there is at least one associated user.\n\nCompanies are looked up via `company_id` in a `POST` request, if not found via `company_id`, the new company will be created, if found, that company will be updated.\n\n{% admonition type=\"attention\" name=\"Using `company_id`\" %}\n  You can set a unique `company_id` value when creating a company. However, it is not possible to update `company_id`. Be sure to set a unique value once upon creation of the company.\n{% /admonition %}\n",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Create or Update a company",
       "operationId": "createOrUpdateCompany",
       "method": "POST",
@@ -4599,9 +4659,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.RetrieveACompanyById": {
-      "id": "endpoint_.RetrieveACompanyById",
+    "endpoint_companies.RetrieveACompanyById": {
+      "id": "endpoint_companies.RetrieveACompanyById",
       "description": "You can fetch a single company.",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Retrieve a company by ID",
       "operationId": "RetrieveACompanyById",
       "method": "GET",
@@ -4793,9 +4856,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.UpdateCompany": {
-      "id": "endpoint_.UpdateCompany",
+    "endpoint_companies.UpdateCompany": {
+      "id": "endpoint_companies.UpdateCompany",
       "description": "You can update a single company using the Intercom provisioned `id`.\n\n{% admonition type=\"attention\" name=\"Using `company_id`\" %}\n  When updating a company it is not possible to update `company_id`. This can only be set once upon creation of the company.\n{% /admonition %}\n",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Update a company",
       "operationId": "UpdateCompany",
       "method": "PUT",
@@ -4987,9 +5053,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.deleteCompany": {
-      "id": "endpoint_.deleteCompany",
+    "endpoint_companies.deleteCompany": {
+      "id": "endpoint_companies.deleteCompany",
       "description": "You can delete a single company.",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Delete a company",
       "operationId": "deleteCompany",
       "method": "DELETE",
@@ -5163,9 +5232,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.ListAttachedContacts": {
-      "id": "endpoint_.ListAttachedContacts",
+    "endpoint_companies.ListAttachedContacts": {
+      "id": "endpoint_companies.ListAttachedContacts",
       "description": "You can fetch a list of all contacts that belong to a company.",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "List attached contacts",
       "operationId": "ListAttachedContacts",
       "method": "GET",
@@ -5353,9 +5425,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.ListAttachedSegmentsForCompanies": {
-      "id": "endpoint_.ListAttachedSegmentsForCompanies",
+    "endpoint_companies.ListAttachedSegmentsForCompanies": {
+      "id": "endpoint_companies.ListAttachedSegmentsForCompanies",
       "description": "You can fetch a list of all segments that belong to a company.",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "List attached segments for companies",
       "operationId": "ListAttachedSegmentsForCompanies",
       "method": "GET",
@@ -5536,9 +5611,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listAllCompanies": {
-      "id": "endpoint_.listAllCompanies",
+    "endpoint_companies.listAllCompanies": {
+      "id": "endpoint_companies.listAllCompanies",
       "description": "You can list companies. The company list is sorted by the `last_request_at` field and by default is ordered descending, most recently requested first.\n\nNote that the API does not include companies who have no associated users in list responses.\n\nWhen using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "List all companies",
       "operationId": "listAllCompanies",
       "method": "POST",
@@ -5754,9 +5832,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.scrollOverAllCompanies": {
-      "id": "endpoint_.scrollOverAllCompanies",
+    "endpoint_companies.scrollOverAllCompanies": {
+      "id": "endpoint_companies.scrollOverAllCompanies",
       "description": "      The `list all companies` functionality does not work well for huge datasets, and can result in errors and performance problems when paging deeply. The Scroll API provides an efficient mechanism for iterating over all companies in a dataset.\n\n- Each app can only have 1 scroll open at a time. You'll get an error message if you try to have more than one open per app.\n- If the scroll isn't used for 1 minute, it expires and calls with that scroll param will fail\n- If the end of the scroll is reached, \"companies\" will be empty and the scroll parameter will expire\n\n{% admonition type=\"info\" name=\"Scroll Parameter\" %}\n  You can get the first page of companies by simply sending a GET request to the scroll endpoint.\n  For subsequent requests you will need to use the scroll parameter from the response.\n{% /admonition %}\n{% admonition type=\"danger\" name=\"Scroll network timeouts\" %}\n  Since scroll is often used on large datasets network errors such as timeouts can be encountered. When this occurs you will see a HTTP 500 error with the following message:\n  \"Request failed due to an internal network error. Please restart the scroll operation.\"\n  If this happens, you will need to restart your scroll query: It is not possible to continue from a specific point when using scroll.\n{% /admonition %}\n",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Scroll over all companies",
       "operationId": "scrollOverAllCompanies",
       "method": "GET",
@@ -5929,9 +6010,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listCompaniesForAContact": {
-      "id": "endpoint_.listCompaniesForAContact",
+    "endpoint_contacts.listCompaniesForAContact": {
+      "id": "endpoint_contacts.listCompaniesForAContact",
       "description": "You can fetch a list of companies that are associated to a contact.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "List attached companies for contact",
       "operationId": "listCompaniesForAContact",
       "method": "GET",
@@ -6145,9 +6229,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.attachContactToACompany": {
-      "id": "endpoint_.attachContactToACompany",
+    "endpoint_companies.attachContactToACompany": {
+      "id": "endpoint_companies.attachContactToACompany",
       "description": "You can attach a company to a single contact.",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Attach a Contact to a Company",
       "operationId": "attachContactToACompany",
       "method": "POST",
@@ -6485,9 +6572,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.detachContactFromACompany": {
-      "id": "endpoint_.detachContactFromACompany",
+    "endpoint_companies.detachContactFromACompany": {
+      "id": "endpoint_companies.detachContactFromACompany",
       "description": "You can detach a company from a single contact.",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Detach a contact from a company",
       "operationId": "detachContactFromACompany",
       "method": "DELETE",
@@ -6725,9 +6815,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listNotes": {
-      "id": "endpoint_.listNotes",
+    "endpoint_notes.listNotes": {
+      "id": "endpoint_notes.listNotes",
       "description": "You can fetch a list of notes that are associated to a contact.",
+      "namespace": [
+        "subpackage_notes"
+      ],
       "displayName": "List all notes",
       "operationId": "listNotes",
       "method": "GET",
@@ -6941,9 +7034,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createNote": {
-      "id": "endpoint_.createNote",
+    "endpoint_notes.createNote": {
+      "id": "endpoint_notes.createNote",
       "description": "You can add a note to a single contact.",
+      "namespace": [
+        "subpackage_notes"
+      ],
       "displayName": "Create a note",
       "operationId": "createNote",
       "method": "POST",
@@ -7268,9 +7364,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listSegmentsForAContact": {
-      "id": "endpoint_.listSegmentsForAContact",
+    "endpoint_contacts.listSegmentsForAContact": {
+      "id": "endpoint_contacts.listSegmentsForAContact",
       "description": "You can fetch a list of segments that are associated to a contact.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "List attached segments for contact",
       "operationId": "listSegmentsForAContact",
       "method": "GET",
@@ -7460,9 +7559,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listSubscriptionsForAContact": {
-      "id": "endpoint_.listSubscriptionsForAContact",
+    "endpoint_contacts.listSubscriptionsForAContact": {
+      "id": "endpoint_contacts.listSubscriptionsForAContact",
       "description": "You can fetch a list of subscription types that are attached to a contact. These can be subscriptions that a user has 'opted-in' to or has 'opted-out' from, depending on the subscription type.\nThis will return a list of Subscription Type objects that the contact is associated with.\n\nThe data property will show a combined list of:\n\n  1.Opt-out subscription types that the user has opted-out from.\n  2.Opt-in subscription types that the user has opted-in to receiving.\n",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "List subscriptions for a contact",
       "operationId": "listSubscriptionsForAContact",
       "method": "GET",
@@ -7686,9 +7788,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.attachSubscriptionTypeToContact": {
-      "id": "endpoint_.attachSubscriptionTypeToContact",
+    "endpoint_subscriptionTypes.attachSubscriptionTypeToContact": {
+      "id": "endpoint_subscriptionTypes.attachSubscriptionTypeToContact",
       "description": "You can add a specific subscription to a contact. In Intercom, we have two different subscription types based on user consent - opt-out and opt-in:\n\n  1.Attaching a contact to an opt-out subscription type will opt that user out from receiving messages related to that subscription type.\n\n  2.Attaching a contact to an opt-in subscription type will opt that user in to receiving messages related to that subscription type.\n\nThis will return a subscription type model for the subscription type that was added to the contact.\n",
+      "namespace": [
+        "subpackage_subscriptionTypes"
+      ],
       "displayName": "Add subscription to a contact",
       "operationId": "attachSubscriptionTypeToContact",
       "method": "POST",
@@ -8024,9 +8129,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.detachSubscriptionTypeToContact": {
-      "id": "endpoint_.detachSubscriptionTypeToContact",
+    "endpoint_subscriptionTypes.detachSubscriptionTypeToContact": {
+      "id": "endpoint_subscriptionTypes.detachSubscriptionTypeToContact",
       "description": "You can remove a specific subscription from a contact. This will return a subscription type model for the subscription type that was removed from the contact.",
+      "namespace": [
+        "subpackage_subscriptionTypes"
+      ],
       "displayName": "Remove subscription from a contact",
       "operationId": "detachSubscriptionTypeToContact",
       "method": "DELETE",
@@ -8262,9 +8370,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listTagsForAContact": {
-      "id": "endpoint_.listTagsForAContact",
+    "endpoint_contacts.listTagsForAContact": {
+      "id": "endpoint_contacts.listTagsForAContact",
       "description": "You can fetch a list of all tags that are attached to a specific contact.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "List tags attached to a contact",
       "operationId": "listTagsForAContact",
       "method": "GET",
@@ -8451,9 +8562,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.attachTagToContact": {
-      "id": "endpoint_.attachTagToContact",
+    "endpoint_tags.attachTagToContact": {
+      "id": "endpoint_tags.attachTagToContact",
       "description": "You can tag a specific contact. This will return a tag object for the tag that was added to the contact.",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Add tag to a contact",
       "operationId": "attachTagToContact",
       "method": "POST",
@@ -8735,9 +8849,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.detachTagFromContact": {
-      "id": "endpoint_.detachTagFromContact",
+    "endpoint_tags.detachTagFromContact": {
+      "id": "endpoint_tags.detachTagFromContact",
       "description": "You can remove tag from a specific contact. This will return a tag object for the tag that was removed from the contact.",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Remove tag from a contact",
       "operationId": "detachTagFromContact",
       "method": "DELETE",
@@ -8957,9 +9074,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.ShowContact": {
-      "id": "endpoint_.ShowContact",
+    "endpoint_contacts.ShowContact": {
+      "id": "endpoint_contacts.ShowContact",
       "description": "You can fetch the details of a single contact.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Get a contact",
       "operationId": "ShowContact",
       "method": "GET",
@@ -9192,9 +9312,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.UpdateContact": {
-      "id": "endpoint_.UpdateContact",
+    "endpoint_contacts.UpdateContact": {
+      "id": "endpoint_contacts.UpdateContact",
       "description": "You can update an existing contact (ie. user or lead).",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Update a contact",
       "operationId": "UpdateContact",
       "method": "PUT",
@@ -9446,9 +9569,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.DeleteContact": {
-      "id": "endpoint_.DeleteContact",
+    "endpoint_contacts.DeleteContact": {
+      "id": "endpoint_contacts.DeleteContact",
       "description": "You can delete a single contact.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Delete a contact",
       "operationId": "DeleteContact",
       "method": "DELETE",
@@ -9593,9 +9719,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.MergeContact": {
-      "id": "endpoint_.MergeContact",
+    "endpoint_contacts.MergeContact": {
+      "id": "endpoint_contacts.MergeContact",
       "description": "You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Merge a lead and a user",
       "operationId": "MergeContact",
       "method": "POST",
@@ -9829,9 +9958,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.SearchContacts": {
-      "id": "endpoint_.SearchContacts",
+    "endpoint_contacts.SearchContacts": {
+      "id": "endpoint_contacts.SearchContacts",
       "description": "You can search for multiple contacts by the value of their attributes in order to fetch exactly who you want.\n\nTo search for contacts, you need to send a `POST` request to `https://api.intercom.io/contacts/search`.\n\nThis will accept a query object in the body which will define your filters in order to search for contacts.\n\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `50` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n### Contact Creation Delay\n\nIf a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiple's there can be:\n* There's a limit of max 2 nested filters\n* There's a limit of max 15 filters for each AND or OR group\n\n### Searching for Timestamp Fields\n\nAll timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second.\nFor example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM). The search results will then include Contacts created from January 2nd, 2020 12:00 AM onwards.\nIf you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM).\nThis behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.\n\n### Accepted Fields\n\nMost key listed as part of the Contacts Model are searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foorbar\"`).\n\n| Field                              | Type                           |\n| ---------------------------------- | ------------------------------ |\n| id                                 | String                         |\n| role                               | String<br>Accepts user or lead |\n| name                               | String                         |\n| avatar                             | String                         |\n| owner_id                           | Integer                        |\n| email                              | String                         |\n| email_domain                       | String                         |\n| phone                              | String                         |\n| formatted_phone                    | String                         |\n| external_id                        | String                         |\n| created_at                         | Date (UNIX Timestamp)          |\n| signed_up_at                       | Date (UNIX Timestamp)          |\n| updated_at                         | Date (UNIX Timestamp)          |\n| last_seen_at                       | Date (UNIX Timestamp)          |\n| last_contacted_at                  | Date (UNIX Timestamp)          |\n| last_replied_at                    | Date (UNIX Timestamp)          |\n| last_email_opened_at               | Date (UNIX Timestamp)          |\n| last_email_clicked_at              | Date (UNIX Timestamp)          |\n| language_override                  | String                         |\n| browser                            | String                         |\n| browser_language                   | String                         |\n| os                                 | String                         |\n| location.country                   | String                         |\n| location.region                    | String                         |\n| location.city                      | String                         |\n| unsubscribed_from_emails           | Boolean                        |\n| marked_email_as_spam               | Boolean                        |\n| has_hard_bounced                   | Boolean                        |\n| ios_last_seen_at                   | Date (UNIX Timestamp)          |\n| ios_app_version                    | String                         |\n| ios_device                         | String                         |\n| ios_app_device                     | String                         |\n| ios_os_version                     | String                         |\n| ios_app_name                       | String                         |\n| ios_sdk_version                    | String                         |\n| android_last_seen_at               | Date (UNIX Timestamp)          |\n| android_app_version                | String                         |\n| android_device                     | String                         |\n| android_app_name                   | String                         |\n| andoid_sdk_version                 | String                         |\n| segment_id                         | String                         |\n| tag_id                             | String                         |\n| custom_attributes.{attribute_name} | String                         |\n\n### Accepted Operators\n\n{% admonition type=\"attention\" name=\"Searching based on `created_at`\" %}\n  You cannot use the `<=` or `>=` operators to search by `created_at`.\n{% /admonition %}\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                      | Description                                                      |\n| :------- | :------------------------------- | :--------------------------------------------------------------- |\n| =        | All                              | Equals                                                           |\n| !=       | All                              | Doesn't Equal                                                    |\n| IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |\n| NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |\n| >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |\n| <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |\n| ~        | String                           | Contains                                                         |\n| !~       | String                           | Doesn't Contain                                                  |\n| ^        | String                           | Starts With                                                      |\n| $        | String                           | Ends With                                                        |\n",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Search contacts",
       "operationId": "SearchContacts",
       "method": "POST",
@@ -9993,9 +10125,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.ListContacts": {
-      "id": "endpoint_.ListContacts",
+    "endpoint_contacts.ListContacts": {
+      "id": "endpoint_contacts.ListContacts",
       "description": "You can fetch a list of all contacts (ie. users or leads) in your workspace.\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `50` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "List all contacts",
       "operationId": "ListContacts",
       "method": "GET",
@@ -10119,9 +10254,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.CreateContact": {
-      "id": "endpoint_.CreateContact",
+    "endpoint_contacts.CreateContact": {
+      "id": "endpoint_contacts.CreateContact",
       "description": "You can create a new contact (ie. user or lead).",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Create contact",
       "operationId": "CreateContact",
       "method": "POST",
@@ -10346,9 +10484,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.ArchiveContact": {
-      "id": "endpoint_.ArchiveContact",
+    "endpoint_contacts.ArchiveContact": {
+      "id": "endpoint_contacts.ArchiveContact",
       "description": "You can archive a single contact.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Archive contact",
       "operationId": "ArchiveContact",
       "method": "POST",
@@ -10470,9 +10611,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.UnarchiveContact": {
-      "id": "endpoint_.UnarchiveContact",
+    "endpoint_contacts.UnarchiveContact": {
+      "id": "endpoint_contacts.UnarchiveContact",
       "description": "You can unarchive a single contact.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Unarchive contact",
       "operationId": "UnarchiveContact",
       "method": "POST",
@@ -10594,9 +10738,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.attachTagToConversation": {
-      "id": "endpoint_.attachTagToConversation",
+    "endpoint_tags.attachTagToConversation": {
+      "id": "endpoint_tags.attachTagToConversation",
       "description": "You can tag a specific conversation. This will return a tag object for the tag that was added to the conversation.",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Add tag to a conversation",
       "operationId": "attachTagToConversation",
       "method": "POST",
@@ -10850,9 +10997,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.detachTagFromConversation": {
-      "id": "endpoint_.detachTagFromConversation",
+    "endpoint_tags.detachTagFromConversation": {
+      "id": "endpoint_tags.detachTagFromConversation",
       "description": "You can remove tag from a specific conversation. This will return a tag object for the tag that was removed from the conversation.",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Remove tag from a conversation",
       "operationId": "detachTagFromConversation",
       "method": "DELETE",
@@ -11158,9 +11308,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listConversations": {
-      "id": "endpoint_.listConversations",
+    "endpoint_conversations.listConversations": {
+      "id": "endpoint_conversations.listConversations",
       "description": "You can fetch a list of all conversations.\n\nYou can optionally request the result page size and the cursor to start after to fetch the result.\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "List all conversations",
       "operationId": "listConversations",
       "method": "GET",
@@ -11418,9 +11571,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createConversation": {
-      "id": "endpoint_.createConversation",
+    "endpoint_conversations.createConversation": {
+      "id": "endpoint_conversations.createConversation",
       "description": "You can create a conversation that has been initiated by a contact (ie. user or lead).\nThe conversation can be an in-app message only.\n\n{% admonition type=\"info\" name=\"Sending for visitors\" %}\nYou can also send a message from a visitor by specifying their `user_id` or `id` value in the `from` field, along with a `type` field value of `contact`.\nThis visitor will be automatically converted to a contact with a lead role once the conversation is created.\n{% /admonition %}\n\nThis will return the Message model that has been created.\n\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Creates a conversation",
       "operationId": "createConversation",
       "method": "POST",
@@ -11649,9 +11805,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveConversation": {
-      "id": "endpoint_.retrieveConversation",
+    "endpoint_conversations.retrieveConversation": {
+      "id": "endpoint_conversations.retrieveConversation",
       "description": "\nYou can fetch the details of a single conversation.\n\nThis will return a single Conversation model with all its conversation parts.\n\n{% admonition type=\"warning\" name=\"Hard limit of 500 parts\" %}\nThe maximum number of conversation parts that can be returned via the API is 500. If you have more than that we will return the 500 most recent conversation parts.\n{% /admonition %}\n\nFor AI agent conversation metadata, please note that you need to have the agent enabled in your workspace, which is a [paid feature](https://www.intercom.com/help/en/articles/8205718-fin-resolutions#h_97f8c2e671).\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Retrieve a conversation",
       "operationId": "retrieveConversation",
       "method": "GET",
@@ -11937,9 +12096,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateConversation": {
-      "id": "endpoint_.updateConversation",
+    "endpoint_conversations.updateConversation": {
+      "id": "endpoint_conversations.updateConversation",
       "description": "\nYou can update an existing conversation.\n\n{% admonition type=\"info\" name=\"Replying and other actions\" %}\nIf you want to reply to a coveration or take an action such as assign, unassign, open, close or snooze, take a look at the reply and manage endpoints.\n{% /admonition %}\n\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Update a conversation",
       "operationId": "updateConversation",
       "method": "PUT",
@@ -12418,9 +12580,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.searchConversations": {
-      "id": "endpoint_.searchConversations",
+    "endpoint_conversations.searchConversations": {
+      "id": "endpoint_conversations.searchConversations",
       "description": "You can search for multiple conversations by the value of their attributes in order to fetch exactly which ones you want.\n\nTo search for conversations, you need to send a `POST` request to `https://api.intercom.io/conversations/search`.\n\nThis will accept a query object in the body which will define your filters in order to search for conversations.\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `20` results per page and maximum is `150`.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiple's there can be:\n- There's a limit of max 2 nested filters\n- There's a limit of max 15 filters for each AND or OR group\n\n### Accepted Fields\n\nMost keys listed as part of the The conversation model is searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foorbar\"`).\n\n| Field                                     | Type                                                                                                                                                   |\n| :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- |\n| id                                        | String                                                                                                                                                 |\n| created_at                                | Date (UNIX timestamp)                                                                                                                                  |\n| updated_at                                | Date (UNIX timestamp)                                                                                                                                  |\n| source.type                               | String<br>Accepted fields are `conversation`, `email`, `facebook`, `instagram`, `phone_call`, `phone_switch`, `push`, `sms`, `twitter` and `whatsapp`. |\n| source.id                                 | String                                                                                                                                                 |\n| source.delivered_as                       | String                                                                                                                                                 |\n| source.subject                            | String                                                                                                                                                 |\n| source.body                               | String                                                                                                                                                 |\n| source.author.id                          | String                                                                                                                                                 |\n| source.author.type                        | String                                                                                                                                                 |\n| source.author.name                        | String                                                                                                                                                 |\n| source.author.email                       | String                                                                                                                                                 |\n| source.url                                | String                                                                                                                                                 |\n| contact_ids                               | String                                                                                                                                                 |\n| teammate_ids                              | String                                                                                                                                                 |\n| admin_assignee_id                         | String                                                                                                                                                 |\n| team_assignee_id                          | String                                                                                                                                                 |\n| channel_initiated                         | String                                                                                                                                                 |\n| open                                      | Boolean                                                                                                                                                |\n| read                                      | Boolean                                                                                                                                                |\n| state                                     | String                                                                                                                                                 |\n| waiting_since                             | Date (UNIX timestamp)                                                                                                                                  |\n| snoozed_until                             | Date (UNIX timestamp)                                                                                                                                  |\n| tag_ids                                   | String                                                                                                                                                 |\n| priority                                  | String                                                                                                                                                 |\n| statistics.time_to_assignment             | Integer                                                                                                                                                |\n| statistics.time_to_admin_reply            | Integer                                                                                                                                                |\n| statistics.time_to_first_close            | Integer                                                                                                                                                |\n| statistics.time_to_last_close             | Integer                                                                                                                                                |\n| statistics.median_time_to_reply           | Integer                                                                                                                                                |\n| statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_assignment_at            | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_close_at                 | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_assignment_at             | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_close_at                  | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_closed_by_id              | String                                                                                                                                                 |\n| statistics.count_reopens                  | Integer                                                                                                                                                |\n| statistics.count_assignments              | Integer                                                                                                                                                |\n| statistics.count_conversation_parts       | Integer                                                                                                                                                |\n| conversation_rating.requested_at          | Date (UNIX timestamp)                                                                                                                                  |\n| conversation_rating.replied_at            | Date (UNIX timestamp)                                                                                                                                  |\n| conversation_rating.score                 | Integer                                                                                                                                                |\n| conversation_rating.remark                | String                                                                                                                                                 |\n| conversation_rating.contact_id            | String                                                                                                                                                 |\n| conversation_rating.admin_d               | String                                                                                                                                                 |\n| ai_agent_participated                     | Boolean                                                                                                                                                |\n| ai_agent.resolution_state                 | String                                                                                                                                                 |\n| ai_agent.last_answer_type                 | String                                                                                                                                                 |\n| ai_agent.rating                           | Integer                                                                                                                                                |\n| ai_agent.rating_remark                    | String                                                                                                                                                 |\n| ai_agent.source_type                      | String                                                                                                                                                 |\n| ai_agent.source_title                     | String                                                                                                                                                 |\n\n### Accepted Operators\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type  (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                    | Description                                                  |\n| :------- | :----------------------------- | :----------------------------------------------------------- |\n| =        | All                            | Equals                                                       |\n| !=       | All                            | Doesn't Equal                                                |\n| IN       | All                            | In  Shortcut for `OR` queries  Values most be in Array       |\n| NIN      | All                            | Not In  Shortcut for `OR !` queries  Values must be in Array |\n| >        | Integer  Date (UNIX Timestamp) | Greater (or equal) than                                      |\n| <       | Integer  Date (UNIX Timestamp) | Lower (or equal) than                                        |\n| ~        | String                         | Contains                                                     |\n| !~       | String                         | Doesn't Contain                                              |\n| ^        | String                         | Starts With                                                  |\n| $        | String                         | Ends With                                                    |\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Search conversations",
       "operationId": "searchConversations",
       "method": "POST",
@@ -12613,9 +12778,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.replyConversation": {
-      "id": "endpoint_.replyConversation",
+    "endpoint_conversations.replyConversation": {
+      "id": "endpoint_conversations.replyConversation",
       "description": "You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Reply to a conversation",
       "operationId": "replyConversation",
       "method": "POST",
@@ -13259,9 +13427,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.manageConversation": {
-      "id": "endpoint_.manageConversation",
+    "endpoint_conversations.manageConversation": {
+      "id": "endpoint_conversations.manageConversation",
       "description": "For managing conversations you can:\n- Close a conversation\n- Snooze a conversation to reopen on a future date\n- Open a conversation which is `snoozed` or `closed`\n- Assign a conversation to an admin and/or team.\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Manage a conversation",
       "operationId": "manageConversation",
       "method": "POST",
@@ -14002,9 +14173,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.autoAssignConversation": {
-      "id": "endpoint_.autoAssignConversation",
+    "endpoint_conversations.autoAssignConversation": {
+      "id": "endpoint_conversations.autoAssignConversation",
       "description": "You can let a conversation be automatically assigned following assignment rules.\n{% admonition type=\"attention\" name=\"When using workflows\" %}\nIt is not possible to use this endpoint with Workflows.\n{% /admonition %}\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Run Assignment Rules on a conversation",
       "operationId": "autoAssignConversation",
       "method": "POST",
@@ -14300,9 +14474,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.attachContactToConversation": {
-      "id": "endpoint_.attachContactToConversation",
+    "endpoint_conversations.attachContactToConversation": {
+      "id": "endpoint_conversations.attachContactToConversation",
       "description": "You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.\n\n{% admonition type=\"attention\" name=\"Contacts without an email\" %}\nIf you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.\n{% /admonition %}\n\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Attach a contact to a conversation",
       "operationId": "attachContactToConversation",
       "method": "POST",
@@ -14566,9 +14743,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.detachContactFromConversation": {
-      "id": "endpoint_.detachContactFromConversation",
+    "endpoint_conversations.detachContactFromConversation": {
+      "id": "endpoint_conversations.detachContactFromConversation",
       "description": "You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.\n\n{% admonition type=\"attention\" name=\"Contacts without an email\" %}\nIf you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.\n{% /admonition %}\n\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Detach a contact from a group conversation",
       "operationId": "detachContactFromConversation",
       "method": "DELETE",
@@ -14959,9 +15139,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.redactConversation": {
-      "id": "endpoint_.redactConversation",
+    "endpoint_conversations.redactConversation": {
+      "id": "endpoint_conversations.redactConversation",
       "description": "You can redact a conversation part or the source message of a conversation (as seen in the source object).\n\n{% admonition type=\"info\" name=\"Redacting parts and messages\" %}\nIf you are redacting a conversation part, it must have a `body`. If you are redacting a source message, it must have been created by a contact. We will return a `conversation_part_not_redactable` error if these criteria are not met.\n{% /admonition %}\n\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Redact a conversation part",
       "operationId": "redactConversation",
       "method": "POST",
@@ -15328,9 +15511,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.convertConversationToTicket": {
-      "id": "endpoint_.convertConversationToTicket",
+    "endpoint_conversations.convertConversationToTicket": {
+      "id": "endpoint_conversations.convertConversationToTicket",
       "description": "You can convert a conversation to a ticket.",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Convert a conversation to a ticket",
       "operationId": "convertConversationToTicket",
       "method": "POST",
@@ -15717,9 +15903,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.lisDataAttributes": {
-      "id": "endpoint_.lisDataAttributes",
+    "endpoint_dataAttributes.lisDataAttributes": {
+      "id": "endpoint_dataAttributes.lisDataAttributes",
       "description": "You can fetch a list of all data attributes belonging to a workspace for contacts, companies or conversations.",
+      "namespace": [
+        "subpackage_dataAttributes"
+      ],
       "displayName": "List all data attributes",
       "operationId": "lisDataAttributes",
       "method": "GET",
@@ -16124,9 +16313,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createDataAttribute": {
-      "id": "endpoint_.createDataAttribute",
+    "endpoint_dataAttributes.createDataAttribute": {
+      "id": "endpoint_dataAttributes.createDataAttribute",
       "description": "You can create a data attributes for a `contact` or a `company`.",
+      "namespace": [
+        "subpackage_dataAttributes"
+      ],
       "displayName": "Create a data attribute",
       "operationId": "createDataAttribute",
       "method": "POST",
@@ -16539,9 +16731,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateDataAttribute": {
-      "id": "endpoint_.updateDataAttribute",
+    "endpoint_dataAttributes.updateDataAttribute": {
+      "id": "endpoint_dataAttributes.updateDataAttribute",
       "description": "\nYou can update a data attribute.\n\n> 🚧 Updating the data type is not possible\n>\n> It is currently a dangerous action to execute changing a data attribute's type via the API. You will need to update the type via the UI instead.\n",
+      "namespace": [
+        "subpackage_dataAttributes"
+      ],
       "displayName": "Update a data attribute",
       "operationId": "updateDataAttribute",
       "method": "PUT",
@@ -16950,9 +17145,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.lisDataEvents": {
-      "id": "endpoint_.lisDataEvents",
+    "endpoint_dataEvents.lisDataEvents": {
+      "id": "endpoint_dataEvents.lisDataEvents",
       "description": "\n> 🚧\n>\n> Please note that you can only 'list' events that are less than 90 days old. Event counts and summaries will still include your events older than 90 days but you cannot 'list' these events individually if they are older than 90 days\n\nThe events belonging to a customer can be listed by sending a GET request to `https://api.intercom.io/events` with a user or lead identifier along with a `type` parameter. The identifier parameter can be one of `user_id`, `email` or `intercom_user_id`. The `type` parameter value must be `user`.\n\n- `https://api.intercom.io/events?type=user&user_id={user_id}`\n- `https://api.intercom.io/events?type=user&email={email}`\n- `https://api.intercom.io/events?type=user&intercom_user_id={id}` (this call can be used to list leads)\n\nThe `email` parameter value should be [url encoded](http://en.wikipedia.org/wiki/Percent-encoding) when sending.\n\nYou can optionally define the result page size as well with the `per_page` parameter.\n",
+      "namespace": [
+        "subpackage_dataEvents"
+      ],
       "displayName": "List all data events",
       "operationId": "lisDataEvents",
       "method": "GET",
@@ -17186,9 +17384,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createDataEvent": {
-      "id": "endpoint_.createDataEvent",
+    "endpoint_dataEvents.createDataEvent": {
+      "id": "endpoint_dataEvents.createDataEvent",
       "description": "\nYou will need an Access Token that has write permissions to send Events. Once you have a key you can submit events via POST to the Events resource, which is located at https://api.intercom.io/events, or you can send events using one of the client libraries. When working with the HTTP API directly a client should send the event with a `Content-Type` of `application/json`.\n\nWhen using the JavaScript API, [adding the code to your app](http://docs.intercom.io/configuring-Intercom/tracking-user-events-in-your-app) makes the Events API available. Once added, you can submit an event using the `trackEvent` method. This will associate the event with the Lead or currently logged-in user or logged-out visitor/lead and send it to Intercom. The final parameter is a map that can be used to send optional metadata about the event.\n\nWith the Ruby client you pass a hash describing the event to `Intercom::Event.create`, or call the `track_user` method directly on the current user object (e.g. `user.track_event`).\n\n**NB: For the JSON object types, please note that we do not currently support nested JSON structure.**\n\n| Type            | Description                                                                                                                                                                                                     | Example                                                                           |\n| :-------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |\n| String          | The value is a JSON String                                                                                                                                                                                      | `\"source\":\"desktop\"`                                                              |\n| Number          | The value is a JSON Number                                                                                                                                                                                      | `\"load\": 3.67`                                                                    |\n| Date            | The key ends with the String `_date` and the value is a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time), assumed to be in the [UTC](http://en.wikipedia.org/wiki/Coordinated_Universal_Time) timezone. | `\"contact_date\": 1392036272`                                                      |\n| Link            | The value is a HTTP or HTTPS URI.                                                                                                                                                                               | `\"article\": \"https://example.org/ab1de.html\"`                                     |\n| Rich Link       | The value is a JSON object that contains `url` and `value` keys.                                                                                                                                                | `\"article\": {\"url\": \"https://example.org/ab1de.html\", \"value\":\"the dude abides\"}` |\n| Monetary Amount | The value is a JSON object that contains `amount` and `currency` keys. The `amount` key is a positive integer representing the amount in cents. The price in the example to the right denotes €349.99.          | `\"price\": {\"amount\": 34999, \"currency\": \"eur\"}`                                   |\n\n**Lead Events**\n\nWhen submitting events for Leads, you will need to specify the Lead's `id`.\n\n**Metadata behaviour**\n\n- We currently limit the number of tracked metadata keys to 10 per event. Once the quota is reached, we ignore any further keys we receive. The first 10 metadata keys are determined by the order in which they are sent in with the event.\n- It is not possible to change the metadata keys once the event has been sent. A new event will need to be created with the new keys and you can archive the old one.\n- There might be up to 24 hrs delay when you send a new metadata for an existing event.\n\n**Event de-duplication**\n\nThe API may detect and ignore duplicate events. Each event is uniquely identified as a combination of the following data - the Workspace identifier, the Contact external identifier, the Data Event name and the Data Event created time. As a result, it is **strongly recommended** to send a second granularity Unix timestamp in the `created_at` field.\n\nDuplicated events are responded to using the normal `202 Accepted` code - an error is not thrown, however repeat requests will be counted against any rate limit that is in place.\n\n### HTTP API Responses\n\n- Successful responses to submitted events return `202 Accepted` with an empty body.\n- Unauthorised access will be rejected with a `401 Unauthorized` or `403 Forbidden` response code.\n- Events sent about users that cannot be found will return a `404 Not Found`.\n- Event lists containing duplicate events will have those duplicates ignored.\n- Server errors will return a `500` response code and may contain an error message in the body.\n\n",
+      "namespace": [
+        "subpackage_dataEvents"
+      ],
       "displayName": "Submit a data event",
       "operationId": "createDataEvent",
       "method": "POST",
@@ -17305,9 +17506,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.dataEventSummaries": {
-      "id": "endpoint_.dataEventSummaries",
+    "endpoint_dataEvents.dataEventSummaries": {
+      "id": "endpoint_dataEvents.dataEventSummaries",
       "description": "Create event summaries for a user. Event summaries are used to track the number of times an event has occurred, the first time it occurred and the last time it occurred.\n\n",
+      "namespace": [
+        "subpackage_dataEvents"
+      ],
       "displayName": "Create event summaries",
       "operationId": "dataEventSummaries",
       "method": "POST",
@@ -17444,9 +17648,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createDataExport": {
-      "id": "endpoint_.createDataExport",
+    "endpoint_dataExport.createDataExport": {
+      "id": "endpoint_dataExport.createDataExport",
       "description": "To create your export job, you need to send a `POST` request to the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe only parameters you need to provide are the range of dates that you want exported.\n\n>🚧 Limit of one active job\n>\n> You can only have one active job per workspace. You will receive a HTTP status code of 429 with the message Exceeded rate limit of 1 pending message data export jobs if you attempt to create a second concurrent job.\n\n>❗️ Updated_at not included\n>\n> It should be noted that the timeframe only includes messages sent during the time period and not messages that were only updated during this period. For example, if a message was updated yesterday but sent two days ago, you would need to set the created_at_after date before the message was sent to include that in your retrieval job.\n\n>📘 Date ranges are inclusive\n>\n> Requesting data for 2018-06-01 until 2018-06-30 will get all data for those days including those specified - e.g. 2018-06-01 00:00:00 until 2018-06-30 23:59:99.\n",
+      "namespace": [
+        "subpackage_dataExport"
+      ],
       "displayName": "Create content data export",
       "operationId": "createDataExport",
       "method": "POST",
@@ -17569,9 +17776,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.getDataExport": {
-      "id": "endpoint_.getDataExport",
+    "endpoint_dataExport.getDataExport": {
+      "id": "endpoint_dataExport.getDataExport",
       "description": "You can view the status of your job by sending a `GET` request to the URL\n`https://api.intercom.io/export/content/data/{job_identifier}` - the `{job_identifier}` is the value returned in the response when you first created the export job. More on it can be seen in the Export Job Model.\n\n> 🚧 Jobs expire after two days\n> All jobs that have completed processing (and are thus available to download from the provided URL) will have an expiry limit of two days from when the export ob completed. After this, the data will no longer be available.\n",
+      "namespace": [
+        "subpackage_dataExport"
+      ],
       "displayName": "Show content data export",
       "operationId": "getDataExport",
       "method": "GET",
@@ -17701,9 +17911,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.cancelDataExport": {
-      "id": "endpoint_.cancelDataExport",
+    "endpoint_dataExport.cancelDataExport": {
+      "id": "endpoint_dataExport.cancelDataExport",
       "description": "You can cancel your job",
+      "namespace": [
+        "subpackage_dataExport"
+      ],
       "displayName": "Cancel content data export",
       "operationId": "cancelDataExport",
       "method": "POST",
@@ -17825,9 +18038,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.downloadDataExport": {
-      "id": "endpoint_.downloadDataExport",
+    "endpoint_dataExport.downloadDataExport": {
+      "id": "endpoint_dataExport.downloadDataExport",
       "description": "When a job has a status of complete, and thus a filled download_url, you can download your data by hitting that provided URL, formatted like so: https://api.intercom.io/download/content/data/xyz1234.\n\nYour exported message data will be streamed continuously back down to you in a gzipped CSV format.\n\n> 📘 Octet header required\n>\n> You will have to specify the header Accept: `application/octet-stream` when hitting this endpoint.\n",
+      "namespace": [
+        "subpackage_dataExport"
+      ],
       "displayName": "Download content data export",
       "operationId": "downloadDataExport",
       "method": "GET",
@@ -17943,9 +18159,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createMessage": {
-      "id": "endpoint_.createMessage",
+    "endpoint_messages.createMessage": {
+      "id": "endpoint_messages.createMessage",
       "description": "You can create a message that has been initiated by an admin. The conversation can be either an in-app message or an email.\n\n> 🚧 Sending for visitors\n>\n> There can be a short delay between when a contact is created and when a contact becomes available to be messaged through the API. A 404 Not Found error will be returned in this case.\n\nThis will return the Message model that has been created.\n\n> 🚧 Retrieving Associated Conversations\n>\n> As this is a message, there will be no conversation present until the contact responds. Once they do, you will have to search for a contact's conversations with the id of the message.\n",
+      "namespace": [
+        "subpackage_messages"
+      ],
       "displayName": "Create a message",
       "operationId": "createMessage",
       "method": "POST",
@@ -18380,9 +18599,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listNewsItems": {
-      "id": "endpoint_.listNewsItems",
+    "endpoint_news.listNewsItems": {
+      "id": "endpoint_news.listNewsItems",
       "description": "You can fetch a list of all news items",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "List all news items",
       "operationId": "listNewsItems",
       "method": "GET",
@@ -18557,9 +18779,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createNewsItem": {
-      "id": "endpoint_.createNewsItem",
+    "endpoint_news.createNewsItem": {
+      "id": "endpoint_news.createNewsItem",
       "description": "You can create a news item",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "Create a news item",
       "operationId": "createNewsItem",
       "method": "POST",
@@ -18745,9 +18970,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveNewsItem": {
-      "id": "endpoint_.retrieveNewsItem",
+    "endpoint_news.retrieveNewsItem": {
+      "id": "endpoint_news.retrieveNewsItem",
       "description": "You can fetch the details of a single news item.",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "Retrieve a news item",
       "operationId": "retrieveNewsItem",
       "method": "GET",
@@ -18950,8 +19178,11 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateNewsItem": {
-      "id": "endpoint_.updateNewsItem",
+    "endpoint_news.updateNewsItem": {
+      "id": "endpoint_news.updateNewsItem",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "Update a news item",
       "operationId": "updateNewsItem",
       "method": "PUT",
@@ -19219,9 +19450,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.deleteNewsItem": {
-      "id": "endpoint_.deleteNewsItem",
+    "endpoint_news.deleteNewsItem": {
+      "id": "endpoint_news.deleteNewsItem",
       "description": "You can delete a single news item.",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "Delete a news item",
       "operationId": "deleteNewsItem",
       "method": "DELETE",
@@ -19403,9 +19637,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listLiveNewsfeedItems": {
-      "id": "endpoint_.listLiveNewsfeedItems",
+    "endpoint_news.listLiveNewsfeedItems": {
+      "id": "endpoint_news.listLiveNewsfeedItems",
       "description": "You can fetch a list of all news items that are live on a given newsfeed",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "List all live newsfeed items",
       "operationId": "listLiveNewsfeedItems",
       "method": "GET",
@@ -19571,9 +19808,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listNewsfeeds": {
-      "id": "endpoint_.listNewsfeeds",
+    "endpoint_news.listNewsfeeds": {
+      "id": "endpoint_news.listNewsfeeds",
       "description": "You can fetch a list of all newsfeeds",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "List all newsfeeds",
       "operationId": "listNewsfeeds",
       "method": "GET",
@@ -19720,9 +19960,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveNewsfeed": {
-      "id": "endpoint_.retrieveNewsfeed",
+    "endpoint_news.retrieveNewsfeed": {
+      "id": "endpoint_news.retrieveNewsfeed",
       "description": "You can fetch the details of a single newsfeed",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "Retrieve a newsfeed",
       "operationId": "retrieveNewsfeed",
       "method": "GET",
@@ -19876,9 +20119,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveNote": {
-      "id": "endpoint_.retrieveNote",
+    "endpoint_notes.retrieveNote": {
+      "id": "endpoint_notes.retrieveNote",
       "description": "You can fetch the details of a single note.",
+      "namespace": [
+        "subpackage_notes"
+      ],
       "displayName": "Retrieve a note",
       "operationId": "retrieveNote",
       "method": "GET",
@@ -20065,9 +20311,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listSegments": {
-      "id": "endpoint_.listSegments",
+    "endpoint_segments.listSegments": {
+      "id": "endpoint_segments.listSegments",
       "description": "You can fetch a list of all segments.",
+      "namespace": [
+        "subpackage_segments"
+      ],
       "displayName": "List all segments",
       "operationId": "listSegments",
       "method": "GET",
@@ -20222,9 +20471,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveSegment": {
-      "id": "endpoint_.retrieveSegment",
+    "endpoint_segments.retrieveSegment": {
+      "id": "endpoint_segments.retrieveSegment",
       "description": "You can fetch the details of a single segment.",
+      "namespace": [
+        "subpackage_segments"
+      ],
       "displayName": "Retrieve a segment",
       "operationId": "retrieveSegment",
       "method": "GET",
@@ -20401,9 +20653,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listSubscriptionTypes": {
-      "id": "endpoint_.listSubscriptionTypes",
+    "endpoint_subscriptionTypes.listSubscriptionTypes": {
+      "id": "endpoint_subscriptionTypes.listSubscriptionTypes",
       "description": "You can list all subscription types. A list of subscription type objects will be returned.",
+      "namespace": [
+        "subpackage_subscriptionTypes"
+      ],
       "displayName": "List subscription types",
       "operationId": "listSubscriptionTypes",
       "method": "GET",
@@ -20542,9 +20797,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createPhoneSwitch": {
-      "id": "endpoint_.createPhoneSwitch",
+    "endpoint_switch.createPhoneSwitch": {
+      "id": "endpoint_switch.createPhoneSwitch",
       "description": "You can use the API to deflect phone calls to the Intercom Messenger.\nCalling this endpoint will send an SMS with a link to the Messenger to the phone number specified.\n\nIf custom attributes are specified, they will be added to the user or lead's custom data attributes.\n",
+      "namespace": [
+        "subpackage_switch"
+      ],
       "displayName": "Create a phone Switch",
       "operationId": "createPhoneSwitch",
       "method": "POST",
@@ -20749,9 +21007,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listTags": {
-      "id": "endpoint_.listTags",
+    "endpoint_tags.listTags": {
+      "id": "endpoint_tags.listTags",
       "description": "You can fetch a list of all tags for a given workspace.\n\n",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "List all tags",
       "operationId": "listTags",
       "method": "GET",
@@ -20874,9 +21135,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createTag": {
-      "id": "endpoint_.createTag",
+    "endpoint_tags.createTag": {
+      "id": "endpoint_tags.createTag",
       "description": "You can use this endpoint to perform the following operations:\n\n  **1. Create a new tag:** You can create a new tag by passing in the tag name as specified in \"Create or Update Tag Request Payload\" described below.\n\n  **2. Update an existing tag:** You can update an existing tag by passing the id of the tag as specified in \"Create or Update Tag Request Payload\" described below.\n\n  **3. Tag Companies:** You can tag single company or a list of companies. You can tag a company by passing in the tag name and the company details as specified in \"Tag Company Request Payload\" described below. Also, if the tag doesn't exist then a new one will be created automatically.\n\n  **4. Untag Companies:** You can untag a single company or a list of companies. You can untag a company by passing in the tag id and the company details as specified in \"Untag Company Request Payload\" described below.\n\n  **5. Tag Multiple Users:** You can tag a list of users. You can tag the users by passing in the tag name and the user details as specified in \"Tag Users Request Payload\" described below.\n\nEach operation will return a tag object.\n",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Create or update a tag, Tag or untag companies, Tag contacts",
       "operationId": "createTag",
       "method": "POST",
@@ -21155,9 +21419,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.findTag": {
-      "id": "endpoint_.findTag",
+    "endpoint_tags.findTag": {
+      "id": "endpoint_tags.findTag",
       "description": "You can fetch the details of tags that are on the workspace by their id.\nThis will return a tag object.\n",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Find a specific tag",
       "operationId": "findTag",
       "method": "GET",
@@ -21331,9 +21598,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.deleteTag": {
-      "id": "endpoint_.deleteTag",
+    "endpoint_tags.deleteTag": {
+      "id": "endpoint_tags.deleteTag",
       "description": "You can delete the details of tags that are on the workspace by passing in the id.",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Delete tag",
       "operationId": "deleteTag",
       "method": "DELETE",
@@ -21524,9 +21794,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listTeams": {
-      "id": "endpoint_.listTeams",
+    "endpoint_teams.listTeams": {
+      "id": "endpoint_teams.listTeams",
       "description": "This will return a list of team objects for the App.",
+      "namespace": [
+        "subpackage_teams"
+      ],
       "displayName": "List all teams",
       "operationId": "listTeams",
       "method": "GET",
@@ -21643,9 +21916,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveTeam": {
-      "id": "endpoint_.retrieveTeam",
+    "endpoint_teams.retrieveTeam": {
+      "id": "endpoint_teams.retrieveTeam",
       "description": "You can fetch the details of a single team, containing an array of admins that belong to this team.",
+      "namespace": [
+        "subpackage_teams"
+      ],
       "displayName": "Retrieve a team",
       "operationId": "retrieveTeam",
       "method": "GET",
@@ -21820,9 +22096,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createTicketTypeAttribute": {
-      "id": "endpoint_.createTicketTypeAttribute",
+    "endpoint_ticketTypeAttributes.createTicketTypeAttribute": {
+      "id": "endpoint_ticketTypeAttributes.createTicketTypeAttribute",
       "description": "You can create a new attribute for a ticket type.",
+      "namespace": [
+        "subpackage_ticketTypeAttributes"
+      ],
       "displayName": "Create a new attribute for a ticket type",
       "operationId": "createTicketTypeAttribute",
       "method": "POST",
@@ -22011,9 +22290,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateTicketTypeAttribute": {
-      "id": "endpoint_.updateTicketTypeAttribute",
+    "endpoint_ticketTypeAttributes.updateTicketTypeAttribute": {
+      "id": "endpoint_ticketTypeAttributes.updateTicketTypeAttribute",
       "description": "You can update an existing attribute for a ticket type.",
+      "namespace": [
+        "subpackage_ticketTypeAttributes"
+      ],
       "displayName": "Update an existing attribute for a ticket type",
       "operationId": "updateTicketTypeAttribute",
       "method": "PUT",
@@ -22218,9 +22500,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listTicketTypes": {
-      "id": "endpoint_.listTicketTypes",
+    "endpoint_ticketTypes.listTicketTypes": {
+      "id": "endpoint_ticketTypes.listTicketTypes",
       "description": "You can get a list of all ticket types for a workspace.",
+      "namespace": [
+        "subpackage_ticketTypes"
+      ],
       "displayName": "List all ticket types",
       "operationId": "listTicketTypes",
       "method": "GET",
@@ -22417,9 +22702,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createTicketType": {
-      "id": "endpoint_.createTicketType",
+    "endpoint_ticketTypes.createTicketType": {
+      "id": "endpoint_ticketTypes.createTicketType",
       "description": "You can create a new ticket type.\n> 📘 Creating ticket types.\n>\n> Every ticket type will be created with two default attributes: _default_title_ and _default_description_.\n> For the `icon` propery, use an emoji from [Twemoji Cheatsheet](https://twemoji-cheatsheet.vercel.app/)\n",
+      "namespace": [
+        "subpackage_ticketTypes"
+      ],
       "displayName": "Create a ticket type",
       "operationId": "createTicketType",
       "method": "POST",
@@ -22613,9 +22901,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.getTicketType": {
-      "id": "endpoint_.getTicketType",
+    "endpoint_ticketTypes.getTicketType": {
+      "id": "endpoint_ticketTypes.getTicketType",
       "description": "You can fetch the details of a single ticket type.",
+      "namespace": [
+        "subpackage_ticketTypes"
+      ],
       "displayName": "Retrieve a ticket type",
       "operationId": "getTicketType",
       "method": "GET",
@@ -22833,9 +23124,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateTicketType": {
-      "id": "endpoint_.updateTicketType",
+    "endpoint_ticketTypes.updateTicketType": {
+      "id": "endpoint_ticketTypes.updateTicketType",
       "description": "\nYou can update a ticket type.\n\n> 📘 Updating a ticket type.\n>\n> For the `icon` propery, use an emoji from [Twemoji Cheatsheet](https://twemoji-cheatsheet.vercel.app/)\n",
+      "namespace": [
+        "subpackage_ticketTypes"
+      ],
       "displayName": "Update a ticket type",
       "operationId": "updateTicketType",
       "method": "PUT",
@@ -23071,9 +23365,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.replyTicket": {
-      "id": "endpoint_.replyTicket",
+    "endpoint_tickets.replyTicket": {
+      "id": "endpoint_tickets.replyTicket",
       "description": "You can reply to a ticket with a message from an admin or on behalf of a contact, or with a note for admins.",
+      "namespace": [
+        "subpackage_tickets"
+      ],
       "displayName": "Reply to a ticket",
       "operationId": "replyTicket",
       "method": "POST",
@@ -23430,9 +23727,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.attachTagToTicket": {
-      "id": "endpoint_.attachTagToTicket",
+    "endpoint_tags.attachTagToTicket": {
+      "id": "endpoint_tags.attachTagToTicket",
       "description": "You can tag a specific ticket. This will return a tag object for the tag that was added to the ticket.",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Add tag to a ticket",
       "operationId": "attachTagToTicket",
       "method": "POST",
@@ -23686,9 +23986,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.detachTagFromTicket": {
-      "id": "endpoint_.detachTagFromTicket",
+    "endpoint_tags.detachTagFromTicket": {
+      "id": "endpoint_tags.detachTagFromTicket",
       "description": "You can remove tag from a specific ticket. This will return a tag object for the tag that was removed from the ticket.",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Remove tag from a ticket",
       "operationId": "detachTagFromTicket",
       "method": "DELETE",
@@ -23994,9 +24297,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createTicket": {
-      "id": "endpoint_.createTicket",
+    "endpoint_tickets.createTicket": {
+      "id": "endpoint_tickets.createTicket",
       "description": "You can create a new ticket.",
+      "namespace": [
+        "subpackage_tickets"
+      ],
       "displayName": "Create a ticket",
       "operationId": "createTicket",
       "method": "POST",
@@ -24250,9 +24556,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.getTicket": {
-      "id": "endpoint_.getTicket",
+    "endpoint_tickets.getTicket": {
+      "id": "endpoint_tickets.getTicket",
       "description": "You can fetch the details of a single ticket.",
+      "namespace": [
+        "subpackage_tickets"
+      ],
       "displayName": "Retrieve a ticket",
       "operationId": "getTicket",
       "method": "GET",
@@ -24505,9 +24814,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateTicket": {
-      "id": "endpoint_.updateTicket",
+    "endpoint_tickets.updateTicket": {
+      "id": "endpoint_tickets.updateTicket",
       "description": "You can update a ticket.",
+      "namespace": [
+        "subpackage_tickets"
+      ],
       "displayName": "Update a ticket",
       "operationId": "updateTicket",
       "method": "PUT",
@@ -25312,9 +25624,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.searchTickets": {
-      "id": "endpoint_.searchTickets",
+    "endpoint_tickets.searchTickets": {
+      "id": "endpoint_tickets.searchTickets",
       "description": "You can search for multiple tickets by the value of their attributes in order to fetch exactly which ones you want.\n\nTo search for tickets, you send a `POST` request to `https://api.intercom.io/tickets/search`.\n\nThis will accept a query object in the body which will define your filters.\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiples there can be:\n- There's a limit of max 2 nested filters\n- There's a limit of max 15 filters for each AND or OR group\n\n### Accepted Fields\n\nMost keys listed as part of the Ticket model are searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foobar\"`).\n\n| Field                                     | Type                                                                                     |\n| :---------------------------------------- | :--------------------------------------------------------------------------------------- |\n| id                                        | String                                                                                   |\n| created_at                                | Date (UNIX timestamp)                                                                    |\n| updated_at                                | Date (UNIX timestamp)                                                                    |\n| _default_title_                           | String                                                                                   |\n| _default_description_                     | String                                                                                   |\n| category                                  | String                                                                                   |\n| ticket_type_id                            | String                                                                                   |\n| contact_ids                               | String                                                                                   |\n| teammate_ids                              | String                                                                                   |\n| admin_assignee_id                         | String                                                                                   |\n| team_assignee_id                          | String                                                                                   |\n| open                                      | Boolean                                                                                  |\n| state                                     | String                                                                                   |\n| snoozed_until                             | Date (UNIX timestamp)                                                                    |\n| ticket_attribute.{id}                     | String or Boolean or Date (UNIX timestamp) or Float or Integer                           |\n\n### Accepted Operators\n\n{% admonition type=\"info\" name=\"Searching based on `created_at`\" %}\n  You may use the `<=` or `>=` operators to search by `created_at`.\n{% /admonition %}\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type  (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                    | Description                                                  |\n| :------- | :----------------------------- | :----------------------------------------------------------- |\n| =        | All                            | Equals                                                       |\n| !=       | All                            | Doesn't Equal                                                |\n| IN       | All                            | In  Shortcut for `OR` queries  Values most be in Array       |\n| NIN      | All                            | Not In  Shortcut for `OR !` queries  Values must be in Array |\n| >        | Integer  Date (UNIX Timestamp) | Greater (or equal) than                                      |\n| <       | Integer  Date (UNIX Timestamp) | Lower (or equal) than                                        |\n| ~        | String                         | Contains                                                     |\n| !~       | String                         | Doesn't Contain                                              |\n| ^        | String                         | Starts With                                                  |\n| $        | String                         | Ends With                                                    |\n",
+      "namespace": [
+        "subpackage_tickets"
+      ],
       "displayName": "Search tickets",
       "operationId": "searchTickets",
       "method": "POST",
@@ -25560,9 +25875,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveVisitorWithUserId": {
-      "id": "endpoint_.retrieveVisitorWithUserId",
+    "endpoint_visitors.retrieveVisitorWithUserId": {
+      "id": "endpoint_visitors.retrieveVisitorWithUserId",
       "description": "You can fetch the details of a single visitor.",
+      "namespace": [
+        "subpackage_visitors"
+      ],
       "displayName": "Retrieve a visitor with User ID",
       "operationId": "retrieveVisitorWithUserId",
       "method": "GET",
@@ -25773,9 +26091,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateVisitor": {
-      "id": "endpoint_.updateVisitor",
+    "endpoint_visitors.updateVisitor": {
+      "id": "endpoint_visitors.updateVisitor",
       "description": "Sending a PUT request to `/visitors` will result in an update of an existing Visitor.\n\n**Option 1.** You can update a visitor by passing in the `user_id` of the visitor in the Request body.\n\n**Option 2.** You can update a visitor by passing in the `id` of the visitor in the Request body.\n",
+      "namespace": [
+        "subpackage_visitors"
+      ],
       "displayName": "Update a visitor",
       "operationId": "updateVisitor",
       "method": "PUT",
@@ -26119,9 +26440,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.convertVisitor": {
-      "id": "endpoint_.convertVisitor",
+    "endpoint_visitors.convertVisitor": {
+      "id": "endpoint_visitors.convertVisitor",
       "description": "You can merge a Visitor to a Contact of role type `lead` or `user`.\n\n> 📘 What happens upon a visitor being converted?\n>\n> If the User exists, then the Visitor will be merged into it, the Visitor deleted and the User returned. If the User does not exist, the Visitor will be converted to a User, with the User identifiers replacing it's Visitor identifiers.\n",
+      "namespace": [
+        "subpackage_visitors"
+      ],
       "displayName": "Convert a visitor",
       "operationId": "convertVisitor",
       "method": "POST",
@@ -43868,7 +44192,113 @@
       }
     }
   },
-  "subpackages": {},
+  "subpackages": {
+    "subpackage_admins": {
+      "id": "subpackage_admins",
+      "name": "admins",
+      "displayName": "Admins"
+    },
+    "subpackage_articles": {
+      "id": "subpackage_articles",
+      "name": "articles",
+      "displayName": "Articles"
+    },
+    "subpackage_helpCenter": {
+      "id": "subpackage_helpCenter",
+      "name": "helpCenter",
+      "displayName": "Help Center"
+    },
+    "subpackage_companies": {
+      "id": "subpackage_companies",
+      "name": "companies",
+      "displayName": "Companies"
+    },
+    "subpackage_contacts": {
+      "id": "subpackage_contacts",
+      "name": "contacts",
+      "displayName": "Contacts"
+    },
+    "subpackage_notes": {
+      "id": "subpackage_notes",
+      "name": "notes",
+      "displayName": "Notes"
+    },
+    "subpackage_subscriptionTypes": {
+      "id": "subpackage_subscriptionTypes",
+      "name": "subscriptionTypes",
+      "displayName": "Subscription Types"
+    },
+    "subpackage_tags": {
+      "id": "subpackage_tags",
+      "name": "tags",
+      "displayName": "Tags"
+    },
+    "subpackage_conversations": {
+      "id": "subpackage_conversations",
+      "name": "conversations",
+      "displayName": "Conversations"
+    },
+    "subpackage_dataAttributes": {
+      "id": "subpackage_dataAttributes",
+      "name": "dataAttributes",
+      "displayName": "Data Attributes"
+    },
+    "subpackage_dataEvents": {
+      "id": "subpackage_dataEvents",
+      "name": "dataEvents",
+      "displayName": "Data Events"
+    },
+    "subpackage_dataExport": {
+      "id": "subpackage_dataExport",
+      "name": "dataExport",
+      "displayName": "Data Export"
+    },
+    "subpackage_messages": {
+      "id": "subpackage_messages",
+      "name": "messages",
+      "displayName": "Messages"
+    },
+    "subpackage_news": {
+      "id": "subpackage_news",
+      "name": "news",
+      "displayName": "News"
+    },
+    "subpackage_segments": {
+      "id": "subpackage_segments",
+      "name": "segments",
+      "displayName": "Segments"
+    },
+    "subpackage_switch": {
+      "id": "subpackage_switch",
+      "name": "switch",
+      "displayName": "Switch"
+    },
+    "subpackage_teams": {
+      "id": "subpackage_teams",
+      "name": "teams",
+      "displayName": "Teams"
+    },
+    "subpackage_ticketTypeAttributes": {
+      "id": "subpackage_ticketTypeAttributes",
+      "name": "ticketTypeAttributes",
+      "displayName": "Ticket Type Attributes"
+    },
+    "subpackage_ticketTypes": {
+      "id": "subpackage_ticketTypes",
+      "name": "ticketTypes",
+      "displayName": "Ticket Types"
+    },
+    "subpackage_tickets": {
+      "id": "subpackage_tickets",
+      "name": "tickets",
+      "displayName": "Tickets"
+    },
+    "subpackage_visitors": {
+      "id": "subpackage_visitors",
+      "name": "visitors",
+      "displayName": "Visitors"
+    }
+  },
   "auths": {
     "bearerAuth": {
       "type": "bearerAuth"

--- a/packages/parsers/src/openapi/__test__/__snapshots__/only-include-referenced-schemas.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/only-include-referenced-schemas.json
@@ -5,7 +5,7 @@
       "id": "endpoint_admins.identifyAdmin",
       "description": "\nYou can view the currently authorised admin along with the embedded app object (a \"workspace\" in legacy terminology).\n\n> 🚧 Single Sign On\n>\n> If you are building a custom \"Log in with Intercom\" flow for your site, and you call the `/me` endpoint to identify the logged-in user, you should not accept any sign-ins from users with unverified email addresses as it poses a potential impersonation security risk.\n",
       "namespace": [
-        "subpackage_admins"
+        "admins"
       ],
       "displayName": "Identify an admin",
       "operationId": "identifyAdmin",
@@ -114,7 +114,7 @@
       "id": "endpoint_admins.setAwayAdmin",
       "description": "You can set an Admin as away for the Inbox.",
       "namespace": [
-        "subpackage_admins"
+        "admins"
       ],
       "displayName": "Set an admin to away",
       "operationId": "setAwayAdmin",
@@ -408,7 +408,7 @@
       "id": "endpoint_admins.listActivityLogs",
       "description": "You can get a log of activities by all admins in an app.",
       "namespace": [
-        "subpackage_admins"
+        "admins"
       ],
       "displayName": "List all activity logs",
       "operationId": "listActivityLogs",
@@ -619,7 +619,7 @@
       "id": "endpoint_admins.listAdmins",
       "description": "You can fetch a list of admins for a given workspace.",
       "namespace": [
-        "subpackage_admins"
+        "admins"
       ],
       "displayName": "List all admins",
       "operationId": "listAdmins",
@@ -752,7 +752,7 @@
       "id": "endpoint_admins.retrieveAdmin",
       "description": "You can retrieve the details of a single admin.",
       "namespace": [
-        "subpackage_admins"
+        "admins"
       ],
       "displayName": "Retrieve an admin",
       "operationId": "retrieveAdmin",
@@ -936,7 +936,7 @@
       "id": "endpoint_articles.listArticles",
       "description": "You can fetch a list of all articles by making a GET request to `https://api.intercom.io/articles`.\n\n> 📘 How are the articles sorted and ordered?\n>\n> Articles will be returned in descending order on the `updated_at` attribute. This means if you need to iterate through results then we'll show the most recently updated articles first.\n",
       "namespace": [
-        "subpackage_articles"
+        "articles"
       ],
       "displayName": "List all articles",
       "operationId": "listArticles",
@@ -1082,7 +1082,7 @@
       "id": "endpoint_articles.createArticle",
       "description": "You can create a new article by making a POST request to `https://api.intercom.io/articles`.",
       "namespace": [
-        "subpackage_articles"
+        "articles"
       ],
       "displayName": "Create an article",
       "operationId": "createArticle",
@@ -1330,7 +1330,7 @@
       "id": "endpoint_articles.retrieveArticle",
       "description": "You can fetch the details of a single article by making a GET request to `https://api.intercom.io/articles/<id>`.",
       "namespace": [
-        "subpackage_articles"
+        "articles"
       ],
       "displayName": "Retrieve an article",
       "operationId": "retrieveArticle",
@@ -1529,7 +1529,7 @@
       "id": "endpoint_articles.updateArticle",
       "description": "You can update the details of a single article by making a PUT request to `https://api.intercom.io/articles/<id>`.",
       "namespace": [
-        "subpackage_articles"
+        "articles"
       ],
       "displayName": "Update an article",
       "operationId": "updateArticle",
@@ -2204,7 +2204,7 @@
       "id": "endpoint_articles.deleteArticle",
       "description": "You can delete a single article by making a DELETE request to `https://api.intercom.io/articles/<id>`.",
       "namespace": [
-        "subpackage_articles"
+        "articles"
       ],
       "displayName": "Delete an article",
       "operationId": "deleteArticle",
@@ -2383,7 +2383,7 @@
       "id": "endpoint_articles.searchArticles",
       "description": "You can search for articles by making a GET request to `https://api.intercom.io/articles/search`.",
       "namespace": [
-        "subpackage_articles"
+        "articles"
       ],
       "displayName": "Search for articles",
       "operationId": "searchArticles",
@@ -2618,7 +2618,7 @@
       "id": "endpoint_helpCenter.listAllCollections",
       "description": "You can fetch a list of all collections by making a GET request to `https://api.intercom.io/help_center/collections`.\n\nCollections will be returned in descending order on the `updated_at` attribute. This means if you need to iterate through results then we'll show the most recently updated collections first.\n",
       "namespace": [
-        "subpackage_helpCenter"
+        "helpCenter"
       ],
       "displayName": "List all collections",
       "operationId": "listAllCollections",
@@ -2782,7 +2782,7 @@
       "id": "endpoint_helpCenter.createCollection",
       "description": "You can create a new collection by making a POST request to `https://api.intercom.io/help_center/collections.`",
       "namespace": [
-        "subpackage_helpCenter"
+        "helpCenter"
       ],
       "displayName": "Create a collection",
       "operationId": "createCollection",
@@ -2996,7 +2996,7 @@
       "id": "endpoint_helpCenter.retrieveCollection",
       "description": "You can fetch the details of a single collection by making a GET request to `https://api.intercom.io/help_center/collections/<id>`.",
       "namespace": [
-        "subpackage_helpCenter"
+        "helpCenter"
       ],
       "displayName": "Retrieve a collection",
       "operationId": "retrieveCollection",
@@ -3191,7 +3191,7 @@
       "id": "endpoint_helpCenter.updateCollection",
       "description": "You can update the details of a single collection by making a PUT request to `https://api.intercom.io/collections/<id>`.",
       "namespace": [
-        "subpackage_helpCenter"
+        "helpCenter"
       ],
       "displayName": "Update a collection",
       "operationId": "updateCollection",
@@ -3623,7 +3623,7 @@
       "id": "endpoint_helpCenter.deleteCollection",
       "description": "You can delete a single collection by making a DELETE request to `https://api.intercom.io/collections/<id>`.",
       "namespace": [
-        "subpackage_helpCenter"
+        "helpCenter"
       ],
       "displayName": "Delete a collection",
       "operationId": "deleteCollection",
@@ -3810,7 +3810,7 @@
       "id": "endpoint_helpCenter.retrieveHelpCenter",
       "description": "You can fetch the details of a single Help Center by making a GET request to `https://api.intercom.io/help_center/help_center/<id>`.",
       "namespace": [
-        "subpackage_helpCenter"
+        "helpCenter"
       ],
       "displayName": "Retrieve a Help Center",
       "operationId": "retrieveHelpCenter",
@@ -4001,7 +4001,7 @@
       "id": "endpoint_helpCenter.listHelpCenters",
       "description": "You can list all Help Centers by making a GET request to `https://api.intercom.io/help_center/help_centers`.",
       "namespace": [
-        "subpackage_helpCenter"
+        "helpCenter"
       ],
       "displayName": "List all Help Centers",
       "operationId": "listHelpCenters",
@@ -4131,7 +4131,7 @@
       "id": "endpoint_companies.retrieveCompany",
       "description": "You can fetch a single company by passing in `company_id` or `name`.\n\n  `https://api.intercom.io/companies?name={name}`\n\n  `https://api.intercom.io/companies?company_id={company_id}`\n\nYou can fetch all companies and filter by `segment_id` or `tag_id` as a query parameter.\n\n  `https://api.intercom.io/companies?tag_id={tag_id}`\n\n  `https://api.intercom.io/companies?segment_id={segment_id}`\n",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Retrieve companies",
       "operationId": "retrieveCompany",
@@ -4431,7 +4431,7 @@
       "id": "endpoint_companies.createOrUpdateCompany",
       "description": "You can create or update a company.\n\nCompanies will be only visible in Intercom when there is at least one associated user.\n\nCompanies are looked up via `company_id` in a `POST` request, if not found via `company_id`, the new company will be created, if found, that company will be updated.\n\n{% admonition type=\"attention\" name=\"Using `company_id`\" %}\n  You can set a unique `company_id` value when creating a company. However, it is not possible to update `company_id`. Be sure to set a unique value once upon creation of the company.\n{% /admonition %}\n",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Create or Update a company",
       "operationId": "createOrUpdateCompany",
@@ -4663,7 +4663,7 @@
       "id": "endpoint_companies.RetrieveACompanyById",
       "description": "You can fetch a single company.",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Retrieve a company by ID",
       "operationId": "RetrieveACompanyById",
@@ -4860,7 +4860,7 @@
       "id": "endpoint_companies.UpdateCompany",
       "description": "You can update a single company using the Intercom provisioned `id`.\n\n{% admonition type=\"attention\" name=\"Using `company_id`\" %}\n  When updating a company it is not possible to update `company_id`. This can only be set once upon creation of the company.\n{% /admonition %}\n",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Update a company",
       "operationId": "UpdateCompany",
@@ -5057,7 +5057,7 @@
       "id": "endpoint_companies.deleteCompany",
       "description": "You can delete a single company.",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Delete a company",
       "operationId": "deleteCompany",
@@ -5236,7 +5236,7 @@
       "id": "endpoint_companies.ListAttachedContacts",
       "description": "You can fetch a list of all contacts that belong to a company.",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "List attached contacts",
       "operationId": "ListAttachedContacts",
@@ -5429,7 +5429,7 @@
       "id": "endpoint_companies.ListAttachedSegmentsForCompanies",
       "description": "You can fetch a list of all segments that belong to a company.",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "List attached segments for companies",
       "operationId": "ListAttachedSegmentsForCompanies",
@@ -5615,7 +5615,7 @@
       "id": "endpoint_companies.listAllCompanies",
       "description": "You can list companies. The company list is sorted by the `last_request_at` field and by default is ordered descending, most recently requested first.\n\nNote that the API does not include companies who have no associated users in list responses.\n\nWhen using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "List all companies",
       "operationId": "listAllCompanies",
@@ -5836,7 +5836,7 @@
       "id": "endpoint_companies.scrollOverAllCompanies",
       "description": "      The `list all companies` functionality does not work well for huge datasets, and can result in errors and performance problems when paging deeply. The Scroll API provides an efficient mechanism for iterating over all companies in a dataset.\n\n- Each app can only have 1 scroll open at a time. You'll get an error message if you try to have more than one open per app.\n- If the scroll isn't used for 1 minute, it expires and calls with that scroll param will fail\n- If the end of the scroll is reached, \"companies\" will be empty and the scroll parameter will expire\n\n{% admonition type=\"info\" name=\"Scroll Parameter\" %}\n  You can get the first page of companies by simply sending a GET request to the scroll endpoint.\n  For subsequent requests you will need to use the scroll parameter from the response.\n{% /admonition %}\n{% admonition type=\"danger\" name=\"Scroll network timeouts\" %}\n  Since scroll is often used on large datasets network errors such as timeouts can be encountered. When this occurs you will see a HTTP 500 error with the following message:\n  \"Request failed due to an internal network error. Please restart the scroll operation.\"\n  If this happens, you will need to restart your scroll query: It is not possible to continue from a specific point when using scroll.\n{% /admonition %}\n",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Scroll over all companies",
       "operationId": "scrollOverAllCompanies",
@@ -6014,7 +6014,7 @@
       "id": "endpoint_contacts.listCompaniesForAContact",
       "description": "You can fetch a list of companies that are associated to a contact.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "List attached companies for contact",
       "operationId": "listCompaniesForAContact",
@@ -6233,7 +6233,7 @@
       "id": "endpoint_companies.attachContactToACompany",
       "description": "You can attach a company to a single contact.",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Attach a Contact to a Company",
       "operationId": "attachContactToACompany",
@@ -6576,7 +6576,7 @@
       "id": "endpoint_companies.detachContactFromACompany",
       "description": "You can detach a company from a single contact.",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Detach a contact from a company",
       "operationId": "detachContactFromACompany",
@@ -6819,7 +6819,7 @@
       "id": "endpoint_notes.listNotes",
       "description": "You can fetch a list of notes that are associated to a contact.",
       "namespace": [
-        "subpackage_notes"
+        "notes"
       ],
       "displayName": "List all notes",
       "operationId": "listNotes",
@@ -7038,7 +7038,7 @@
       "id": "endpoint_notes.createNote",
       "description": "You can add a note to a single contact.",
       "namespace": [
-        "subpackage_notes"
+        "notes"
       ],
       "displayName": "Create a note",
       "operationId": "createNote",
@@ -7368,7 +7368,7 @@
       "id": "endpoint_contacts.listSegmentsForAContact",
       "description": "You can fetch a list of segments that are associated to a contact.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "List attached segments for contact",
       "operationId": "listSegmentsForAContact",
@@ -7563,7 +7563,7 @@
       "id": "endpoint_contacts.listSubscriptionsForAContact",
       "description": "You can fetch a list of subscription types that are attached to a contact. These can be subscriptions that a user has 'opted-in' to or has 'opted-out' from, depending on the subscription type.\nThis will return a list of Subscription Type objects that the contact is associated with.\n\nThe data property will show a combined list of:\n\n  1.Opt-out subscription types that the user has opted-out from.\n  2.Opt-in subscription types that the user has opted-in to receiving.\n",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "List subscriptions for a contact",
       "operationId": "listSubscriptionsForAContact",
@@ -7792,7 +7792,7 @@
       "id": "endpoint_subscriptionTypes.attachSubscriptionTypeToContact",
       "description": "You can add a specific subscription to a contact. In Intercom, we have two different subscription types based on user consent - opt-out and opt-in:\n\n  1.Attaching a contact to an opt-out subscription type will opt that user out from receiving messages related to that subscription type.\n\n  2.Attaching a contact to an opt-in subscription type will opt that user in to receiving messages related to that subscription type.\n\nThis will return a subscription type model for the subscription type that was added to the contact.\n",
       "namespace": [
-        "subpackage_subscriptionTypes"
+        "subscriptionTypes"
       ],
       "displayName": "Add subscription to a contact",
       "operationId": "attachSubscriptionTypeToContact",
@@ -8133,7 +8133,7 @@
       "id": "endpoint_subscriptionTypes.detachSubscriptionTypeToContact",
       "description": "You can remove a specific subscription from a contact. This will return a subscription type model for the subscription type that was removed from the contact.",
       "namespace": [
-        "subpackage_subscriptionTypes"
+        "subscriptionTypes"
       ],
       "displayName": "Remove subscription from a contact",
       "operationId": "detachSubscriptionTypeToContact",
@@ -8374,7 +8374,7 @@
       "id": "endpoint_contacts.listTagsForAContact",
       "description": "You can fetch a list of all tags that are attached to a specific contact.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "List tags attached to a contact",
       "operationId": "listTagsForAContact",
@@ -8566,7 +8566,7 @@
       "id": "endpoint_tags.attachTagToContact",
       "description": "You can tag a specific contact. This will return a tag object for the tag that was added to the contact.",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Add tag to a contact",
       "operationId": "attachTagToContact",
@@ -8853,7 +8853,7 @@
       "id": "endpoint_tags.detachTagFromContact",
       "description": "You can remove tag from a specific contact. This will return a tag object for the tag that was removed from the contact.",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Remove tag from a contact",
       "operationId": "detachTagFromContact",
@@ -9078,7 +9078,7 @@
       "id": "endpoint_contacts.ShowContact",
       "description": "You can fetch the details of a single contact.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Get a contact",
       "operationId": "ShowContact",
@@ -9316,7 +9316,7 @@
       "id": "endpoint_contacts.UpdateContact",
       "description": "You can update an existing contact (ie. user or lead).",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Update a contact",
       "operationId": "UpdateContact",
@@ -9573,7 +9573,7 @@
       "id": "endpoint_contacts.DeleteContact",
       "description": "You can delete a single contact.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Delete a contact",
       "operationId": "DeleteContact",
@@ -9723,7 +9723,7 @@
       "id": "endpoint_contacts.MergeContact",
       "description": "You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Merge a lead and a user",
       "operationId": "MergeContact",
@@ -9962,7 +9962,7 @@
       "id": "endpoint_contacts.SearchContacts",
       "description": "You can search for multiple contacts by the value of their attributes in order to fetch exactly who you want.\n\nTo search for contacts, you need to send a `POST` request to `https://api.intercom.io/contacts/search`.\n\nThis will accept a query object in the body which will define your filters in order to search for contacts.\n\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `50` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n### Contact Creation Delay\n\nIf a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiple's there can be:\n* There's a limit of max 2 nested filters\n* There's a limit of max 15 filters for each AND or OR group\n\n### Searching for Timestamp Fields\n\nAll timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second.\nFor example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM). The search results will then include Contacts created from January 2nd, 2020 12:00 AM onwards.\nIf you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM).\nThis behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.\n\n### Accepted Fields\n\nMost key listed as part of the Contacts Model are searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foorbar\"`).\n\n| Field                              | Type                           |\n| ---------------------------------- | ------------------------------ |\n| id                                 | String                         |\n| role                               | String<br>Accepts user or lead |\n| name                               | String                         |\n| avatar                             | String                         |\n| owner_id                           | Integer                        |\n| email                              | String                         |\n| email_domain                       | String                         |\n| phone                              | String                         |\n| formatted_phone                    | String                         |\n| external_id                        | String                         |\n| created_at                         | Date (UNIX Timestamp)          |\n| signed_up_at                       | Date (UNIX Timestamp)          |\n| updated_at                         | Date (UNIX Timestamp)          |\n| last_seen_at                       | Date (UNIX Timestamp)          |\n| last_contacted_at                  | Date (UNIX Timestamp)          |\n| last_replied_at                    | Date (UNIX Timestamp)          |\n| last_email_opened_at               | Date (UNIX Timestamp)          |\n| last_email_clicked_at              | Date (UNIX Timestamp)          |\n| language_override                  | String                         |\n| browser                            | String                         |\n| browser_language                   | String                         |\n| os                                 | String                         |\n| location.country                   | String                         |\n| location.region                    | String                         |\n| location.city                      | String                         |\n| unsubscribed_from_emails           | Boolean                        |\n| marked_email_as_spam               | Boolean                        |\n| has_hard_bounced                   | Boolean                        |\n| ios_last_seen_at                   | Date (UNIX Timestamp)          |\n| ios_app_version                    | String                         |\n| ios_device                         | String                         |\n| ios_app_device                     | String                         |\n| ios_os_version                     | String                         |\n| ios_app_name                       | String                         |\n| ios_sdk_version                    | String                         |\n| android_last_seen_at               | Date (UNIX Timestamp)          |\n| android_app_version                | String                         |\n| android_device                     | String                         |\n| android_app_name                   | String                         |\n| andoid_sdk_version                 | String                         |\n| segment_id                         | String                         |\n| tag_id                             | String                         |\n| custom_attributes.{attribute_name} | String                         |\n\n### Accepted Operators\n\n{% admonition type=\"attention\" name=\"Searching based on `created_at`\" %}\n  You cannot use the `<=` or `>=` operators to search by `created_at`.\n{% /admonition %}\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                      | Description                                                      |\n| :------- | :------------------------------- | :--------------------------------------------------------------- |\n| =        | All                              | Equals                                                           |\n| !=       | All                              | Doesn't Equal                                                    |\n| IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |\n| NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |\n| >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |\n| <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |\n| ~        | String                           | Contains                                                         |\n| !~       | String                           | Doesn't Contain                                                  |\n| ^        | String                           | Starts With                                                      |\n| $        | String                           | Ends With                                                        |\n",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Search contacts",
       "operationId": "SearchContacts",
@@ -10129,7 +10129,7 @@
       "id": "endpoint_contacts.ListContacts",
       "description": "You can fetch a list of all contacts (ie. users or leads) in your workspace.\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `50` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "List all contacts",
       "operationId": "ListContacts",
@@ -10258,7 +10258,7 @@
       "id": "endpoint_contacts.CreateContact",
       "description": "You can create a new contact (ie. user or lead).",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Create contact",
       "operationId": "CreateContact",
@@ -10488,7 +10488,7 @@
       "id": "endpoint_contacts.ArchiveContact",
       "description": "You can archive a single contact.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Archive contact",
       "operationId": "ArchiveContact",
@@ -10615,7 +10615,7 @@
       "id": "endpoint_contacts.UnarchiveContact",
       "description": "You can unarchive a single contact.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Unarchive contact",
       "operationId": "UnarchiveContact",
@@ -10742,7 +10742,7 @@
       "id": "endpoint_tags.attachTagToConversation",
       "description": "You can tag a specific conversation. This will return a tag object for the tag that was added to the conversation.",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Add tag to a conversation",
       "operationId": "attachTagToConversation",
@@ -11001,7 +11001,7 @@
       "id": "endpoint_tags.detachTagFromConversation",
       "description": "You can remove tag from a specific conversation. This will return a tag object for the tag that was removed from the conversation.",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Remove tag from a conversation",
       "operationId": "detachTagFromConversation",
@@ -11312,7 +11312,7 @@
       "id": "endpoint_conversations.listConversations",
       "description": "You can fetch a list of all conversations.\n\nYou can optionally request the result page size and the cursor to start after to fetch the result.\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "List all conversations",
       "operationId": "listConversations",
@@ -11575,7 +11575,7 @@
       "id": "endpoint_conversations.createConversation",
       "description": "You can create a conversation that has been initiated by a contact (ie. user or lead).\nThe conversation can be an in-app message only.\n\n{% admonition type=\"info\" name=\"Sending for visitors\" %}\nYou can also send a message from a visitor by specifying their `user_id` or `id` value in the `from` field, along with a `type` field value of `contact`.\nThis visitor will be automatically converted to a contact with a lead role once the conversation is created.\n{% /admonition %}\n\nThis will return the Message model that has been created.\n\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Creates a conversation",
       "operationId": "createConversation",
@@ -11809,7 +11809,7 @@
       "id": "endpoint_conversations.retrieveConversation",
       "description": "\nYou can fetch the details of a single conversation.\n\nThis will return a single Conversation model with all its conversation parts.\n\n{% admonition type=\"warning\" name=\"Hard limit of 500 parts\" %}\nThe maximum number of conversation parts that can be returned via the API is 500. If you have more than that we will return the 500 most recent conversation parts.\n{% /admonition %}\n\nFor AI agent conversation metadata, please note that you need to have the agent enabled in your workspace, which is a [paid feature](https://www.intercom.com/help/en/articles/8205718-fin-resolutions#h_97f8c2e671).\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Retrieve a conversation",
       "operationId": "retrieveConversation",
@@ -12100,7 +12100,7 @@
       "id": "endpoint_conversations.updateConversation",
       "description": "\nYou can update an existing conversation.\n\n{% admonition type=\"info\" name=\"Replying and other actions\" %}\nIf you want to reply to a coveration or take an action such as assign, unassign, open, close or snooze, take a look at the reply and manage endpoints.\n{% /admonition %}\n\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Update a conversation",
       "operationId": "updateConversation",
@@ -12584,7 +12584,7 @@
       "id": "endpoint_conversations.searchConversations",
       "description": "You can search for multiple conversations by the value of their attributes in order to fetch exactly which ones you want.\n\nTo search for conversations, you need to send a `POST` request to `https://api.intercom.io/conversations/search`.\n\nThis will accept a query object in the body which will define your filters in order to search for conversations.\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `20` results per page and maximum is `150`.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiple's there can be:\n- There's a limit of max 2 nested filters\n- There's a limit of max 15 filters for each AND or OR group\n\n### Accepted Fields\n\nMost keys listed as part of the The conversation model is searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foorbar\"`).\n\n| Field                                     | Type                                                                                                                                                   |\n| :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- |\n| id                                        | String                                                                                                                                                 |\n| created_at                                | Date (UNIX timestamp)                                                                                                                                  |\n| updated_at                                | Date (UNIX timestamp)                                                                                                                                  |\n| source.type                               | String<br>Accepted fields are `conversation`, `email`, `facebook`, `instagram`, `phone_call`, `phone_switch`, `push`, `sms`, `twitter` and `whatsapp`. |\n| source.id                                 | String                                                                                                                                                 |\n| source.delivered_as                       | String                                                                                                                                                 |\n| source.subject                            | String                                                                                                                                                 |\n| source.body                               | String                                                                                                                                                 |\n| source.author.id                          | String                                                                                                                                                 |\n| source.author.type                        | String                                                                                                                                                 |\n| source.author.name                        | String                                                                                                                                                 |\n| source.author.email                       | String                                                                                                                                                 |\n| source.url                                | String                                                                                                                                                 |\n| contact_ids                               | String                                                                                                                                                 |\n| teammate_ids                              | String                                                                                                                                                 |\n| admin_assignee_id                         | String                                                                                                                                                 |\n| team_assignee_id                          | String                                                                                                                                                 |\n| channel_initiated                         | String                                                                                                                                                 |\n| open                                      | Boolean                                                                                                                                                |\n| read                                      | Boolean                                                                                                                                                |\n| state                                     | String                                                                                                                                                 |\n| waiting_since                             | Date (UNIX timestamp)                                                                                                                                  |\n| snoozed_until                             | Date (UNIX timestamp)                                                                                                                                  |\n| tag_ids                                   | String                                                                                                                                                 |\n| priority                                  | String                                                                                                                                                 |\n| statistics.time_to_assignment             | Integer                                                                                                                                                |\n| statistics.time_to_admin_reply            | Integer                                                                                                                                                |\n| statistics.time_to_first_close            | Integer                                                                                                                                                |\n| statistics.time_to_last_close             | Integer                                                                                                                                                |\n| statistics.median_time_to_reply           | Integer                                                                                                                                                |\n| statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_assignment_at            | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_close_at                 | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_assignment_at             | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_close_at                  | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_closed_by_id              | String                                                                                                                                                 |\n| statistics.count_reopens                  | Integer                                                                                                                                                |\n| statistics.count_assignments              | Integer                                                                                                                                                |\n| statistics.count_conversation_parts       | Integer                                                                                                                                                |\n| conversation_rating.requested_at          | Date (UNIX timestamp)                                                                                                                                  |\n| conversation_rating.replied_at            | Date (UNIX timestamp)                                                                                                                                  |\n| conversation_rating.score                 | Integer                                                                                                                                                |\n| conversation_rating.remark                | String                                                                                                                                                 |\n| conversation_rating.contact_id            | String                                                                                                                                                 |\n| conversation_rating.admin_d               | String                                                                                                                                                 |\n| ai_agent_participated                     | Boolean                                                                                                                                                |\n| ai_agent.resolution_state                 | String                                                                                                                                                 |\n| ai_agent.last_answer_type                 | String                                                                                                                                                 |\n| ai_agent.rating                           | Integer                                                                                                                                                |\n| ai_agent.rating_remark                    | String                                                                                                                                                 |\n| ai_agent.source_type                      | String                                                                                                                                                 |\n| ai_agent.source_title                     | String                                                                                                                                                 |\n\n### Accepted Operators\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type  (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                    | Description                                                  |\n| :------- | :----------------------------- | :----------------------------------------------------------- |\n| =        | All                            | Equals                                                       |\n| !=       | All                            | Doesn't Equal                                                |\n| IN       | All                            | In  Shortcut for `OR` queries  Values most be in Array       |\n| NIN      | All                            | Not In  Shortcut for `OR !` queries  Values must be in Array |\n| >        | Integer  Date (UNIX Timestamp) | Greater (or equal) than                                      |\n| <       | Integer  Date (UNIX Timestamp) | Lower (or equal) than                                        |\n| ~        | String                         | Contains                                                     |\n| !~       | String                         | Doesn't Contain                                              |\n| ^        | String                         | Starts With                                                  |\n| $        | String                         | Ends With                                                    |\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Search conversations",
       "operationId": "searchConversations",
@@ -12782,7 +12782,7 @@
       "id": "endpoint_conversations.replyConversation",
       "description": "You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Reply to a conversation",
       "operationId": "replyConversation",
@@ -13431,7 +13431,7 @@
       "id": "endpoint_conversations.manageConversation",
       "description": "For managing conversations you can:\n- Close a conversation\n- Snooze a conversation to reopen on a future date\n- Open a conversation which is `snoozed` or `closed`\n- Assign a conversation to an admin and/or team.\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Manage a conversation",
       "operationId": "manageConversation",
@@ -14177,7 +14177,7 @@
       "id": "endpoint_conversations.autoAssignConversation",
       "description": "You can let a conversation be automatically assigned following assignment rules.\n{% admonition type=\"attention\" name=\"When using workflows\" %}\nIt is not possible to use this endpoint with Workflows.\n{% /admonition %}\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Run Assignment Rules on a conversation",
       "operationId": "autoAssignConversation",
@@ -14478,7 +14478,7 @@
       "id": "endpoint_conversations.attachContactToConversation",
       "description": "You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.\n\n{% admonition type=\"attention\" name=\"Contacts without an email\" %}\nIf you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.\n{% /admonition %}\n\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Attach a contact to a conversation",
       "operationId": "attachContactToConversation",
@@ -14747,7 +14747,7 @@
       "id": "endpoint_conversations.detachContactFromConversation",
       "description": "You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.\n\n{% admonition type=\"attention\" name=\"Contacts without an email\" %}\nIf you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.\n{% /admonition %}\n\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Detach a contact from a group conversation",
       "operationId": "detachContactFromConversation",
@@ -15143,7 +15143,7 @@
       "id": "endpoint_conversations.redactConversation",
       "description": "You can redact a conversation part or the source message of a conversation (as seen in the source object).\n\n{% admonition type=\"info\" name=\"Redacting parts and messages\" %}\nIf you are redacting a conversation part, it must have a `body`. If you are redacting a source message, it must have been created by a contact. We will return a `conversation_part_not_redactable` error if these criteria are not met.\n{% /admonition %}\n\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Redact a conversation part",
       "operationId": "redactConversation",
@@ -15515,7 +15515,7 @@
       "id": "endpoint_conversations.convertConversationToTicket",
       "description": "You can convert a conversation to a ticket.",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Convert a conversation to a ticket",
       "operationId": "convertConversationToTicket",
@@ -15907,7 +15907,7 @@
       "id": "endpoint_dataAttributes.lisDataAttributes",
       "description": "You can fetch a list of all data attributes belonging to a workspace for contacts, companies or conversations.",
       "namespace": [
-        "subpackage_dataAttributes"
+        "dataAttributes"
       ],
       "displayName": "List all data attributes",
       "operationId": "lisDataAttributes",
@@ -16317,7 +16317,7 @@
       "id": "endpoint_dataAttributes.createDataAttribute",
       "description": "You can create a data attributes for a `contact` or a `company`.",
       "namespace": [
-        "subpackage_dataAttributes"
+        "dataAttributes"
       ],
       "displayName": "Create a data attribute",
       "operationId": "createDataAttribute",
@@ -16735,7 +16735,7 @@
       "id": "endpoint_dataAttributes.updateDataAttribute",
       "description": "\nYou can update a data attribute.\n\n> 🚧 Updating the data type is not possible\n>\n> It is currently a dangerous action to execute changing a data attribute's type via the API. You will need to update the type via the UI instead.\n",
       "namespace": [
-        "subpackage_dataAttributes"
+        "dataAttributes"
       ],
       "displayName": "Update a data attribute",
       "operationId": "updateDataAttribute",
@@ -17149,7 +17149,7 @@
       "id": "endpoint_dataEvents.lisDataEvents",
       "description": "\n> 🚧\n>\n> Please note that you can only 'list' events that are less than 90 days old. Event counts and summaries will still include your events older than 90 days but you cannot 'list' these events individually if they are older than 90 days\n\nThe events belonging to a customer can be listed by sending a GET request to `https://api.intercom.io/events` with a user or lead identifier along with a `type` parameter. The identifier parameter can be one of `user_id`, `email` or `intercom_user_id`. The `type` parameter value must be `user`.\n\n- `https://api.intercom.io/events?type=user&user_id={user_id}`\n- `https://api.intercom.io/events?type=user&email={email}`\n- `https://api.intercom.io/events?type=user&intercom_user_id={id}` (this call can be used to list leads)\n\nThe `email` parameter value should be [url encoded](http://en.wikipedia.org/wiki/Percent-encoding) when sending.\n\nYou can optionally define the result page size as well with the `per_page` parameter.\n",
       "namespace": [
-        "subpackage_dataEvents"
+        "dataEvents"
       ],
       "displayName": "List all data events",
       "operationId": "lisDataEvents",
@@ -17388,7 +17388,7 @@
       "id": "endpoint_dataEvents.createDataEvent",
       "description": "\nYou will need an Access Token that has write permissions to send Events. Once you have a key you can submit events via POST to the Events resource, which is located at https://api.intercom.io/events, or you can send events using one of the client libraries. When working with the HTTP API directly a client should send the event with a `Content-Type` of `application/json`.\n\nWhen using the JavaScript API, [adding the code to your app](http://docs.intercom.io/configuring-Intercom/tracking-user-events-in-your-app) makes the Events API available. Once added, you can submit an event using the `trackEvent` method. This will associate the event with the Lead or currently logged-in user or logged-out visitor/lead and send it to Intercom. The final parameter is a map that can be used to send optional metadata about the event.\n\nWith the Ruby client you pass a hash describing the event to `Intercom::Event.create`, or call the `track_user` method directly on the current user object (e.g. `user.track_event`).\n\n**NB: For the JSON object types, please note that we do not currently support nested JSON structure.**\n\n| Type            | Description                                                                                                                                                                                                     | Example                                                                           |\n| :-------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |\n| String          | The value is a JSON String                                                                                                                                                                                      | `\"source\":\"desktop\"`                                                              |\n| Number          | The value is a JSON Number                                                                                                                                                                                      | `\"load\": 3.67`                                                                    |\n| Date            | The key ends with the String `_date` and the value is a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time), assumed to be in the [UTC](http://en.wikipedia.org/wiki/Coordinated_Universal_Time) timezone. | `\"contact_date\": 1392036272`                                                      |\n| Link            | The value is a HTTP or HTTPS URI.                                                                                                                                                                               | `\"article\": \"https://example.org/ab1de.html\"`                                     |\n| Rich Link       | The value is a JSON object that contains `url` and `value` keys.                                                                                                                                                | `\"article\": {\"url\": \"https://example.org/ab1de.html\", \"value\":\"the dude abides\"}` |\n| Monetary Amount | The value is a JSON object that contains `amount` and `currency` keys. The `amount` key is a positive integer representing the amount in cents. The price in the example to the right denotes €349.99.          | `\"price\": {\"amount\": 34999, \"currency\": \"eur\"}`                                   |\n\n**Lead Events**\n\nWhen submitting events for Leads, you will need to specify the Lead's `id`.\n\n**Metadata behaviour**\n\n- We currently limit the number of tracked metadata keys to 10 per event. Once the quota is reached, we ignore any further keys we receive. The first 10 metadata keys are determined by the order in which they are sent in with the event.\n- It is not possible to change the metadata keys once the event has been sent. A new event will need to be created with the new keys and you can archive the old one.\n- There might be up to 24 hrs delay when you send a new metadata for an existing event.\n\n**Event de-duplication**\n\nThe API may detect and ignore duplicate events. Each event is uniquely identified as a combination of the following data - the Workspace identifier, the Contact external identifier, the Data Event name and the Data Event created time. As a result, it is **strongly recommended** to send a second granularity Unix timestamp in the `created_at` field.\n\nDuplicated events are responded to using the normal `202 Accepted` code - an error is not thrown, however repeat requests will be counted against any rate limit that is in place.\n\n### HTTP API Responses\n\n- Successful responses to submitted events return `202 Accepted` with an empty body.\n- Unauthorised access will be rejected with a `401 Unauthorized` or `403 Forbidden` response code.\n- Events sent about users that cannot be found will return a `404 Not Found`.\n- Event lists containing duplicate events will have those duplicates ignored.\n- Server errors will return a `500` response code and may contain an error message in the body.\n\n",
       "namespace": [
-        "subpackage_dataEvents"
+        "dataEvents"
       ],
       "displayName": "Submit a data event",
       "operationId": "createDataEvent",
@@ -17510,7 +17510,7 @@
       "id": "endpoint_dataEvents.dataEventSummaries",
       "description": "Create event summaries for a user. Event summaries are used to track the number of times an event has occurred, the first time it occurred and the last time it occurred.\n\n",
       "namespace": [
-        "subpackage_dataEvents"
+        "dataEvents"
       ],
       "displayName": "Create event summaries",
       "operationId": "dataEventSummaries",
@@ -17652,7 +17652,7 @@
       "id": "endpoint_dataExport.createDataExport",
       "description": "To create your export job, you need to send a `POST` request to the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe only parameters you need to provide are the range of dates that you want exported.\n\n>🚧 Limit of one active job\n>\n> You can only have one active job per workspace. You will receive a HTTP status code of 429 with the message Exceeded rate limit of 1 pending message data export jobs if you attempt to create a second concurrent job.\n\n>❗️ Updated_at not included\n>\n> It should be noted that the timeframe only includes messages sent during the time period and not messages that were only updated during this period. For example, if a message was updated yesterday but sent two days ago, you would need to set the created_at_after date before the message was sent to include that in your retrieval job.\n\n>📘 Date ranges are inclusive\n>\n> Requesting data for 2018-06-01 until 2018-06-30 will get all data for those days including those specified - e.g. 2018-06-01 00:00:00 until 2018-06-30 23:59:99.\n",
       "namespace": [
-        "subpackage_dataExport"
+        "dataExport"
       ],
       "displayName": "Create content data export",
       "operationId": "createDataExport",
@@ -17780,7 +17780,7 @@
       "id": "endpoint_dataExport.getDataExport",
       "description": "You can view the status of your job by sending a `GET` request to the URL\n`https://api.intercom.io/export/content/data/{job_identifier}` - the `{job_identifier}` is the value returned in the response when you first created the export job. More on it can be seen in the Export Job Model.\n\n> 🚧 Jobs expire after two days\n> All jobs that have completed processing (and are thus available to download from the provided URL) will have an expiry limit of two days from when the export ob completed. After this, the data will no longer be available.\n",
       "namespace": [
-        "subpackage_dataExport"
+        "dataExport"
       ],
       "displayName": "Show content data export",
       "operationId": "getDataExport",
@@ -17915,7 +17915,7 @@
       "id": "endpoint_dataExport.cancelDataExport",
       "description": "You can cancel your job",
       "namespace": [
-        "subpackage_dataExport"
+        "dataExport"
       ],
       "displayName": "Cancel content data export",
       "operationId": "cancelDataExport",
@@ -18042,7 +18042,7 @@
       "id": "endpoint_dataExport.downloadDataExport",
       "description": "When a job has a status of complete, and thus a filled download_url, you can download your data by hitting that provided URL, formatted like so: https://api.intercom.io/download/content/data/xyz1234.\n\nYour exported message data will be streamed continuously back down to you in a gzipped CSV format.\n\n> 📘 Octet header required\n>\n> You will have to specify the header Accept: `application/octet-stream` when hitting this endpoint.\n",
       "namespace": [
-        "subpackage_dataExport"
+        "dataExport"
       ],
       "displayName": "Download content data export",
       "operationId": "downloadDataExport",
@@ -18163,7 +18163,7 @@
       "id": "endpoint_messages.createMessage",
       "description": "You can create a message that has been initiated by an admin. The conversation can be either an in-app message or an email.\n\n> 🚧 Sending for visitors\n>\n> There can be a short delay between when a contact is created and when a contact becomes available to be messaged through the API. A 404 Not Found error will be returned in this case.\n\nThis will return the Message model that has been created.\n\n> 🚧 Retrieving Associated Conversations\n>\n> As this is a message, there will be no conversation present until the contact responds. Once they do, you will have to search for a contact's conversations with the id of the message.\n",
       "namespace": [
-        "subpackage_messages"
+        "messages"
       ],
       "displayName": "Create a message",
       "operationId": "createMessage",
@@ -18603,7 +18603,7 @@
       "id": "endpoint_news.listNewsItems",
       "description": "You can fetch a list of all news items",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "List all news items",
       "operationId": "listNewsItems",
@@ -18783,7 +18783,7 @@
       "id": "endpoint_news.createNewsItem",
       "description": "You can create a news item",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "Create a news item",
       "operationId": "createNewsItem",
@@ -18974,7 +18974,7 @@
       "id": "endpoint_news.retrieveNewsItem",
       "description": "You can fetch the details of a single news item.",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "Retrieve a news item",
       "operationId": "retrieveNewsItem",
@@ -19181,7 +19181,7 @@
     "endpoint_news.updateNewsItem": {
       "id": "endpoint_news.updateNewsItem",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "Update a news item",
       "operationId": "updateNewsItem",
@@ -19454,7 +19454,7 @@
       "id": "endpoint_news.deleteNewsItem",
       "description": "You can delete a single news item.",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "Delete a news item",
       "operationId": "deleteNewsItem",
@@ -19641,7 +19641,7 @@
       "id": "endpoint_news.listLiveNewsfeedItems",
       "description": "You can fetch a list of all news items that are live on a given newsfeed",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "List all live newsfeed items",
       "operationId": "listLiveNewsfeedItems",
@@ -19812,7 +19812,7 @@
       "id": "endpoint_news.listNewsfeeds",
       "description": "You can fetch a list of all newsfeeds",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "List all newsfeeds",
       "operationId": "listNewsfeeds",
@@ -19964,7 +19964,7 @@
       "id": "endpoint_news.retrieveNewsfeed",
       "description": "You can fetch the details of a single newsfeed",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "Retrieve a newsfeed",
       "operationId": "retrieveNewsfeed",
@@ -20123,7 +20123,7 @@
       "id": "endpoint_notes.retrieveNote",
       "description": "You can fetch the details of a single note.",
       "namespace": [
-        "subpackage_notes"
+        "notes"
       ],
       "displayName": "Retrieve a note",
       "operationId": "retrieveNote",
@@ -20315,7 +20315,7 @@
       "id": "endpoint_segments.listSegments",
       "description": "You can fetch a list of all segments.",
       "namespace": [
-        "subpackage_segments"
+        "segments"
       ],
       "displayName": "List all segments",
       "operationId": "listSegments",
@@ -20475,7 +20475,7 @@
       "id": "endpoint_segments.retrieveSegment",
       "description": "You can fetch the details of a single segment.",
       "namespace": [
-        "subpackage_segments"
+        "segments"
       ],
       "displayName": "Retrieve a segment",
       "operationId": "retrieveSegment",
@@ -20657,7 +20657,7 @@
       "id": "endpoint_subscriptionTypes.listSubscriptionTypes",
       "description": "You can list all subscription types. A list of subscription type objects will be returned.",
       "namespace": [
-        "subpackage_subscriptionTypes"
+        "subscriptionTypes"
       ],
       "displayName": "List subscription types",
       "operationId": "listSubscriptionTypes",
@@ -20801,7 +20801,7 @@
       "id": "endpoint_switch.createPhoneSwitch",
       "description": "You can use the API to deflect phone calls to the Intercom Messenger.\nCalling this endpoint will send an SMS with a link to the Messenger to the phone number specified.\n\nIf custom attributes are specified, they will be added to the user or lead's custom data attributes.\n",
       "namespace": [
-        "subpackage_switch"
+        "switch"
       ],
       "displayName": "Create a phone Switch",
       "operationId": "createPhoneSwitch",
@@ -21011,7 +21011,7 @@
       "id": "endpoint_tags.listTags",
       "description": "You can fetch a list of all tags for a given workspace.\n\n",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "List all tags",
       "operationId": "listTags",
@@ -21139,7 +21139,7 @@
       "id": "endpoint_tags.createTag",
       "description": "You can use this endpoint to perform the following operations:\n\n  **1. Create a new tag:** You can create a new tag by passing in the tag name as specified in \"Create or Update Tag Request Payload\" described below.\n\n  **2. Update an existing tag:** You can update an existing tag by passing the id of the tag as specified in \"Create or Update Tag Request Payload\" described below.\n\n  **3. Tag Companies:** You can tag single company or a list of companies. You can tag a company by passing in the tag name and the company details as specified in \"Tag Company Request Payload\" described below. Also, if the tag doesn't exist then a new one will be created automatically.\n\n  **4. Untag Companies:** You can untag a single company or a list of companies. You can untag a company by passing in the tag id and the company details as specified in \"Untag Company Request Payload\" described below.\n\n  **5. Tag Multiple Users:** You can tag a list of users. You can tag the users by passing in the tag name and the user details as specified in \"Tag Users Request Payload\" described below.\n\nEach operation will return a tag object.\n",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Create or update a tag, Tag or untag companies, Tag contacts",
       "operationId": "createTag",
@@ -21423,7 +21423,7 @@
       "id": "endpoint_tags.findTag",
       "description": "You can fetch the details of tags that are on the workspace by their id.\nThis will return a tag object.\n",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Find a specific tag",
       "operationId": "findTag",
@@ -21602,7 +21602,7 @@
       "id": "endpoint_tags.deleteTag",
       "description": "You can delete the details of tags that are on the workspace by passing in the id.",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Delete tag",
       "operationId": "deleteTag",
@@ -21798,7 +21798,7 @@
       "id": "endpoint_teams.listTeams",
       "description": "This will return a list of team objects for the App.",
       "namespace": [
-        "subpackage_teams"
+        "teams"
       ],
       "displayName": "List all teams",
       "operationId": "listTeams",
@@ -21920,7 +21920,7 @@
       "id": "endpoint_teams.retrieveTeam",
       "description": "You can fetch the details of a single team, containing an array of admins that belong to this team.",
       "namespace": [
-        "subpackage_teams"
+        "teams"
       ],
       "displayName": "Retrieve a team",
       "operationId": "retrieveTeam",
@@ -22100,7 +22100,7 @@
       "id": "endpoint_ticketTypeAttributes.createTicketTypeAttribute",
       "description": "You can create a new attribute for a ticket type.",
       "namespace": [
-        "subpackage_ticketTypeAttributes"
+        "ticketTypeAttributes"
       ],
       "displayName": "Create a new attribute for a ticket type",
       "operationId": "createTicketTypeAttribute",
@@ -22294,7 +22294,7 @@
       "id": "endpoint_ticketTypeAttributes.updateTicketTypeAttribute",
       "description": "You can update an existing attribute for a ticket type.",
       "namespace": [
-        "subpackage_ticketTypeAttributes"
+        "ticketTypeAttributes"
       ],
       "displayName": "Update an existing attribute for a ticket type",
       "operationId": "updateTicketTypeAttribute",
@@ -22504,7 +22504,7 @@
       "id": "endpoint_ticketTypes.listTicketTypes",
       "description": "You can get a list of all ticket types for a workspace.",
       "namespace": [
-        "subpackage_ticketTypes"
+        "ticketTypes"
       ],
       "displayName": "List all ticket types",
       "operationId": "listTicketTypes",
@@ -22706,7 +22706,7 @@
       "id": "endpoint_ticketTypes.createTicketType",
       "description": "You can create a new ticket type.\n> 📘 Creating ticket types.\n>\n> Every ticket type will be created with two default attributes: _default_title_ and _default_description_.\n> For the `icon` propery, use an emoji from [Twemoji Cheatsheet](https://twemoji-cheatsheet.vercel.app/)\n",
       "namespace": [
-        "subpackage_ticketTypes"
+        "ticketTypes"
       ],
       "displayName": "Create a ticket type",
       "operationId": "createTicketType",
@@ -22905,7 +22905,7 @@
       "id": "endpoint_ticketTypes.getTicketType",
       "description": "You can fetch the details of a single ticket type.",
       "namespace": [
-        "subpackage_ticketTypes"
+        "ticketTypes"
       ],
       "displayName": "Retrieve a ticket type",
       "operationId": "getTicketType",
@@ -23128,7 +23128,7 @@
       "id": "endpoint_ticketTypes.updateTicketType",
       "description": "\nYou can update a ticket type.\n\n> 📘 Updating a ticket type.\n>\n> For the `icon` propery, use an emoji from [Twemoji Cheatsheet](https://twemoji-cheatsheet.vercel.app/)\n",
       "namespace": [
-        "subpackage_ticketTypes"
+        "ticketTypes"
       ],
       "displayName": "Update a ticket type",
       "operationId": "updateTicketType",
@@ -23369,7 +23369,7 @@
       "id": "endpoint_tickets.replyTicket",
       "description": "You can reply to a ticket with a message from an admin or on behalf of a contact, or with a note for admins.",
       "namespace": [
-        "subpackage_tickets"
+        "tickets"
       ],
       "displayName": "Reply to a ticket",
       "operationId": "replyTicket",
@@ -23731,7 +23731,7 @@
       "id": "endpoint_tags.attachTagToTicket",
       "description": "You can tag a specific ticket. This will return a tag object for the tag that was added to the ticket.",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Add tag to a ticket",
       "operationId": "attachTagToTicket",
@@ -23990,7 +23990,7 @@
       "id": "endpoint_tags.detachTagFromTicket",
       "description": "You can remove tag from a specific ticket. This will return a tag object for the tag that was removed from the ticket.",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Remove tag from a ticket",
       "operationId": "detachTagFromTicket",
@@ -24301,7 +24301,7 @@
       "id": "endpoint_tickets.createTicket",
       "description": "You can create a new ticket.",
       "namespace": [
-        "subpackage_tickets"
+        "tickets"
       ],
       "displayName": "Create a ticket",
       "operationId": "createTicket",
@@ -24560,7 +24560,7 @@
       "id": "endpoint_tickets.getTicket",
       "description": "You can fetch the details of a single ticket.",
       "namespace": [
-        "subpackage_tickets"
+        "tickets"
       ],
       "displayName": "Retrieve a ticket",
       "operationId": "getTicket",
@@ -24818,7 +24818,7 @@
       "id": "endpoint_tickets.updateTicket",
       "description": "You can update a ticket.",
       "namespace": [
-        "subpackage_tickets"
+        "tickets"
       ],
       "displayName": "Update a ticket",
       "operationId": "updateTicket",
@@ -25628,7 +25628,7 @@
       "id": "endpoint_tickets.searchTickets",
       "description": "You can search for multiple tickets by the value of their attributes in order to fetch exactly which ones you want.\n\nTo search for tickets, you send a `POST` request to `https://api.intercom.io/tickets/search`.\n\nThis will accept a query object in the body which will define your filters.\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiples there can be:\n- There's a limit of max 2 nested filters\n- There's a limit of max 15 filters for each AND or OR group\n\n### Accepted Fields\n\nMost keys listed as part of the Ticket model are searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foobar\"`).\n\n| Field                                     | Type                                                                                     |\n| :---------------------------------------- | :--------------------------------------------------------------------------------------- |\n| id                                        | String                                                                                   |\n| created_at                                | Date (UNIX timestamp)                                                                    |\n| updated_at                                | Date (UNIX timestamp)                                                                    |\n| _default_title_                           | String                                                                                   |\n| _default_description_                     | String                                                                                   |\n| category                                  | String                                                                                   |\n| ticket_type_id                            | String                                                                                   |\n| contact_ids                               | String                                                                                   |\n| teammate_ids                              | String                                                                                   |\n| admin_assignee_id                         | String                                                                                   |\n| team_assignee_id                          | String                                                                                   |\n| open                                      | Boolean                                                                                  |\n| state                                     | String                                                                                   |\n| snoozed_until                             | Date (UNIX timestamp)                                                                    |\n| ticket_attribute.{id}                     | String or Boolean or Date (UNIX timestamp) or Float or Integer                           |\n\n### Accepted Operators\n\n{% admonition type=\"info\" name=\"Searching based on `created_at`\" %}\n  You may use the `<=` or `>=` operators to search by `created_at`.\n{% /admonition %}\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type  (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                    | Description                                                  |\n| :------- | :----------------------------- | :----------------------------------------------------------- |\n| =        | All                            | Equals                                                       |\n| !=       | All                            | Doesn't Equal                                                |\n| IN       | All                            | In  Shortcut for `OR` queries  Values most be in Array       |\n| NIN      | All                            | Not In  Shortcut for `OR !` queries  Values must be in Array |\n| >        | Integer  Date (UNIX Timestamp) | Greater (or equal) than                                      |\n| <       | Integer  Date (UNIX Timestamp) | Lower (or equal) than                                        |\n| ~        | String                         | Contains                                                     |\n| !~       | String                         | Doesn't Contain                                              |\n| ^        | String                         | Starts With                                                  |\n| $        | String                         | Ends With                                                    |\n",
       "namespace": [
-        "subpackage_tickets"
+        "tickets"
       ],
       "displayName": "Search tickets",
       "operationId": "searchTickets",
@@ -25879,7 +25879,7 @@
       "id": "endpoint_visitors.retrieveVisitorWithUserId",
       "description": "You can fetch the details of a single visitor.",
       "namespace": [
-        "subpackage_visitors"
+        "visitors"
       ],
       "displayName": "Retrieve a visitor with User ID",
       "operationId": "retrieveVisitorWithUserId",
@@ -26095,7 +26095,7 @@
       "id": "endpoint_visitors.updateVisitor",
       "description": "Sending a PUT request to `/visitors` will result in an update of an existing Visitor.\n\n**Option 1.** You can update a visitor by passing in the `user_id` of the visitor in the Request body.\n\n**Option 2.** You can update a visitor by passing in the `id` of the visitor in the Request body.\n",
       "namespace": [
-        "subpackage_visitors"
+        "visitors"
       ],
       "displayName": "Update a visitor",
       "operationId": "updateVisitor",
@@ -26444,7 +26444,7 @@
       "id": "endpoint_visitors.convertVisitor",
       "description": "You can merge a Visitor to a Contact of role type `lead` or `user`.\n\n> 📘 What happens upon a visitor being converted?\n>\n> If the User exists, then the Visitor will be merged into it, the Visitor deleted and the User returned. If the User does not exist, the Visitor will be converted to a User, with the User identifiers replacing it's Visitor identifiers.\n",
       "namespace": [
-        "subpackage_visitors"
+        "visitors"
       ],
       "displayName": "Convert a visitor",
       "operationId": "convertVisitor",
@@ -26703,9 +26703,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -26714,62 +26720,92 @@
               {
                 "key": "performed_by",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "String representing the object's type. Always has the value `admin`."
+                        },
+                        {
+                          "key": "id",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The id representing the admin."
+                        },
+                        {
+                          "key": "email",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The email of the admin."
+                        },
+                        {
+                          "key": "ip",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The IP address of the admin."
                         }
-                      },
-                      "description": "String representing the object's type. Always has the value `admin`."
-                    },
-                    {
-                      "key": "id",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The id representing the admin."
-                    },
-                    {
-                      "key": "email",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The email of the admin."
-                    },
-                    {
-                      "key": "ip",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The IP address of the admin."
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "Details about the Admin involved in the activity."
               },
@@ -26778,8 +26814,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "activity_log_metadata"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "activity_log_metadata"
+                      }
+                    }
                   }
                 }
               },
@@ -26788,9 +26830,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -26799,210 +26847,216 @@
               {
                 "key": "activity_type",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "admin_assignment_limit_change"
-                    },
-                    {
-                      "value": "admin_away_mode_change"
-                    },
-                    {
-                      "value": "admin_deletion"
-                    },
-                    {
-                      "value": "admin_deprovisioned"
-                    },
-                    {
-                      "value": "admin_impersonation_end"
-                    },
-                    {
-                      "value": "admin_impersonation_start"
-                    },
-                    {
-                      "value": "admin_invite_change"
-                    },
-                    {
-                      "value": "admin_invite_creation"
-                    },
-                    {
-                      "value": "admin_invite_deletion"
-                    },
-                    {
-                      "value": "admin_login_failure"
-                    },
-                    {
-                      "value": "admin_login_success"
-                    },
-                    {
-                      "value": "admin_logout"
-                    },
-                    {
-                      "value": "admin_password_reset_request"
-                    },
-                    {
-                      "value": "admin_password_reset_success"
-                    },
-                    {
-                      "value": "admin_permission_change"
-                    },
-                    {
-                      "value": "admin_provisioned"
-                    },
-                    {
-                      "value": "admin_two_factor_auth_change"
-                    },
-                    {
-                      "value": "admin_unauthorized_sign_in_method"
-                    },
-                    {
-                      "value": "app_admin_join"
-                    },
-                    {
-                      "value": "app_authentication_method_change"
-                    },
-                    {
-                      "value": "app_data_deletion"
-                    },
-                    {
-                      "value": "app_data_export"
-                    },
-                    {
-                      "value": "app_google_sso_domain_change"
-                    },
-                    {
-                      "value": "app_identity_verification_change"
-                    },
-                    {
-                      "value": "app_name_change"
-                    },
-                    {
-                      "value": "app_outbound_address_change"
-                    },
-                    {
-                      "value": "app_package_installation"
-                    },
-                    {
-                      "value": "app_package_token_regeneration"
-                    },
-                    {
-                      "value": "app_package_uninstallation"
-                    },
-                    {
-                      "value": "app_team_creation"
-                    },
-                    {
-                      "value": "app_team_deletion"
-                    },
-                    {
-                      "value": "app_team_membership_modification"
-                    },
-                    {
-                      "value": "app_timezone_change"
-                    },
-                    {
-                      "value": "app_webhook_creation"
-                    },
-                    {
-                      "value": "app_webhook_deletion"
-                    },
-                    {
-                      "value": "articles_in_messenger_enabled_change"
-                    },
-                    {
-                      "value": "bulk_delete"
-                    },
-                    {
-                      "value": "bulk_export"
-                    },
-                    {
-                      "value": "campaign_deletion"
-                    },
-                    {
-                      "value": "campaign_state_change"
-                    },
-                    {
-                      "value": "conversation_part_deletion"
-                    },
-                    {
-                      "value": "conversation_topic_change"
-                    },
-                    {
-                      "value": "conversation_topic_creation"
-                    },
-                    {
-                      "value": "conversation_topic_deletion"
-                    },
-                    {
-                      "value": "help_center_settings_change"
-                    },
-                    {
-                      "value": "inbound_conversations_change"
-                    },
-                    {
-                      "value": "inbox_access_change"
-                    },
-                    {
-                      "value": "message_deletion"
-                    },
-                    {
-                      "value": "message_state_change"
-                    },
-                    {
-                      "value": "messenger_look_and_feel_change"
-                    },
-                    {
-                      "value": "messenger_search_required_change"
-                    },
-                    {
-                      "value": "messenger_spaces_change"
-                    },
-                    {
-                      "value": "office_hours_change"
-                    },
-                    {
-                      "value": "role_change"
-                    },
-                    {
-                      "value": "role_creation"
-                    },
-                    {
-                      "value": "role_deletion"
-                    },
-                    {
-                      "value": "ruleset_activation_title_preview"
-                    },
-                    {
-                      "value": "ruleset_creation"
-                    },
-                    {
-                      "value": "ruleset_deletion"
-                    },
-                    {
-                      "value": "search_browse_enabled_change"
-                    },
-                    {
-                      "value": "search_browse_required_change"
-                    },
-                    {
-                      "value": "seat_change"
-                    },
-                    {
-                      "value": "seat_revoke"
-                    },
-                    {
-                      "value": "security_settings_change"
-                    },
-                    {
-                      "value": "temporary_expectation_change"
-                    },
-                    {
-                      "value": "upfront_email_collection_change"
-                    },
-                    {
-                      "value": "welcome_message_change"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "admin_assignment_limit_change"
+                        },
+                        {
+                          "value": "admin_away_mode_change"
+                        },
+                        {
+                          "value": "admin_deletion"
+                        },
+                        {
+                          "value": "admin_deprovisioned"
+                        },
+                        {
+                          "value": "admin_impersonation_end"
+                        },
+                        {
+                          "value": "admin_impersonation_start"
+                        },
+                        {
+                          "value": "admin_invite_change"
+                        },
+                        {
+                          "value": "admin_invite_creation"
+                        },
+                        {
+                          "value": "admin_invite_deletion"
+                        },
+                        {
+                          "value": "admin_login_failure"
+                        },
+                        {
+                          "value": "admin_login_success"
+                        },
+                        {
+                          "value": "admin_logout"
+                        },
+                        {
+                          "value": "admin_password_reset_request"
+                        },
+                        {
+                          "value": "admin_password_reset_success"
+                        },
+                        {
+                          "value": "admin_permission_change"
+                        },
+                        {
+                          "value": "admin_provisioned"
+                        },
+                        {
+                          "value": "admin_two_factor_auth_change"
+                        },
+                        {
+                          "value": "admin_unauthorized_sign_in_method"
+                        },
+                        {
+                          "value": "app_admin_join"
+                        },
+                        {
+                          "value": "app_authentication_method_change"
+                        },
+                        {
+                          "value": "app_data_deletion"
+                        },
+                        {
+                          "value": "app_data_export"
+                        },
+                        {
+                          "value": "app_google_sso_domain_change"
+                        },
+                        {
+                          "value": "app_identity_verification_change"
+                        },
+                        {
+                          "value": "app_name_change"
+                        },
+                        {
+                          "value": "app_outbound_address_change"
+                        },
+                        {
+                          "value": "app_package_installation"
+                        },
+                        {
+                          "value": "app_package_token_regeneration"
+                        },
+                        {
+                          "value": "app_package_uninstallation"
+                        },
+                        {
+                          "value": "app_team_creation"
+                        },
+                        {
+                          "value": "app_team_deletion"
+                        },
+                        {
+                          "value": "app_team_membership_modification"
+                        },
+                        {
+                          "value": "app_timezone_change"
+                        },
+                        {
+                          "value": "app_webhook_creation"
+                        },
+                        {
+                          "value": "app_webhook_deletion"
+                        },
+                        {
+                          "value": "articles_in_messenger_enabled_change"
+                        },
+                        {
+                          "value": "bulk_delete"
+                        },
+                        {
+                          "value": "bulk_export"
+                        },
+                        {
+                          "value": "campaign_deletion"
+                        },
+                        {
+                          "value": "campaign_state_change"
+                        },
+                        {
+                          "value": "conversation_part_deletion"
+                        },
+                        {
+                          "value": "conversation_topic_change"
+                        },
+                        {
+                          "value": "conversation_topic_creation"
+                        },
+                        {
+                          "value": "conversation_topic_deletion"
+                        },
+                        {
+                          "value": "help_center_settings_change"
+                        },
+                        {
+                          "value": "inbound_conversations_change"
+                        },
+                        {
+                          "value": "inbox_access_change"
+                        },
+                        {
+                          "value": "message_deletion"
+                        },
+                        {
+                          "value": "message_state_change"
+                        },
+                        {
+                          "value": "messenger_look_and_feel_change"
+                        },
+                        {
+                          "value": "messenger_search_required_change"
+                        },
+                        {
+                          "value": "messenger_spaces_change"
+                        },
+                        {
+                          "value": "office_hours_change"
+                        },
+                        {
+                          "value": "role_change"
+                        },
+                        {
+                          "value": "role_creation"
+                        },
+                        {
+                          "value": "role_deletion"
+                        },
+                        {
+                          "value": "ruleset_activation_title_preview"
+                        },
+                        {
+                          "value": "ruleset_creation"
+                        },
+                        {
+                          "value": "ruleset_deletion"
+                        },
+                        {
+                          "value": "search_browse_enabled_change"
+                        },
+                        {
+                          "value": "search_browse_required_change"
+                        },
+                        {
+                          "value": "seat_change"
+                        },
+                        {
+                          "value": "seat_revoke"
+                        },
+                        {
+                          "value": "security_settings_change"
+                        },
+                        {
+                          "value": "temporary_expectation_change"
+                        },
+                        {
+                          "value": "upfront_email_collection_change"
+                        },
+                        {
+                          "value": "welcome_message_change"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
@@ -27010,9 +27064,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27035,9 +27095,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -27048,8 +27114,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           },
@@ -27058,12 +27130,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "activity_log"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "activity_log"
+                      }
+                    }
                   }
                 }
               }
@@ -27089,13 +27167,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -27108,13 +27192,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -27127,13 +27217,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "boolean"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "boolean"
+                            }
+                          }
                         }
                       }
                     }
@@ -27146,13 +27242,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -27165,13 +27267,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "boolean"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "boolean"
+                            }
+                          }
                         }
                       }
                     }
@@ -27184,13 +27292,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -27203,13 +27317,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -27222,13 +27342,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -27241,13 +27367,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -27272,10 +27404,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "uri"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
                 }
               }
             },
@@ -27286,9 +27424,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -27299,10 +27443,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "uri"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
                 }
               }
             },
@@ -27327,9 +27477,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27340,9 +27496,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27353,9 +27515,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27366,9 +27534,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27379,9 +27553,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27392,9 +27572,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -27405,9 +27591,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -27418,9 +27610,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -27431,13 +27629,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -27450,14 +27654,20 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string",
-                          "format": "uri"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string",
+                              "format": "uri"
+                            }
+                          }
                         }
                       }
                     }
@@ -27470,8 +27680,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "team_priority_level"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "team_priority_level"
+                      }
+                    }
                   }
                 }
               }
@@ -27492,9 +27708,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -27505,12 +27727,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "admin"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "admin"
+                      }
+                    }
                   }
                 }
               }
@@ -27536,13 +27764,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -27555,13 +27789,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -27888,9 +28128,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27901,9 +28147,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27914,9 +28166,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27927,9 +28185,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27940,9 +28204,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27953,9 +28223,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -27966,9 +28242,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -27979,9 +28261,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -27992,13 +28280,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -28009,44 +28303,62 @@
               {
                 "key": "avatar",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string",
-                            "default": "avatar"
-                          }
-                        }
-                      },
-                      "description": "This is a string that identifies the type of the object. It will always have the value `avatar`."
-                    },
-                    {
-                      "key": "image_url",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "nullable",
-                          "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string",
-                                "format": "uri"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string",
+                                    "default": "avatar"
+                                  }
+                                }
                               }
                             }
-                          }
+                          },
+                          "description": "This is a string that identifies the type of the object. It will always have the value `avatar`."
+                        },
+                        {
+                          "key": "image_url",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "nullable",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "This object represents the avatar associated with the admin."
                         }
-                      },
-                      "description": "This object represents the avatar associated with the admin."
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "This object represents the avatar associated with the admin."
               },
@@ -28055,13 +28367,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "boolean"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "boolean"
+                            }
+                          }
                         }
                       }
                     }
@@ -28074,12 +28392,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "app"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "app"
+                          }
+                        }
                       }
                     }
                   }
@@ -28101,24 +28425,30 @@
           {
             "key": "source_type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "essentials_plan_setup"
-                },
-                {
-                  "value": "profile"
-                },
-                {
-                  "value": "workflow"
-                },
-                {
-                  "value": "workflow_preview"
-                },
-                {
-                  "value": "fin_preview"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "essentials_plan_setup"
+                    },
+                    {
+                      "value": "profile"
+                    },
+                    {
+                      "value": "workflow"
+                    },
+                    {
+                      "value": "workflow_preview"
+                    },
+                    {
+                      "value": "fin_preview"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the source that triggered AI Agent involvement in the conversation."
           },
@@ -28127,13 +28457,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -28146,10 +28482,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
-                  "type": "enum",
-                  "values": []
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "enum",
+                      "values": []
+                    }
+                  }
                 }
               }
             },
@@ -28160,23 +28502,29 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "assumed_resolution"
-                    },
-                    {
-                      "value": "confirmed_resolution"
-                    },
-                    {
-                      "value": "routed_to_team"
-                    },
-                    {
-                      "value": "abandoned"
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "assumed_resolution"
+                        },
+                        {
+                          "value": "confirmed_resolution"
+                        },
+                        {
+                          "value": "routed_to_team"
+                        },
+                        {
+                          "value": "abandoned"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             },
@@ -28187,13 +28535,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -28206,13 +28560,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -28225,8 +28585,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "content_sources_list"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "content_sources_list"
+                  }
+                }
               }
             }
           }
@@ -28249,10 +28615,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "default": "app"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "default": "app"
+                        }
+                      }
                     }
                   }
                 },
@@ -28263,9 +28635,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28276,9 +28654,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28289,9 +28673,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28302,9 +28692,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28315,9 +28711,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -28328,9 +28730,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -28355,12 +28763,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_statistics"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_statistics"
+                      }
+                    }
                   }
                 }
               }
@@ -28385,10 +28799,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
-                      "type": "enum",
-                      "values": []
+                      "type": "alias",
+                      "value": {
+                        "type": "nullable",
+                        "shape": {
+                          "type": "enum",
+                          "values": []
+                        }
+                      }
                     }
                   }
                 },
@@ -28399,9 +28819,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28412,9 +28838,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28425,9 +28857,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28438,9 +28876,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -28449,15 +28893,21 @@
               {
                 "key": "state",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "published"
-                    },
-                    {
-                      "value": "draft"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "published"
+                        },
+                        {
+                          "value": "draft"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "Whether the article is `published` or is a `draft` ."
               },
@@ -28466,9 +28916,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -28479,9 +28935,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -28492,9 +28954,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28515,12 +28983,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object - `list`."
           },
@@ -28529,8 +29003,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           },
@@ -28539,9 +29019,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -28552,12 +29038,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_list_item"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_list_item"
+                      }
+                    }
                   }
                 }
               }
@@ -28577,13 +29069,20 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "article"
-                }
-              ],
-              "default": "article"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "article"
+                    }
+                  ],
+                  "default": "article"
+                },
+                "default": "article"
+              }
             },
             "description": "The type of object - `article`."
           },
@@ -28592,9 +29091,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -28605,9 +29110,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -28618,9 +29129,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -28631,13 +29148,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -28650,13 +29173,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -28669,9 +29198,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -28680,16 +29215,23 @@
           {
             "key": "state",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "published"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "published"
+                    },
+                    {
+                      "value": "draft"
+                    }
+                  ],
+                  "default": "draft"
                 },
-                {
-                  "value": "draft"
-                }
-              ],
-              "default": "draft"
+                "default": "draft"
+              }
             },
             "description": "Whether the article is `published` or is a `draft`. For multilingual articles, this will be the state of the default language's content."
           },
@@ -28698,9 +29240,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -28711,9 +29259,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -28724,13 +29278,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -28743,13 +29303,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -28762,13 +29328,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -28781,13 +29353,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -28800,9 +29378,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -28813,12 +29397,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_translated_content"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_translated_content"
+                      }
+                    }
                   }
                 }
               }
@@ -28839,9 +29429,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -28852,52 +29448,8 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "enum",
-                        "values": [
-                          {
-                            "value": "highlight"
-                          },
-                          {
-                            "value": "plain"
-                          }
-                        ]
-                      },
-                      "description": "The type of text - `highlight` or `plain`."
-                    },
-                    {
-                      "key": "text",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The text of the title."
-                    }
-                  ]
-                }
-              }
-            },
-            "description": "An Article title highlighted."
-          },
-          {
-            "key": "highlighted_summary",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
                     "type": "list",
@@ -28908,15 +29460,21 @@
                         {
                           "key": "type",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "highlight"
-                              },
-                              {
-                                "value": "plain"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "highlight"
+                                  },
+                                  {
+                                    "value": "plain"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "The type of text - `highlight` or `plain`."
                         },
@@ -28925,15 +29483,89 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
                               }
                             }
                           },
                           "description": "The text of the title."
                         }
                       ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "An Article title highlighted."
+          },
+          {
+            "key": "highlighted_summary",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "list",
+                        "itemShape": {
+                          "type": "object",
+                          "extends": [],
+                          "properties": [
+                            {
+                              "key": "type",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "enum",
+                                    "values": [
+                                      {
+                                        "value": "highlight"
+                                      },
+                                      {
+                                        "value": "plain"
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              "description": "The type of text - `highlight` or `plain`."
+                            },
+                            {
+                              "key": "text",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "The text of the title."
+                            }
+                          ]
+                        }
+                      }
                     }
                   }
                 }
@@ -28954,12 +29586,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object - `list`."
           },
@@ -28968,9 +29606,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -28979,44 +29623,62 @@
           {
             "key": "data",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "articles",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "list",
-                      "itemShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "articles",
+                      "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "article"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "list",
+                              "itemShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "id",
+                                  "id": "article"
+                                }
+                              }
+                            }
+                          }
                         }
-                      }
-                    }
-                  },
-                  "description": "An array of Article objects"
-                },
-                {
-                  "key": "highlights",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "list",
-                      "itemShape": {
+                      },
+                      "description": "An array of Article objects"
+                    },
+                    {
+                      "key": "highlights",
+                      "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "article_search_highlights"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "list",
+                              "itemShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "id",
+                                  "id": "article_search_highlights"
+                                }
+                              }
+                            }
+                          }
                         }
-                      }
+                      },
+                      "description": "A corresponding array of highlighted Article content"
                     }
-                  },
-                  "description": "A corresponding array of highlighted Article content"
+                  ]
                 }
-              ]
+              }
             },
             "description": "An object containing the results of the search."
           },
@@ -29025,8 +29687,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           }
@@ -29047,13 +29715,20 @@
               {
                 "key": "type",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "article_statistics"
-                    }
-                  ],
-                  "default": "article_statistics"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "article_statistics"
+                        }
+                      ],
+                      "default": "article_statistics"
+                    },
+                    "default": "article_statistics"
+                  }
                 },
                 "description": "The type of object - `article_statistics`."
               },
@@ -29062,9 +29737,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -29075,9 +29756,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -29088,9 +29775,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -29101,9 +29794,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -29114,9 +29813,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -29127,9 +29832,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -29156,10 +29867,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
-                      "type": "enum",
-                      "values": []
+                      "type": "alias",
+                      "value": {
+                        "type": "nullable",
+                        "shape": {
+                          "type": "enum",
+                          "values": []
+                        }
+                      }
                     }
                   }
                 },
@@ -29170,8 +29887,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Arabic"
@@ -29181,8 +29904,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Bulgarian"
@@ -29192,8 +29921,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Bosnian"
@@ -29203,8 +29938,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Catalan"
@@ -29214,8 +29955,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Czech"
@@ -29225,8 +29972,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Danish"
@@ -29236,8 +29989,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in German"
@@ -29247,8 +30006,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Greek"
@@ -29258,8 +30023,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in English"
@@ -29269,8 +30040,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Spanish"
@@ -29280,8 +30057,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Estonian"
@@ -29291,8 +30074,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Finnish"
@@ -29302,8 +30091,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in French"
@@ -29313,8 +30108,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Hebrew"
@@ -29324,8 +30125,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Croatian"
@@ -29335,8 +30142,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Hungarian"
@@ -29346,8 +30159,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Indonesian"
@@ -29357,8 +30176,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Italian"
@@ -29368,8 +30193,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Japanese"
@@ -29379,8 +30210,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Korean"
@@ -29390,8 +30227,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Lithuanian"
@@ -29401,8 +30244,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Latvian"
@@ -29412,8 +30261,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Mongolian"
@@ -29423,8 +30278,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Norwegian"
@@ -29434,8 +30295,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Dutch"
@@ -29445,8 +30312,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Polish"
@@ -29456,8 +30329,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Portuguese (Portugal)"
@@ -29467,8 +30346,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Romanian"
@@ -29478,8 +30363,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Russian"
@@ -29489,8 +30380,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Slovenian"
@@ -29500,8 +30397,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Serbian"
@@ -29511,8 +30414,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Swedish"
@@ -29522,8 +30431,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Turkish"
@@ -29533,8 +30448,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Vietnamese"
@@ -29544,8 +30465,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Portuguese (Brazil)"
@@ -29555,8 +30482,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Chinese (China)"
@@ -29566,8 +30499,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Chinese (Taiwan)"
@@ -29669,9 +30608,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -29680,123 +30625,129 @@
           {
             "key": "customer",
             "valueShape": {
-              "type": "undiscriminatedUnion",
-              "variants": [
-                {
-                  "displayName": "Intercom User ID",
-                  "shape": {
-                    "type": "object",
-                    "extends": [],
-                    "properties": [
-                      {
-                        "key": "intercom_user_id",
-                        "valueShape": {
-                          "type": "alias",
-                          "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "description": "The identifier for the contact as given by Intercom."
-                      },
-                      {
-                        "key": "customer",
-                        "valueShape": {
-                          "type": "alias",
-                          "value": {
-                            "type": "optional",
-                            "shape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "undiscriminatedUnion",
+                  "variants": [
+                    {
+                      "displayName": "Intercom User ID",
+                      "shape": {
+                        "type": "object",
+                        "extends": [],
+                        "properties": [
+                          {
+                            "key": "intercom_user_id",
+                            "valueShape": {
                               "type": "alias",
                               "value": {
-                                "type": "id",
-                                "id": "customer_request"
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "description": "The identifier for the contact as given by Intercom."
+                          },
+                          {
+                            "key": "customer",
+                            "valueShape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "optional",
+                                "shape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "id",
+                                    "id": "customer_request"
+                                  }
+                                }
                               }
                             }
                           }
-                        }
+                        ]
                       }
-                    ]
-                  }
-                },
-                {
-                  "displayName": "User ID",
-                  "shape": {
-                    "type": "object",
-                    "extends": [],
-                    "properties": [
-                      {
-                        "key": "user_id",
-                        "valueShape": {
-                          "type": "alias",
-                          "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "description": "The external_id you have defined for the contact who is being added as a participant."
-                      },
-                      {
-                        "key": "customer",
-                        "valueShape": {
-                          "type": "alias",
-                          "value": {
-                            "type": "optional",
-                            "shape": {
+                    },
+                    {
+                      "displayName": "User ID",
+                      "shape": {
+                        "type": "object",
+                        "extends": [],
+                        "properties": [
+                          {
+                            "key": "user_id",
+                            "valueShape": {
                               "type": "alias",
                               "value": {
-                                "type": "id",
-                                "id": "customer_request"
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "description": "The external_id you have defined for the contact who is being added as a participant."
+                          },
+                          {
+                            "key": "customer",
+                            "valueShape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "optional",
+                                "shape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "id",
+                                    "id": "customer_request"
+                                  }
+                                }
                               }
                             }
                           }
-                        }
+                        ]
                       }
-                    ]
-                  }
-                },
-                {
-                  "displayName": "Email",
-                  "shape": {
-                    "type": "object",
-                    "extends": [],
-                    "properties": [
-                      {
-                        "key": "email",
-                        "valueShape": {
-                          "type": "alias",
-                          "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "description": "The email you have defined for the contact who is being added as a participant."
-                      },
-                      {
-                        "key": "customer",
-                        "valueShape": {
-                          "type": "alias",
-                          "value": {
-                            "type": "optional",
-                            "shape": {
+                    },
+                    {
+                      "displayName": "Email",
+                      "shape": {
+                        "type": "object",
+                        "extends": [],
+                        "properties": [
+                          {
+                            "key": "email",
+                            "valueShape": {
                               "type": "alias",
                               "value": {
-                                "type": "id",
-                                "id": "customer_request"
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "description": "The email you have defined for the contact who is being added as a participant."
+                          },
+                          {
+                            "key": "customer",
+                            "valueShape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "optional",
+                                "shape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "id",
+                                    "id": "customer_request"
+                                  }
+                                }
                               }
                             }
                           }
-                        }
+                        ]
                       }
-                    ]
-                  }
+                    }
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -29878,9 +30829,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -29891,9 +30848,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -29904,9 +30867,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -29917,13 +30886,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -29936,9 +30911,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -29949,9 +30930,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -29962,13 +30949,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -29981,13 +30974,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -30000,9 +30999,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30013,9 +31018,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30026,12 +31037,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_translated_content"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_translated_content"
+                      }
+                    }
                   }
                 }
               }
@@ -30042,13 +31059,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -30061,13 +31084,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -30088,12 +31117,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object - `list`."
           },
@@ -30102,8 +31137,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           },
@@ -30112,9 +31153,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30125,12 +31172,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "collection"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "collection"
+                      }
+                    }
                   }
                 }
               }
@@ -30150,12 +31203,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "company"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "company"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Value is `company`"
           },
@@ -30164,9 +31223,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30177,9 +31242,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30190,9 +31261,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30201,49 +31278,73 @@
           {
             "key": "plan",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "type",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "type",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "Value is always \"plan\""
+                    },
+                    {
+                      "key": "id",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The id of the plan"
+                    },
+                    {
+                      "key": "name",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The name of the plan"
                     }
-                  },
-                  "description": "Value is always \"plan\""
-                },
-                {
-                  "key": "id",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "description": "The id of the plan"
-                },
-                {
-                  "key": "name",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "description": "The name of the plan"
+                  ]
                 }
-              ]
+              }
             }
           },
           {
@@ -30251,9 +31352,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30264,9 +31371,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30277,9 +31390,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30290,9 +31409,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30303,9 +31428,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30316,9 +31447,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30329,9 +31466,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30342,9 +31485,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30355,9 +31504,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30368,9 +31523,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30381,9 +31542,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30394,22 +31561,28 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "map",
-                "keyShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "valueShape": {
-                  "type": "alias",
-                  "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "map",
+                    "keyShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "valueShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -30420,75 +31593,111 @@
           {
             "key": "tags",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "type",
-                  "valueShape": {
-                    "type": "enum",
-                    "values": [
-                      {
-                        "value": "tag.list"
-                      }
-                    ]
-                  },
-                  "description": "The type of the object"
-                },
-                {
-                  "key": "tags",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "list",
-                      "itemShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "type",
+                      "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "unknown"
+                          "type": "optional",
+                          "shape": {
+                            "type": "enum",
+                            "values": [
+                              {
+                                "value": "tag.list"
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "description": "The type of the object"
+                    },
+                    {
+                      "key": "tags",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "list",
+                              "itemShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "unknown"
+                                }
+                              }
+                            }
+                          }
                         }
                       }
                     }
-                  }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The list of tags associated with the company"
           },
           {
             "key": "segments",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "type",
-                  "valueShape": {
-                    "type": "enum",
-                    "values": [
-                      {
-                        "value": "segment.list"
-                      }
-                    ]
-                  },
-                  "description": "The type of the object"
-                },
-                {
-                  "key": "segments",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "list",
-                      "itemShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "type",
+                      "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "segment"
+                          "type": "optional",
+                          "shape": {
+                            "type": "enum",
+                            "values": [
+                              {
+                                "value": "segment.list"
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "description": "The type of the object"
+                    },
+                    {
+                      "key": "segments",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "list",
+                              "itemShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "id",
+                                  "id": "segment"
+                                }
+                              }
+                            }
+                          }
                         }
                       }
                     }
-                  }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The list of segments associated with the company"
           }
@@ -30505,12 +31714,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object - `list`"
           },
@@ -30519,12 +31734,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "contact"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "contact"
+                      }
+                    }
                   }
                 }
               }
@@ -30536,9 +31757,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30549,8 +31776,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           }
@@ -30567,12 +31800,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object - `list`"
           },
@@ -30581,12 +31820,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "segment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "segment"
+                      }
+                    }
                   }
                 }
               }
@@ -30606,12 +31851,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object - `list`."
           },
@@ -30620,8 +31871,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           },
@@ -30630,9 +31887,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30643,12 +31906,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "company"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "company"
+                      }
+                    }
                   }
                 }
               }
@@ -30672,12 +31941,18 @@
               {
                 "key": "type",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "list"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "list"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "The type of object - `list`"
               },
@@ -30686,12 +31961,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "company"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "company"
+                          }
+                        }
                       }
                     }
                   }
@@ -30702,8 +31983,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "cursor_pages"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "cursor_pages"
+                      }
+                    }
                   }
                 }
               },
@@ -30712,13 +31999,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -30731,9 +32024,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -30756,9 +32055,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30769,9 +32074,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30782,13 +32093,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -30801,9 +32118,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30814,9 +32137,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30827,9 +32156,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30840,9 +32175,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30853,13 +32194,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -30872,13 +32219,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -30891,13 +32244,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -30910,13 +32269,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -30929,9 +32294,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -30942,9 +32313,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -30955,9 +32332,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -30968,9 +32351,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30981,9 +32370,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30994,13 +32389,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31013,13 +32414,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31032,13 +32439,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31051,13 +32464,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31070,13 +32489,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31089,13 +32514,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31108,13 +32539,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31127,13 +32564,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31146,13 +32589,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31165,13 +32614,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31184,13 +32639,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31203,13 +32664,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31222,13 +32689,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31241,13 +32714,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31260,13 +32739,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31279,13 +32764,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31298,13 +32789,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31317,13 +32814,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31336,13 +32839,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31355,13 +32864,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31374,13 +32889,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31393,13 +32914,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31412,13 +32939,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31429,9 +32962,15 @@
           {
             "key": "custom_attributes",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": []
+                }
+              }
             },
             "description": "The custom attributes which are set for the contact."
           },
@@ -31440,45 +32979,63 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The type of object"
-                    },
-                    {
-                      "key": "image_url",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "nullable",
-                          "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string",
-                                "format": "uri"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
                               }
                             }
-                          }
+                          },
+                          "description": "The type of object"
+                        },
+                        {
+                          "key": "image_url",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "nullable",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "An image URL containing the avatar of a contact."
                         }
-                      },
-                      "description": "An image URL containing the avatar of a contact."
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -31488,8 +33045,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "contact_tags"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "contact_tags"
+                  }
+                }
               }
             }
           },
@@ -31498,8 +33061,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "contact_notes"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "contact_notes"
+                  }
+                }
               }
             }
           },
@@ -31508,8 +33077,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "contact_companies"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "contact_companies"
+                  }
+                }
               }
             }
           },
@@ -31518,8 +33093,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "contact_location"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "contact_location"
+                  }
+                }
               }
             }
           },
@@ -31528,8 +33109,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "contact_social_profiles"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "contact_social_profiles"
+                  }
+                }
               }
             }
           }
@@ -31546,12 +33133,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "always contact"
           },
@@ -31560,9 +33153,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -31573,13 +33172,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31592,9 +33197,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -31613,12 +33224,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object"
           },
@@ -31627,12 +33244,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "company"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "company"
+                      }
+                    }
                   }
                 }
               }
@@ -31644,9 +33267,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -31657,8 +33286,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "pages_link"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "pages_link"
+                  }
+                }
               }
             }
           }
@@ -31677,10 +33312,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "uri"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
                 }
               }
             },
@@ -31691,9 +33332,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -31704,9 +33351,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -31725,12 +33378,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "always contact"
           },
@@ -31739,9 +33398,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -31752,13 +33417,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31771,9 +33442,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -31792,12 +33469,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Always list"
           },
@@ -31806,12 +33489,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "contact"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "contact"
+                      }
+                    }
                   }
                 }
               }
@@ -31823,9 +33512,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -31836,8 +33531,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           }
@@ -31856,13 +33557,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31875,13 +33582,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31894,13 +33607,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31913,13 +33632,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31942,12 +33667,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "addressable_list"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "addressable_list"
+                      }
+                    }
                   }
                 }
               }
@@ -31959,10 +33690,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "uri"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
                 }
               }
             },
@@ -31973,9 +33710,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -31986,9 +33729,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -32007,12 +33756,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "always contact"
           },
@@ -32021,9 +33776,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32034,13 +33795,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -32445,12 +34212,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -32459,12 +34232,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "segment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "segment"
+                      }
+                    }
                   }
                 }
               }
@@ -32486,12 +34265,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "social_profile"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "social_profile"
+                      }
+                    }
                   }
                 }
               }
@@ -32513,12 +34298,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "addressable_list"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "addressable_list"
+                      }
+                    }
                   }
                 }
               }
@@ -32530,10 +34321,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "uri"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
                 }
               }
             },
@@ -32544,9 +34341,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -32557,9 +34360,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -32584,12 +34393,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "addressable_list"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "addressable_list"
+                          }
+                        }
                       }
                     }
                   }
@@ -32601,10 +34416,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "format": "uri"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      }
                     }
                   }
                 },
@@ -32615,9 +34436,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -32628,9 +34455,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -32651,12 +34484,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "always contact"
           },
@@ -32665,9 +34504,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32678,13 +34523,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -32697,9 +34548,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -32718,24 +34575,30 @@
           {
             "key": "content_type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "file"
-                },
-                {
-                  "value": "article"
-                },
-                {
-                  "value": "external_content"
-                },
-                {
-                  "value": "content_snippet"
-                },
-                {
-                  "value": "workflow_connector_action"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "file"
+                    },
+                    {
+                      "value": "article"
+                    },
+                    {
+                      "value": "external_content"
+                    },
+                    {
+                      "value": "content_snippet"
+                    },
+                    {
+                      "value": "workflow_connector_action"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the content source."
           },
@@ -32744,9 +34607,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32757,9 +34626,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32770,9 +34645,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32791,12 +34672,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "content_source.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "content_source.list"
+                    }
+                  ]
                 }
-              ]
+              }
             }
           },
           {
@@ -32804,9 +34691,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -32817,12 +34710,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "content_source"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "content_source"
+                      }
+                    }
                   }
                 }
               }
@@ -32843,9 +34742,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32856,9 +34761,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32869,13 +34780,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -32888,9 +34805,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -32901,9 +34824,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -32914,13 +34843,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -32933,13 +34868,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -32952,9 +34893,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -32963,18 +34910,24 @@
           {
             "key": "state",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "open"
-                },
-                {
-                  "value": "closed"
-                },
-                {
-                  "value": "snoozed"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "open"
+                    },
+                    {
+                      "value": "closed"
+                    },
+                    {
+                      "value": "snoozed"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Can be set to \"open\", \"closed\" or \"snoozed\"."
           },
@@ -32983,9 +34936,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -32994,15 +34953,21 @@
           {
             "key": "priority",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "priority"
-                },
-                {
-                  "value": "not_priority"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "priority"
+                    },
+                    {
+                      "value": "not_priority"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "If marked as priority, it will return priority or else not_priority."
           },
@@ -33011,13 +34976,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -33030,13 +35001,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -33049,8 +35026,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "tags"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "tags"
+                  }
+                }
               }
             }
           },
@@ -33059,8 +35042,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_rating"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_rating"
+                  }
+                }
               }
             }
           },
@@ -33069,8 +35058,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_source"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_source"
+                  }
+                }
               }
             }
           },
@@ -33079,8 +35074,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_contacts"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_contacts"
+                  }
+                }
               }
             }
           },
@@ -33089,8 +35090,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_teammates"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_teammates"
+                  }
+                }
               }
             }
           },
@@ -33099,8 +35106,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "custom_attributes"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "custom_attributes"
+                  }
+                }
               }
             }
           },
@@ -33109,8 +35122,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_first_contact_reply"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_first_contact_reply"
+                  }
+                }
               }
             }
           },
@@ -33119,8 +35138,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "sla_applied"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "sla_applied"
+                  }
+                }
               }
             }
           },
@@ -33129,8 +35154,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_statistics"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_statistics"
+                  }
+                }
               }
             }
           },
@@ -33139,8 +35170,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_parts"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_parts"
+                  }
+                }
               }
             }
           },
@@ -33149,8 +35186,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "linked_object_list"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "linked_object_list"
+                  }
+                }
               }
             }
           },
@@ -33159,9 +35202,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -33172,12 +35221,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ai_agent"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ai_agent"
+                      }
+                    }
                   }
                 }
               }
@@ -33198,9 +35253,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33211,9 +35272,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33224,9 +35291,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33245,12 +35318,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": ""
           },
@@ -33259,12 +35338,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "contact_reference"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "contact_reference"
+                      }
+                    }
                   }
                 }
               }
@@ -33290,9 +35375,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33303,9 +35394,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -33316,13 +35413,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -33345,12 +35448,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "conversation.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "conversation.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Always conversation.list"
           },
@@ -33359,12 +35468,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "conversation"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "conversation"
+                      }
+                    }
                   }
                 }
               }
@@ -33376,9 +35491,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -33389,8 +35510,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           }
@@ -33409,9 +35536,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33422,9 +35555,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33435,9 +35574,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33448,13 +35593,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -33467,9 +35618,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -33480,9 +35637,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -33493,9 +35656,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -33506,12 +35675,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "reference"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "reference"
+                      }
+                    }
                   }
                 }
               }
@@ -33523,8 +35698,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_part_author"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_part_author"
+                  }
+                }
               }
             }
           },
@@ -33533,12 +35714,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "part_attachment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "part_attachment"
+                      }
+                    }
                   }
                 }
               }
@@ -33550,13 +35737,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -33569,9 +35762,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -33592,9 +35791,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33605,9 +35810,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33618,9 +35829,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33631,10 +35848,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "email"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "email"
+                    }
+                  }
                 }
               }
             },
@@ -33653,12 +35876,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "conversation_part.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "conversation_part.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": ""
           },
@@ -33667,12 +35896,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "conversation_part"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "conversation_part"
+                      }
+                    }
                   }
                 }
               }
@@ -33684,9 +35919,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -33711,9 +35952,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33724,9 +35971,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -33737,9 +35990,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33750,8 +36009,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "contact_reference"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "contact_reference"
+                      }
+                    }
                   }
                 }
               },
@@ -33760,8 +36025,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "reference"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "reference"
+                      }
+                    }
                   }
                 }
               }
@@ -33782,9 +36053,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33795,9 +36072,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33808,9 +36091,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33821,9 +36110,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33834,9 +36129,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33847,8 +36148,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_part_author"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_part_author"
+                  }
+                }
               }
             }
           },
@@ -33857,12 +36164,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "part_attachment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "part_attachment"
+                      }
+                    }
                   }
                 }
               }
@@ -33874,13 +36187,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -33893,9 +36212,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -33920,9 +36245,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -33933,9 +36264,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33946,9 +36283,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33959,9 +36302,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33972,9 +36321,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33985,9 +36340,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33998,9 +36359,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34011,9 +36378,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34024,9 +36397,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34037,9 +36416,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34050,9 +36435,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34063,9 +36454,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34076,9 +36473,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34089,9 +36492,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34102,9 +36511,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34115,9 +36530,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -34128,9 +36549,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34141,9 +36568,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34154,9 +36587,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34183,9 +36622,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -34196,12 +36641,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "reference"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "reference"
+                          }
+                        }
                       }
                     }
                   }
@@ -34879,9 +37330,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -34890,62 +37347,92 @@
           {
             "key": "event_summaries",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "event_name",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "event_name",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The name of the event that occurred. A good event name is typically a past tense 'verb-noun' combination, to improve readability, for example `updated-plan`."
+                    },
+                    {
+                      "key": "count",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of times the event occurred."
+                    },
+                    {
+                      "key": "first",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The first time the event was sent"
+                    },
+                    {
+                      "key": "last",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The last time the event was sent"
                     }
-                  },
-                  "description": "The name of the event that occurred. A good event name is typically a past tense 'verb-noun' combination, to improve readability, for example `updated-plan`."
-                },
-                {
-                  "key": "count",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "integer"
-                      }
-                    }
-                  },
-                  "description": "The number of times the event occurred."
-                },
-                {
-                  "key": "first",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "integer"
-                      }
-                    }
-                  },
-                  "description": "The first time the event was sent"
-                },
-                {
-                  "key": "last",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "integer"
-                      }
-                    }
-                  },
-                  "description": "The last time the event was sent"
+                  ]
                 }
-              ]
+              }
             },
             "description": "A list of event summaries for the user. Each event summary should contain the event name, the time the event occurred, and the number of times the event occurred. The event name should be a past tense 'verb-noun' combination, to improve readability, for example `updated-plan`."
           }
@@ -35037,9 +37524,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35050,9 +37543,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35063,9 +37562,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35076,9 +37581,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -35089,9 +37600,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35102,9 +37619,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35115,22 +37638,28 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "map",
-                    "keyShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "valueShape": {
-                      "type": "alias",
-                      "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "map",
+                        "keyShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "valueShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -35143,9 +37672,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -35156,9 +37691,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -35771,12 +38312,18 @@
               {
                 "key": "type",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "pages"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "pages"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "the type of object `pages`."
               },
@@ -35785,9 +38332,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -35798,8 +38351,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "starting_after_paging"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "starting_after_paging"
+                      }
+                    }
                   }
                 }
               },
@@ -35808,9 +38367,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -35821,9 +38386,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -35838,9 +38409,45 @@
     "custom_attributes": {
       "name": "Custom Attributes",
       "shape": {
-        "type": "object",
-        "extends": [],
-        "properties": []
+        "type": "alias",
+        "value": {
+          "type": "map",
+          "keyShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "valueShape": {
+            "type": "undiscriminatedUnion",
+            "variants": [
+              {
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              {
+                "displayName": "Custom Object Instance",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "custom_object_instance"
+                  }
+                }
+              }
+            ]
+          }
+        }
       },
       "description": "An object containing the different custom attributes associated to the conversation as key-value pairs. For relationship attributes the value will be a list of custom object instance models."
     },
@@ -35859,9 +38466,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35872,9 +38485,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35885,9 +38504,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35898,22 +38523,28 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "map",
-                    "keyShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "valueShape": {
-                      "type": "alias",
-                      "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "map",
+                        "keyShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "valueShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -36016,12 +38647,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "data_attribute"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "data_attribute"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Value is `data_attribute`."
           },
@@ -36030,9 +38667,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -36041,15 +38684,21 @@
           {
             "key": "model",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact"
-                },
-                {
-                  "value": "company"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact"
+                    },
+                    {
+                      "value": "company"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Value is `contact` for user/lead attributes and `company` for company attributes."
           },
@@ -36058,9 +38707,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36071,9 +38726,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36084,9 +38745,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36097,9 +38764,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36108,24 +38781,30 @@
           {
             "key": "data_type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "string"
-                },
-                {
-                  "value": "integer"
-                },
-                {
-                  "value": "float"
-                },
-                {
-                  "value": "boolean"
-                },
-                {
-                  "value": "date"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "string"
+                    },
+                    {
+                      "value": "integer"
+                    },
+                    {
+                      "value": "float"
+                    },
+                    {
+                      "value": "boolean"
+                    },
+                    {
+                      "value": "date"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The data type of the attribute."
           },
@@ -36134,13 +38813,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -36153,9 +38838,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -36166,9 +38857,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -36179,9 +38876,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -36192,9 +38895,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -36205,9 +38914,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -36218,9 +38933,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -36231,9 +38952,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -36244,9 +38971,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36265,12 +38998,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -36279,12 +39018,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "data_attribute"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "data_attribute"
+                      }
+                    }
                   }
                 }
               }
@@ -36468,12 +39213,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "event.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "event.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -36482,12 +39233,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "data_event"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "data_event"
+                      }
+                    }
                   }
                 }
               }
@@ -36497,34 +39254,52 @@
           {
             "key": "pages",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "next",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "next",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "key": "since",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
                       }
                     }
-                  }
-                },
-                {
-                  "key": "since",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Pagination"
           }
@@ -36541,12 +39316,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "event.summary"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "event.summary"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -36555,9 +39336,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36568,9 +39355,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36581,9 +39374,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36594,12 +39393,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "data_event_summary_item"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "data_event_summary_item"
+                      }
+                    }
                   }
                 }
               }
@@ -36625,9 +39430,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -36638,9 +39449,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -36651,9 +39468,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -36664,9 +39487,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -36677,9 +39506,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -36702,9 +39537,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36713,27 +39554,33 @@
           {
             "key": "status",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "pending"
-                },
-                {
-                  "value": "in_progress"
-                },
-                {
-                  "value": "failed"
-                },
-                {
-                  "value": "completed"
-                },
-                {
-                  "value": "no_data"
-                },
-                {
-                  "value": "canceled"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "pending"
+                    },
+                    {
+                      "value": "in_progress"
+                    },
+                    {
+                      "value": "failed"
+                    },
+                    {
+                      "value": "completed"
+                    },
+                    {
+                      "value": "no_data"
+                    },
+                    {
+                      "value": "canceled"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The current state of your job."
           },
@@ -36742,9 +39589,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36755,9 +39608,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36778,9 +39637,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36791,9 +39656,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36804,9 +39675,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36817,9 +39694,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36830,9 +39713,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36843,9 +39732,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36856,9 +39751,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36869,9 +39770,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36882,9 +39789,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36895,9 +39808,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36908,9 +39827,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36921,9 +39846,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -36934,9 +39865,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36947,9 +39884,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36960,9 +39903,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36973,9 +39922,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -36986,9 +39941,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -36999,9 +39960,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37012,9 +39979,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37025,9 +39998,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37038,9 +40017,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37051,9 +40036,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37064,9 +40055,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37077,9 +40074,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37090,9 +40093,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37103,9 +40112,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37126,9 +40141,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37137,12 +40158,18 @@
           {
             "key": "object",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "article"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "article"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object which was deleted. - article"
           },
@@ -37151,9 +40178,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -37174,9 +40207,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37185,12 +40224,18 @@
           {
             "key": "object",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "collection"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "collection"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object which was deleted. - `collection`"
           },
@@ -37199,9 +40244,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -37222,9 +40273,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37233,12 +40290,18 @@
           {
             "key": "object",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "company"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "company"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object which was deleted. - `company`"
           },
@@ -37247,9 +40310,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -37270,9 +40339,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37281,12 +40356,18 @@
           {
             "key": "object",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "news-item"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "news-item"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object which was deleted - news-item."
           },
@@ -37295,9 +40376,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -37467,9 +40554,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -37479,9 +40572,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37492,9 +40591,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37505,9 +40610,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37518,9 +40629,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37531,9 +40648,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37544,9 +40667,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37571,10 +40700,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
-                      "type": "enum",
-                      "values": []
+                      "type": "alias",
+                      "value": {
+                        "type": "nullable",
+                        "shape": {
+                          "type": "enum",
+                          "values": []
+                        }
+                      }
                     }
                   }
                 },
@@ -37585,9 +40720,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -37598,9 +40739,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -37627,10 +40774,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
-                      "type": "enum",
-                      "values": []
+                      "type": "alias",
+                      "value": {
+                        "type": "nullable",
+                        "shape": {
+                          "type": "enum",
+                          "values": []
+                        }
+                      }
                     }
                   }
                 },
@@ -37641,8 +40794,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Arabic"
@@ -37652,8 +40811,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Bulgarian"
@@ -37663,8 +40828,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Bosnian"
@@ -37674,8 +40845,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Catalan"
@@ -37685,8 +40862,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Czech"
@@ -37696,8 +40879,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Danish"
@@ -37707,8 +40896,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in German"
@@ -37718,8 +40913,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Greek"
@@ -37729,8 +40930,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in English"
@@ -37740,8 +40947,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Spanish"
@@ -37751,8 +40964,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Estonian"
@@ -37762,8 +40981,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Finnish"
@@ -37773,8 +40998,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in French"
@@ -37784,8 +41015,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Hebrew"
@@ -37795,8 +41032,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Croatian"
@@ -37806,8 +41049,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Hungarian"
@@ -37817,8 +41066,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Indonesian"
@@ -37828,8 +41083,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Italian"
@@ -37839,8 +41100,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Japanese"
@@ -37850,8 +41117,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Korean"
@@ -37861,8 +41134,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Lithuanian"
@@ -37872,8 +41151,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Latvian"
@@ -37883,8 +41168,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Mongolian"
@@ -37894,8 +41185,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Norwegian"
@@ -37905,8 +41202,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Dutch"
@@ -37916,8 +41219,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Polish"
@@ -37927,8 +41236,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Portuguese (Portugal)"
@@ -37938,8 +41253,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Romanian"
@@ -37949,8 +41270,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Russian"
@@ -37960,8 +41287,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Slovenian"
@@ -37971,8 +41304,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Serbian"
@@ -37982,8 +41321,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Swedish"
@@ -37993,8 +41338,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Turkish"
@@ -38004,8 +41355,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Vietnamese"
@@ -38015,8 +41372,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Portuguese (Brazil)"
@@ -38026,8 +41389,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Chinese (China)"
@@ -38037,8 +41406,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Chinese (Taiwan)"
@@ -38060,9 +41435,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38073,9 +41454,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38086,9 +41473,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -38099,9 +41492,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -38112,9 +41511,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38125,9 +41530,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -38138,9 +41549,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38159,12 +41576,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object - `list`."
           },
@@ -38173,12 +41596,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "help_center"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "help_center"
+                      }
+                    }
                   }
                 }
               }
@@ -38262,15 +41691,21 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "ticket"
-                },
-                {
-                  "value": "conversation"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "ticket"
+                    },
+                    {
+                      "value": "conversation"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "ticket or conversation"
           },
@@ -38279,9 +41714,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38292,20 +41733,26 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "Customer"
-                    },
-                    {
-                      "value": "Back-office"
-                    },
-                    {
-                      "value": "Tracker"
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "Customer"
+                        },
+                        {
+                          "value": "Back-office"
+                        },
+                        {
+                          "value": "Tracker"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             },
@@ -38324,12 +41771,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Always list."
           },
@@ -38338,9 +41791,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -38351,9 +41810,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -38364,12 +41829,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "linked_object"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "linked_object"
+                      }
+                    }
                   }
                 }
               }
@@ -38391,9 +41862,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38404,9 +41881,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38546,58 +42029,70 @@
           {
             "key": "operator",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "AND"
-                },
-                {
-                  "value": "OR"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "AND"
+                    },
+                    {
+                      "value": "OR"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "An operator to allow boolean inspection between multiple fields."
           },
           {
             "key": "value",
             "valueShape": {
-              "type": "undiscriminatedUnion",
-              "variants": [
-                {
-                  "displayName": "multiple filter search request",
-                  "shape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "list",
-                      "itemShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "undiscriminatedUnion",
+                  "variants": [
+                    {
+                      "displayName": "multiple filter search request",
+                      "shape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "multiple_filter_search_request"
+                          "type": "list",
+                          "itemShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "multiple_filter_search_request"
+                            }
+                          }
                         }
-                      }
-                    }
-                  },
-                  "description": "Add mutiple filters."
-                },
-                {
-                  "displayName": "single filter search request",
-                  "shape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "list",
-                      "itemShape": {
+                      },
+                      "description": "Add mutiple filters."
+                    },
+                    {
+                      "displayName": "single filter search request",
+                      "shape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "single_filter_search_request"
+                          "type": "list",
+                          "itemShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "single_filter_search_request"
+                            }
+                          }
                         }
-                      }
+                      },
+                      "description": "Add a single filter field."
                     }
-                  },
-                  "description": "Add a single filter field."
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -38613,12 +42108,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "news-item"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "news-item"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object."
           },
@@ -38627,9 +42128,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38640,9 +42147,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38653,9 +42166,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38666,9 +42185,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38679,9 +42204,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -38690,15 +42221,21 @@
           {
             "key": "state",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "draft"
-                },
-                {
-                  "value": "live"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "draft"
+                    },
+                    {
+                      "value": "live"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "News items will not be visible to your users in the assigned newsfeeds until they are set live."
           },
@@ -38707,12 +42244,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "newsfeed_assignment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "newsfeed_assignment"
+                      }
+                    }
                   }
                 }
               }
@@ -38724,17 +42267,23 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
-                    "shape": {
+                    "type": "list",
+                    "itemShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -38749,14 +42298,20 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "format": "uri"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      }
                     }
                   }
                 }
@@ -38769,17 +42324,23 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
-                    "shape": {
+                    "type": "list",
+                    "itemShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -38794,9 +42355,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -38807,9 +42374,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -38820,9 +42393,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39017,9 +42596,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39028,12 +42613,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "newsfeed"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "newsfeed"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object."
           },
@@ -39042,9 +42633,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39055,9 +42652,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39068,9 +42671,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39091,9 +42700,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39104,9 +42719,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39127,9 +42748,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39140,9 +42767,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39153,9 +42786,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39166,38 +42805,56 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "String representing the object's type. Always has the value `contact`."
+                        },
+                        {
+                          "key": "id",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The id of the contact."
                         }
-                      },
-                      "description": "String representing the object's type. Always has the value `contact`."
-                    },
-                    {
-                      "key": "id",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The id of the contact."
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             },
@@ -39208,8 +42865,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "admin"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "admin"
+                  }
+                }
               }
             },
             "description": "Optional. Represents the Admin that created the note."
@@ -39219,9 +42882,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39242,9 +42911,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39255,12 +42930,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "note"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "note"
+                      }
+                    }
                   }
                 }
               }
@@ -39272,9 +42953,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39285,8 +42972,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           }
@@ -39337,12 +43030,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "pages"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "pages"
+                    }
+                  ]
                 }
-              ]
+              }
             }
           },
           {
@@ -39350,9 +43049,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -39362,14 +43067,20 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "format": "uri"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      }
                     }
                   }
                 }
@@ -39382,9 +43093,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -39394,9 +43111,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -39414,15 +43137,21 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
-                },
-                {
-                  "value": "conversation.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    },
+                    {
+                      "value": "conversation.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object"
           },
@@ -39431,8 +43160,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           },
@@ -39441,9 +43176,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39454,31 +43195,37 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
-                  "type": "undiscriminatedUnion",
-                  "variants": [
-                    {
-                      "displayName": "News Item",
-                      "shape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "id",
-                          "id": "news_item"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "list",
+                    "itemShape": {
+                      "type": "undiscriminatedUnion",
+                      "variants": [
+                        {
+                          "displayName": "News Item",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "news_item"
+                            }
+                          }
+                        },
+                        {
+                          "displayName": "Newsfeed",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "newsfeed"
+                            }
+                          }
                         }
-                      }
-                    },
-                    {
-                      "displayName": "Newsfeed",
-                      "shape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "id",
-                          "id": "newsfeed"
-                        }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             },
@@ -39499,9 +43246,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39512,9 +43265,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39525,9 +43284,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39538,9 +43303,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39551,9 +43322,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39564,9 +43341,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39577,9 +43360,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39602,13 +43391,20 @@
               {
                 "key": "type",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "phone_call_redirect"
-                    }
-                  ],
-                  "default": "phone_call_redirect"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "phone_call_redirect"
+                        }
+                      ],
+                      "default": "phone_call_redirect"
+                    },
+                    "default": "phone_call_redirect"
+                  }
                 },
                 "description": ""
               },
@@ -39617,9 +43413,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -39746,9 +43548,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39759,13 +43567,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -39868,12 +43682,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "segment"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "segment"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object."
           },
@@ -39882,9 +43702,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39895,9 +43721,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39908,9 +43740,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39921,9 +43759,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39932,15 +43776,21 @@
           {
             "key": "person_type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact"
-                },
-                {
-                  "value": "user"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact"
+                    },
+                    {
+                      "value": "user"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Type of the contact: contact (lead) or user."
           },
@@ -39949,13 +43799,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -39976,12 +43832,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "segment.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "segment.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -39990,12 +43852,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "segment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "segment"
+                      }
+                    }
                   }
                 }
               }
@@ -40005,9 +43873,15 @@
           {
             "key": "pages",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": []
+                }
+              }
             },
             "description": "A pagination object, which may be empty, indicating no further pages to fetch."
           }
@@ -40026,9 +43900,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40037,39 +43917,45 @@
           {
             "key": "operator",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "="
-                },
-                {
-                  "value": "!="
-                },
-                {
-                  "value": "IN"
-                },
-                {
-                  "value": "NIN"
-                },
-                {
-                  "value": "<"
-                },
-                {
-                  "value": ">"
-                },
-                {
-                  "value": "~"
-                },
-                {
-                  "value": "!~"
-                },
-                {
-                  "value": "^"
-                },
-                {
-                  "value": "$"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "="
+                    },
+                    {
+                      "value": "!="
+                    },
+                    {
+                      "value": "IN"
+                    },
+                    {
+                      "value": "NIN"
+                    },
+                    {
+                      "value": "<"
+                    },
+                    {
+                      "value": ">"
+                    },
+                    {
+                      "value": "~"
+                    },
+                    {
+                      "value": "!~"
+                    },
+                    {
+                      "value": "^"
+                    },
+                    {
+                      "value": "$"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The accepted operators you can use to define how you want to search for the value."
           },
@@ -40078,9 +43964,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40105,9 +43997,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -40118,9 +44016,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -40129,21 +44033,27 @@
               {
                 "key": "sla_status",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "hit"
-                    },
-                    {
-                      "value": "missed"
-                    },
-                    {
-                      "value": "cancelled"
-                    },
-                    {
-                      "value": "active"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "hit"
+                        },
+                        {
+                          "value": "missed"
+                        },
+                        {
+                          "value": "cancelled"
+                        },
+                        {
+                          "value": "active"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "SLA statuses:\n            - `hit`: If there’s at least one hit event in the underlying sla_events table, and no “missed” or “canceled” events for the conversation.\n            - `missed`: If there are any missed sla_events for the conversation and no canceled events. If there’s even a single missed sla event, the status will always be missed. A missed status is not applied when the SLA expires, only the next time a teammate replies.\n            - `active`: An SLA has been applied to a conversation, but has not yet been fulfilled. SLA status is active only if there are no “hit, “missed”, or “canceled” events."
               }
@@ -40211,9 +44121,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40224,9 +44140,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40237,10 +44159,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "uri"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
                 }
               }
             },
@@ -40265,9 +44193,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -40278,13 +44212,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -40308,9 +44248,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40321,9 +44267,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40332,18 +44284,24 @@
           {
             "key": "state",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "live"
-                },
-                {
-                  "value": "draft"
-                },
-                {
-                  "value": "archived"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "live"
+                    },
+                    {
+                      "value": "draft"
+                    },
+                    {
+                      "value": "archived"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The state of the subscription type."
           },
@@ -40352,8 +44310,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "translation"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "translation"
+                  }
+                }
               }
             }
           },
@@ -40362,12 +44326,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "translation"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "translation"
+                      }
+                    }
                   }
                 }
               }
@@ -40377,15 +44347,21 @@
           {
             "key": "consent_type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "opt_out"
-                },
-                {
-                  "value": "opt_in"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "opt_out"
+                    },
+                    {
+                      "value": "opt_in"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Describes the type of consent."
           },
@@ -40394,17 +44370,23 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "email"
-                    },
-                    {
-                      "value": "sms_message"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "list",
+                    "itemShape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "email"
+                        },
+                        {
+                          "value": "sms_message"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             },
@@ -40423,12 +44405,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -40437,12 +44425,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "subscription_type"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "subscription_type"
+                      }
+                    }
                   }
                 }
               }
@@ -40464,9 +44458,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40477,9 +44477,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40490,9 +44496,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40503,9 +44515,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -40516,8 +44534,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "reference"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "reference"
+                  }
+                }
               }
             }
           }
@@ -40559,9 +44583,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
                           }
                         }
                       },
@@ -40572,9 +44602,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
                           }
                         }
                       },
@@ -40599,12 +44635,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -40613,12 +44655,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "tag"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "tag"
+                      }
+                    }
                   }
                 }
               }
@@ -40663,9 +44711,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
                           }
                         }
                       },
@@ -40689,12 +44743,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "tag.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "tag.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -40703,12 +44763,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "tag"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "tag"
+                      }
+                    }
                   }
                 }
               }
@@ -40730,9 +44796,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40743,9 +44815,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40756,9 +44834,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40769,13 +44853,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -40788,8 +44878,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "admin_priority_level"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "admin_priority_level"
+                  }
+                }
               }
             }
           }
@@ -40806,12 +44902,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "team.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "team.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -40820,12 +44922,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "team"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "team"
+                      }
+                    }
                   }
                 }
               }
@@ -40851,13 +44959,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -40870,13 +44984,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -40903,13 +45023,20 @@
               {
                 "key": "type",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "ticket"
-                    }
-                  ],
-                  "default": "ticket"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "ticket"
+                        }
+                      ],
+                      "default": "ticket"
+                    },
+                    "default": "ticket"
+                  }
                 },
                 "description": "Always ticket"
               },
@@ -40918,9 +45045,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -40931,9 +45064,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -40942,18 +45081,24 @@
               {
                 "key": "category",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "Customer"
-                    },
-                    {
-                      "value": "Back-office"
-                    },
-                    {
-                      "value": "Tracker"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "Customer"
+                        },
+                        {
+                          "value": "Back-office"
+                        },
+                        {
+                          "value": "Tracker"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "Category of the Ticket."
               },
@@ -40962,29 +45107,41 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_custom_attributes"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_custom_attributes"
+                      }
+                    }
                   }
                 }
               },
               {
                 "key": "ticket_state",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "submitted"
-                    },
-                    {
-                      "value": "in_progress"
-                    },
-                    {
-                      "value": "waiting_on_customer"
-                    },
-                    {
-                      "value": "resolved"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "submitted"
+                        },
+                        {
+                          "value": "in_progress"
+                        },
+                        {
+                          "value": "waiting_on_customer"
+                        },
+                        {
+                          "value": "resolved"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "The state the ticket is currently in"
               },
@@ -40993,8 +45150,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_type"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_type"
+                      }
+                    }
                   }
                 }
               },
@@ -41003,8 +45166,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_contacts"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_contacts"
+                      }
+                    }
                   }
                 }
               },
@@ -41013,9 +45182,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41026,9 +45201,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41039,9 +45220,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -41052,9 +45239,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -41065,9 +45258,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -41078,9 +45277,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -41091,8 +45296,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "linked_object_list"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "linked_object_list"
+                      }
+                    }
                   }
                 }
               },
@@ -41101,8 +45312,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_parts"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_parts"
+                      }
+                    }
                   }
                 }
               },
@@ -41111,9 +45328,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -41124,9 +45347,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41137,9 +45366,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41160,12 +45395,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "always contact.list"
           },
@@ -41174,12 +45415,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "contact_reference"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "contact_reference"
+                      }
+                    }
                   }
                 }
               }
@@ -41193,9 +45440,73 @@
     "ticket_custom_attributes": {
       "name": "Ticket Attributes",
       "shape": {
-        "type": "object",
-        "extends": [],
-        "properties": []
+        "type": "alias",
+        "value": {
+          "type": "map",
+          "keyShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "valueShape": {
+            "type": "undiscriminatedUnion",
+            "variants": [
+              {
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
+                }
+              },
+              {
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              },
+              {
+                "displayName": "File Attribute",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "file_attribute"
+                  }
+                }
+              }
+            ]
+          }
+        }
       },
       "description": "An object containing the different attributes associated to the ticket as key-value pairs. For the default title and description attributes, the keys are `_default_title_` and `_default_description_`."
     },
@@ -41208,12 +45519,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "ticket.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "ticket.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Always ticket.list"
           },
@@ -41222,12 +45539,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket"
+                      }
+                    }
                   }
                 }
               }
@@ -41239,9 +45562,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -41252,8 +45581,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           }
@@ -41272,46 +45607,7 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "Always ticket_part"
-          },
-          {
-            "key": "id",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "The id representing the ticket part."
-          },
-          {
-            "key": "part_type",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "The type of ticket part."
-          },
-          {
-            "key": "body",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
@@ -41323,47 +45619,122 @@
                 }
               }
             },
+            "description": "Always ticket_part"
+          },
+          {
+            "key": "id",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "The id representing the ticket part."
+          },
+          {
+            "key": "part_type",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "The type of ticket part."
+          },
+          {
+            "key": "body",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "description": "The message body, which may contain HTML."
           },
           {
             "key": "previous_ticket_state",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "submitted"
-                },
-                {
-                  "value": "in_progress"
-                },
-                {
-                  "value": "waiting_on_customer"
-                },
-                {
-                  "value": "resolved"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "submitted"
+                    },
+                    {
+                      "value": "in_progress"
+                    },
+                    {
+                      "value": "waiting_on_customer"
+                    },
+                    {
+                      "value": "resolved"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The previous state of the ticket."
           },
           {
             "key": "ticket_state",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "submitted"
-                },
-                {
-                  "value": "in_progress"
-                },
-                {
-                  "value": "waiting_on_customer"
-                },
-                {
-                  "value": "resolved"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "submitted"
+                    },
+                    {
+                      "value": "in_progress"
+                    },
+                    {
+                      "value": "waiting_on_customer"
+                    },
+                    {
+                      "value": "resolved"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The state of the ticket."
           },
@@ -41372,9 +45743,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -41385,9 +45762,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -41398,12 +45781,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "reference"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "reference"
+                      }
+                    }
                   }
                 }
               }
@@ -41415,8 +45804,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ticket_part_author"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ticket_part_author"
+                  }
+                }
               }
             }
           },
@@ -41425,12 +45820,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "part_attachment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "part_attachment"
+                      }
+                    }
                   }
                 }
               }
@@ -41442,13 +45843,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -41461,9 +45868,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -41482,21 +45895,27 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "admin"
-                },
-                {
-                  "value": "bot"
-                },
-                {
-                  "value": "team"
-                },
-                {
-                  "value": "user"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "admin"
+                    },
+                    {
+                      "value": "bot"
+                    },
+                    {
+                      "value": "team"
+                    },
+                    {
+                      "value": "user"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the author"
           },
@@ -41505,9 +45924,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -41518,13 +45943,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -41537,10 +45968,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "email"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "email"
+                    }
+                  }
                 }
               }
             },
@@ -41559,12 +45996,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "ticket_part.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "ticket_part.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": ""
           },
@@ -41573,12 +46016,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_part"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_part"
+                      }
+                    }
                   }
                 }
               }
@@ -41590,9 +46039,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -41611,12 +46066,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "ticket_part"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "ticket_part"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Always ticket_part"
           },
@@ -41625,9 +46086,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -41636,18 +46103,24 @@
           {
             "key": "part_type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "note"
-                },
-                {
-                  "value": "comment"
-                },
-                {
-                  "value": "quick_reply"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "note"
+                    },
+                    {
+                      "value": "comment"
+                    },
+                    {
+                      "value": "quick_reply"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Type of the part"
           },
@@ -41656,13 +46129,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -41675,9 +46154,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -41688,9 +46173,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -41701,8 +46192,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ticket_part_author"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ticket_part_author"
+                  }
+                }
               }
             }
           },
@@ -41711,12 +46208,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "part_attachment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "part_attachment"
+                      }
+                    }
                   }
                 }
               }
@@ -41728,9 +46231,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -41743,9 +46252,63 @@
     "ticket_request_custom_attributes": {
       "name": "Ticket Attributes",
       "shape": {
-        "type": "object",
-        "extends": [],
-        "properties": []
+        "type": "alias",
+        "value": {
+          "type": "map",
+          "keyShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "valueShape": {
+            "type": "undiscriminatedUnion",
+            "variants": [
+              {
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
+                }
+              },
+              {
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
       },
       "description": "The attributes set on the ticket. When setting the default title and description attributes, the attribute keys that should be used are `_default_title_` and `_default_description_`. When setting ticket type attributes of the list attribute type, the key should be the attribute name and the value of the attribute should be the list item id, obtainable by [listing the ticket type](ref:get_ticket-types). For example, if the ticket type has an attribute called `priority` of type `list`, the key should be `priority` and the value of the attribute should be the guid of the list item (e.g. `de1825a0-0164-4070-8ca6-13e22462fa7e`)."
     },
@@ -41764,9 +46327,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41777,9 +46346,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41788,18 +46363,24 @@
               {
                 "key": "category",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "Customer"
-                    },
-                    {
-                      "value": "Back-office"
-                    },
-                    {
-                      "value": "Tracker"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "Customer"
+                        },
+                        {
+                          "value": "Back-office"
+                        },
+                        {
+                          "value": "Tracker"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "Category of the Ticket Type."
               },
@@ -41808,9 +46389,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41821,9 +46408,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41834,9 +46427,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41847,9 +46446,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41860,8 +46465,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_type_attribute_list"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_type_attribute_list"
+                      }
+                    }
                   }
                 }
               },
@@ -41870,9 +46481,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -41883,9 +46500,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -41896,9 +46519,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -41925,9 +46554,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41938,9 +46573,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41951,9 +46592,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41964,9 +46611,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41977,9 +46630,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41990,9 +46649,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -42001,9 +46666,15 @@
               {
                 "key": "input_options",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": []
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": []
+                    }
+                  }
                 },
                 "description": "Input options for the attribute"
               },
@@ -42012,9 +46683,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -42025,10 +46702,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean",
-                      "default": false
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean",
+                          "default": false
+                        }
+                      }
                     }
                   }
                 },
@@ -42039,10 +46722,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean",
-                      "default": false
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean",
+                          "default": false
+                        }
+                      }
                     }
                   }
                 },
@@ -42053,10 +46742,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean",
-                      "default": true
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean",
+                          "default": true
+                        }
+                      }
                     }
                   }
                 },
@@ -42067,10 +46762,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean",
-                      "default": true
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean",
+                          "default": true
+                        }
+                      }
                     }
                   }
                 },
@@ -42081,9 +46782,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -42094,9 +46801,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -42107,9 +46820,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -42120,9 +46839,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -42133,9 +46858,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -42158,9 +46889,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42171,12 +46908,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_type_attribute"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_type_attribute"
+                      }
+                    }
                   }
                 }
               }
@@ -42198,9 +46941,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42211,12 +46960,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_type"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_type"
+                      }
+                    }
                   }
                 }
               }
@@ -42238,9 +46993,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42251,9 +47012,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42264,9 +47031,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42310,9 +47083,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
                           }
                         }
                       },
@@ -42323,9 +47102,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
                           }
                         }
                       },
@@ -42336,9 +47121,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "boolean"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "boolean"
+                              }
+                            }
                           }
                         }
                       },
@@ -42369,9 +47160,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -42382,9 +47179,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -42395,9 +47198,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -42408,9 +47217,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -42419,15 +47234,21 @@
               {
                 "key": "state",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "published"
-                    },
-                    {
-                      "value": "draft"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "published"
+                        },
+                        {
+                          "value": "draft"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "Whether the article will be `published` or will be a `draft`. Defaults to draft. For multilingual articles, this will be the state of the default language's content."
               },
@@ -42436,9 +47257,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -42449,9 +47276,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -42462,8 +47295,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_translated_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_translated_content"
+                      }
+                    }
                   }
                 }
               }
@@ -42484,9 +47323,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42497,9 +47342,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42510,12 +47361,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_translated_content"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_translated_content"
+                      }
+                    }
                   }
                 }
               }
@@ -42526,13 +47383,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -42555,9 +47418,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42568,9 +47437,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42581,9 +47456,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42594,13 +47475,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -42613,13 +47500,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -42632,13 +47525,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -42651,13 +47550,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -42670,13 +47575,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -42689,13 +47600,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -42708,13 +47625,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 }
@@ -42727,11 +47650,17 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": []
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": []
+                    }
+                  }
                 }
               }
             },
@@ -42752,9 +47681,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -42765,8 +47700,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "custom_attributes"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "custom_attributes"
+                  }
+                }
               }
             }
           }
@@ -42785,9 +47726,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -42798,9 +47745,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42811,13 +47764,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -42830,9 +47789,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -42851,27 +47816,39 @@
           {
             "key": "ticket_attributes",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": []
+                }
+              }
             },
             "description": "The attributes set on the ticket."
           },
           {
             "key": "state",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "in_progress"
-                },
-                {
-                  "value": "waiting_on_customer"
-                },
-                {
-                  "value": "resolved"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "in_progress"
+                    },
+                    {
+                      "value": "waiting_on_customer"
+                    },
+                    {
+                      "value": "resolved"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The state of the ticket."
           },
@@ -42880,9 +47857,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -42893,9 +47876,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -42906,9 +47895,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -42917,36 +47912,54 @@
           {
             "key": "assignment",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "admin_id",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "admin_id",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The ID of the admin performing the action."
+                    },
+                    {
+                      "key": "assignee_id",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The ID of the admin or team to which the ticket is assigned. Set this 0 to unassign it."
                     }
-                  },
-                  "description": "The ID of the admin performing the action."
-                },
-                {
-                  "key": "assignee_id",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "description": "The ID of the admin or team to which the ticket is assigned. Set this 0 to unassign it."
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -42964,9 +47977,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42977,9 +47996,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42990,10 +48015,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean",
-                  "default": false
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean",
+                      "default": false
+                    }
+                  }
                 }
               }
             },
@@ -43004,10 +48035,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean",
-                  "default": false
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean",
+                      "default": false
+                    }
+                  }
                 }
               }
             },
@@ -43018,10 +48055,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean",
-                  "default": true
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean",
+                      "default": true
+                    }
+                  }
                 }
               }
             },
@@ -43032,10 +48075,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean",
-                  "default": true
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean",
+                      "default": true
+                    }
+                  }
                 }
               }
             },
@@ -43046,9 +48095,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -43059,9 +48114,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -43072,9 +48133,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -43085,9 +48152,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -43112,9 +48185,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -43125,9 +48204,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -43136,18 +48221,24 @@
               {
                 "key": "category",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "Customer"
-                    },
-                    {
-                      "value": "Back-office"
-                    },
-                    {
-                      "value": "Tracker"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "Customer"
+                        },
+                        {
+                          "value": "Back-office"
+                        },
+                        {
+                          "value": "Tracker"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "Category of the Ticket Type."
               },
@@ -43156,10 +48247,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "default": "🎟️"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "default": "🎟️"
+                        }
+                      }
                     }
                   }
                 },
@@ -43170,9 +48267,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -43183,10 +48286,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean",
-                      "default": false
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean",
+                          "default": false
+                        }
+                      }
                     }
                   }
                 },
@@ -43238,10 +48347,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "default": "visitor"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "default": "visitor"
+                        }
+                      }
                     }
                   }
                 },
@@ -43252,9 +48367,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -43265,9 +48386,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -43278,9 +48405,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -43291,10 +48424,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "format": "email"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "format": "email"
+                        }
+                      }
                     }
                   }
                 },
@@ -43305,13 +48444,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43324,13 +48469,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43343,13 +48494,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43360,44 +48517,62 @@
               {
                 "key": "avatar",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string",
-                            "default": "avatar"
-                          }
-                        }
-                      },
-                      "description": ""
-                    },
-                    {
-                      "key": "image_url",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "nullable",
-                          "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string",
-                                "format": "uri"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string",
+                                    "default": "avatar"
+                                  }
+                                }
                               }
                             }
-                          }
+                          },
+                          "description": ""
+                        },
+                        {
+                          "key": "image_url",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "nullable",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "This object represents the avatar associated with the visitor."
                         }
-                      },
-                      "description": "This object represents the avatar associated with the visitor."
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
@@ -43405,9 +48580,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -43416,152 +48597,224 @@
               {
                 "key": "companies",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "enum",
-                        "values": [
-                          {
-                            "value": "company.list"
-                          }
-                        ]
-                      },
-                      "description": "The type of the object"
-                    },
-                    {
-                      "key": "companies",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "list",
-                          "itemShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "id",
-                              "id": "company"
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "company.list"
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "description": "The type of the object"
+                        },
+                        {
+                          "key": "companies",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "list",
+                                  "itemShape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "id",
+                                      "id": "company"
+                                    }
+                                  }
+                                }
+                              }
                             }
                           }
                         }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
                 "key": "location_data",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string",
-                            "default": "location_data"
-                          }
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string",
+                                    "default": "location_data"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": ""
+                        },
+                        {
+                          "key": "city_name",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The city name of the visitor."
+                        },
+                        {
+                          "key": "continent_code",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The continent code of the visitor."
+                        },
+                        {
+                          "key": "country_code",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The country code of the visitor."
+                        },
+                        {
+                          "key": "country_name",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The country name of the visitor."
+                        },
+                        {
+                          "key": "postal_code",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The postal code of the visitor."
+                        },
+                        {
+                          "key": "region_name",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The region name of the visitor."
+                        },
+                        {
+                          "key": "timezone",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The timezone of the visitor."
                         }
-                      },
-                      "description": ""
-                    },
-                    {
-                      "key": "city_name",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The city name of the visitor."
-                    },
-                    {
-                      "key": "continent_code",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The continent code of the visitor."
-                    },
-                    {
-                      "key": "country_code",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The country code of the visitor."
-                    },
-                    {
-                      "key": "country_name",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The country name of the visitor."
-                    },
-                    {
-                      "key": "postal_code",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The postal code of the visitor."
-                    },
-                    {
-                      "key": "region_name",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The region name of the visitor."
-                    },
-                    {
-                      "key": "timezone",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The timezone of the visitor."
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
@@ -43569,9 +48822,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -43582,9 +48841,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -43595,9 +48860,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -43608,9 +48879,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -43621,9 +48898,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -43634,9 +48917,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -43645,40 +48934,58 @@
               {
                 "key": "social_profiles",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "enum",
-                        "values": [
-                          {
-                            "value": "social_profile.list"
-                          }
-                        ]
-                      },
-                      "description": "The type of the object"
-                    },
-                    {
-                      "key": "social_profiles",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "list",
-                          "itemShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "social_profile.list"
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "description": "The type of the object"
+                        },
+                        {
+                          "key": "social_profiles",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "list",
+                                  "itemShape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
                               }
                             }
                           }
                         }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
@@ -43686,13 +48993,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43705,9 +49018,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -43718,9 +49037,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -43731,9 +49056,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -43742,114 +49073,168 @@
               {
                 "key": "tags",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "enum",
-                        "values": [
-                          {
-                            "value": "tag.list"
-                          }
-                        ]
-                      },
-                      "description": "The type of the object"
-                    },
-                    {
-                      "key": "tags",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "list",
-                          "itemShape": {
-                            "type": "object",
-                            "extends": [],
-                            "properties": [
-                              {
-                                "key": "type",
-                                "valueShape": {
-                                  "type": "enum",
-                                  "values": [
-                                    {
-                                      "value": "tag"
-                                    }
-                                  ]
-                                },
-                                "description": "The type of the object"
-                              },
-                              {
-                                "key": "id",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "string"
-                                    }
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "tag.list"
                                   }
-                                },
-                                "description": "The id of the tag."
-                              },
-                              {
-                                "key": "name",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  }
-                                },
-                                "description": "The name of the tag."
+                                ]
                               }
-                            ]
+                            }
+                          },
+                          "description": "The type of the object"
+                        },
+                        {
+                          "key": "tags",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "list",
+                                  "itemShape": {
+                                    "type": "object",
+                                    "extends": [],
+                                    "properties": [
+                                      {
+                                        "key": "type",
+                                        "valueShape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "optional",
+                                            "shape": {
+                                              "type": "enum",
+                                              "values": [
+                                                {
+                                                  "value": "tag"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "description": "The type of the object"
+                                      },
+                                      {
+                                        "key": "id",
+                                        "valueShape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "optional",
+                                            "shape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "primitive",
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "description": "The id of the tag."
+                                      },
+                                      {
+                                        "key": "name",
+                                        "valueShape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "optional",
+                                            "shape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "primitive",
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "description": "The name of the tag."
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            }
                           }
                         }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
                 "key": "segments",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "enum",
-                        "values": [
-                          {
-                            "value": "segment.list"
-                          }
-                        ]
-                      },
-                      "description": "The type of the object"
-                    },
-                    {
-                      "key": "segments",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "list",
-                          "itemShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "segment.list"
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "description": "The type of the object"
+                        },
+                        {
+                          "key": "segments",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "list",
+                                  "itemShape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
                               }
                             }
                           }
                         }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
@@ -43857,22 +49242,28 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "map",
-                    "keyShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "valueShape": {
-                      "type": "alias",
-                      "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "map",
+                        "keyShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "valueShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43885,13 +49276,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43904,13 +49301,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43923,13 +49326,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43942,13 +49351,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43961,13 +49376,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43980,13 +49401,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43999,13 +49426,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "boolean"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "boolean"
+                            }
+                          }
                         }
                       }
                     }
@@ -44030,9 +49463,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -44041,12 +49480,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "visitor"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "visitor"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object which was deleted"
           },
@@ -44055,9 +49500,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -44193,108 +49644,108 @@
     }
   },
   "subpackages": {
-    "subpackage_admins": {
-      "id": "subpackage_admins",
+    "admins": {
+      "id": "admins",
       "name": "admins",
       "displayName": "Admins"
     },
-    "subpackage_articles": {
-      "id": "subpackage_articles",
+    "articles": {
+      "id": "articles",
       "name": "articles",
       "displayName": "Articles"
     },
-    "subpackage_helpCenter": {
-      "id": "subpackage_helpCenter",
+    "helpCenter": {
+      "id": "helpCenter",
       "name": "helpCenter",
       "displayName": "Help Center"
     },
-    "subpackage_companies": {
-      "id": "subpackage_companies",
+    "companies": {
+      "id": "companies",
       "name": "companies",
       "displayName": "Companies"
     },
-    "subpackage_contacts": {
-      "id": "subpackage_contacts",
+    "contacts": {
+      "id": "contacts",
       "name": "contacts",
       "displayName": "Contacts"
     },
-    "subpackage_notes": {
-      "id": "subpackage_notes",
+    "notes": {
+      "id": "notes",
       "name": "notes",
       "displayName": "Notes"
     },
-    "subpackage_subscriptionTypes": {
-      "id": "subpackage_subscriptionTypes",
+    "subscriptionTypes": {
+      "id": "subscriptionTypes",
       "name": "subscriptionTypes",
       "displayName": "Subscription Types"
     },
-    "subpackage_tags": {
-      "id": "subpackage_tags",
+    "tags": {
+      "id": "tags",
       "name": "tags",
       "displayName": "Tags"
     },
-    "subpackage_conversations": {
-      "id": "subpackage_conversations",
+    "conversations": {
+      "id": "conversations",
       "name": "conversations",
       "displayName": "Conversations"
     },
-    "subpackage_dataAttributes": {
-      "id": "subpackage_dataAttributes",
+    "dataAttributes": {
+      "id": "dataAttributes",
       "name": "dataAttributes",
       "displayName": "Data Attributes"
     },
-    "subpackage_dataEvents": {
-      "id": "subpackage_dataEvents",
+    "dataEvents": {
+      "id": "dataEvents",
       "name": "dataEvents",
       "displayName": "Data Events"
     },
-    "subpackage_dataExport": {
-      "id": "subpackage_dataExport",
+    "dataExport": {
+      "id": "dataExport",
       "name": "dataExport",
       "displayName": "Data Export"
     },
-    "subpackage_messages": {
-      "id": "subpackage_messages",
+    "messages": {
+      "id": "messages",
       "name": "messages",
       "displayName": "Messages"
     },
-    "subpackage_news": {
-      "id": "subpackage_news",
+    "news": {
+      "id": "news",
       "name": "news",
       "displayName": "News"
     },
-    "subpackage_segments": {
-      "id": "subpackage_segments",
+    "segments": {
+      "id": "segments",
       "name": "segments",
       "displayName": "Segments"
     },
-    "subpackage_switch": {
-      "id": "subpackage_switch",
+    "switch": {
+      "id": "switch",
       "name": "switch",
       "displayName": "Switch"
     },
-    "subpackage_teams": {
-      "id": "subpackage_teams",
+    "teams": {
+      "id": "teams",
       "name": "teams",
       "displayName": "Teams"
     },
-    "subpackage_ticketTypeAttributes": {
-      "id": "subpackage_ticketTypeAttributes",
+    "ticketTypeAttributes": {
+      "id": "ticketTypeAttributes",
       "name": "ticketTypeAttributes",
       "displayName": "Ticket Type Attributes"
     },
-    "subpackage_ticketTypes": {
-      "id": "subpackage_ticketTypes",
+    "ticketTypes": {
+      "id": "ticketTypes",
       "name": "ticketTypes",
       "displayName": "Ticket Types"
     },
-    "subpackage_tickets": {
-      "id": "subpackage_tickets",
+    "tickets": {
+      "id": "tickets",
       "name": "tickets",
       "displayName": "Tickets"
     },
-    "subpackage_visitors": {
-      "id": "subpackage_visitors",
+    "visitors": {
+      "id": "visitors",
       "name": "visitors",
       "displayName": "Visitors"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/openapi-filter.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/openapi-filter.json
@@ -1,12 +1,9 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_admins.identifyAdmin": {
-      "id": "endpoint_admins.identifyAdmin",
+    "endpoint_.identifyAdmin": {
+      "id": "endpoint_.identifyAdmin",
       "description": "\nYou can view the currently authorised admin along with the embedded app object (a \"workspace\" in legacy terminology).\n\n> 🚧 Single Sign On\n>\n> If you are building a custom \"Log in with Intercom\" flow for your site, and you call the `/me` endpoint to identify the logged-in user, you should not accept any sign-ins from users with unverified email addresses as it poses a potential impersonation security risk.\n",
-      "namespace": [
-        "Admins"
-      ],
       "displayName": "Identify an admin",
       "operationId": "identifyAdmin",
       "method": "GET",
@@ -110,12 +107,9 @@
         "type": "rest"
       }
     },
-    "endpoint_admins.setAwayAdmin": {
-      "id": "endpoint_admins.setAwayAdmin",
+    "endpoint_.setAwayAdmin": {
+      "id": "endpoint_.setAwayAdmin",
       "description": "You can set an Admin as away for the Inbox.",
-      "namespace": [
-        "Admins"
-      ],
       "displayName": "Set an admin to away",
       "operationId": "setAwayAdmin",
       "method": "PUT",
@@ -404,12 +398,9 @@
         "type": "rest"
       }
     },
-    "endpoint_admins.listActivityLogs": {
-      "id": "endpoint_admins.listActivityLogs",
+    "endpoint_.listActivityLogs": {
+      "id": "endpoint_.listActivityLogs",
       "description": "You can get a log of activities by all admins in an app.",
-      "namespace": [
-        "Admins"
-      ],
       "displayName": "List all activity logs",
       "operationId": "listActivityLogs",
       "method": "GET",
@@ -615,12 +606,9 @@
         "type": "rest"
       }
     },
-    "endpoint_admins.listAdmins": {
-      "id": "endpoint_admins.listAdmins",
+    "endpoint_.listAdmins": {
+      "id": "endpoint_.listAdmins",
       "description": "You can fetch a list of admins for a given workspace.",
-      "namespace": [
-        "Admins"
-      ],
       "displayName": "List all admins",
       "operationId": "listAdmins",
       "method": "GET",
@@ -748,12 +736,9 @@
         "type": "rest"
       }
     },
-    "endpoint_admins.retrieveAdmin": {
-      "id": "endpoint_admins.retrieveAdmin",
+    "endpoint_.retrieveAdmin": {
+      "id": "endpoint_.retrieveAdmin",
       "description": "You can retrieve the details of a single admin.",
-      "namespace": [
-        "Admins"
-      ],
       "displayName": "Retrieve an admin",
       "operationId": "retrieveAdmin",
       "method": "GET",
@@ -932,12 +917,9 @@
         "type": "rest"
       }
     },
-    "endpoint_articles.listArticles": {
-      "id": "endpoint_articles.listArticles",
+    "endpoint_.listArticles": {
+      "id": "endpoint_.listArticles",
       "description": "You can fetch a list of all articles by making a GET request to `https://api.intercom.io/articles`.\n\n> 📘 How are the articles sorted and ordered?\n>\n> Articles will be returned in descending order on the `updated_at` attribute. This means if you need to iterate through results then we'll show the most recently updated articles first.\n",
-      "namespace": [
-        "Articles"
-      ],
       "displayName": "List all articles",
       "operationId": "listArticles",
       "method": "GET",
@@ -1078,12 +1060,9 @@
         "type": "rest"
       }
     },
-    "endpoint_articles.createArticle": {
-      "id": "endpoint_articles.createArticle",
+    "endpoint_.createArticle": {
+      "id": "endpoint_.createArticle",
       "description": "You can create a new article by making a POST request to `https://api.intercom.io/articles`.",
-      "namespace": [
-        "Articles"
-      ],
       "displayName": "Create an article",
       "operationId": "createArticle",
       "method": "POST",
@@ -1326,12 +1305,9 @@
         "type": "rest"
       }
     },
-    "endpoint_articles.retrieveArticle": {
-      "id": "endpoint_articles.retrieveArticle",
+    "endpoint_.retrieveArticle": {
+      "id": "endpoint_.retrieveArticle",
       "description": "You can fetch the details of a single article by making a GET request to `https://api.intercom.io/articles/<id>`.",
-      "namespace": [
-        "Articles"
-      ],
       "displayName": "Retrieve an article",
       "operationId": "retrieveArticle",
       "method": "GET",
@@ -1525,12 +1501,9 @@
         "type": "rest"
       }
     },
-    "endpoint_articles.updateArticle": {
-      "id": "endpoint_articles.updateArticle",
+    "endpoint_.updateArticle": {
+      "id": "endpoint_.updateArticle",
       "description": "You can update the details of a single article by making a PUT request to `https://api.intercom.io/articles/<id>`.",
-      "namespace": [
-        "Articles"
-      ],
       "displayName": "Update an article",
       "operationId": "updateArticle",
       "method": "PUT",
@@ -2200,12 +2173,9 @@
         "type": "rest"
       }
     },
-    "endpoint_articles.deleteArticle": {
-      "id": "endpoint_articles.deleteArticle",
+    "endpoint_.deleteArticle": {
+      "id": "endpoint_.deleteArticle",
       "description": "You can delete a single article by making a DELETE request to `https://api.intercom.io/articles/<id>`.",
-      "namespace": [
-        "Articles"
-      ],
       "displayName": "Delete an article",
       "operationId": "deleteArticle",
       "method": "DELETE",
@@ -2379,12 +2349,9 @@
         "type": "rest"
       }
     },
-    "endpoint_articles.searchArticles": {
-      "id": "endpoint_articles.searchArticles",
+    "endpoint_.searchArticles": {
+      "id": "endpoint_.searchArticles",
       "description": "You can search for articles by making a GET request to `https://api.intercom.io/articles/search`.",
-      "namespace": [
-        "Articles"
-      ],
       "displayName": "Search for articles",
       "operationId": "searchArticles",
       "method": "GET",
@@ -2614,12 +2581,9 @@
         "type": "rest"
       }
     },
-    "endpoint_helpCenter.listAllCollections": {
-      "id": "endpoint_helpCenter.listAllCollections",
+    "endpoint_.listAllCollections": {
+      "id": "endpoint_.listAllCollections",
       "description": "You can fetch a list of all collections by making a GET request to `https://api.intercom.io/help_center/collections`.\n\nCollections will be returned in descending order on the `updated_at` attribute. This means if you need to iterate through results then we'll show the most recently updated collections first.\n",
-      "namespace": [
-        "Help Center"
-      ],
       "displayName": "List all collections",
       "operationId": "listAllCollections",
       "method": "GET",
@@ -2778,12 +2742,9 @@
         "type": "rest"
       }
     },
-    "endpoint_helpCenter.createCollection": {
-      "id": "endpoint_helpCenter.createCollection",
+    "endpoint_.createCollection": {
+      "id": "endpoint_.createCollection",
       "description": "You can create a new collection by making a POST request to `https://api.intercom.io/help_center/collections.`",
-      "namespace": [
-        "Help Center"
-      ],
       "displayName": "Create a collection",
       "operationId": "createCollection",
       "method": "POST",
@@ -2992,12 +2953,9 @@
         "type": "rest"
       }
     },
-    "endpoint_helpCenter.retrieveCollection": {
-      "id": "endpoint_helpCenter.retrieveCollection",
+    "endpoint_.retrieveCollection": {
+      "id": "endpoint_.retrieveCollection",
       "description": "You can fetch the details of a single collection by making a GET request to `https://api.intercom.io/help_center/collections/<id>`.",
-      "namespace": [
-        "Help Center"
-      ],
       "displayName": "Retrieve a collection",
       "operationId": "retrieveCollection",
       "method": "GET",
@@ -3187,12 +3145,9 @@
         "type": "rest"
       }
     },
-    "endpoint_helpCenter.updateCollection": {
-      "id": "endpoint_helpCenter.updateCollection",
+    "endpoint_.updateCollection": {
+      "id": "endpoint_.updateCollection",
       "description": "You can update the details of a single collection by making a PUT request to `https://api.intercom.io/collections/<id>`.",
-      "namespace": [
-        "Help Center"
-      ],
       "displayName": "Update a collection",
       "operationId": "updateCollection",
       "method": "PUT",
@@ -3619,12 +3574,9 @@
         "type": "rest"
       }
     },
-    "endpoint_helpCenter.deleteCollection": {
-      "id": "endpoint_helpCenter.deleteCollection",
+    "endpoint_.deleteCollection": {
+      "id": "endpoint_.deleteCollection",
       "description": "You can delete a single collection by making a DELETE request to `https://api.intercom.io/collections/<id>`.",
-      "namespace": [
-        "Help Center"
-      ],
       "displayName": "Delete a collection",
       "operationId": "deleteCollection",
       "method": "DELETE",
@@ -3806,12 +3758,9 @@
         "type": "rest"
       }
     },
-    "endpoint_helpCenter.retrieveHelpCenter": {
-      "id": "endpoint_helpCenter.retrieveHelpCenter",
+    "endpoint_.retrieveHelpCenter": {
+      "id": "endpoint_.retrieveHelpCenter",
       "description": "You can fetch the details of a single Help Center by making a GET request to `https://api.intercom.io/help_center/help_center/<id>`.",
-      "namespace": [
-        "Help Center"
-      ],
       "displayName": "Retrieve a Help Center",
       "operationId": "retrieveHelpCenter",
       "method": "GET",
@@ -3997,12 +3946,9 @@
         "type": "rest"
       }
     },
-    "endpoint_helpCenter.listHelpCenters": {
-      "id": "endpoint_helpCenter.listHelpCenters",
+    "endpoint_.listHelpCenters": {
+      "id": "endpoint_.listHelpCenters",
       "description": "You can list all Help Centers by making a GET request to `https://api.intercom.io/help_center/help_centers`.",
-      "namespace": [
-        "Help Center"
-      ],
       "displayName": "List all Help Centers",
       "operationId": "listHelpCenters",
       "method": "GET",
@@ -4127,12 +4073,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.retrieveCompany": {
-      "id": "endpoint_companies.retrieveCompany",
+    "endpoint_.retrieveCompany": {
+      "id": "endpoint_.retrieveCompany",
       "description": "You can fetch a single company by passing in `company_id` or `name`.\n\n  `https://api.intercom.io/companies?name={name}`\n\n  `https://api.intercom.io/companies?company_id={company_id}`\n\nYou can fetch all companies and filter by `segment_id` or `tag_id` as a query parameter.\n\n  `https://api.intercom.io/companies?tag_id={tag_id}`\n\n  `https://api.intercom.io/companies?segment_id={segment_id}`\n",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "Retrieve companies",
       "operationId": "retrieveCompany",
       "method": "GET",
@@ -4427,12 +4370,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.createOrUpdateCompany": {
-      "id": "endpoint_companies.createOrUpdateCompany",
+    "endpoint_.createOrUpdateCompany": {
+      "id": "endpoint_.createOrUpdateCompany",
       "description": "You can create or update a company.\n\nCompanies will be only visible in Intercom when there is at least one associated user.\n\nCompanies are looked up via `company_id` in a `POST` request, if not found via `company_id`, the new company will be created, if found, that company will be updated.\n\n{% admonition type=\"attention\" name=\"Using `company_id`\" %}\n  You can set a unique `company_id` value when creating a company. However, it is not possible to update `company_id`. Be sure to set a unique value once upon creation of the company.\n{% /admonition %}\n",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "Create or Update a company",
       "operationId": "createOrUpdateCompany",
       "method": "POST",
@@ -4659,12 +4599,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.RetrieveACompanyById": {
-      "id": "endpoint_companies.RetrieveACompanyById",
+    "endpoint_.RetrieveACompanyById": {
+      "id": "endpoint_.RetrieveACompanyById",
       "description": "You can fetch a single company.",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "Retrieve a company by ID",
       "operationId": "RetrieveACompanyById",
       "method": "GET",
@@ -4856,12 +4793,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.UpdateCompany": {
-      "id": "endpoint_companies.UpdateCompany",
+    "endpoint_.UpdateCompany": {
+      "id": "endpoint_.UpdateCompany",
       "description": "You can update a single company using the Intercom provisioned `id`.\n\n{% admonition type=\"attention\" name=\"Using `company_id`\" %}\n  When updating a company it is not possible to update `company_id`. This can only be set once upon creation of the company.\n{% /admonition %}\n",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "Update a company",
       "operationId": "UpdateCompany",
       "method": "PUT",
@@ -5053,12 +4987,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.deleteCompany": {
-      "id": "endpoint_companies.deleteCompany",
+    "endpoint_.deleteCompany": {
+      "id": "endpoint_.deleteCompany",
       "description": "You can delete a single company.",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "Delete a company",
       "operationId": "deleteCompany",
       "method": "DELETE",
@@ -5232,13 +5163,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companiesContacts.ListAttachedContacts": {
-      "id": "endpoint_companiesContacts.ListAttachedContacts",
+    "endpoint_.ListAttachedContacts": {
+      "id": "endpoint_.ListAttachedContacts",
       "description": "You can fetch a list of all contacts that belong to a company.",
-      "namespace": [
-        "Companies",
-        "Contacts"
-      ],
       "displayName": "List attached contacts",
       "operationId": "ListAttachedContacts",
       "method": "GET",
@@ -5426,12 +5353,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.ListAttachedSegmentsForCompanies": {
-      "id": "endpoint_companies.ListAttachedSegmentsForCompanies",
+    "endpoint_.ListAttachedSegmentsForCompanies": {
+      "id": "endpoint_.ListAttachedSegmentsForCompanies",
       "description": "You can fetch a list of all segments that belong to a company.",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "List attached segments for companies",
       "operationId": "ListAttachedSegmentsForCompanies",
       "method": "GET",
@@ -5612,12 +5536,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.listAllCompanies": {
-      "id": "endpoint_companies.listAllCompanies",
+    "endpoint_.listAllCompanies": {
+      "id": "endpoint_.listAllCompanies",
       "description": "You can list companies. The company list is sorted by the `last_request_at` field and by default is ordered descending, most recently requested first.\n\nNote that the API does not include companies who have no associated users in list responses.\n\nWhen using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "List all companies",
       "operationId": "listAllCompanies",
       "method": "POST",
@@ -5833,12 +5754,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companies.scrollOverAllCompanies": {
-      "id": "endpoint_companies.scrollOverAllCompanies",
+    "endpoint_.scrollOverAllCompanies": {
+      "id": "endpoint_.scrollOverAllCompanies",
       "description": "      The `list all companies` functionality does not work well for huge datasets, and can result in errors and performance problems when paging deeply. The Scroll API provides an efficient mechanism for iterating over all companies in a dataset.\n\n- Each app can only have 1 scroll open at a time. You'll get an error message if you try to have more than one open per app.\n- If the scroll isn't used for 1 minute, it expires and calls with that scroll param will fail\n- If the end of the scroll is reached, \"companies\" will be empty and the scroll parameter will expire\n\n{% admonition type=\"info\" name=\"Scroll Parameter\" %}\n  You can get the first page of companies by simply sending a GET request to the scroll endpoint.\n  For subsequent requests you will need to use the scroll parameter from the response.\n{% /admonition %}\n{% admonition type=\"danger\" name=\"Scroll network timeouts\" %}\n  Since scroll is often used on large datasets network errors such as timeouts can be encountered. When this occurs you will see a HTTP 500 error with the following message:\n  \"Request failed due to an internal network error. Please restart the scroll operation.\"\n  If this happens, you will need to restart your scroll query: It is not possible to continue from a specific point when using scroll.\n{% /admonition %}\n",
-      "namespace": [
-        "Companies"
-      ],
       "displayName": "Scroll over all companies",
       "operationId": "scrollOverAllCompanies",
       "method": "GET",
@@ -6011,13 +5929,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contactsCompanies.listCompaniesForAContact": {
-      "id": "endpoint_contactsCompanies.listCompaniesForAContact",
+    "endpoint_.listCompaniesForAContact": {
+      "id": "endpoint_.listCompaniesForAContact",
       "description": "You can fetch a list of companies that are associated to a contact.",
-      "namespace": [
-        "Contacts",
-        "Companies"
-      ],
       "displayName": "List attached companies for contact",
       "operationId": "listCompaniesForAContact",
       "method": "GET",
@@ -6231,13 +6145,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companiesContacts.attachContactToACompany": {
-      "id": "endpoint_companiesContacts.attachContactToACompany",
+    "endpoint_.attachContactToACompany": {
+      "id": "endpoint_.attachContactToACompany",
       "description": "You can attach a company to a single contact.",
-      "namespace": [
-        "Companies",
-        "Contacts"
-      ],
       "displayName": "Attach a Contact to a Company",
       "operationId": "attachContactToACompany",
       "method": "POST",
@@ -6575,13 +6485,9 @@
         "type": "rest"
       }
     },
-    "endpoint_companiesContacts.detachContactFromACompany": {
-      "id": "endpoint_companiesContacts.detachContactFromACompany",
+    "endpoint_.detachContactFromACompany": {
+      "id": "endpoint_.detachContactFromACompany",
       "description": "You can detach a company from a single contact.",
-      "namespace": [
-        "Companies",
-        "Contacts"
-      ],
       "displayName": "Detach a contact from a company",
       "operationId": "detachContactFromACompany",
       "method": "DELETE",
@@ -6819,13 +6725,9 @@
         "type": "rest"
       }
     },
-    "endpoint_notesContacts.listNotes": {
-      "id": "endpoint_notesContacts.listNotes",
+    "endpoint_.listNotes": {
+      "id": "endpoint_.listNotes",
       "description": "You can fetch a list of notes that are associated to a contact.",
-      "namespace": [
-        "Notes",
-        "Contacts"
-      ],
       "displayName": "List all notes",
       "operationId": "listNotes",
       "method": "GET",
@@ -7039,13 +6941,9 @@
         "type": "rest"
       }
     },
-    "endpoint_notesContacts.createNote": {
-      "id": "endpoint_notesContacts.createNote",
+    "endpoint_.createNote": {
+      "id": "endpoint_.createNote",
       "description": "You can add a note to a single contact.",
-      "namespace": [
-        "Notes",
-        "Contacts"
-      ],
       "displayName": "Create a note",
       "operationId": "createNote",
       "method": "POST",
@@ -7370,13 +7268,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contactsSegments.listSegmentsForAContact": {
-      "id": "endpoint_contactsSegments.listSegmentsForAContact",
+    "endpoint_.listSegmentsForAContact": {
+      "id": "endpoint_.listSegmentsForAContact",
       "description": "You can fetch a list of segments that are associated to a contact.",
-      "namespace": [
-        "Contacts",
-        "Segments"
-      ],
       "displayName": "List attached segments for contact",
       "operationId": "listSegmentsForAContact",
       "method": "GET",
@@ -7566,13 +7460,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contactsSubscriptionTypes.listSubscriptionsForAContact": {
-      "id": "endpoint_contactsSubscriptionTypes.listSubscriptionsForAContact",
+    "endpoint_.listSubscriptionsForAContact": {
+      "id": "endpoint_.listSubscriptionsForAContact",
       "description": "You can fetch a list of subscription types that are attached to a contact. These can be subscriptions that a user has 'opted-in' to or has 'opted-out' from, depending on the subscription type.\nThis will return a list of Subscription Type objects that the contact is associated with.\n\nThe data property will show a combined list of:\n\n  1.Opt-out subscription types that the user has opted-out from.\n  2.Opt-in subscription types that the user has opted-in to receiving.\n",
-      "namespace": [
-        "Contacts",
-        "Subscription Types"
-      ],
       "displayName": "List subscriptions for a contact",
       "operationId": "listSubscriptionsForAContact",
       "method": "GET",
@@ -7796,13 +7686,9 @@
         "type": "rest"
       }
     },
-    "endpoint_subscriptionTypesContacts.attachSubscriptionTypeToContact": {
-      "id": "endpoint_subscriptionTypesContacts.attachSubscriptionTypeToContact",
+    "endpoint_.attachSubscriptionTypeToContact": {
+      "id": "endpoint_.attachSubscriptionTypeToContact",
       "description": "You can add a specific subscription to a contact. In Intercom, we have two different subscription types based on user consent - opt-out and opt-in:\n\n  1.Attaching a contact to an opt-out subscription type will opt that user out from receiving messages related to that subscription type.\n\n  2.Attaching a contact to an opt-in subscription type will opt that user in to receiving messages related to that subscription type.\n\nThis will return a subscription type model for the subscription type that was added to the contact.\n",
-      "namespace": [
-        "Subscription Types",
-        "Contacts"
-      ],
       "displayName": "Add subscription to a contact",
       "operationId": "attachSubscriptionTypeToContact",
       "method": "POST",
@@ -8138,13 +8024,9 @@
         "type": "rest"
       }
     },
-    "endpoint_subscriptionTypesContacts.detachSubscriptionTypeToContact": {
-      "id": "endpoint_subscriptionTypesContacts.detachSubscriptionTypeToContact",
+    "endpoint_.detachSubscriptionTypeToContact": {
+      "id": "endpoint_.detachSubscriptionTypeToContact",
       "description": "You can remove a specific subscription from a contact. This will return a subscription type model for the subscription type that was removed from the contact.",
-      "namespace": [
-        "Subscription Types",
-        "Contacts"
-      ],
       "displayName": "Remove subscription from a contact",
       "operationId": "detachSubscriptionTypeToContact",
       "method": "DELETE",
@@ -8380,13 +8262,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contactsTags.listTagsForAContact": {
-      "id": "endpoint_contactsTags.listTagsForAContact",
+    "endpoint_.listTagsForAContact": {
+      "id": "endpoint_.listTagsForAContact",
       "description": "You can fetch a list of all tags that are attached to a specific contact.",
-      "namespace": [
-        "Contacts",
-        "Tags"
-      ],
       "displayName": "List tags attached to a contact",
       "operationId": "listTagsForAContact",
       "method": "GET",
@@ -8573,13 +8451,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tagsContacts.attachTagToContact": {
-      "id": "endpoint_tagsContacts.attachTagToContact",
+    "endpoint_.attachTagToContact": {
+      "id": "endpoint_.attachTagToContact",
       "description": "You can tag a specific contact. This will return a tag object for the tag that was added to the contact.",
-      "namespace": [
-        "Tags",
-        "Contacts"
-      ],
       "displayName": "Add tag to a contact",
       "operationId": "attachTagToContact",
       "method": "POST",
@@ -8861,13 +8735,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tagsContacts.detachTagFromContact": {
-      "id": "endpoint_tagsContacts.detachTagFromContact",
+    "endpoint_.detachTagFromContact": {
+      "id": "endpoint_.detachTagFromContact",
       "description": "You can remove tag from a specific contact. This will return a tag object for the tag that was removed from the contact.",
-      "namespace": [
-        "Tags",
-        "Contacts"
-      ],
       "displayName": "Remove tag from a contact",
       "operationId": "detachTagFromContact",
       "method": "DELETE",
@@ -9087,12 +8957,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.ShowContact": {
-      "id": "endpoint_contacts.ShowContact",
+    "endpoint_.ShowContact": {
+      "id": "endpoint_.ShowContact",
       "description": "You can fetch the details of a single contact.",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Get a contact",
       "operationId": "ShowContact",
       "method": "GET",
@@ -9325,12 +9192,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.UpdateContact": {
-      "id": "endpoint_contacts.UpdateContact",
+    "endpoint_.UpdateContact": {
+      "id": "endpoint_.UpdateContact",
       "description": "You can update an existing contact (ie. user or lead).",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Update a contact",
       "operationId": "UpdateContact",
       "method": "PUT",
@@ -9582,12 +9446,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.DeleteContact": {
-      "id": "endpoint_contacts.DeleteContact",
+    "endpoint_.DeleteContact": {
+      "id": "endpoint_.DeleteContact",
       "description": "You can delete a single contact.",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Delete a contact",
       "operationId": "DeleteContact",
       "method": "DELETE",
@@ -9732,12 +9593,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.MergeContact": {
-      "id": "endpoint_contacts.MergeContact",
+    "endpoint_.MergeContact": {
+      "id": "endpoint_.MergeContact",
       "description": "You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Merge a lead and a user",
       "operationId": "MergeContact",
       "method": "POST",
@@ -9971,12 +9829,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.SearchContacts": {
-      "id": "endpoint_contacts.SearchContacts",
+    "endpoint_.SearchContacts": {
+      "id": "endpoint_.SearchContacts",
       "description": "You can search for multiple contacts by the value of their attributes in order to fetch exactly who you want.\n\nTo search for contacts, you need to send a `POST` request to `https://api.intercom.io/contacts/search`.\n\nThis will accept a query object in the body which will define your filters in order to search for contacts.\n\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `50` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n### Contact Creation Delay\n\nIf a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiple's there can be:\n* There's a limit of max 2 nested filters\n* There's a limit of max 15 filters for each AND or OR group\n\n### Searching for Timestamp Fields\n\nAll timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second.\nFor example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM). The search results will then include Contacts created from January 2nd, 2020 12:00 AM onwards.\nIf you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM).\nThis behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.\n\n### Accepted Fields\n\nMost key listed as part of the Contacts Model are searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foorbar\"`).\n\n| Field                              | Type                           |\n| ---------------------------------- | ------------------------------ |\n| id                                 | String                         |\n| role                               | String<br>Accepts user or lead |\n| name                               | String                         |\n| avatar                             | String                         |\n| owner_id                           | Integer                        |\n| email                              | String                         |\n| email_domain                       | String                         |\n| phone                              | String                         |\n| formatted_phone                    | String                         |\n| external_id                        | String                         |\n| created_at                         | Date (UNIX Timestamp)          |\n| signed_up_at                       | Date (UNIX Timestamp)          |\n| updated_at                         | Date (UNIX Timestamp)          |\n| last_seen_at                       | Date (UNIX Timestamp)          |\n| last_contacted_at                  | Date (UNIX Timestamp)          |\n| last_replied_at                    | Date (UNIX Timestamp)          |\n| last_email_opened_at               | Date (UNIX Timestamp)          |\n| last_email_clicked_at              | Date (UNIX Timestamp)          |\n| language_override                  | String                         |\n| browser                            | String                         |\n| browser_language                   | String                         |\n| os                                 | String                         |\n| location.country                   | String                         |\n| location.region                    | String                         |\n| location.city                      | String                         |\n| unsubscribed_from_emails           | Boolean                        |\n| marked_email_as_spam               | Boolean                        |\n| has_hard_bounced                   | Boolean                        |\n| ios_last_seen_at                   | Date (UNIX Timestamp)          |\n| ios_app_version                    | String                         |\n| ios_device                         | String                         |\n| ios_app_device                     | String                         |\n| ios_os_version                     | String                         |\n| ios_app_name                       | String                         |\n| ios_sdk_version                    | String                         |\n| android_last_seen_at               | Date (UNIX Timestamp)          |\n| android_app_version                | String                         |\n| android_device                     | String                         |\n| android_app_name                   | String                         |\n| andoid_sdk_version                 | String                         |\n| segment_id                         | String                         |\n| tag_id                             | String                         |\n| custom_attributes.{attribute_name} | String                         |\n\n### Accepted Operators\n\n{% admonition type=\"attention\" name=\"Searching based on `created_at`\" %}\n  You cannot use the `<=` or `>=` operators to search by `created_at`.\n{% /admonition %}\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                      | Description                                                      |\n| :------- | :------------------------------- | :--------------------------------------------------------------- |\n| =        | All                              | Equals                                                           |\n| !=       | All                              | Doesn't Equal                                                    |\n| IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |\n| NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |\n| >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |\n| <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |\n| ~        | String                           | Contains                                                         |\n| !~       | String                           | Doesn't Contain                                                  |\n| ^        | String                           | Starts With                                                      |\n| $        | String                           | Ends With                                                        |\n",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Search contacts",
       "operationId": "SearchContacts",
       "method": "POST",
@@ -10138,12 +9993,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.ListContacts": {
-      "id": "endpoint_contacts.ListContacts",
+    "endpoint_.ListContacts": {
+      "id": "endpoint_.ListContacts",
       "description": "You can fetch a list of all contacts (ie. users or leads) in your workspace.\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `50` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "List all contacts",
       "operationId": "ListContacts",
       "method": "GET",
@@ -10267,12 +10119,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.CreateContact": {
-      "id": "endpoint_contacts.CreateContact",
+    "endpoint_.CreateContact": {
+      "id": "endpoint_.CreateContact",
       "description": "You can create a new contact (ie. user or lead).",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Create contact",
       "operationId": "CreateContact",
       "method": "POST",
@@ -10497,12 +10346,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.ArchiveContact": {
-      "id": "endpoint_contacts.ArchiveContact",
+    "endpoint_.ArchiveContact": {
+      "id": "endpoint_.ArchiveContact",
       "description": "You can archive a single contact.",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Archive contact",
       "operationId": "ArchiveContact",
       "method": "POST",
@@ -10624,12 +10470,9 @@
         "type": "rest"
       }
     },
-    "endpoint_contacts.UnarchiveContact": {
-      "id": "endpoint_contacts.UnarchiveContact",
+    "endpoint_.UnarchiveContact": {
+      "id": "endpoint_.UnarchiveContact",
       "description": "You can unarchive a single contact.",
-      "namespace": [
-        "Contacts"
-      ],
       "displayName": "Unarchive contact",
       "operationId": "UnarchiveContact",
       "method": "POST",
@@ -10751,13 +10594,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tagsConversations.attachTagToConversation": {
-      "id": "endpoint_tagsConversations.attachTagToConversation",
+    "endpoint_.attachTagToConversation": {
+      "id": "endpoint_.attachTagToConversation",
       "description": "You can tag a specific conversation. This will return a tag object for the tag that was added to the conversation.",
-      "namespace": [
-        "Tags",
-        "Conversations"
-      ],
       "displayName": "Add tag to a conversation",
       "operationId": "attachTagToConversation",
       "method": "POST",
@@ -11011,13 +10850,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tagsConversations.detachTagFromConversation": {
-      "id": "endpoint_tagsConversations.detachTagFromConversation",
+    "endpoint_.detachTagFromConversation": {
+      "id": "endpoint_.detachTagFromConversation",
       "description": "You can remove tag from a specific conversation. This will return a tag object for the tag that was removed from the conversation.",
-      "namespace": [
-        "Tags",
-        "Conversations"
-      ],
       "displayName": "Remove tag from a conversation",
       "operationId": "detachTagFromConversation",
       "method": "DELETE",
@@ -11323,12 +11158,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.listConversations": {
-      "id": "endpoint_conversations.listConversations",
+    "endpoint_.listConversations": {
+      "id": "endpoint_.listConversations",
       "description": "You can fetch a list of all conversations.\n\nYou can optionally request the result page size and the cursor to start after to fetch the result.\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "List all conversations",
       "operationId": "listConversations",
       "method": "GET",
@@ -11586,12 +11418,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.createConversation": {
-      "id": "endpoint_conversations.createConversation",
+    "endpoint_.createConversation": {
+      "id": "endpoint_.createConversation",
       "description": "You can create a conversation that has been initiated by a contact (ie. user or lead).\nThe conversation can be an in-app message only.\n\n{% admonition type=\"info\" name=\"Sending for visitors\" %}\nYou can also send a message from a visitor by specifying their `user_id` or `id` value in the `from` field, along with a `type` field value of `contact`.\nThis visitor will be automatically converted to a contact with a lead role once the conversation is created.\n{% /admonition %}\n\nThis will return the Message model that has been created.\n\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Creates a conversation",
       "operationId": "createConversation",
       "method": "POST",
@@ -11820,12 +11649,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.retrieveConversation": {
-      "id": "endpoint_conversations.retrieveConversation",
+    "endpoint_.retrieveConversation": {
+      "id": "endpoint_.retrieveConversation",
       "description": "\nYou can fetch the details of a single conversation.\n\nThis will return a single Conversation model with all its conversation parts.\n\n{% admonition type=\"warning\" name=\"Hard limit of 500 parts\" %}\nThe maximum number of conversation parts that can be returned via the API is 500. If you have more than that we will return the 500 most recent conversation parts.\n{% /admonition %}\n\nFor AI agent conversation metadata, please note that you need to have the agent enabled in your workspace, which is a [paid feature](https://www.intercom.com/help/en/articles/8205718-fin-resolutions#h_97f8c2e671).\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Retrieve a conversation",
       "operationId": "retrieveConversation",
       "method": "GET",
@@ -12111,12 +11937,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.updateConversation": {
-      "id": "endpoint_conversations.updateConversation",
+    "endpoint_.updateConversation": {
+      "id": "endpoint_.updateConversation",
       "description": "\nYou can update an existing conversation.\n\n{% admonition type=\"info\" name=\"Replying and other actions\" %}\nIf you want to reply to a coveration or take an action such as assign, unassign, open, close or snooze, take a look at the reply and manage endpoints.\n{% /admonition %}\n\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Update a conversation",
       "operationId": "updateConversation",
       "method": "PUT",
@@ -12595,12 +12418,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.searchConversations": {
-      "id": "endpoint_conversations.searchConversations",
+    "endpoint_.searchConversations": {
+      "id": "endpoint_.searchConversations",
       "description": "You can search for multiple conversations by the value of their attributes in order to fetch exactly which ones you want.\n\nTo search for conversations, you need to send a `POST` request to `https://api.intercom.io/conversations/search`.\n\nThis will accept a query object in the body which will define your filters in order to search for conversations.\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `20` results per page and maximum is `150`.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiple's there can be:\n- There's a limit of max 2 nested filters\n- There's a limit of max 15 filters for each AND or OR group\n\n### Accepted Fields\n\nMost keys listed as part of the The conversation model is searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foorbar\"`).\n\n| Field                                     | Type                                                                                                                                                   |\n| :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- |\n| id                                        | String                                                                                                                                                 |\n| created_at                                | Date (UNIX timestamp)                                                                                                                                  |\n| updated_at                                | Date (UNIX timestamp)                                                                                                                                  |\n| source.type                               | String<br>Accepted fields are `conversation`, `email`, `facebook`, `instagram`, `phone_call`, `phone_switch`, `push`, `sms`, `twitter` and `whatsapp`. |\n| source.id                                 | String                                                                                                                                                 |\n| source.delivered_as                       | String                                                                                                                                                 |\n| source.subject                            | String                                                                                                                                                 |\n| source.body                               | String                                                                                                                                                 |\n| source.author.id                          | String                                                                                                                                                 |\n| source.author.type                        | String                                                                                                                                                 |\n| source.author.name                        | String                                                                                                                                                 |\n| source.author.email                       | String                                                                                                                                                 |\n| source.url                                | String                                                                                                                                                 |\n| contact_ids                               | String                                                                                                                                                 |\n| teammate_ids                              | String                                                                                                                                                 |\n| admin_assignee_id                         | String                                                                                                                                                 |\n| team_assignee_id                          | String                                                                                                                                                 |\n| channel_initiated                         | String                                                                                                                                                 |\n| open                                      | Boolean                                                                                                                                                |\n| read                                      | Boolean                                                                                                                                                |\n| state                                     | String                                                                                                                                                 |\n| waiting_since                             | Date (UNIX timestamp)                                                                                                                                  |\n| snoozed_until                             | Date (UNIX timestamp)                                                                                                                                  |\n| tag_ids                                   | String                                                                                                                                                 |\n| priority                                  | String                                                                                                                                                 |\n| statistics.time_to_assignment             | Integer                                                                                                                                                |\n| statistics.time_to_admin_reply            | Integer                                                                                                                                                |\n| statistics.time_to_first_close            | Integer                                                                                                                                                |\n| statistics.time_to_last_close             | Integer                                                                                                                                                |\n| statistics.median_time_to_reply           | Integer                                                                                                                                                |\n| statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_assignment_at            | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_close_at                 | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_assignment_at             | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_close_at                  | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_closed_by_id              | String                                                                                                                                                 |\n| statistics.count_reopens                  | Integer                                                                                                                                                |\n| statistics.count_assignments              | Integer                                                                                                                                                |\n| statistics.count_conversation_parts       | Integer                                                                                                                                                |\n| conversation_rating.requested_at          | Date (UNIX timestamp)                                                                                                                                  |\n| conversation_rating.replied_at            | Date (UNIX timestamp)                                                                                                                                  |\n| conversation_rating.score                 | Integer                                                                                                                                                |\n| conversation_rating.remark                | String                                                                                                                                                 |\n| conversation_rating.contact_id            | String                                                                                                                                                 |\n| conversation_rating.admin_d               | String                                                                                                                                                 |\n| ai_agent_participated                     | Boolean                                                                                                                                                |\n| ai_agent.resolution_state                 | String                                                                                                                                                 |\n| ai_agent.last_answer_type                 | String                                                                                                                                                 |\n| ai_agent.rating                           | Integer                                                                                                                                                |\n| ai_agent.rating_remark                    | String                                                                                                                                                 |\n| ai_agent.source_type                      | String                                                                                                                                                 |\n| ai_agent.source_title                     | String                                                                                                                                                 |\n\n### Accepted Operators\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type  (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                    | Description                                                  |\n| :------- | :----------------------------- | :----------------------------------------------------------- |\n| =        | All                            | Equals                                                       |\n| !=       | All                            | Doesn't Equal                                                |\n| IN       | All                            | In  Shortcut for `OR` queries  Values most be in Array       |\n| NIN      | All                            | Not In  Shortcut for `OR !` queries  Values must be in Array |\n| >        | Integer  Date (UNIX Timestamp) | Greater (or equal) than                                      |\n| <       | Integer  Date (UNIX Timestamp) | Lower (or equal) than                                        |\n| ~        | String                         | Contains                                                     |\n| !~       | String                         | Doesn't Contain                                              |\n| ^        | String                         | Starts With                                                  |\n| $        | String                         | Ends With                                                    |\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Search conversations",
       "operationId": "searchConversations",
       "method": "POST",
@@ -12793,12 +12613,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.replyConversation": {
-      "id": "endpoint_conversations.replyConversation",
+    "endpoint_.replyConversation": {
+      "id": "endpoint_.replyConversation",
       "description": "You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Reply to a conversation",
       "operationId": "replyConversation",
       "method": "POST",
@@ -13442,12 +13259,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.manageConversation": {
-      "id": "endpoint_conversations.manageConversation",
+    "endpoint_.manageConversation": {
+      "id": "endpoint_.manageConversation",
       "description": "For managing conversations you can:\n- Close a conversation\n- Snooze a conversation to reopen on a future date\n- Open a conversation which is `snoozed` or `closed`\n- Assign a conversation to an admin and/or team.\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Manage a conversation",
       "operationId": "manageConversation",
       "method": "POST",
@@ -14188,12 +14002,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.autoAssignConversation": {
-      "id": "endpoint_conversations.autoAssignConversation",
+    "endpoint_.autoAssignConversation": {
+      "id": "endpoint_.autoAssignConversation",
       "description": "You can let a conversation be automatically assigned following assignment rules.\n{% admonition type=\"attention\" name=\"When using workflows\" %}\nIt is not possible to use this endpoint with Workflows.\n{% /admonition %}\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Run Assignment Rules on a conversation",
       "operationId": "autoAssignConversation",
       "method": "POST",
@@ -14489,12 +14300,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.attachContactToConversation": {
-      "id": "endpoint_conversations.attachContactToConversation",
+    "endpoint_.attachContactToConversation": {
+      "id": "endpoint_.attachContactToConversation",
       "description": "You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.\n\n{% admonition type=\"attention\" name=\"Contacts without an email\" %}\nIf you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.\n{% /admonition %}\n\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Attach a contact to a conversation",
       "operationId": "attachContactToConversation",
       "method": "POST",
@@ -14758,12 +14566,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.detachContactFromConversation": {
-      "id": "endpoint_conversations.detachContactFromConversation",
+    "endpoint_.detachContactFromConversation": {
+      "id": "endpoint_.detachContactFromConversation",
       "description": "You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.\n\n{% admonition type=\"attention\" name=\"Contacts without an email\" %}\nIf you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.\n{% /admonition %}\n\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Detach a contact from a group conversation",
       "operationId": "detachContactFromConversation",
       "method": "DELETE",
@@ -15154,12 +14959,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.redactConversation": {
-      "id": "endpoint_conversations.redactConversation",
+    "endpoint_.redactConversation": {
+      "id": "endpoint_.redactConversation",
       "description": "You can redact a conversation part or the source message of a conversation (as seen in the source object).\n\n{% admonition type=\"info\" name=\"Redacting parts and messages\" %}\nIf you are redacting a conversation part, it must have a `body`. If you are redacting a source message, it must have been created by a contact. We will return a `conversation_part_not_redactable` error if these criteria are not met.\n{% /admonition %}\n\n",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Redact a conversation part",
       "operationId": "redactConversation",
       "method": "POST",
@@ -15526,12 +15328,9 @@
         "type": "rest"
       }
     },
-    "endpoint_conversations.convertConversationToTicket": {
-      "id": "endpoint_conversations.convertConversationToTicket",
+    "endpoint_.convertConversationToTicket": {
+      "id": "endpoint_.convertConversationToTicket",
       "description": "You can convert a conversation to a ticket.",
-      "namespace": [
-        "Conversations"
-      ],
       "displayName": "Convert a conversation to a ticket",
       "operationId": "convertConversationToTicket",
       "method": "POST",
@@ -15918,12 +15717,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataAttributes.lisDataAttributes": {
-      "id": "endpoint_dataAttributes.lisDataAttributes",
+    "endpoint_.lisDataAttributes": {
+      "id": "endpoint_.lisDataAttributes",
       "description": "You can fetch a list of all data attributes belonging to a workspace for contacts, companies or conversations.",
-      "namespace": [
-        "Data Attributes"
-      ],
       "displayName": "List all data attributes",
       "operationId": "lisDataAttributes",
       "method": "GET",
@@ -16328,12 +16124,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataAttributes.createDataAttribute": {
-      "id": "endpoint_dataAttributes.createDataAttribute",
+    "endpoint_.createDataAttribute": {
+      "id": "endpoint_.createDataAttribute",
       "description": "You can create a data attributes for a `contact` or a `company`.",
-      "namespace": [
-        "Data Attributes"
-      ],
       "displayName": "Create a data attribute",
       "operationId": "createDataAttribute",
       "method": "POST",
@@ -16746,12 +16539,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataAttributes.updateDataAttribute": {
-      "id": "endpoint_dataAttributes.updateDataAttribute",
+    "endpoint_.updateDataAttribute": {
+      "id": "endpoint_.updateDataAttribute",
       "description": "\nYou can update a data attribute.\n\n> 🚧 Updating the data type is not possible\n>\n> It is currently a dangerous action to execute changing a data attribute's type via the API. You will need to update the type via the UI instead.\n",
-      "namespace": [
-        "Data Attributes"
-      ],
       "displayName": "Update a data attribute",
       "operationId": "updateDataAttribute",
       "method": "PUT",
@@ -17160,12 +16950,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataEvents.lisDataEvents": {
-      "id": "endpoint_dataEvents.lisDataEvents",
+    "endpoint_.lisDataEvents": {
+      "id": "endpoint_.lisDataEvents",
       "description": "\n> 🚧\n>\n> Please note that you can only 'list' events that are less than 90 days old. Event counts and summaries will still include your events older than 90 days but you cannot 'list' these events individually if they are older than 90 days\n\nThe events belonging to a customer can be listed by sending a GET request to `https://api.intercom.io/events` with a user or lead identifier along with a `type` parameter. The identifier parameter can be one of `user_id`, `email` or `intercom_user_id`. The `type` parameter value must be `user`.\n\n- `https://api.intercom.io/events?type=user&user_id={user_id}`\n- `https://api.intercom.io/events?type=user&email={email}`\n- `https://api.intercom.io/events?type=user&intercom_user_id={id}` (this call can be used to list leads)\n\nThe `email` parameter value should be [url encoded](http://en.wikipedia.org/wiki/Percent-encoding) when sending.\n\nYou can optionally define the result page size as well with the `per_page` parameter.\n",
-      "namespace": [
-        "Data Events"
-      ],
       "displayName": "List all data events",
       "operationId": "lisDataEvents",
       "method": "GET",
@@ -17399,12 +17186,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataEvents.createDataEvent": {
-      "id": "endpoint_dataEvents.createDataEvent",
+    "endpoint_.createDataEvent": {
+      "id": "endpoint_.createDataEvent",
       "description": "\nYou will need an Access Token that has write permissions to send Events. Once you have a key you can submit events via POST to the Events resource, which is located at https://api.intercom.io/events, or you can send events using one of the client libraries. When working with the HTTP API directly a client should send the event with a `Content-Type` of `application/json`.\n\nWhen using the JavaScript API, [adding the code to your app](http://docs.intercom.io/configuring-Intercom/tracking-user-events-in-your-app) makes the Events API available. Once added, you can submit an event using the `trackEvent` method. This will associate the event with the Lead or currently logged-in user or logged-out visitor/lead and send it to Intercom. The final parameter is a map that can be used to send optional metadata about the event.\n\nWith the Ruby client you pass a hash describing the event to `Intercom::Event.create`, or call the `track_user` method directly on the current user object (e.g. `user.track_event`).\n\n**NB: For the JSON object types, please note that we do not currently support nested JSON structure.**\n\n| Type            | Description                                                                                                                                                                                                     | Example                                                                           |\n| :-------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |\n| String          | The value is a JSON String                                                                                                                                                                                      | `\"source\":\"desktop\"`                                                              |\n| Number          | The value is a JSON Number                                                                                                                                                                                      | `\"load\": 3.67`                                                                    |\n| Date            | The key ends with the String `_date` and the value is a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time), assumed to be in the [UTC](http://en.wikipedia.org/wiki/Coordinated_Universal_Time) timezone. | `\"contact_date\": 1392036272`                                                      |\n| Link            | The value is a HTTP or HTTPS URI.                                                                                                                                                                               | `\"article\": \"https://example.org/ab1de.html\"`                                     |\n| Rich Link       | The value is a JSON object that contains `url` and `value` keys.                                                                                                                                                | `\"article\": {\"url\": \"https://example.org/ab1de.html\", \"value\":\"the dude abides\"}` |\n| Monetary Amount | The value is a JSON object that contains `amount` and `currency` keys. The `amount` key is a positive integer representing the amount in cents. The price in the example to the right denotes €349.99.          | `\"price\": {\"amount\": 34999, \"currency\": \"eur\"}`                                   |\n\n**Lead Events**\n\nWhen submitting events for Leads, you will need to specify the Lead's `id`.\n\n**Metadata behaviour**\n\n- We currently limit the number of tracked metadata keys to 10 per event. Once the quota is reached, we ignore any further keys we receive. The first 10 metadata keys are determined by the order in which they are sent in with the event.\n- It is not possible to change the metadata keys once the event has been sent. A new event will need to be created with the new keys and you can archive the old one.\n- There might be up to 24 hrs delay when you send a new metadata for an existing event.\n\n**Event de-duplication**\n\nThe API may detect and ignore duplicate events. Each event is uniquely identified as a combination of the following data - the Workspace identifier, the Contact external identifier, the Data Event name and the Data Event created time. As a result, it is **strongly recommended** to send a second granularity Unix timestamp in the `created_at` field.\n\nDuplicated events are responded to using the normal `202 Accepted` code - an error is not thrown, however repeat requests will be counted against any rate limit that is in place.\n\n### HTTP API Responses\n\n- Successful responses to submitted events return `202 Accepted` with an empty body.\n- Unauthorised access will be rejected with a `401 Unauthorized` or `403 Forbidden` response code.\n- Events sent about users that cannot be found will return a `404 Not Found`.\n- Event lists containing duplicate events will have those duplicates ignored.\n- Server errors will return a `500` response code and may contain an error message in the body.\n\n",
-      "namespace": [
-        "Data Events"
-      ],
       "displayName": "Submit a data event",
       "operationId": "createDataEvent",
       "method": "POST",
@@ -17521,12 +17305,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataEvents.dataEventSummaries": {
-      "id": "endpoint_dataEvents.dataEventSummaries",
+    "endpoint_.dataEventSummaries": {
+      "id": "endpoint_.dataEventSummaries",
       "description": "Create event summaries for a user. Event summaries are used to track the number of times an event has occurred, the first time it occurred and the last time it occurred.\n\n",
-      "namespace": [
-        "Data Events"
-      ],
       "displayName": "Create event summaries",
       "operationId": "dataEventSummaries",
       "method": "POST",
@@ -17663,12 +17444,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataExport.createDataExport": {
-      "id": "endpoint_dataExport.createDataExport",
+    "endpoint_.createDataExport": {
+      "id": "endpoint_.createDataExport",
       "description": "To create your export job, you need to send a `POST` request to the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe only parameters you need to provide are the range of dates that you want exported.\n\n>🚧 Limit of one active job\n>\n> You can only have one active job per workspace. You will receive a HTTP status code of 429 with the message Exceeded rate limit of 1 pending message data export jobs if you attempt to create a second concurrent job.\n\n>❗️ Updated_at not included\n>\n> It should be noted that the timeframe only includes messages sent during the time period and not messages that were only updated during this period. For example, if a message was updated yesterday but sent two days ago, you would need to set the created_at_after date before the message was sent to include that in your retrieval job.\n\n>📘 Date ranges are inclusive\n>\n> Requesting data for 2018-06-01 until 2018-06-30 will get all data for those days including those specified - e.g. 2018-06-01 00:00:00 until 2018-06-30 23:59:99.\n",
-      "namespace": [
-        "Data Export"
-      ],
       "displayName": "Create content data export",
       "operationId": "createDataExport",
       "method": "POST",
@@ -17791,12 +17569,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataExport.getDataExport": {
-      "id": "endpoint_dataExport.getDataExport",
+    "endpoint_.getDataExport": {
+      "id": "endpoint_.getDataExport",
       "description": "You can view the status of your job by sending a `GET` request to the URL\n`https://api.intercom.io/export/content/data/{job_identifier}` - the `{job_identifier}` is the value returned in the response when you first created the export job. More on it can be seen in the Export Job Model.\n\n> 🚧 Jobs expire after two days\n> All jobs that have completed processing (and are thus available to download from the provided URL) will have an expiry limit of two days from when the export ob completed. After this, the data will no longer be available.\n",
-      "namespace": [
-        "Data Export"
-      ],
       "displayName": "Show content data export",
       "operationId": "getDataExport",
       "method": "GET",
@@ -17926,12 +17701,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataExport.cancelDataExport": {
-      "id": "endpoint_dataExport.cancelDataExport",
+    "endpoint_.cancelDataExport": {
+      "id": "endpoint_.cancelDataExport",
       "description": "You can cancel your job",
-      "namespace": [
-        "Data Export"
-      ],
       "displayName": "Cancel content data export",
       "operationId": "cancelDataExport",
       "method": "POST",
@@ -18053,12 +17825,9 @@
         "type": "rest"
       }
     },
-    "endpoint_dataExport.downloadDataExport": {
-      "id": "endpoint_dataExport.downloadDataExport",
+    "endpoint_.downloadDataExport": {
+      "id": "endpoint_.downloadDataExport",
       "description": "When a job has a status of complete, and thus a filled download_url, you can download your data by hitting that provided URL, formatted like so: https://api.intercom.io/download/content/data/xyz1234.\n\nYour exported message data will be streamed continuously back down to you in a gzipped CSV format.\n\n> 📘 Octet header required\n>\n> You will have to specify the header Accept: `application/octet-stream` when hitting this endpoint.\n",
-      "namespace": [
-        "Data Export"
-      ],
       "displayName": "Download content data export",
       "operationId": "downloadDataExport",
       "method": "GET",
@@ -18174,12 +17943,9 @@
         "type": "rest"
       }
     },
-    "endpoint_messages.createMessage": {
-      "id": "endpoint_messages.createMessage",
+    "endpoint_.createMessage": {
+      "id": "endpoint_.createMessage",
       "description": "You can create a message that has been initiated by an admin. The conversation can be either an in-app message or an email.\n\n> 🚧 Sending for visitors\n>\n> There can be a short delay between when a contact is created and when a contact becomes available to be messaged through the API. A 404 Not Found error will be returned in this case.\n\nThis will return the Message model that has been created.\n\n> 🚧 Retrieving Associated Conversations\n>\n> As this is a message, there will be no conversation present until the contact responds. Once they do, you will have to search for a contact's conversations with the id of the message.\n",
-      "namespace": [
-        "Messages"
-      ],
       "displayName": "Create a message",
       "operationId": "createMessage",
       "method": "POST",
@@ -18614,12 +18380,9 @@
         "type": "rest"
       }
     },
-    "endpoint_news.listNewsItems": {
-      "id": "endpoint_news.listNewsItems",
+    "endpoint_.listNewsItems": {
+      "id": "endpoint_.listNewsItems",
       "description": "You can fetch a list of all news items",
-      "namespace": [
-        "News"
-      ],
       "displayName": "List all news items",
       "operationId": "listNewsItems",
       "method": "GET",
@@ -18794,12 +18557,9 @@
         "type": "rest"
       }
     },
-    "endpoint_news.createNewsItem": {
-      "id": "endpoint_news.createNewsItem",
+    "endpoint_.createNewsItem": {
+      "id": "endpoint_.createNewsItem",
       "description": "You can create a news item",
-      "namespace": [
-        "News"
-      ],
       "displayName": "Create a news item",
       "operationId": "createNewsItem",
       "method": "POST",
@@ -18985,12 +18745,9 @@
         "type": "rest"
       }
     },
-    "endpoint_news.retrieveNewsItem": {
-      "id": "endpoint_news.retrieveNewsItem",
+    "endpoint_.retrieveNewsItem": {
+      "id": "endpoint_.retrieveNewsItem",
       "description": "You can fetch the details of a single news item.",
-      "namespace": [
-        "News"
-      ],
       "displayName": "Retrieve a news item",
       "operationId": "retrieveNewsItem",
       "method": "GET",
@@ -19193,11 +18950,8 @@
         "type": "rest"
       }
     },
-    "endpoint_news.updateNewsItem": {
-      "id": "endpoint_news.updateNewsItem",
-      "namespace": [
-        "News"
-      ],
+    "endpoint_.updateNewsItem": {
+      "id": "endpoint_.updateNewsItem",
       "displayName": "Update a news item",
       "operationId": "updateNewsItem",
       "method": "PUT",
@@ -19465,12 +19219,9 @@
         "type": "rest"
       }
     },
-    "endpoint_news.deleteNewsItem": {
-      "id": "endpoint_news.deleteNewsItem",
+    "endpoint_.deleteNewsItem": {
+      "id": "endpoint_.deleteNewsItem",
       "description": "You can delete a single news item.",
-      "namespace": [
-        "News"
-      ],
       "displayName": "Delete a news item",
       "operationId": "deleteNewsItem",
       "method": "DELETE",
@@ -19652,12 +19403,9 @@
         "type": "rest"
       }
     },
-    "endpoint_news.listLiveNewsfeedItems": {
-      "id": "endpoint_news.listLiveNewsfeedItems",
+    "endpoint_.listLiveNewsfeedItems": {
+      "id": "endpoint_.listLiveNewsfeedItems",
       "description": "You can fetch a list of all news items that are live on a given newsfeed",
-      "namespace": [
-        "News"
-      ],
       "displayName": "List all live newsfeed items",
       "operationId": "listLiveNewsfeedItems",
       "method": "GET",
@@ -19823,12 +19571,9 @@
         "type": "rest"
       }
     },
-    "endpoint_news.listNewsfeeds": {
-      "id": "endpoint_news.listNewsfeeds",
+    "endpoint_.listNewsfeeds": {
+      "id": "endpoint_.listNewsfeeds",
       "description": "You can fetch a list of all newsfeeds",
-      "namespace": [
-        "News"
-      ],
       "displayName": "List all newsfeeds",
       "operationId": "listNewsfeeds",
       "method": "GET",
@@ -19975,12 +19720,9 @@
         "type": "rest"
       }
     },
-    "endpoint_news.retrieveNewsfeed": {
-      "id": "endpoint_news.retrieveNewsfeed",
+    "endpoint_.retrieveNewsfeed": {
+      "id": "endpoint_.retrieveNewsfeed",
       "description": "You can fetch the details of a single newsfeed",
-      "namespace": [
-        "News"
-      ],
       "displayName": "Retrieve a newsfeed",
       "operationId": "retrieveNewsfeed",
       "method": "GET",
@@ -20134,12 +19876,9 @@
         "type": "rest"
       }
     },
-    "endpoint_notes.retrieveNote": {
-      "id": "endpoint_notes.retrieveNote",
+    "endpoint_.retrieveNote": {
+      "id": "endpoint_.retrieveNote",
       "description": "You can fetch the details of a single note.",
-      "namespace": [
-        "Notes"
-      ],
       "displayName": "Retrieve a note",
       "operationId": "retrieveNote",
       "method": "GET",
@@ -20326,12 +20065,9 @@
         "type": "rest"
       }
     },
-    "endpoint_segments.listSegments": {
-      "id": "endpoint_segments.listSegments",
+    "endpoint_.listSegments": {
+      "id": "endpoint_.listSegments",
       "description": "You can fetch a list of all segments.",
-      "namespace": [
-        "Segments"
-      ],
       "displayName": "List all segments",
       "operationId": "listSegments",
       "method": "GET",
@@ -20486,12 +20222,9 @@
         "type": "rest"
       }
     },
-    "endpoint_segments.retrieveSegment": {
-      "id": "endpoint_segments.retrieveSegment",
+    "endpoint_.retrieveSegment": {
+      "id": "endpoint_.retrieveSegment",
       "description": "You can fetch the details of a single segment.",
-      "namespace": [
-        "Segments"
-      ],
       "displayName": "Retrieve a segment",
       "operationId": "retrieveSegment",
       "method": "GET",
@@ -20668,12 +20401,9 @@
         "type": "rest"
       }
     },
-    "endpoint_subscriptionTypes.listSubscriptionTypes": {
-      "id": "endpoint_subscriptionTypes.listSubscriptionTypes",
+    "endpoint_.listSubscriptionTypes": {
+      "id": "endpoint_.listSubscriptionTypes",
       "description": "You can list all subscription types. A list of subscription type objects will be returned.",
-      "namespace": [
-        "Subscription Types"
-      ],
       "displayName": "List subscription types",
       "operationId": "listSubscriptionTypes",
       "method": "GET",
@@ -20812,12 +20542,9 @@
         "type": "rest"
       }
     },
-    "endpoint_switch.createPhoneSwitch": {
-      "id": "endpoint_switch.createPhoneSwitch",
+    "endpoint_.createPhoneSwitch": {
+      "id": "endpoint_.createPhoneSwitch",
       "description": "You can use the API to deflect phone calls to the Intercom Messenger.\nCalling this endpoint will send an SMS with a link to the Messenger to the phone number specified.\n\nIf custom attributes are specified, they will be added to the user or lead's custom data attributes.\n",
-      "namespace": [
-        "Switch"
-      ],
       "displayName": "Create a phone Switch",
       "operationId": "createPhoneSwitch",
       "method": "POST",
@@ -21022,12 +20749,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tags.listTags": {
-      "id": "endpoint_tags.listTags",
+    "endpoint_.listTags": {
+      "id": "endpoint_.listTags",
       "description": "You can fetch a list of all tags for a given workspace.\n\n",
-      "namespace": [
-        "Tags"
-      ],
       "displayName": "List all tags",
       "operationId": "listTags",
       "method": "GET",
@@ -21150,12 +20874,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tags.createTag": {
-      "id": "endpoint_tags.createTag",
+    "endpoint_.createTag": {
+      "id": "endpoint_.createTag",
       "description": "You can use this endpoint to perform the following operations:\n\n  **1. Create a new tag:** You can create a new tag by passing in the tag name as specified in \"Create or Update Tag Request Payload\" described below.\n\n  **2. Update an existing tag:** You can update an existing tag by passing the id of the tag as specified in \"Create or Update Tag Request Payload\" described below.\n\n  **3. Tag Companies:** You can tag single company or a list of companies. You can tag a company by passing in the tag name and the company details as specified in \"Tag Company Request Payload\" described below. Also, if the tag doesn't exist then a new one will be created automatically.\n\n  **4. Untag Companies:** You can untag a single company or a list of companies. You can untag a company by passing in the tag id and the company details as specified in \"Untag Company Request Payload\" described below.\n\n  **5. Tag Multiple Users:** You can tag a list of users. You can tag the users by passing in the tag name and the user details as specified in \"Tag Users Request Payload\" described below.\n\nEach operation will return a tag object.\n",
-      "namespace": [
-        "Tags"
-      ],
       "displayName": "Create or update a tag, Tag or untag companies, Tag contacts",
       "operationId": "createTag",
       "method": "POST",
@@ -21434,12 +21155,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tags.findTag": {
-      "id": "endpoint_tags.findTag",
+    "endpoint_.findTag": {
+      "id": "endpoint_.findTag",
       "description": "You can fetch the details of tags that are on the workspace by their id.\nThis will return a tag object.\n",
-      "namespace": [
-        "Tags"
-      ],
       "displayName": "Find a specific tag",
       "operationId": "findTag",
       "method": "GET",
@@ -21613,12 +21331,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tags.deleteTag": {
-      "id": "endpoint_tags.deleteTag",
+    "endpoint_.deleteTag": {
+      "id": "endpoint_.deleteTag",
       "description": "You can delete the details of tags that are on the workspace by passing in the id.",
-      "namespace": [
-        "Tags"
-      ],
       "displayName": "Delete tag",
       "operationId": "deleteTag",
       "method": "DELETE",
@@ -21809,12 +21524,9 @@
         "type": "rest"
       }
     },
-    "endpoint_teams.listTeams": {
-      "id": "endpoint_teams.listTeams",
+    "endpoint_.listTeams": {
+      "id": "endpoint_.listTeams",
       "description": "This will return a list of team objects for the App.",
-      "namespace": [
-        "Teams"
-      ],
       "displayName": "List all teams",
       "operationId": "listTeams",
       "method": "GET",
@@ -21931,12 +21643,9 @@
         "type": "rest"
       }
     },
-    "endpoint_teams.retrieveTeam": {
-      "id": "endpoint_teams.retrieveTeam",
+    "endpoint_.retrieveTeam": {
+      "id": "endpoint_.retrieveTeam",
       "description": "You can fetch the details of a single team, containing an array of admins that belong to this team.",
-      "namespace": [
-        "Teams"
-      ],
       "displayName": "Retrieve a team",
       "operationId": "retrieveTeam",
       "method": "GET",
@@ -22111,12 +21820,9 @@
         "type": "rest"
       }
     },
-    "endpoint_ticketTypeAttributes.createTicketTypeAttribute": {
-      "id": "endpoint_ticketTypeAttributes.createTicketTypeAttribute",
+    "endpoint_.createTicketTypeAttribute": {
+      "id": "endpoint_.createTicketTypeAttribute",
       "description": "You can create a new attribute for a ticket type.",
-      "namespace": [
-        "Ticket Type Attributes"
-      ],
       "displayName": "Create a new attribute for a ticket type",
       "operationId": "createTicketTypeAttribute",
       "method": "POST",
@@ -22305,12 +22011,9 @@
         "type": "rest"
       }
     },
-    "endpoint_ticketTypeAttributes.updateTicketTypeAttribute": {
-      "id": "endpoint_ticketTypeAttributes.updateTicketTypeAttribute",
+    "endpoint_.updateTicketTypeAttribute": {
+      "id": "endpoint_.updateTicketTypeAttribute",
       "description": "You can update an existing attribute for a ticket type.",
-      "namespace": [
-        "Ticket Type Attributes"
-      ],
       "displayName": "Update an existing attribute for a ticket type",
       "operationId": "updateTicketTypeAttribute",
       "method": "PUT",
@@ -22515,12 +22218,9 @@
         "type": "rest"
       }
     },
-    "endpoint_ticketTypes.listTicketTypes": {
-      "id": "endpoint_ticketTypes.listTicketTypes",
+    "endpoint_.listTicketTypes": {
+      "id": "endpoint_.listTicketTypes",
       "description": "You can get a list of all ticket types for a workspace.",
-      "namespace": [
-        "Ticket Types"
-      ],
       "displayName": "List all ticket types",
       "operationId": "listTicketTypes",
       "method": "GET",
@@ -22717,12 +22417,9 @@
         "type": "rest"
       }
     },
-    "endpoint_ticketTypes.createTicketType": {
-      "id": "endpoint_ticketTypes.createTicketType",
+    "endpoint_.createTicketType": {
+      "id": "endpoint_.createTicketType",
       "description": "You can create a new ticket type.\n> 📘 Creating ticket types.\n>\n> Every ticket type will be created with two default attributes: _default_title_ and _default_description_.\n> For the `icon` propery, use an emoji from [Twemoji Cheatsheet](https://twemoji-cheatsheet.vercel.app/)\n",
-      "namespace": [
-        "Ticket Types"
-      ],
       "displayName": "Create a ticket type",
       "operationId": "createTicketType",
       "method": "POST",
@@ -22916,12 +22613,9 @@
         "type": "rest"
       }
     },
-    "endpoint_ticketTypes.getTicketType": {
-      "id": "endpoint_ticketTypes.getTicketType",
+    "endpoint_.getTicketType": {
+      "id": "endpoint_.getTicketType",
       "description": "You can fetch the details of a single ticket type.",
-      "namespace": [
-        "Ticket Types"
-      ],
       "displayName": "Retrieve a ticket type",
       "operationId": "getTicketType",
       "method": "GET",
@@ -23139,12 +22833,9 @@
         "type": "rest"
       }
     },
-    "endpoint_ticketTypes.updateTicketType": {
-      "id": "endpoint_ticketTypes.updateTicketType",
+    "endpoint_.updateTicketType": {
+      "id": "endpoint_.updateTicketType",
       "description": "\nYou can update a ticket type.\n\n> 📘 Updating a ticket type.\n>\n> For the `icon` propery, use an emoji from [Twemoji Cheatsheet](https://twemoji-cheatsheet.vercel.app/)\n",
-      "namespace": [
-        "Ticket Types"
-      ],
       "displayName": "Update a ticket type",
       "operationId": "updateTicketType",
       "method": "PUT",
@@ -23380,12 +23071,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tickets.replyTicket": {
-      "id": "endpoint_tickets.replyTicket",
+    "endpoint_.replyTicket": {
+      "id": "endpoint_.replyTicket",
       "description": "You can reply to a ticket with a message from an admin or on behalf of a contact, or with a note for admins.",
-      "namespace": [
-        "Tickets"
-      ],
       "displayName": "Reply to a ticket",
       "operationId": "replyTicket",
       "method": "POST",
@@ -23742,13 +23430,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tagsTickets.attachTagToTicket": {
-      "id": "endpoint_tagsTickets.attachTagToTicket",
+    "endpoint_.attachTagToTicket": {
+      "id": "endpoint_.attachTagToTicket",
       "description": "You can tag a specific ticket. This will return a tag object for the tag that was added to the ticket.",
-      "namespace": [
-        "Tags",
-        "Tickets"
-      ],
       "displayName": "Add tag to a ticket",
       "operationId": "attachTagToTicket",
       "method": "POST",
@@ -24002,13 +23686,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tagsTickets.detachTagFromTicket": {
-      "id": "endpoint_tagsTickets.detachTagFromTicket",
+    "endpoint_.detachTagFromTicket": {
+      "id": "endpoint_.detachTagFromTicket",
       "description": "You can remove tag from a specific ticket. This will return a tag object for the tag that was removed from the ticket.",
-      "namespace": [
-        "Tags",
-        "Tickets"
-      ],
       "displayName": "Remove tag from a ticket",
       "operationId": "detachTagFromTicket",
       "method": "DELETE",
@@ -24314,12 +23994,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tickets.createTicket": {
-      "id": "endpoint_tickets.createTicket",
+    "endpoint_.createTicket": {
+      "id": "endpoint_.createTicket",
       "description": "You can create a new ticket.",
-      "namespace": [
-        "Tickets"
-      ],
       "displayName": "Create a ticket",
       "operationId": "createTicket",
       "method": "POST",
@@ -24573,12 +24250,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tickets.getTicket": {
-      "id": "endpoint_tickets.getTicket",
+    "endpoint_.getTicket": {
+      "id": "endpoint_.getTicket",
       "description": "You can fetch the details of a single ticket.",
-      "namespace": [
-        "Tickets"
-      ],
       "displayName": "Retrieve a ticket",
       "operationId": "getTicket",
       "method": "GET",
@@ -24831,12 +24505,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tickets.updateTicket": {
-      "id": "endpoint_tickets.updateTicket",
+    "endpoint_.updateTicket": {
+      "id": "endpoint_.updateTicket",
       "description": "You can update a ticket.",
-      "namespace": [
-        "Tickets"
-      ],
       "displayName": "Update a ticket",
       "operationId": "updateTicket",
       "method": "PUT",
@@ -25641,12 +25312,9 @@
         "type": "rest"
       }
     },
-    "endpoint_tickets.searchTickets": {
-      "id": "endpoint_tickets.searchTickets",
+    "endpoint_.searchTickets": {
+      "id": "endpoint_.searchTickets",
       "description": "You can search for multiple tickets by the value of their attributes in order to fetch exactly which ones you want.\n\nTo search for tickets, you send a `POST` request to `https://api.intercom.io/tickets/search`.\n\nThis will accept a query object in the body which will define your filters.\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiples there can be:\n- There's a limit of max 2 nested filters\n- There's a limit of max 15 filters for each AND or OR group\n\n### Accepted Fields\n\nMost keys listed as part of the Ticket model are searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foobar\"`).\n\n| Field                                     | Type                                                                                     |\n| :---------------------------------------- | :--------------------------------------------------------------------------------------- |\n| id                                        | String                                                                                   |\n| created_at                                | Date (UNIX timestamp)                                                                    |\n| updated_at                                | Date (UNIX timestamp)                                                                    |\n| _default_title_                           | String                                                                                   |\n| _default_description_                     | String                                                                                   |\n| category                                  | String                                                                                   |\n| ticket_type_id                            | String                                                                                   |\n| contact_ids                               | String                                                                                   |\n| teammate_ids                              | String                                                                                   |\n| admin_assignee_id                         | String                                                                                   |\n| team_assignee_id                          | String                                                                                   |\n| open                                      | Boolean                                                                                  |\n| state                                     | String                                                                                   |\n| snoozed_until                             | Date (UNIX timestamp)                                                                    |\n| ticket_attribute.{id}                     | String or Boolean or Date (UNIX timestamp) or Float or Integer                           |\n\n### Accepted Operators\n\n{% admonition type=\"info\" name=\"Searching based on `created_at`\" %}\n  You may use the `<=` or `>=` operators to search by `created_at`.\n{% /admonition %}\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type  (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                    | Description                                                  |\n| :------- | :----------------------------- | :----------------------------------------------------------- |\n| =        | All                            | Equals                                                       |\n| !=       | All                            | Doesn't Equal                                                |\n| IN       | All                            | In  Shortcut for `OR` queries  Values most be in Array       |\n| NIN      | All                            | Not In  Shortcut for `OR !` queries  Values must be in Array |\n| >        | Integer  Date (UNIX Timestamp) | Greater (or equal) than                                      |\n| <       | Integer  Date (UNIX Timestamp) | Lower (or equal) than                                        |\n| ~        | String                         | Contains                                                     |\n| !~       | String                         | Doesn't Contain                                              |\n| ^        | String                         | Starts With                                                  |\n| $        | String                         | Ends With                                                    |\n",
-      "namespace": [
-        "Tickets"
-      ],
       "displayName": "Search tickets",
       "operationId": "searchTickets",
       "method": "POST",
@@ -25892,12 +25560,9 @@
         "type": "rest"
       }
     },
-    "endpoint_visitors.retrieveVisitorWithUserId": {
-      "id": "endpoint_visitors.retrieveVisitorWithUserId",
+    "endpoint_.retrieveVisitorWithUserId": {
+      "id": "endpoint_.retrieveVisitorWithUserId",
       "description": "You can fetch the details of a single visitor.",
-      "namespace": [
-        "Visitors"
-      ],
       "displayName": "Retrieve a visitor with User ID",
       "operationId": "retrieveVisitorWithUserId",
       "method": "GET",
@@ -26108,12 +25773,9 @@
         "type": "rest"
       }
     },
-    "endpoint_visitors.updateVisitor": {
-      "id": "endpoint_visitors.updateVisitor",
+    "endpoint_.updateVisitor": {
+      "id": "endpoint_.updateVisitor",
       "description": "Sending a PUT request to `/visitors` will result in an update of an existing Visitor.\n\n**Option 1.** You can update a visitor by passing in the `user_id` of the visitor in the Request body.\n\n**Option 2.** You can update a visitor by passing in the `id` of the visitor in the Request body.\n",
-      "namespace": [
-        "Visitors"
-      ],
       "displayName": "Update a visitor",
       "operationId": "updateVisitor",
       "method": "PUT",
@@ -26457,12 +26119,9 @@
         "type": "rest"
       }
     },
-    "endpoint_visitors.convertVisitor": {
-      "id": "endpoint_visitors.convertVisitor",
+    "endpoint_.convertVisitor": {
+      "id": "endpoint_.convertVisitor",
       "description": "You can merge a Visitor to a Contact of role type `lead` or `user`.\n\n> 📘 What happens upon a visitor being converted?\n>\n> If the User exists, then the Visitor will be merged into it, the Visitor deleted and the User returned. If the User does not exist, the Visitor will be converted to a User, with the User identifiers replacing it's Visitor identifiers.\n",
-      "namespace": [
-        "Visitors"
-      ],
       "displayName": "Convert a visitor",
       "operationId": "convertVisitor",
       "method": "POST",
@@ -44209,113 +43868,7 @@
       }
     }
   },
-  "subpackages": {
-    "admins": {
-      "id": "admins",
-      "name": "Admins",
-      "displayName": "Admins"
-    },
-    "articles": {
-      "id": "articles",
-      "name": "Articles",
-      "displayName": "Articles"
-    },
-    "helpCenter": {
-      "id": "helpCenter",
-      "name": "Help Center",
-      "displayName": "Help Center"
-    },
-    "companies": {
-      "id": "companies",
-      "name": "Companies",
-      "displayName": "Companies"
-    },
-    "contacts": {
-      "id": "contacts",
-      "name": "Contacts",
-      "displayName": "Contacts"
-    },
-    "notes": {
-      "id": "notes",
-      "name": "Notes",
-      "displayName": "Notes"
-    },
-    "segments": {
-      "id": "segments",
-      "name": "Segments",
-      "displayName": "Segments"
-    },
-    "subscriptionTypes": {
-      "id": "subscriptionTypes",
-      "name": "Subscription Types",
-      "displayName": "Subscription Types"
-    },
-    "tags": {
-      "id": "tags",
-      "name": "Tags",
-      "displayName": "Tags"
-    },
-    "conversations": {
-      "id": "conversations",
-      "name": "Conversations",
-      "displayName": "Conversations"
-    },
-    "dataAttributes": {
-      "id": "dataAttributes",
-      "name": "Data Attributes",
-      "displayName": "Data Attributes"
-    },
-    "dataEvents": {
-      "id": "dataEvents",
-      "name": "Data Events",
-      "displayName": "Data Events"
-    },
-    "dataExport": {
-      "id": "dataExport",
-      "name": "Data Export",
-      "displayName": "Data Export"
-    },
-    "messages": {
-      "id": "messages",
-      "name": "Messages",
-      "displayName": "Messages"
-    },
-    "news": {
-      "id": "news",
-      "name": "News",
-      "displayName": "News"
-    },
-    "switch": {
-      "id": "switch",
-      "name": "Switch",
-      "displayName": "Switch"
-    },
-    "teams": {
-      "id": "teams",
-      "name": "Teams",
-      "displayName": "Teams"
-    },
-    "ticketTypeAttributes": {
-      "id": "ticketTypeAttributes",
-      "name": "Ticket Type Attributes",
-      "displayName": "Ticket Type Attributes"
-    },
-    "ticketTypes": {
-      "id": "ticketTypes",
-      "name": "Ticket Types",
-      "displayName": "Ticket Types"
-    },
-    "tickets": {
-      "id": "tickets",
-      "name": "Tickets",
-      "displayName": "Tickets"
-    },
-    "visitors": {
-      "id": "visitors",
-      "name": "Visitors",
-      "displayName": "Visitors"
-    }
-  },
+  "subpackages": {},
   "auths": {
     "bearerAuth": {
       "type": "bearerAuth"

--- a/packages/parsers/src/openapi/__test__/__snapshots__/openapi-filter.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/openapi-filter.json
@@ -1,9 +1,12 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.identifyAdmin": {
-      "id": "endpoint_.identifyAdmin",
+    "endpoint_admins.identifyAdmin": {
+      "id": "endpoint_admins.identifyAdmin",
       "description": "\nYou can view the currently authorised admin along with the embedded app object (a \"workspace\" in legacy terminology).\n\n> 🚧 Single Sign On\n>\n> If you are building a custom \"Log in with Intercom\" flow for your site, and you call the `/me` endpoint to identify the logged-in user, you should not accept any sign-ins from users with unverified email addresses as it poses a potential impersonation security risk.\n",
+      "namespace": [
+        "subpackage_admins"
+      ],
       "displayName": "Identify an admin",
       "operationId": "identifyAdmin",
       "method": "GET",
@@ -107,9 +110,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.setAwayAdmin": {
-      "id": "endpoint_.setAwayAdmin",
+    "endpoint_admins.setAwayAdmin": {
+      "id": "endpoint_admins.setAwayAdmin",
       "description": "You can set an Admin as away for the Inbox.",
+      "namespace": [
+        "subpackage_admins"
+      ],
       "displayName": "Set an admin to away",
       "operationId": "setAwayAdmin",
       "method": "PUT",
@@ -398,9 +404,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listActivityLogs": {
-      "id": "endpoint_.listActivityLogs",
+    "endpoint_admins.listActivityLogs": {
+      "id": "endpoint_admins.listActivityLogs",
       "description": "You can get a log of activities by all admins in an app.",
+      "namespace": [
+        "subpackage_admins"
+      ],
       "displayName": "List all activity logs",
       "operationId": "listActivityLogs",
       "method": "GET",
@@ -606,9 +615,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listAdmins": {
-      "id": "endpoint_.listAdmins",
+    "endpoint_admins.listAdmins": {
+      "id": "endpoint_admins.listAdmins",
       "description": "You can fetch a list of admins for a given workspace.",
+      "namespace": [
+        "subpackage_admins"
+      ],
       "displayName": "List all admins",
       "operationId": "listAdmins",
       "method": "GET",
@@ -736,9 +748,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveAdmin": {
-      "id": "endpoint_.retrieveAdmin",
+    "endpoint_admins.retrieveAdmin": {
+      "id": "endpoint_admins.retrieveAdmin",
       "description": "You can retrieve the details of a single admin.",
+      "namespace": [
+        "subpackage_admins"
+      ],
       "displayName": "Retrieve an admin",
       "operationId": "retrieveAdmin",
       "method": "GET",
@@ -917,9 +932,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listArticles": {
-      "id": "endpoint_.listArticles",
+    "endpoint_articles.listArticles": {
+      "id": "endpoint_articles.listArticles",
       "description": "You can fetch a list of all articles by making a GET request to `https://api.intercom.io/articles`.\n\n> 📘 How are the articles sorted and ordered?\n>\n> Articles will be returned in descending order on the `updated_at` attribute. This means if you need to iterate through results then we'll show the most recently updated articles first.\n",
+      "namespace": [
+        "subpackage_articles"
+      ],
       "displayName": "List all articles",
       "operationId": "listArticles",
       "method": "GET",
@@ -1060,9 +1078,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createArticle": {
-      "id": "endpoint_.createArticle",
+    "endpoint_articles.createArticle": {
+      "id": "endpoint_articles.createArticle",
       "description": "You can create a new article by making a POST request to `https://api.intercom.io/articles`.",
+      "namespace": [
+        "subpackage_articles"
+      ],
       "displayName": "Create an article",
       "operationId": "createArticle",
       "method": "POST",
@@ -1305,9 +1326,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveArticle": {
-      "id": "endpoint_.retrieveArticle",
+    "endpoint_articles.retrieveArticle": {
+      "id": "endpoint_articles.retrieveArticle",
       "description": "You can fetch the details of a single article by making a GET request to `https://api.intercom.io/articles/<id>`.",
+      "namespace": [
+        "subpackage_articles"
+      ],
       "displayName": "Retrieve an article",
       "operationId": "retrieveArticle",
       "method": "GET",
@@ -1501,9 +1525,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateArticle": {
-      "id": "endpoint_.updateArticle",
+    "endpoint_articles.updateArticle": {
+      "id": "endpoint_articles.updateArticle",
       "description": "You can update the details of a single article by making a PUT request to `https://api.intercom.io/articles/<id>`.",
+      "namespace": [
+        "subpackage_articles"
+      ],
       "displayName": "Update an article",
       "operationId": "updateArticle",
       "method": "PUT",
@@ -2173,9 +2200,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.deleteArticle": {
-      "id": "endpoint_.deleteArticle",
+    "endpoint_articles.deleteArticle": {
+      "id": "endpoint_articles.deleteArticle",
       "description": "You can delete a single article by making a DELETE request to `https://api.intercom.io/articles/<id>`.",
+      "namespace": [
+        "subpackage_articles"
+      ],
       "displayName": "Delete an article",
       "operationId": "deleteArticle",
       "method": "DELETE",
@@ -2349,9 +2379,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.searchArticles": {
-      "id": "endpoint_.searchArticles",
+    "endpoint_articles.searchArticles": {
+      "id": "endpoint_articles.searchArticles",
       "description": "You can search for articles by making a GET request to `https://api.intercom.io/articles/search`.",
+      "namespace": [
+        "subpackage_articles"
+      ],
       "displayName": "Search for articles",
       "operationId": "searchArticles",
       "method": "GET",
@@ -2581,9 +2614,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listAllCollections": {
-      "id": "endpoint_.listAllCollections",
+    "endpoint_helpCenter.listAllCollections": {
+      "id": "endpoint_helpCenter.listAllCollections",
       "description": "You can fetch a list of all collections by making a GET request to `https://api.intercom.io/help_center/collections`.\n\nCollections will be returned in descending order on the `updated_at` attribute. This means if you need to iterate through results then we'll show the most recently updated collections first.\n",
+      "namespace": [
+        "subpackage_helpCenter"
+      ],
       "displayName": "List all collections",
       "operationId": "listAllCollections",
       "method": "GET",
@@ -2742,9 +2778,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createCollection": {
-      "id": "endpoint_.createCollection",
+    "endpoint_helpCenter.createCollection": {
+      "id": "endpoint_helpCenter.createCollection",
       "description": "You can create a new collection by making a POST request to `https://api.intercom.io/help_center/collections.`",
+      "namespace": [
+        "subpackage_helpCenter"
+      ],
       "displayName": "Create a collection",
       "operationId": "createCollection",
       "method": "POST",
@@ -2953,9 +2992,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveCollection": {
-      "id": "endpoint_.retrieveCollection",
+    "endpoint_helpCenter.retrieveCollection": {
+      "id": "endpoint_helpCenter.retrieveCollection",
       "description": "You can fetch the details of a single collection by making a GET request to `https://api.intercom.io/help_center/collections/<id>`.",
+      "namespace": [
+        "subpackage_helpCenter"
+      ],
       "displayName": "Retrieve a collection",
       "operationId": "retrieveCollection",
       "method": "GET",
@@ -3145,9 +3187,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateCollection": {
-      "id": "endpoint_.updateCollection",
+    "endpoint_helpCenter.updateCollection": {
+      "id": "endpoint_helpCenter.updateCollection",
       "description": "You can update the details of a single collection by making a PUT request to `https://api.intercom.io/collections/<id>`.",
+      "namespace": [
+        "subpackage_helpCenter"
+      ],
       "displayName": "Update a collection",
       "operationId": "updateCollection",
       "method": "PUT",
@@ -3574,9 +3619,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.deleteCollection": {
-      "id": "endpoint_.deleteCollection",
+    "endpoint_helpCenter.deleteCollection": {
+      "id": "endpoint_helpCenter.deleteCollection",
       "description": "You can delete a single collection by making a DELETE request to `https://api.intercom.io/collections/<id>`.",
+      "namespace": [
+        "subpackage_helpCenter"
+      ],
       "displayName": "Delete a collection",
       "operationId": "deleteCollection",
       "method": "DELETE",
@@ -3758,9 +3806,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveHelpCenter": {
-      "id": "endpoint_.retrieveHelpCenter",
+    "endpoint_helpCenter.retrieveHelpCenter": {
+      "id": "endpoint_helpCenter.retrieveHelpCenter",
       "description": "You can fetch the details of a single Help Center by making a GET request to `https://api.intercom.io/help_center/help_center/<id>`.",
+      "namespace": [
+        "subpackage_helpCenter"
+      ],
       "displayName": "Retrieve a Help Center",
       "operationId": "retrieveHelpCenter",
       "method": "GET",
@@ -3946,9 +3997,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listHelpCenters": {
-      "id": "endpoint_.listHelpCenters",
+    "endpoint_helpCenter.listHelpCenters": {
+      "id": "endpoint_helpCenter.listHelpCenters",
       "description": "You can list all Help Centers by making a GET request to `https://api.intercom.io/help_center/help_centers`.",
+      "namespace": [
+        "subpackage_helpCenter"
+      ],
       "displayName": "List all Help Centers",
       "operationId": "listHelpCenters",
       "method": "GET",
@@ -4073,9 +4127,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveCompany": {
-      "id": "endpoint_.retrieveCompany",
+    "endpoint_companies.retrieveCompany": {
+      "id": "endpoint_companies.retrieveCompany",
       "description": "You can fetch a single company by passing in `company_id` or `name`.\n\n  `https://api.intercom.io/companies?name={name}`\n\n  `https://api.intercom.io/companies?company_id={company_id}`\n\nYou can fetch all companies and filter by `segment_id` or `tag_id` as a query parameter.\n\n  `https://api.intercom.io/companies?tag_id={tag_id}`\n\n  `https://api.intercom.io/companies?segment_id={segment_id}`\n",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Retrieve companies",
       "operationId": "retrieveCompany",
       "method": "GET",
@@ -4370,9 +4427,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createOrUpdateCompany": {
-      "id": "endpoint_.createOrUpdateCompany",
+    "endpoint_companies.createOrUpdateCompany": {
+      "id": "endpoint_companies.createOrUpdateCompany",
       "description": "You can create or update a company.\n\nCompanies will be only visible in Intercom when there is at least one associated user.\n\nCompanies are looked up via `company_id` in a `POST` request, if not found via `company_id`, the new company will be created, if found, that company will be updated.\n\n{% admonition type=\"attention\" name=\"Using `company_id`\" %}\n  You can set a unique `company_id` value when creating a company. However, it is not possible to update `company_id`. Be sure to set a unique value once upon creation of the company.\n{% /admonition %}\n",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Create or Update a company",
       "operationId": "createOrUpdateCompany",
       "method": "POST",
@@ -4599,9 +4659,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.RetrieveACompanyById": {
-      "id": "endpoint_.RetrieveACompanyById",
+    "endpoint_companies.RetrieveACompanyById": {
+      "id": "endpoint_companies.RetrieveACompanyById",
       "description": "You can fetch a single company.",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Retrieve a company by ID",
       "operationId": "RetrieveACompanyById",
       "method": "GET",
@@ -4793,9 +4856,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.UpdateCompany": {
-      "id": "endpoint_.UpdateCompany",
+    "endpoint_companies.UpdateCompany": {
+      "id": "endpoint_companies.UpdateCompany",
       "description": "You can update a single company using the Intercom provisioned `id`.\n\n{% admonition type=\"attention\" name=\"Using `company_id`\" %}\n  When updating a company it is not possible to update `company_id`. This can only be set once upon creation of the company.\n{% /admonition %}\n",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Update a company",
       "operationId": "UpdateCompany",
       "method": "PUT",
@@ -4987,9 +5053,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.deleteCompany": {
-      "id": "endpoint_.deleteCompany",
+    "endpoint_companies.deleteCompany": {
+      "id": "endpoint_companies.deleteCompany",
       "description": "You can delete a single company.",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Delete a company",
       "operationId": "deleteCompany",
       "method": "DELETE",
@@ -5163,9 +5232,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.ListAttachedContacts": {
-      "id": "endpoint_.ListAttachedContacts",
+    "endpoint_companies.ListAttachedContacts": {
+      "id": "endpoint_companies.ListAttachedContacts",
       "description": "You can fetch a list of all contacts that belong to a company.",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "List attached contacts",
       "operationId": "ListAttachedContacts",
       "method": "GET",
@@ -5353,9 +5425,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.ListAttachedSegmentsForCompanies": {
-      "id": "endpoint_.ListAttachedSegmentsForCompanies",
+    "endpoint_companies.ListAttachedSegmentsForCompanies": {
+      "id": "endpoint_companies.ListAttachedSegmentsForCompanies",
       "description": "You can fetch a list of all segments that belong to a company.",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "List attached segments for companies",
       "operationId": "ListAttachedSegmentsForCompanies",
       "method": "GET",
@@ -5536,9 +5611,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listAllCompanies": {
-      "id": "endpoint_.listAllCompanies",
+    "endpoint_companies.listAllCompanies": {
+      "id": "endpoint_companies.listAllCompanies",
       "description": "You can list companies. The company list is sorted by the `last_request_at` field and by default is ordered descending, most recently requested first.\n\nNote that the API does not include companies who have no associated users in list responses.\n\nWhen using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "List all companies",
       "operationId": "listAllCompanies",
       "method": "POST",
@@ -5754,9 +5832,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.scrollOverAllCompanies": {
-      "id": "endpoint_.scrollOverAllCompanies",
+    "endpoint_companies.scrollOverAllCompanies": {
+      "id": "endpoint_companies.scrollOverAllCompanies",
       "description": "      The `list all companies` functionality does not work well for huge datasets, and can result in errors and performance problems when paging deeply. The Scroll API provides an efficient mechanism for iterating over all companies in a dataset.\n\n- Each app can only have 1 scroll open at a time. You'll get an error message if you try to have more than one open per app.\n- If the scroll isn't used for 1 minute, it expires and calls with that scroll param will fail\n- If the end of the scroll is reached, \"companies\" will be empty and the scroll parameter will expire\n\n{% admonition type=\"info\" name=\"Scroll Parameter\" %}\n  You can get the first page of companies by simply sending a GET request to the scroll endpoint.\n  For subsequent requests you will need to use the scroll parameter from the response.\n{% /admonition %}\n{% admonition type=\"danger\" name=\"Scroll network timeouts\" %}\n  Since scroll is often used on large datasets network errors such as timeouts can be encountered. When this occurs you will see a HTTP 500 error with the following message:\n  \"Request failed due to an internal network error. Please restart the scroll operation.\"\n  If this happens, you will need to restart your scroll query: It is not possible to continue from a specific point when using scroll.\n{% /admonition %}\n",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Scroll over all companies",
       "operationId": "scrollOverAllCompanies",
       "method": "GET",
@@ -5929,9 +6010,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listCompaniesForAContact": {
-      "id": "endpoint_.listCompaniesForAContact",
+    "endpoint_contacts.listCompaniesForAContact": {
+      "id": "endpoint_contacts.listCompaniesForAContact",
       "description": "You can fetch a list of companies that are associated to a contact.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "List attached companies for contact",
       "operationId": "listCompaniesForAContact",
       "method": "GET",
@@ -6145,9 +6229,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.attachContactToACompany": {
-      "id": "endpoint_.attachContactToACompany",
+    "endpoint_companies.attachContactToACompany": {
+      "id": "endpoint_companies.attachContactToACompany",
       "description": "You can attach a company to a single contact.",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Attach a Contact to a Company",
       "operationId": "attachContactToACompany",
       "method": "POST",
@@ -6485,9 +6572,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.detachContactFromACompany": {
-      "id": "endpoint_.detachContactFromACompany",
+    "endpoint_companies.detachContactFromACompany": {
+      "id": "endpoint_companies.detachContactFromACompany",
       "description": "You can detach a company from a single contact.",
+      "namespace": [
+        "subpackage_companies"
+      ],
       "displayName": "Detach a contact from a company",
       "operationId": "detachContactFromACompany",
       "method": "DELETE",
@@ -6725,9 +6815,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listNotes": {
-      "id": "endpoint_.listNotes",
+    "endpoint_notes.listNotes": {
+      "id": "endpoint_notes.listNotes",
       "description": "You can fetch a list of notes that are associated to a contact.",
+      "namespace": [
+        "subpackage_notes"
+      ],
       "displayName": "List all notes",
       "operationId": "listNotes",
       "method": "GET",
@@ -6941,9 +7034,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createNote": {
-      "id": "endpoint_.createNote",
+    "endpoint_notes.createNote": {
+      "id": "endpoint_notes.createNote",
       "description": "You can add a note to a single contact.",
+      "namespace": [
+        "subpackage_notes"
+      ],
       "displayName": "Create a note",
       "operationId": "createNote",
       "method": "POST",
@@ -7268,9 +7364,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listSegmentsForAContact": {
-      "id": "endpoint_.listSegmentsForAContact",
+    "endpoint_contacts.listSegmentsForAContact": {
+      "id": "endpoint_contacts.listSegmentsForAContact",
       "description": "You can fetch a list of segments that are associated to a contact.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "List attached segments for contact",
       "operationId": "listSegmentsForAContact",
       "method": "GET",
@@ -7460,9 +7559,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listSubscriptionsForAContact": {
-      "id": "endpoint_.listSubscriptionsForAContact",
+    "endpoint_contacts.listSubscriptionsForAContact": {
+      "id": "endpoint_contacts.listSubscriptionsForAContact",
       "description": "You can fetch a list of subscription types that are attached to a contact. These can be subscriptions that a user has 'opted-in' to or has 'opted-out' from, depending on the subscription type.\nThis will return a list of Subscription Type objects that the contact is associated with.\n\nThe data property will show a combined list of:\n\n  1.Opt-out subscription types that the user has opted-out from.\n  2.Opt-in subscription types that the user has opted-in to receiving.\n",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "List subscriptions for a contact",
       "operationId": "listSubscriptionsForAContact",
       "method": "GET",
@@ -7686,9 +7788,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.attachSubscriptionTypeToContact": {
-      "id": "endpoint_.attachSubscriptionTypeToContact",
+    "endpoint_subscriptionTypes.attachSubscriptionTypeToContact": {
+      "id": "endpoint_subscriptionTypes.attachSubscriptionTypeToContact",
       "description": "You can add a specific subscription to a contact. In Intercom, we have two different subscription types based on user consent - opt-out and opt-in:\n\n  1.Attaching a contact to an opt-out subscription type will opt that user out from receiving messages related to that subscription type.\n\n  2.Attaching a contact to an opt-in subscription type will opt that user in to receiving messages related to that subscription type.\n\nThis will return a subscription type model for the subscription type that was added to the contact.\n",
+      "namespace": [
+        "subpackage_subscriptionTypes"
+      ],
       "displayName": "Add subscription to a contact",
       "operationId": "attachSubscriptionTypeToContact",
       "method": "POST",
@@ -8024,9 +8129,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.detachSubscriptionTypeToContact": {
-      "id": "endpoint_.detachSubscriptionTypeToContact",
+    "endpoint_subscriptionTypes.detachSubscriptionTypeToContact": {
+      "id": "endpoint_subscriptionTypes.detachSubscriptionTypeToContact",
       "description": "You can remove a specific subscription from a contact. This will return a subscription type model for the subscription type that was removed from the contact.",
+      "namespace": [
+        "subpackage_subscriptionTypes"
+      ],
       "displayName": "Remove subscription from a contact",
       "operationId": "detachSubscriptionTypeToContact",
       "method": "DELETE",
@@ -8262,9 +8370,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listTagsForAContact": {
-      "id": "endpoint_.listTagsForAContact",
+    "endpoint_contacts.listTagsForAContact": {
+      "id": "endpoint_contacts.listTagsForAContact",
       "description": "You can fetch a list of all tags that are attached to a specific contact.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "List tags attached to a contact",
       "operationId": "listTagsForAContact",
       "method": "GET",
@@ -8451,9 +8562,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.attachTagToContact": {
-      "id": "endpoint_.attachTagToContact",
+    "endpoint_tags.attachTagToContact": {
+      "id": "endpoint_tags.attachTagToContact",
       "description": "You can tag a specific contact. This will return a tag object for the tag that was added to the contact.",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Add tag to a contact",
       "operationId": "attachTagToContact",
       "method": "POST",
@@ -8735,9 +8849,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.detachTagFromContact": {
-      "id": "endpoint_.detachTagFromContact",
+    "endpoint_tags.detachTagFromContact": {
+      "id": "endpoint_tags.detachTagFromContact",
       "description": "You can remove tag from a specific contact. This will return a tag object for the tag that was removed from the contact.",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Remove tag from a contact",
       "operationId": "detachTagFromContact",
       "method": "DELETE",
@@ -8957,9 +9074,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.ShowContact": {
-      "id": "endpoint_.ShowContact",
+    "endpoint_contacts.ShowContact": {
+      "id": "endpoint_contacts.ShowContact",
       "description": "You can fetch the details of a single contact.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Get a contact",
       "operationId": "ShowContact",
       "method": "GET",
@@ -9192,9 +9312,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.UpdateContact": {
-      "id": "endpoint_.UpdateContact",
+    "endpoint_contacts.UpdateContact": {
+      "id": "endpoint_contacts.UpdateContact",
       "description": "You can update an existing contact (ie. user or lead).",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Update a contact",
       "operationId": "UpdateContact",
       "method": "PUT",
@@ -9446,9 +9569,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.DeleteContact": {
-      "id": "endpoint_.DeleteContact",
+    "endpoint_contacts.DeleteContact": {
+      "id": "endpoint_contacts.DeleteContact",
       "description": "You can delete a single contact.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Delete a contact",
       "operationId": "DeleteContact",
       "method": "DELETE",
@@ -9593,9 +9719,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.MergeContact": {
-      "id": "endpoint_.MergeContact",
+    "endpoint_contacts.MergeContact": {
+      "id": "endpoint_contacts.MergeContact",
       "description": "You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Merge a lead and a user",
       "operationId": "MergeContact",
       "method": "POST",
@@ -9829,9 +9958,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.SearchContacts": {
-      "id": "endpoint_.SearchContacts",
+    "endpoint_contacts.SearchContacts": {
+      "id": "endpoint_contacts.SearchContacts",
       "description": "You can search for multiple contacts by the value of their attributes in order to fetch exactly who you want.\n\nTo search for contacts, you need to send a `POST` request to `https://api.intercom.io/contacts/search`.\n\nThis will accept a query object in the body which will define your filters in order to search for contacts.\n\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `50` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n### Contact Creation Delay\n\nIf a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiple's there can be:\n* There's a limit of max 2 nested filters\n* There's a limit of max 15 filters for each AND or OR group\n\n### Searching for Timestamp Fields\n\nAll timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second.\nFor example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM). The search results will then include Contacts created from January 2nd, 2020 12:00 AM onwards.\nIf you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM).\nThis behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.\n\n### Accepted Fields\n\nMost key listed as part of the Contacts Model are searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foorbar\"`).\n\n| Field                              | Type                           |\n| ---------------------------------- | ------------------------------ |\n| id                                 | String                         |\n| role                               | String<br>Accepts user or lead |\n| name                               | String                         |\n| avatar                             | String                         |\n| owner_id                           | Integer                        |\n| email                              | String                         |\n| email_domain                       | String                         |\n| phone                              | String                         |\n| formatted_phone                    | String                         |\n| external_id                        | String                         |\n| created_at                         | Date (UNIX Timestamp)          |\n| signed_up_at                       | Date (UNIX Timestamp)          |\n| updated_at                         | Date (UNIX Timestamp)          |\n| last_seen_at                       | Date (UNIX Timestamp)          |\n| last_contacted_at                  | Date (UNIX Timestamp)          |\n| last_replied_at                    | Date (UNIX Timestamp)          |\n| last_email_opened_at               | Date (UNIX Timestamp)          |\n| last_email_clicked_at              | Date (UNIX Timestamp)          |\n| language_override                  | String                         |\n| browser                            | String                         |\n| browser_language                   | String                         |\n| os                                 | String                         |\n| location.country                   | String                         |\n| location.region                    | String                         |\n| location.city                      | String                         |\n| unsubscribed_from_emails           | Boolean                        |\n| marked_email_as_spam               | Boolean                        |\n| has_hard_bounced                   | Boolean                        |\n| ios_last_seen_at                   | Date (UNIX Timestamp)          |\n| ios_app_version                    | String                         |\n| ios_device                         | String                         |\n| ios_app_device                     | String                         |\n| ios_os_version                     | String                         |\n| ios_app_name                       | String                         |\n| ios_sdk_version                    | String                         |\n| android_last_seen_at               | Date (UNIX Timestamp)          |\n| android_app_version                | String                         |\n| android_device                     | String                         |\n| android_app_name                   | String                         |\n| andoid_sdk_version                 | String                         |\n| segment_id                         | String                         |\n| tag_id                             | String                         |\n| custom_attributes.{attribute_name} | String                         |\n\n### Accepted Operators\n\n{% admonition type=\"attention\" name=\"Searching based on `created_at`\" %}\n  You cannot use the `<=` or `>=` operators to search by `created_at`.\n{% /admonition %}\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                      | Description                                                      |\n| :------- | :------------------------------- | :--------------------------------------------------------------- |\n| =        | All                              | Equals                                                           |\n| !=       | All                              | Doesn't Equal                                                    |\n| IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |\n| NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |\n| >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |\n| <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |\n| ~        | String                           | Contains                                                         |\n| !~       | String                           | Doesn't Contain                                                  |\n| ^        | String                           | Starts With                                                      |\n| $        | String                           | Ends With                                                        |\n",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Search contacts",
       "operationId": "SearchContacts",
       "method": "POST",
@@ -9993,9 +10125,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.ListContacts": {
-      "id": "endpoint_.ListContacts",
+    "endpoint_contacts.ListContacts": {
+      "id": "endpoint_contacts.ListContacts",
       "description": "You can fetch a list of all contacts (ie. users or leads) in your workspace.\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `50` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "List all contacts",
       "operationId": "ListContacts",
       "method": "GET",
@@ -10119,9 +10254,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.CreateContact": {
-      "id": "endpoint_.CreateContact",
+    "endpoint_contacts.CreateContact": {
+      "id": "endpoint_contacts.CreateContact",
       "description": "You can create a new contact (ie. user or lead).",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Create contact",
       "operationId": "CreateContact",
       "method": "POST",
@@ -10346,9 +10484,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.ArchiveContact": {
-      "id": "endpoint_.ArchiveContact",
+    "endpoint_contacts.ArchiveContact": {
+      "id": "endpoint_contacts.ArchiveContact",
       "description": "You can archive a single contact.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Archive contact",
       "operationId": "ArchiveContact",
       "method": "POST",
@@ -10470,9 +10611,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.UnarchiveContact": {
-      "id": "endpoint_.UnarchiveContact",
+    "endpoint_contacts.UnarchiveContact": {
+      "id": "endpoint_contacts.UnarchiveContact",
       "description": "You can unarchive a single contact.",
+      "namespace": [
+        "subpackage_contacts"
+      ],
       "displayName": "Unarchive contact",
       "operationId": "UnarchiveContact",
       "method": "POST",
@@ -10594,9 +10738,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.attachTagToConversation": {
-      "id": "endpoint_.attachTagToConversation",
+    "endpoint_tags.attachTagToConversation": {
+      "id": "endpoint_tags.attachTagToConversation",
       "description": "You can tag a specific conversation. This will return a tag object for the tag that was added to the conversation.",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Add tag to a conversation",
       "operationId": "attachTagToConversation",
       "method": "POST",
@@ -10850,9 +10997,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.detachTagFromConversation": {
-      "id": "endpoint_.detachTagFromConversation",
+    "endpoint_tags.detachTagFromConversation": {
+      "id": "endpoint_tags.detachTagFromConversation",
       "description": "You can remove tag from a specific conversation. This will return a tag object for the tag that was removed from the conversation.",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Remove tag from a conversation",
       "operationId": "detachTagFromConversation",
       "method": "DELETE",
@@ -11158,9 +11308,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listConversations": {
-      "id": "endpoint_.listConversations",
+    "endpoint_conversations.listConversations": {
+      "id": "endpoint_conversations.listConversations",
       "description": "You can fetch a list of all conversations.\n\nYou can optionally request the result page size and the cursor to start after to fetch the result.\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "List all conversations",
       "operationId": "listConversations",
       "method": "GET",
@@ -11418,9 +11571,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createConversation": {
-      "id": "endpoint_.createConversation",
+    "endpoint_conversations.createConversation": {
+      "id": "endpoint_conversations.createConversation",
       "description": "You can create a conversation that has been initiated by a contact (ie. user or lead).\nThe conversation can be an in-app message only.\n\n{% admonition type=\"info\" name=\"Sending for visitors\" %}\nYou can also send a message from a visitor by specifying their `user_id` or `id` value in the `from` field, along with a `type` field value of `contact`.\nThis visitor will be automatically converted to a contact with a lead role once the conversation is created.\n{% /admonition %}\n\nThis will return the Message model that has been created.\n\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Creates a conversation",
       "operationId": "createConversation",
       "method": "POST",
@@ -11649,9 +11805,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveConversation": {
-      "id": "endpoint_.retrieveConversation",
+    "endpoint_conversations.retrieveConversation": {
+      "id": "endpoint_conversations.retrieveConversation",
       "description": "\nYou can fetch the details of a single conversation.\n\nThis will return a single Conversation model with all its conversation parts.\n\n{% admonition type=\"warning\" name=\"Hard limit of 500 parts\" %}\nThe maximum number of conversation parts that can be returned via the API is 500. If you have more than that we will return the 500 most recent conversation parts.\n{% /admonition %}\n\nFor AI agent conversation metadata, please note that you need to have the agent enabled in your workspace, which is a [paid feature](https://www.intercom.com/help/en/articles/8205718-fin-resolutions#h_97f8c2e671).\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Retrieve a conversation",
       "operationId": "retrieveConversation",
       "method": "GET",
@@ -11937,9 +12096,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateConversation": {
-      "id": "endpoint_.updateConversation",
+    "endpoint_conversations.updateConversation": {
+      "id": "endpoint_conversations.updateConversation",
       "description": "\nYou can update an existing conversation.\n\n{% admonition type=\"info\" name=\"Replying and other actions\" %}\nIf you want to reply to a coveration or take an action such as assign, unassign, open, close or snooze, take a look at the reply and manage endpoints.\n{% /admonition %}\n\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Update a conversation",
       "operationId": "updateConversation",
       "method": "PUT",
@@ -12418,9 +12580,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.searchConversations": {
-      "id": "endpoint_.searchConversations",
+    "endpoint_conversations.searchConversations": {
+      "id": "endpoint_conversations.searchConversations",
       "description": "You can search for multiple conversations by the value of their attributes in order to fetch exactly which ones you want.\n\nTo search for conversations, you need to send a `POST` request to `https://api.intercom.io/conversations/search`.\n\nThis will accept a query object in the body which will define your filters in order to search for conversations.\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `20` results per page and maximum is `150`.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiple's there can be:\n- There's a limit of max 2 nested filters\n- There's a limit of max 15 filters for each AND or OR group\n\n### Accepted Fields\n\nMost keys listed as part of the The conversation model is searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foorbar\"`).\n\n| Field                                     | Type                                                                                                                                                   |\n| :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- |\n| id                                        | String                                                                                                                                                 |\n| created_at                                | Date (UNIX timestamp)                                                                                                                                  |\n| updated_at                                | Date (UNIX timestamp)                                                                                                                                  |\n| source.type                               | String<br>Accepted fields are `conversation`, `email`, `facebook`, `instagram`, `phone_call`, `phone_switch`, `push`, `sms`, `twitter` and `whatsapp`. |\n| source.id                                 | String                                                                                                                                                 |\n| source.delivered_as                       | String                                                                                                                                                 |\n| source.subject                            | String                                                                                                                                                 |\n| source.body                               | String                                                                                                                                                 |\n| source.author.id                          | String                                                                                                                                                 |\n| source.author.type                        | String                                                                                                                                                 |\n| source.author.name                        | String                                                                                                                                                 |\n| source.author.email                       | String                                                                                                                                                 |\n| source.url                                | String                                                                                                                                                 |\n| contact_ids                               | String                                                                                                                                                 |\n| teammate_ids                              | String                                                                                                                                                 |\n| admin_assignee_id                         | String                                                                                                                                                 |\n| team_assignee_id                          | String                                                                                                                                                 |\n| channel_initiated                         | String                                                                                                                                                 |\n| open                                      | Boolean                                                                                                                                                |\n| read                                      | Boolean                                                                                                                                                |\n| state                                     | String                                                                                                                                                 |\n| waiting_since                             | Date (UNIX timestamp)                                                                                                                                  |\n| snoozed_until                             | Date (UNIX timestamp)                                                                                                                                  |\n| tag_ids                                   | String                                                                                                                                                 |\n| priority                                  | String                                                                                                                                                 |\n| statistics.time_to_assignment             | Integer                                                                                                                                                |\n| statistics.time_to_admin_reply            | Integer                                                                                                                                                |\n| statistics.time_to_first_close            | Integer                                                                                                                                                |\n| statistics.time_to_last_close             | Integer                                                                                                                                                |\n| statistics.median_time_to_reply           | Integer                                                                                                                                                |\n| statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_assignment_at            | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_close_at                 | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_assignment_at             | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_close_at                  | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_closed_by_id              | String                                                                                                                                                 |\n| statistics.count_reopens                  | Integer                                                                                                                                                |\n| statistics.count_assignments              | Integer                                                                                                                                                |\n| statistics.count_conversation_parts       | Integer                                                                                                                                                |\n| conversation_rating.requested_at          | Date (UNIX timestamp)                                                                                                                                  |\n| conversation_rating.replied_at            | Date (UNIX timestamp)                                                                                                                                  |\n| conversation_rating.score                 | Integer                                                                                                                                                |\n| conversation_rating.remark                | String                                                                                                                                                 |\n| conversation_rating.contact_id            | String                                                                                                                                                 |\n| conversation_rating.admin_d               | String                                                                                                                                                 |\n| ai_agent_participated                     | Boolean                                                                                                                                                |\n| ai_agent.resolution_state                 | String                                                                                                                                                 |\n| ai_agent.last_answer_type                 | String                                                                                                                                                 |\n| ai_agent.rating                           | Integer                                                                                                                                                |\n| ai_agent.rating_remark                    | String                                                                                                                                                 |\n| ai_agent.source_type                      | String                                                                                                                                                 |\n| ai_agent.source_title                     | String                                                                                                                                                 |\n\n### Accepted Operators\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type  (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                    | Description                                                  |\n| :------- | :----------------------------- | :----------------------------------------------------------- |\n| =        | All                            | Equals                                                       |\n| !=       | All                            | Doesn't Equal                                                |\n| IN       | All                            | In  Shortcut for `OR` queries  Values most be in Array       |\n| NIN      | All                            | Not In  Shortcut for `OR !` queries  Values must be in Array |\n| >        | Integer  Date (UNIX Timestamp) | Greater (or equal) than                                      |\n| <       | Integer  Date (UNIX Timestamp) | Lower (or equal) than                                        |\n| ~        | String                         | Contains                                                     |\n| !~       | String                         | Doesn't Contain                                              |\n| ^        | String                         | Starts With                                                  |\n| $        | String                         | Ends With                                                    |\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Search conversations",
       "operationId": "searchConversations",
       "method": "POST",
@@ -12613,9 +12778,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.replyConversation": {
-      "id": "endpoint_.replyConversation",
+    "endpoint_conversations.replyConversation": {
+      "id": "endpoint_conversations.replyConversation",
       "description": "You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Reply to a conversation",
       "operationId": "replyConversation",
       "method": "POST",
@@ -13259,9 +13427,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.manageConversation": {
-      "id": "endpoint_.manageConversation",
+    "endpoint_conversations.manageConversation": {
+      "id": "endpoint_conversations.manageConversation",
       "description": "For managing conversations you can:\n- Close a conversation\n- Snooze a conversation to reopen on a future date\n- Open a conversation which is `snoozed` or `closed`\n- Assign a conversation to an admin and/or team.\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Manage a conversation",
       "operationId": "manageConversation",
       "method": "POST",
@@ -14002,9 +14173,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.autoAssignConversation": {
-      "id": "endpoint_.autoAssignConversation",
+    "endpoint_conversations.autoAssignConversation": {
+      "id": "endpoint_conversations.autoAssignConversation",
       "description": "You can let a conversation be automatically assigned following assignment rules.\n{% admonition type=\"attention\" name=\"When using workflows\" %}\nIt is not possible to use this endpoint with Workflows.\n{% /admonition %}\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Run Assignment Rules on a conversation",
       "operationId": "autoAssignConversation",
       "method": "POST",
@@ -14300,9 +14474,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.attachContactToConversation": {
-      "id": "endpoint_.attachContactToConversation",
+    "endpoint_conversations.attachContactToConversation": {
+      "id": "endpoint_conversations.attachContactToConversation",
       "description": "You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.\n\n{% admonition type=\"attention\" name=\"Contacts without an email\" %}\nIf you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.\n{% /admonition %}\n\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Attach a contact to a conversation",
       "operationId": "attachContactToConversation",
       "method": "POST",
@@ -14566,9 +14743,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.detachContactFromConversation": {
-      "id": "endpoint_.detachContactFromConversation",
+    "endpoint_conversations.detachContactFromConversation": {
+      "id": "endpoint_conversations.detachContactFromConversation",
       "description": "You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.\n\n{% admonition type=\"attention\" name=\"Contacts without an email\" %}\nIf you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.\n{% /admonition %}\n\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Detach a contact from a group conversation",
       "operationId": "detachContactFromConversation",
       "method": "DELETE",
@@ -14959,9 +15139,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.redactConversation": {
-      "id": "endpoint_.redactConversation",
+    "endpoint_conversations.redactConversation": {
+      "id": "endpoint_conversations.redactConversation",
       "description": "You can redact a conversation part or the source message of a conversation (as seen in the source object).\n\n{% admonition type=\"info\" name=\"Redacting parts and messages\" %}\nIf you are redacting a conversation part, it must have a `body`. If you are redacting a source message, it must have been created by a contact. We will return a `conversation_part_not_redactable` error if these criteria are not met.\n{% /admonition %}\n\n",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Redact a conversation part",
       "operationId": "redactConversation",
       "method": "POST",
@@ -15328,9 +15511,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.convertConversationToTicket": {
-      "id": "endpoint_.convertConversationToTicket",
+    "endpoint_conversations.convertConversationToTicket": {
+      "id": "endpoint_conversations.convertConversationToTicket",
       "description": "You can convert a conversation to a ticket.",
+      "namespace": [
+        "subpackage_conversations"
+      ],
       "displayName": "Convert a conversation to a ticket",
       "operationId": "convertConversationToTicket",
       "method": "POST",
@@ -15717,9 +15903,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.lisDataAttributes": {
-      "id": "endpoint_.lisDataAttributes",
+    "endpoint_dataAttributes.lisDataAttributes": {
+      "id": "endpoint_dataAttributes.lisDataAttributes",
       "description": "You can fetch a list of all data attributes belonging to a workspace for contacts, companies or conversations.",
+      "namespace": [
+        "subpackage_dataAttributes"
+      ],
       "displayName": "List all data attributes",
       "operationId": "lisDataAttributes",
       "method": "GET",
@@ -16124,9 +16313,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createDataAttribute": {
-      "id": "endpoint_.createDataAttribute",
+    "endpoint_dataAttributes.createDataAttribute": {
+      "id": "endpoint_dataAttributes.createDataAttribute",
       "description": "You can create a data attributes for a `contact` or a `company`.",
+      "namespace": [
+        "subpackage_dataAttributes"
+      ],
       "displayName": "Create a data attribute",
       "operationId": "createDataAttribute",
       "method": "POST",
@@ -16539,9 +16731,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateDataAttribute": {
-      "id": "endpoint_.updateDataAttribute",
+    "endpoint_dataAttributes.updateDataAttribute": {
+      "id": "endpoint_dataAttributes.updateDataAttribute",
       "description": "\nYou can update a data attribute.\n\n> 🚧 Updating the data type is not possible\n>\n> It is currently a dangerous action to execute changing a data attribute's type via the API. You will need to update the type via the UI instead.\n",
+      "namespace": [
+        "subpackage_dataAttributes"
+      ],
       "displayName": "Update a data attribute",
       "operationId": "updateDataAttribute",
       "method": "PUT",
@@ -16950,9 +17145,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.lisDataEvents": {
-      "id": "endpoint_.lisDataEvents",
+    "endpoint_dataEvents.lisDataEvents": {
+      "id": "endpoint_dataEvents.lisDataEvents",
       "description": "\n> 🚧\n>\n> Please note that you can only 'list' events that are less than 90 days old. Event counts and summaries will still include your events older than 90 days but you cannot 'list' these events individually if they are older than 90 days\n\nThe events belonging to a customer can be listed by sending a GET request to `https://api.intercom.io/events` with a user or lead identifier along with a `type` parameter. The identifier parameter can be one of `user_id`, `email` or `intercom_user_id`. The `type` parameter value must be `user`.\n\n- `https://api.intercom.io/events?type=user&user_id={user_id}`\n- `https://api.intercom.io/events?type=user&email={email}`\n- `https://api.intercom.io/events?type=user&intercom_user_id={id}` (this call can be used to list leads)\n\nThe `email` parameter value should be [url encoded](http://en.wikipedia.org/wiki/Percent-encoding) when sending.\n\nYou can optionally define the result page size as well with the `per_page` parameter.\n",
+      "namespace": [
+        "subpackage_dataEvents"
+      ],
       "displayName": "List all data events",
       "operationId": "lisDataEvents",
       "method": "GET",
@@ -17186,9 +17384,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createDataEvent": {
-      "id": "endpoint_.createDataEvent",
+    "endpoint_dataEvents.createDataEvent": {
+      "id": "endpoint_dataEvents.createDataEvent",
       "description": "\nYou will need an Access Token that has write permissions to send Events. Once you have a key you can submit events via POST to the Events resource, which is located at https://api.intercom.io/events, or you can send events using one of the client libraries. When working with the HTTP API directly a client should send the event with a `Content-Type` of `application/json`.\n\nWhen using the JavaScript API, [adding the code to your app](http://docs.intercom.io/configuring-Intercom/tracking-user-events-in-your-app) makes the Events API available. Once added, you can submit an event using the `trackEvent` method. This will associate the event with the Lead or currently logged-in user or logged-out visitor/lead and send it to Intercom. The final parameter is a map that can be used to send optional metadata about the event.\n\nWith the Ruby client you pass a hash describing the event to `Intercom::Event.create`, or call the `track_user` method directly on the current user object (e.g. `user.track_event`).\n\n**NB: For the JSON object types, please note that we do not currently support nested JSON structure.**\n\n| Type            | Description                                                                                                                                                                                                     | Example                                                                           |\n| :-------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |\n| String          | The value is a JSON String                                                                                                                                                                                      | `\"source\":\"desktop\"`                                                              |\n| Number          | The value is a JSON Number                                                                                                                                                                                      | `\"load\": 3.67`                                                                    |\n| Date            | The key ends with the String `_date` and the value is a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time), assumed to be in the [UTC](http://en.wikipedia.org/wiki/Coordinated_Universal_Time) timezone. | `\"contact_date\": 1392036272`                                                      |\n| Link            | The value is a HTTP or HTTPS URI.                                                                                                                                                                               | `\"article\": \"https://example.org/ab1de.html\"`                                     |\n| Rich Link       | The value is a JSON object that contains `url` and `value` keys.                                                                                                                                                | `\"article\": {\"url\": \"https://example.org/ab1de.html\", \"value\":\"the dude abides\"}` |\n| Monetary Amount | The value is a JSON object that contains `amount` and `currency` keys. The `amount` key is a positive integer representing the amount in cents. The price in the example to the right denotes €349.99.          | `\"price\": {\"amount\": 34999, \"currency\": \"eur\"}`                                   |\n\n**Lead Events**\n\nWhen submitting events for Leads, you will need to specify the Lead's `id`.\n\n**Metadata behaviour**\n\n- We currently limit the number of tracked metadata keys to 10 per event. Once the quota is reached, we ignore any further keys we receive. The first 10 metadata keys are determined by the order in which they are sent in with the event.\n- It is not possible to change the metadata keys once the event has been sent. A new event will need to be created with the new keys and you can archive the old one.\n- There might be up to 24 hrs delay when you send a new metadata for an existing event.\n\n**Event de-duplication**\n\nThe API may detect and ignore duplicate events. Each event is uniquely identified as a combination of the following data - the Workspace identifier, the Contact external identifier, the Data Event name and the Data Event created time. As a result, it is **strongly recommended** to send a second granularity Unix timestamp in the `created_at` field.\n\nDuplicated events are responded to using the normal `202 Accepted` code - an error is not thrown, however repeat requests will be counted against any rate limit that is in place.\n\n### HTTP API Responses\n\n- Successful responses to submitted events return `202 Accepted` with an empty body.\n- Unauthorised access will be rejected with a `401 Unauthorized` or `403 Forbidden` response code.\n- Events sent about users that cannot be found will return a `404 Not Found`.\n- Event lists containing duplicate events will have those duplicates ignored.\n- Server errors will return a `500` response code and may contain an error message in the body.\n\n",
+      "namespace": [
+        "subpackage_dataEvents"
+      ],
       "displayName": "Submit a data event",
       "operationId": "createDataEvent",
       "method": "POST",
@@ -17305,9 +17506,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.dataEventSummaries": {
-      "id": "endpoint_.dataEventSummaries",
+    "endpoint_dataEvents.dataEventSummaries": {
+      "id": "endpoint_dataEvents.dataEventSummaries",
       "description": "Create event summaries for a user. Event summaries are used to track the number of times an event has occurred, the first time it occurred and the last time it occurred.\n\n",
+      "namespace": [
+        "subpackage_dataEvents"
+      ],
       "displayName": "Create event summaries",
       "operationId": "dataEventSummaries",
       "method": "POST",
@@ -17444,9 +17648,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createDataExport": {
-      "id": "endpoint_.createDataExport",
+    "endpoint_dataExport.createDataExport": {
+      "id": "endpoint_dataExport.createDataExport",
       "description": "To create your export job, you need to send a `POST` request to the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe only parameters you need to provide are the range of dates that you want exported.\n\n>🚧 Limit of one active job\n>\n> You can only have one active job per workspace. You will receive a HTTP status code of 429 with the message Exceeded rate limit of 1 pending message data export jobs if you attempt to create a second concurrent job.\n\n>❗️ Updated_at not included\n>\n> It should be noted that the timeframe only includes messages sent during the time period and not messages that were only updated during this period. For example, if a message was updated yesterday but sent two days ago, you would need to set the created_at_after date before the message was sent to include that in your retrieval job.\n\n>📘 Date ranges are inclusive\n>\n> Requesting data for 2018-06-01 until 2018-06-30 will get all data for those days including those specified - e.g. 2018-06-01 00:00:00 until 2018-06-30 23:59:99.\n",
+      "namespace": [
+        "subpackage_dataExport"
+      ],
       "displayName": "Create content data export",
       "operationId": "createDataExport",
       "method": "POST",
@@ -17569,9 +17776,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.getDataExport": {
-      "id": "endpoint_.getDataExport",
+    "endpoint_dataExport.getDataExport": {
+      "id": "endpoint_dataExport.getDataExport",
       "description": "You can view the status of your job by sending a `GET` request to the URL\n`https://api.intercom.io/export/content/data/{job_identifier}` - the `{job_identifier}` is the value returned in the response when you first created the export job. More on it can be seen in the Export Job Model.\n\n> 🚧 Jobs expire after two days\n> All jobs that have completed processing (and are thus available to download from the provided URL) will have an expiry limit of two days from when the export ob completed. After this, the data will no longer be available.\n",
+      "namespace": [
+        "subpackage_dataExport"
+      ],
       "displayName": "Show content data export",
       "operationId": "getDataExport",
       "method": "GET",
@@ -17701,9 +17911,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.cancelDataExport": {
-      "id": "endpoint_.cancelDataExport",
+    "endpoint_dataExport.cancelDataExport": {
+      "id": "endpoint_dataExport.cancelDataExport",
       "description": "You can cancel your job",
+      "namespace": [
+        "subpackage_dataExport"
+      ],
       "displayName": "Cancel content data export",
       "operationId": "cancelDataExport",
       "method": "POST",
@@ -17825,9 +18038,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.downloadDataExport": {
-      "id": "endpoint_.downloadDataExport",
+    "endpoint_dataExport.downloadDataExport": {
+      "id": "endpoint_dataExport.downloadDataExport",
       "description": "When a job has a status of complete, and thus a filled download_url, you can download your data by hitting that provided URL, formatted like so: https://api.intercom.io/download/content/data/xyz1234.\n\nYour exported message data will be streamed continuously back down to you in a gzipped CSV format.\n\n> 📘 Octet header required\n>\n> You will have to specify the header Accept: `application/octet-stream` when hitting this endpoint.\n",
+      "namespace": [
+        "subpackage_dataExport"
+      ],
       "displayName": "Download content data export",
       "operationId": "downloadDataExport",
       "method": "GET",
@@ -17943,9 +18159,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createMessage": {
-      "id": "endpoint_.createMessage",
+    "endpoint_messages.createMessage": {
+      "id": "endpoint_messages.createMessage",
       "description": "You can create a message that has been initiated by an admin. The conversation can be either an in-app message or an email.\n\n> 🚧 Sending for visitors\n>\n> There can be a short delay between when a contact is created and when a contact becomes available to be messaged through the API. A 404 Not Found error will be returned in this case.\n\nThis will return the Message model that has been created.\n\n> 🚧 Retrieving Associated Conversations\n>\n> As this is a message, there will be no conversation present until the contact responds. Once they do, you will have to search for a contact's conversations with the id of the message.\n",
+      "namespace": [
+        "subpackage_messages"
+      ],
       "displayName": "Create a message",
       "operationId": "createMessage",
       "method": "POST",
@@ -18380,9 +18599,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listNewsItems": {
-      "id": "endpoint_.listNewsItems",
+    "endpoint_news.listNewsItems": {
+      "id": "endpoint_news.listNewsItems",
       "description": "You can fetch a list of all news items",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "List all news items",
       "operationId": "listNewsItems",
       "method": "GET",
@@ -18557,9 +18779,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createNewsItem": {
-      "id": "endpoint_.createNewsItem",
+    "endpoint_news.createNewsItem": {
+      "id": "endpoint_news.createNewsItem",
       "description": "You can create a news item",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "Create a news item",
       "operationId": "createNewsItem",
       "method": "POST",
@@ -18745,9 +18970,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveNewsItem": {
-      "id": "endpoint_.retrieveNewsItem",
+    "endpoint_news.retrieveNewsItem": {
+      "id": "endpoint_news.retrieveNewsItem",
       "description": "You can fetch the details of a single news item.",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "Retrieve a news item",
       "operationId": "retrieveNewsItem",
       "method": "GET",
@@ -18950,8 +19178,11 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateNewsItem": {
-      "id": "endpoint_.updateNewsItem",
+    "endpoint_news.updateNewsItem": {
+      "id": "endpoint_news.updateNewsItem",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "Update a news item",
       "operationId": "updateNewsItem",
       "method": "PUT",
@@ -19219,9 +19450,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.deleteNewsItem": {
-      "id": "endpoint_.deleteNewsItem",
+    "endpoint_news.deleteNewsItem": {
+      "id": "endpoint_news.deleteNewsItem",
       "description": "You can delete a single news item.",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "Delete a news item",
       "operationId": "deleteNewsItem",
       "method": "DELETE",
@@ -19403,9 +19637,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listLiveNewsfeedItems": {
-      "id": "endpoint_.listLiveNewsfeedItems",
+    "endpoint_news.listLiveNewsfeedItems": {
+      "id": "endpoint_news.listLiveNewsfeedItems",
       "description": "You can fetch a list of all news items that are live on a given newsfeed",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "List all live newsfeed items",
       "operationId": "listLiveNewsfeedItems",
       "method": "GET",
@@ -19571,9 +19808,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listNewsfeeds": {
-      "id": "endpoint_.listNewsfeeds",
+    "endpoint_news.listNewsfeeds": {
+      "id": "endpoint_news.listNewsfeeds",
       "description": "You can fetch a list of all newsfeeds",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "List all newsfeeds",
       "operationId": "listNewsfeeds",
       "method": "GET",
@@ -19720,9 +19960,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveNewsfeed": {
-      "id": "endpoint_.retrieveNewsfeed",
+    "endpoint_news.retrieveNewsfeed": {
+      "id": "endpoint_news.retrieveNewsfeed",
       "description": "You can fetch the details of a single newsfeed",
+      "namespace": [
+        "subpackage_news"
+      ],
       "displayName": "Retrieve a newsfeed",
       "operationId": "retrieveNewsfeed",
       "method": "GET",
@@ -19876,9 +20119,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveNote": {
-      "id": "endpoint_.retrieveNote",
+    "endpoint_notes.retrieveNote": {
+      "id": "endpoint_notes.retrieveNote",
       "description": "You can fetch the details of a single note.",
+      "namespace": [
+        "subpackage_notes"
+      ],
       "displayName": "Retrieve a note",
       "operationId": "retrieveNote",
       "method": "GET",
@@ -20065,9 +20311,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listSegments": {
-      "id": "endpoint_.listSegments",
+    "endpoint_segments.listSegments": {
+      "id": "endpoint_segments.listSegments",
       "description": "You can fetch a list of all segments.",
+      "namespace": [
+        "subpackage_segments"
+      ],
       "displayName": "List all segments",
       "operationId": "listSegments",
       "method": "GET",
@@ -20222,9 +20471,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveSegment": {
-      "id": "endpoint_.retrieveSegment",
+    "endpoint_segments.retrieveSegment": {
+      "id": "endpoint_segments.retrieveSegment",
       "description": "You can fetch the details of a single segment.",
+      "namespace": [
+        "subpackage_segments"
+      ],
       "displayName": "Retrieve a segment",
       "operationId": "retrieveSegment",
       "method": "GET",
@@ -20401,9 +20653,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listSubscriptionTypes": {
-      "id": "endpoint_.listSubscriptionTypes",
+    "endpoint_subscriptionTypes.listSubscriptionTypes": {
+      "id": "endpoint_subscriptionTypes.listSubscriptionTypes",
       "description": "You can list all subscription types. A list of subscription type objects will be returned.",
+      "namespace": [
+        "subpackage_subscriptionTypes"
+      ],
       "displayName": "List subscription types",
       "operationId": "listSubscriptionTypes",
       "method": "GET",
@@ -20542,9 +20797,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createPhoneSwitch": {
-      "id": "endpoint_.createPhoneSwitch",
+    "endpoint_switch.createPhoneSwitch": {
+      "id": "endpoint_switch.createPhoneSwitch",
       "description": "You can use the API to deflect phone calls to the Intercom Messenger.\nCalling this endpoint will send an SMS with a link to the Messenger to the phone number specified.\n\nIf custom attributes are specified, they will be added to the user or lead's custom data attributes.\n",
+      "namespace": [
+        "subpackage_switch"
+      ],
       "displayName": "Create a phone Switch",
       "operationId": "createPhoneSwitch",
       "method": "POST",
@@ -20749,9 +21007,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listTags": {
-      "id": "endpoint_.listTags",
+    "endpoint_tags.listTags": {
+      "id": "endpoint_tags.listTags",
       "description": "You can fetch a list of all tags for a given workspace.\n\n",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "List all tags",
       "operationId": "listTags",
       "method": "GET",
@@ -20874,9 +21135,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createTag": {
-      "id": "endpoint_.createTag",
+    "endpoint_tags.createTag": {
+      "id": "endpoint_tags.createTag",
       "description": "You can use this endpoint to perform the following operations:\n\n  **1. Create a new tag:** You can create a new tag by passing in the tag name as specified in \"Create or Update Tag Request Payload\" described below.\n\n  **2. Update an existing tag:** You can update an existing tag by passing the id of the tag as specified in \"Create or Update Tag Request Payload\" described below.\n\n  **3. Tag Companies:** You can tag single company or a list of companies. You can tag a company by passing in the tag name and the company details as specified in \"Tag Company Request Payload\" described below. Also, if the tag doesn't exist then a new one will be created automatically.\n\n  **4. Untag Companies:** You can untag a single company or a list of companies. You can untag a company by passing in the tag id and the company details as specified in \"Untag Company Request Payload\" described below.\n\n  **5. Tag Multiple Users:** You can tag a list of users. You can tag the users by passing in the tag name and the user details as specified in \"Tag Users Request Payload\" described below.\n\nEach operation will return a tag object.\n",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Create or update a tag, Tag or untag companies, Tag contacts",
       "operationId": "createTag",
       "method": "POST",
@@ -21155,9 +21419,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.findTag": {
-      "id": "endpoint_.findTag",
+    "endpoint_tags.findTag": {
+      "id": "endpoint_tags.findTag",
       "description": "You can fetch the details of tags that are on the workspace by their id.\nThis will return a tag object.\n",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Find a specific tag",
       "operationId": "findTag",
       "method": "GET",
@@ -21331,9 +21598,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.deleteTag": {
-      "id": "endpoint_.deleteTag",
+    "endpoint_tags.deleteTag": {
+      "id": "endpoint_tags.deleteTag",
       "description": "You can delete the details of tags that are on the workspace by passing in the id.",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Delete tag",
       "operationId": "deleteTag",
       "method": "DELETE",
@@ -21524,9 +21794,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listTeams": {
-      "id": "endpoint_.listTeams",
+    "endpoint_teams.listTeams": {
+      "id": "endpoint_teams.listTeams",
       "description": "This will return a list of team objects for the App.",
+      "namespace": [
+        "subpackage_teams"
+      ],
       "displayName": "List all teams",
       "operationId": "listTeams",
       "method": "GET",
@@ -21643,9 +21916,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveTeam": {
-      "id": "endpoint_.retrieveTeam",
+    "endpoint_teams.retrieveTeam": {
+      "id": "endpoint_teams.retrieveTeam",
       "description": "You can fetch the details of a single team, containing an array of admins that belong to this team.",
+      "namespace": [
+        "subpackage_teams"
+      ],
       "displayName": "Retrieve a team",
       "operationId": "retrieveTeam",
       "method": "GET",
@@ -21820,9 +22096,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createTicketTypeAttribute": {
-      "id": "endpoint_.createTicketTypeAttribute",
+    "endpoint_ticketTypeAttributes.createTicketTypeAttribute": {
+      "id": "endpoint_ticketTypeAttributes.createTicketTypeAttribute",
       "description": "You can create a new attribute for a ticket type.",
+      "namespace": [
+        "subpackage_ticketTypeAttributes"
+      ],
       "displayName": "Create a new attribute for a ticket type",
       "operationId": "createTicketTypeAttribute",
       "method": "POST",
@@ -22011,9 +22290,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateTicketTypeAttribute": {
-      "id": "endpoint_.updateTicketTypeAttribute",
+    "endpoint_ticketTypeAttributes.updateTicketTypeAttribute": {
+      "id": "endpoint_ticketTypeAttributes.updateTicketTypeAttribute",
       "description": "You can update an existing attribute for a ticket type.",
+      "namespace": [
+        "subpackage_ticketTypeAttributes"
+      ],
       "displayName": "Update an existing attribute for a ticket type",
       "operationId": "updateTicketTypeAttribute",
       "method": "PUT",
@@ -22218,9 +22500,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.listTicketTypes": {
-      "id": "endpoint_.listTicketTypes",
+    "endpoint_ticketTypes.listTicketTypes": {
+      "id": "endpoint_ticketTypes.listTicketTypes",
       "description": "You can get a list of all ticket types for a workspace.",
+      "namespace": [
+        "subpackage_ticketTypes"
+      ],
       "displayName": "List all ticket types",
       "operationId": "listTicketTypes",
       "method": "GET",
@@ -22417,9 +22702,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createTicketType": {
-      "id": "endpoint_.createTicketType",
+    "endpoint_ticketTypes.createTicketType": {
+      "id": "endpoint_ticketTypes.createTicketType",
       "description": "You can create a new ticket type.\n> 📘 Creating ticket types.\n>\n> Every ticket type will be created with two default attributes: _default_title_ and _default_description_.\n> For the `icon` propery, use an emoji from [Twemoji Cheatsheet](https://twemoji-cheatsheet.vercel.app/)\n",
+      "namespace": [
+        "subpackage_ticketTypes"
+      ],
       "displayName": "Create a ticket type",
       "operationId": "createTicketType",
       "method": "POST",
@@ -22613,9 +22901,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.getTicketType": {
-      "id": "endpoint_.getTicketType",
+    "endpoint_ticketTypes.getTicketType": {
+      "id": "endpoint_ticketTypes.getTicketType",
       "description": "You can fetch the details of a single ticket type.",
+      "namespace": [
+        "subpackage_ticketTypes"
+      ],
       "displayName": "Retrieve a ticket type",
       "operationId": "getTicketType",
       "method": "GET",
@@ -22833,9 +23124,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateTicketType": {
-      "id": "endpoint_.updateTicketType",
+    "endpoint_ticketTypes.updateTicketType": {
+      "id": "endpoint_ticketTypes.updateTicketType",
       "description": "\nYou can update a ticket type.\n\n> 📘 Updating a ticket type.\n>\n> For the `icon` propery, use an emoji from [Twemoji Cheatsheet](https://twemoji-cheatsheet.vercel.app/)\n",
+      "namespace": [
+        "subpackage_ticketTypes"
+      ],
       "displayName": "Update a ticket type",
       "operationId": "updateTicketType",
       "method": "PUT",
@@ -23071,9 +23365,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.replyTicket": {
-      "id": "endpoint_.replyTicket",
+    "endpoint_tickets.replyTicket": {
+      "id": "endpoint_tickets.replyTicket",
       "description": "You can reply to a ticket with a message from an admin or on behalf of a contact, or with a note for admins.",
+      "namespace": [
+        "subpackage_tickets"
+      ],
       "displayName": "Reply to a ticket",
       "operationId": "replyTicket",
       "method": "POST",
@@ -23430,9 +23727,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.attachTagToTicket": {
-      "id": "endpoint_.attachTagToTicket",
+    "endpoint_tags.attachTagToTicket": {
+      "id": "endpoint_tags.attachTagToTicket",
       "description": "You can tag a specific ticket. This will return a tag object for the tag that was added to the ticket.",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Add tag to a ticket",
       "operationId": "attachTagToTicket",
       "method": "POST",
@@ -23686,9 +23986,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.detachTagFromTicket": {
-      "id": "endpoint_.detachTagFromTicket",
+    "endpoint_tags.detachTagFromTicket": {
+      "id": "endpoint_tags.detachTagFromTicket",
       "description": "You can remove tag from a specific ticket. This will return a tag object for the tag that was removed from the ticket.",
+      "namespace": [
+        "subpackage_tags"
+      ],
       "displayName": "Remove tag from a ticket",
       "operationId": "detachTagFromTicket",
       "method": "DELETE",
@@ -23994,9 +24297,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.createTicket": {
-      "id": "endpoint_.createTicket",
+    "endpoint_tickets.createTicket": {
+      "id": "endpoint_tickets.createTicket",
       "description": "You can create a new ticket.",
+      "namespace": [
+        "subpackage_tickets"
+      ],
       "displayName": "Create a ticket",
       "operationId": "createTicket",
       "method": "POST",
@@ -24250,9 +24556,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.getTicket": {
-      "id": "endpoint_.getTicket",
+    "endpoint_tickets.getTicket": {
+      "id": "endpoint_tickets.getTicket",
       "description": "You can fetch the details of a single ticket.",
+      "namespace": [
+        "subpackage_tickets"
+      ],
       "displayName": "Retrieve a ticket",
       "operationId": "getTicket",
       "method": "GET",
@@ -24505,9 +24814,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateTicket": {
-      "id": "endpoint_.updateTicket",
+    "endpoint_tickets.updateTicket": {
+      "id": "endpoint_tickets.updateTicket",
       "description": "You can update a ticket.",
+      "namespace": [
+        "subpackage_tickets"
+      ],
       "displayName": "Update a ticket",
       "operationId": "updateTicket",
       "method": "PUT",
@@ -25312,9 +25624,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.searchTickets": {
-      "id": "endpoint_.searchTickets",
+    "endpoint_tickets.searchTickets": {
+      "id": "endpoint_tickets.searchTickets",
       "description": "You can search for multiple tickets by the value of their attributes in order to fetch exactly which ones you want.\n\nTo search for tickets, you send a `POST` request to `https://api.intercom.io/tickets/search`.\n\nThis will accept a query object in the body which will define your filters.\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiples there can be:\n- There's a limit of max 2 nested filters\n- There's a limit of max 15 filters for each AND or OR group\n\n### Accepted Fields\n\nMost keys listed as part of the Ticket model are searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foobar\"`).\n\n| Field                                     | Type                                                                                     |\n| :---------------------------------------- | :--------------------------------------------------------------------------------------- |\n| id                                        | String                                                                                   |\n| created_at                                | Date (UNIX timestamp)                                                                    |\n| updated_at                                | Date (UNIX timestamp)                                                                    |\n| _default_title_                           | String                                                                                   |\n| _default_description_                     | String                                                                                   |\n| category                                  | String                                                                                   |\n| ticket_type_id                            | String                                                                                   |\n| contact_ids                               | String                                                                                   |\n| teammate_ids                              | String                                                                                   |\n| admin_assignee_id                         | String                                                                                   |\n| team_assignee_id                          | String                                                                                   |\n| open                                      | Boolean                                                                                  |\n| state                                     | String                                                                                   |\n| snoozed_until                             | Date (UNIX timestamp)                                                                    |\n| ticket_attribute.{id}                     | String or Boolean or Date (UNIX timestamp) or Float or Integer                           |\n\n### Accepted Operators\n\n{% admonition type=\"info\" name=\"Searching based on `created_at`\" %}\n  You may use the `<=` or `>=` operators to search by `created_at`.\n{% /admonition %}\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type  (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                    | Description                                                  |\n| :------- | :----------------------------- | :----------------------------------------------------------- |\n| =        | All                            | Equals                                                       |\n| !=       | All                            | Doesn't Equal                                                |\n| IN       | All                            | In  Shortcut for `OR` queries  Values most be in Array       |\n| NIN      | All                            | Not In  Shortcut for `OR !` queries  Values must be in Array |\n| >        | Integer  Date (UNIX Timestamp) | Greater (or equal) than                                      |\n| <       | Integer  Date (UNIX Timestamp) | Lower (or equal) than                                        |\n| ~        | String                         | Contains                                                     |\n| !~       | String                         | Doesn't Contain                                              |\n| ^        | String                         | Starts With                                                  |\n| $        | String                         | Ends With                                                    |\n",
+      "namespace": [
+        "subpackage_tickets"
+      ],
       "displayName": "Search tickets",
       "operationId": "searchTickets",
       "method": "POST",
@@ -25560,9 +25875,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.retrieveVisitorWithUserId": {
-      "id": "endpoint_.retrieveVisitorWithUserId",
+    "endpoint_visitors.retrieveVisitorWithUserId": {
+      "id": "endpoint_visitors.retrieveVisitorWithUserId",
       "description": "You can fetch the details of a single visitor.",
+      "namespace": [
+        "subpackage_visitors"
+      ],
       "displayName": "Retrieve a visitor with User ID",
       "operationId": "retrieveVisitorWithUserId",
       "method": "GET",
@@ -25773,9 +26091,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updateVisitor": {
-      "id": "endpoint_.updateVisitor",
+    "endpoint_visitors.updateVisitor": {
+      "id": "endpoint_visitors.updateVisitor",
       "description": "Sending a PUT request to `/visitors` will result in an update of an existing Visitor.\n\n**Option 1.** You can update a visitor by passing in the `user_id` of the visitor in the Request body.\n\n**Option 2.** You can update a visitor by passing in the `id` of the visitor in the Request body.\n",
+      "namespace": [
+        "subpackage_visitors"
+      ],
       "displayName": "Update a visitor",
       "operationId": "updateVisitor",
       "method": "PUT",
@@ -26119,9 +26440,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.convertVisitor": {
-      "id": "endpoint_.convertVisitor",
+    "endpoint_visitors.convertVisitor": {
+      "id": "endpoint_visitors.convertVisitor",
       "description": "You can merge a Visitor to a Contact of role type `lead` or `user`.\n\n> 📘 What happens upon a visitor being converted?\n>\n> If the User exists, then the Visitor will be merged into it, the Visitor deleted and the User returned. If the User does not exist, the Visitor will be converted to a User, with the User identifiers replacing it's Visitor identifiers.\n",
+      "namespace": [
+        "subpackage_visitors"
+      ],
       "displayName": "Convert a visitor",
       "operationId": "convertVisitor",
       "method": "POST",
@@ -43868,7 +44192,113 @@
       }
     }
   },
-  "subpackages": {},
+  "subpackages": {
+    "subpackage_admins": {
+      "id": "subpackage_admins",
+      "name": "admins",
+      "displayName": "Admins"
+    },
+    "subpackage_articles": {
+      "id": "subpackage_articles",
+      "name": "articles",
+      "displayName": "Articles"
+    },
+    "subpackage_helpCenter": {
+      "id": "subpackage_helpCenter",
+      "name": "helpCenter",
+      "displayName": "Help Center"
+    },
+    "subpackage_companies": {
+      "id": "subpackage_companies",
+      "name": "companies",
+      "displayName": "Companies"
+    },
+    "subpackage_contacts": {
+      "id": "subpackage_contacts",
+      "name": "contacts",
+      "displayName": "Contacts"
+    },
+    "subpackage_notes": {
+      "id": "subpackage_notes",
+      "name": "notes",
+      "displayName": "Notes"
+    },
+    "subpackage_subscriptionTypes": {
+      "id": "subpackage_subscriptionTypes",
+      "name": "subscriptionTypes",
+      "displayName": "Subscription Types"
+    },
+    "subpackage_tags": {
+      "id": "subpackage_tags",
+      "name": "tags",
+      "displayName": "Tags"
+    },
+    "subpackage_conversations": {
+      "id": "subpackage_conversations",
+      "name": "conversations",
+      "displayName": "Conversations"
+    },
+    "subpackage_dataAttributes": {
+      "id": "subpackage_dataAttributes",
+      "name": "dataAttributes",
+      "displayName": "Data Attributes"
+    },
+    "subpackage_dataEvents": {
+      "id": "subpackage_dataEvents",
+      "name": "dataEvents",
+      "displayName": "Data Events"
+    },
+    "subpackage_dataExport": {
+      "id": "subpackage_dataExport",
+      "name": "dataExport",
+      "displayName": "Data Export"
+    },
+    "subpackage_messages": {
+      "id": "subpackage_messages",
+      "name": "messages",
+      "displayName": "Messages"
+    },
+    "subpackage_news": {
+      "id": "subpackage_news",
+      "name": "news",
+      "displayName": "News"
+    },
+    "subpackage_segments": {
+      "id": "subpackage_segments",
+      "name": "segments",
+      "displayName": "Segments"
+    },
+    "subpackage_switch": {
+      "id": "subpackage_switch",
+      "name": "switch",
+      "displayName": "Switch"
+    },
+    "subpackage_teams": {
+      "id": "subpackage_teams",
+      "name": "teams",
+      "displayName": "Teams"
+    },
+    "subpackage_ticketTypeAttributes": {
+      "id": "subpackage_ticketTypeAttributes",
+      "name": "ticketTypeAttributes",
+      "displayName": "Ticket Type Attributes"
+    },
+    "subpackage_ticketTypes": {
+      "id": "subpackage_ticketTypes",
+      "name": "ticketTypes",
+      "displayName": "Ticket Types"
+    },
+    "subpackage_tickets": {
+      "id": "subpackage_tickets",
+      "name": "tickets",
+      "displayName": "Tickets"
+    },
+    "subpackage_visitors": {
+      "id": "subpackage_visitors",
+      "name": "visitors",
+      "displayName": "Visitors"
+    }
+  },
   "auths": {
     "bearerAuth": {
       "type": "bearerAuth"

--- a/packages/parsers/src/openapi/__test__/__snapshots__/openapi-filter.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/openapi-filter.json
@@ -5,7 +5,7 @@
       "id": "endpoint_admins.identifyAdmin",
       "description": "\nYou can view the currently authorised admin along with the embedded app object (a \"workspace\" in legacy terminology).\n\n> 🚧 Single Sign On\n>\n> If you are building a custom \"Log in with Intercom\" flow for your site, and you call the `/me` endpoint to identify the logged-in user, you should not accept any sign-ins from users with unverified email addresses as it poses a potential impersonation security risk.\n",
       "namespace": [
-        "subpackage_admins"
+        "admins"
       ],
       "displayName": "Identify an admin",
       "operationId": "identifyAdmin",
@@ -114,7 +114,7 @@
       "id": "endpoint_admins.setAwayAdmin",
       "description": "You can set an Admin as away for the Inbox.",
       "namespace": [
-        "subpackage_admins"
+        "admins"
       ],
       "displayName": "Set an admin to away",
       "operationId": "setAwayAdmin",
@@ -408,7 +408,7 @@
       "id": "endpoint_admins.listActivityLogs",
       "description": "You can get a log of activities by all admins in an app.",
       "namespace": [
-        "subpackage_admins"
+        "admins"
       ],
       "displayName": "List all activity logs",
       "operationId": "listActivityLogs",
@@ -619,7 +619,7 @@
       "id": "endpoint_admins.listAdmins",
       "description": "You can fetch a list of admins for a given workspace.",
       "namespace": [
-        "subpackage_admins"
+        "admins"
       ],
       "displayName": "List all admins",
       "operationId": "listAdmins",
@@ -752,7 +752,7 @@
       "id": "endpoint_admins.retrieveAdmin",
       "description": "You can retrieve the details of a single admin.",
       "namespace": [
-        "subpackage_admins"
+        "admins"
       ],
       "displayName": "Retrieve an admin",
       "operationId": "retrieveAdmin",
@@ -936,7 +936,7 @@
       "id": "endpoint_articles.listArticles",
       "description": "You can fetch a list of all articles by making a GET request to `https://api.intercom.io/articles`.\n\n> 📘 How are the articles sorted and ordered?\n>\n> Articles will be returned in descending order on the `updated_at` attribute. This means if you need to iterate through results then we'll show the most recently updated articles first.\n",
       "namespace": [
-        "subpackage_articles"
+        "articles"
       ],
       "displayName": "List all articles",
       "operationId": "listArticles",
@@ -1082,7 +1082,7 @@
       "id": "endpoint_articles.createArticle",
       "description": "You can create a new article by making a POST request to `https://api.intercom.io/articles`.",
       "namespace": [
-        "subpackage_articles"
+        "articles"
       ],
       "displayName": "Create an article",
       "operationId": "createArticle",
@@ -1330,7 +1330,7 @@
       "id": "endpoint_articles.retrieveArticle",
       "description": "You can fetch the details of a single article by making a GET request to `https://api.intercom.io/articles/<id>`.",
       "namespace": [
-        "subpackage_articles"
+        "articles"
       ],
       "displayName": "Retrieve an article",
       "operationId": "retrieveArticle",
@@ -1529,7 +1529,7 @@
       "id": "endpoint_articles.updateArticle",
       "description": "You can update the details of a single article by making a PUT request to `https://api.intercom.io/articles/<id>`.",
       "namespace": [
-        "subpackage_articles"
+        "articles"
       ],
       "displayName": "Update an article",
       "operationId": "updateArticle",
@@ -2204,7 +2204,7 @@
       "id": "endpoint_articles.deleteArticle",
       "description": "You can delete a single article by making a DELETE request to `https://api.intercom.io/articles/<id>`.",
       "namespace": [
-        "subpackage_articles"
+        "articles"
       ],
       "displayName": "Delete an article",
       "operationId": "deleteArticle",
@@ -2383,7 +2383,7 @@
       "id": "endpoint_articles.searchArticles",
       "description": "You can search for articles by making a GET request to `https://api.intercom.io/articles/search`.",
       "namespace": [
-        "subpackage_articles"
+        "articles"
       ],
       "displayName": "Search for articles",
       "operationId": "searchArticles",
@@ -2618,7 +2618,7 @@
       "id": "endpoint_helpCenter.listAllCollections",
       "description": "You can fetch a list of all collections by making a GET request to `https://api.intercom.io/help_center/collections`.\n\nCollections will be returned in descending order on the `updated_at` attribute. This means if you need to iterate through results then we'll show the most recently updated collections first.\n",
       "namespace": [
-        "subpackage_helpCenter"
+        "helpCenter"
       ],
       "displayName": "List all collections",
       "operationId": "listAllCollections",
@@ -2782,7 +2782,7 @@
       "id": "endpoint_helpCenter.createCollection",
       "description": "You can create a new collection by making a POST request to `https://api.intercom.io/help_center/collections.`",
       "namespace": [
-        "subpackage_helpCenter"
+        "helpCenter"
       ],
       "displayName": "Create a collection",
       "operationId": "createCollection",
@@ -2996,7 +2996,7 @@
       "id": "endpoint_helpCenter.retrieveCollection",
       "description": "You can fetch the details of a single collection by making a GET request to `https://api.intercom.io/help_center/collections/<id>`.",
       "namespace": [
-        "subpackage_helpCenter"
+        "helpCenter"
       ],
       "displayName": "Retrieve a collection",
       "operationId": "retrieveCollection",
@@ -3191,7 +3191,7 @@
       "id": "endpoint_helpCenter.updateCollection",
       "description": "You can update the details of a single collection by making a PUT request to `https://api.intercom.io/collections/<id>`.",
       "namespace": [
-        "subpackage_helpCenter"
+        "helpCenter"
       ],
       "displayName": "Update a collection",
       "operationId": "updateCollection",
@@ -3623,7 +3623,7 @@
       "id": "endpoint_helpCenter.deleteCollection",
       "description": "You can delete a single collection by making a DELETE request to `https://api.intercom.io/collections/<id>`.",
       "namespace": [
-        "subpackage_helpCenter"
+        "helpCenter"
       ],
       "displayName": "Delete a collection",
       "operationId": "deleteCollection",
@@ -3810,7 +3810,7 @@
       "id": "endpoint_helpCenter.retrieveHelpCenter",
       "description": "You can fetch the details of a single Help Center by making a GET request to `https://api.intercom.io/help_center/help_center/<id>`.",
       "namespace": [
-        "subpackage_helpCenter"
+        "helpCenter"
       ],
       "displayName": "Retrieve a Help Center",
       "operationId": "retrieveHelpCenter",
@@ -4001,7 +4001,7 @@
       "id": "endpoint_helpCenter.listHelpCenters",
       "description": "You can list all Help Centers by making a GET request to `https://api.intercom.io/help_center/help_centers`.",
       "namespace": [
-        "subpackage_helpCenter"
+        "helpCenter"
       ],
       "displayName": "List all Help Centers",
       "operationId": "listHelpCenters",
@@ -4131,7 +4131,7 @@
       "id": "endpoint_companies.retrieveCompany",
       "description": "You can fetch a single company by passing in `company_id` or `name`.\n\n  `https://api.intercom.io/companies?name={name}`\n\n  `https://api.intercom.io/companies?company_id={company_id}`\n\nYou can fetch all companies and filter by `segment_id` or `tag_id` as a query parameter.\n\n  `https://api.intercom.io/companies?tag_id={tag_id}`\n\n  `https://api.intercom.io/companies?segment_id={segment_id}`\n",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Retrieve companies",
       "operationId": "retrieveCompany",
@@ -4431,7 +4431,7 @@
       "id": "endpoint_companies.createOrUpdateCompany",
       "description": "You can create or update a company.\n\nCompanies will be only visible in Intercom when there is at least one associated user.\n\nCompanies are looked up via `company_id` in a `POST` request, if not found via `company_id`, the new company will be created, if found, that company will be updated.\n\n{% admonition type=\"attention\" name=\"Using `company_id`\" %}\n  You can set a unique `company_id` value when creating a company. However, it is not possible to update `company_id`. Be sure to set a unique value once upon creation of the company.\n{% /admonition %}\n",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Create or Update a company",
       "operationId": "createOrUpdateCompany",
@@ -4663,7 +4663,7 @@
       "id": "endpoint_companies.RetrieveACompanyById",
       "description": "You can fetch a single company.",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Retrieve a company by ID",
       "operationId": "RetrieveACompanyById",
@@ -4860,7 +4860,7 @@
       "id": "endpoint_companies.UpdateCompany",
       "description": "You can update a single company using the Intercom provisioned `id`.\n\n{% admonition type=\"attention\" name=\"Using `company_id`\" %}\n  When updating a company it is not possible to update `company_id`. This can only be set once upon creation of the company.\n{% /admonition %}\n",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Update a company",
       "operationId": "UpdateCompany",
@@ -5057,7 +5057,7 @@
       "id": "endpoint_companies.deleteCompany",
       "description": "You can delete a single company.",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Delete a company",
       "operationId": "deleteCompany",
@@ -5236,7 +5236,7 @@
       "id": "endpoint_companies.ListAttachedContacts",
       "description": "You can fetch a list of all contacts that belong to a company.",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "List attached contacts",
       "operationId": "ListAttachedContacts",
@@ -5429,7 +5429,7 @@
       "id": "endpoint_companies.ListAttachedSegmentsForCompanies",
       "description": "You can fetch a list of all segments that belong to a company.",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "List attached segments for companies",
       "operationId": "ListAttachedSegmentsForCompanies",
@@ -5615,7 +5615,7 @@
       "id": "endpoint_companies.listAllCompanies",
       "description": "You can list companies. The company list is sorted by the `last_request_at` field and by default is ordered descending, most recently requested first.\n\nNote that the API does not include companies who have no associated users in list responses.\n\nWhen using the Companies endpoint and the pages object to iterate through the returned companies, there is a limit of 10,000 Companies that can be returned. If you need to list or iterate on more than 10,000 Companies, please use the [Scroll API](https://developers.intercom.com/reference#iterating-over-all-companies).\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "List all companies",
       "operationId": "listAllCompanies",
@@ -5836,7 +5836,7 @@
       "id": "endpoint_companies.scrollOverAllCompanies",
       "description": "      The `list all companies` functionality does not work well for huge datasets, and can result in errors and performance problems when paging deeply. The Scroll API provides an efficient mechanism for iterating over all companies in a dataset.\n\n- Each app can only have 1 scroll open at a time. You'll get an error message if you try to have more than one open per app.\n- If the scroll isn't used for 1 minute, it expires and calls with that scroll param will fail\n- If the end of the scroll is reached, \"companies\" will be empty and the scroll parameter will expire\n\n{% admonition type=\"info\" name=\"Scroll Parameter\" %}\n  You can get the first page of companies by simply sending a GET request to the scroll endpoint.\n  For subsequent requests you will need to use the scroll parameter from the response.\n{% /admonition %}\n{% admonition type=\"danger\" name=\"Scroll network timeouts\" %}\n  Since scroll is often used on large datasets network errors such as timeouts can be encountered. When this occurs you will see a HTTP 500 error with the following message:\n  \"Request failed due to an internal network error. Please restart the scroll operation.\"\n  If this happens, you will need to restart your scroll query: It is not possible to continue from a specific point when using scroll.\n{% /admonition %}\n",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Scroll over all companies",
       "operationId": "scrollOverAllCompanies",
@@ -6014,7 +6014,7 @@
       "id": "endpoint_contacts.listCompaniesForAContact",
       "description": "You can fetch a list of companies that are associated to a contact.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "List attached companies for contact",
       "operationId": "listCompaniesForAContact",
@@ -6233,7 +6233,7 @@
       "id": "endpoint_companies.attachContactToACompany",
       "description": "You can attach a company to a single contact.",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Attach a Contact to a Company",
       "operationId": "attachContactToACompany",
@@ -6576,7 +6576,7 @@
       "id": "endpoint_companies.detachContactFromACompany",
       "description": "You can detach a company from a single contact.",
       "namespace": [
-        "subpackage_companies"
+        "companies"
       ],
       "displayName": "Detach a contact from a company",
       "operationId": "detachContactFromACompany",
@@ -6819,7 +6819,7 @@
       "id": "endpoint_notes.listNotes",
       "description": "You can fetch a list of notes that are associated to a contact.",
       "namespace": [
-        "subpackage_notes"
+        "notes"
       ],
       "displayName": "List all notes",
       "operationId": "listNotes",
@@ -7038,7 +7038,7 @@
       "id": "endpoint_notes.createNote",
       "description": "You can add a note to a single contact.",
       "namespace": [
-        "subpackage_notes"
+        "notes"
       ],
       "displayName": "Create a note",
       "operationId": "createNote",
@@ -7368,7 +7368,7 @@
       "id": "endpoint_contacts.listSegmentsForAContact",
       "description": "You can fetch a list of segments that are associated to a contact.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "List attached segments for contact",
       "operationId": "listSegmentsForAContact",
@@ -7563,7 +7563,7 @@
       "id": "endpoint_contacts.listSubscriptionsForAContact",
       "description": "You can fetch a list of subscription types that are attached to a contact. These can be subscriptions that a user has 'opted-in' to or has 'opted-out' from, depending on the subscription type.\nThis will return a list of Subscription Type objects that the contact is associated with.\n\nThe data property will show a combined list of:\n\n  1.Opt-out subscription types that the user has opted-out from.\n  2.Opt-in subscription types that the user has opted-in to receiving.\n",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "List subscriptions for a contact",
       "operationId": "listSubscriptionsForAContact",
@@ -7792,7 +7792,7 @@
       "id": "endpoint_subscriptionTypes.attachSubscriptionTypeToContact",
       "description": "You can add a specific subscription to a contact. In Intercom, we have two different subscription types based on user consent - opt-out and opt-in:\n\n  1.Attaching a contact to an opt-out subscription type will opt that user out from receiving messages related to that subscription type.\n\n  2.Attaching a contact to an opt-in subscription type will opt that user in to receiving messages related to that subscription type.\n\nThis will return a subscription type model for the subscription type that was added to the contact.\n",
       "namespace": [
-        "subpackage_subscriptionTypes"
+        "subscriptionTypes"
       ],
       "displayName": "Add subscription to a contact",
       "operationId": "attachSubscriptionTypeToContact",
@@ -8133,7 +8133,7 @@
       "id": "endpoint_subscriptionTypes.detachSubscriptionTypeToContact",
       "description": "You can remove a specific subscription from a contact. This will return a subscription type model for the subscription type that was removed from the contact.",
       "namespace": [
-        "subpackage_subscriptionTypes"
+        "subscriptionTypes"
       ],
       "displayName": "Remove subscription from a contact",
       "operationId": "detachSubscriptionTypeToContact",
@@ -8374,7 +8374,7 @@
       "id": "endpoint_contacts.listTagsForAContact",
       "description": "You can fetch a list of all tags that are attached to a specific contact.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "List tags attached to a contact",
       "operationId": "listTagsForAContact",
@@ -8566,7 +8566,7 @@
       "id": "endpoint_tags.attachTagToContact",
       "description": "You can tag a specific contact. This will return a tag object for the tag that was added to the contact.",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Add tag to a contact",
       "operationId": "attachTagToContact",
@@ -8853,7 +8853,7 @@
       "id": "endpoint_tags.detachTagFromContact",
       "description": "You can remove tag from a specific contact. This will return a tag object for the tag that was removed from the contact.",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Remove tag from a contact",
       "operationId": "detachTagFromContact",
@@ -9078,7 +9078,7 @@
       "id": "endpoint_contacts.ShowContact",
       "description": "You can fetch the details of a single contact.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Get a contact",
       "operationId": "ShowContact",
@@ -9316,7 +9316,7 @@
       "id": "endpoint_contacts.UpdateContact",
       "description": "You can update an existing contact (ie. user or lead).",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Update a contact",
       "operationId": "UpdateContact",
@@ -9573,7 +9573,7 @@
       "id": "endpoint_contacts.DeleteContact",
       "description": "You can delete a single contact.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Delete a contact",
       "operationId": "DeleteContact",
@@ -9723,7 +9723,7 @@
       "id": "endpoint_contacts.MergeContact",
       "description": "You can merge a contact with a `role` of `lead` into a contact with a `role` of `user`.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Merge a lead and a user",
       "operationId": "MergeContact",
@@ -9962,7 +9962,7 @@
       "id": "endpoint_contacts.SearchContacts",
       "description": "You can search for multiple contacts by the value of their attributes in order to fetch exactly who you want.\n\nTo search for contacts, you need to send a `POST` request to `https://api.intercom.io/contacts/search`.\n\nThis will accept a query object in the body which will define your filters in order to search for contacts.\n\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `50` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n### Contact Creation Delay\n\nIf a contact has recently been created, there is a possibility that it will not yet be available when searching. This means that it may not appear in the response. This delay can take a few minutes. If you need to be instantly notified it is recommended to use webhooks and iterate to see if they match your search filters.\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiple's there can be:\n* There's a limit of max 2 nested filters\n* There's a limit of max 15 filters for each AND or OR group\n\n### Searching for Timestamp Fields\n\nAll timestamp fields (created_at, updated_at etc.) are indexed as Dates for Contact Search queries; Datetime queries are not currently supported. This means you can only query for timestamp fields by day - not hour, minute or second.\nFor example, if you search for all Contacts with a created_at value greater (>) than 1577869200 (the UNIX timestamp for January 1st, 2020 9:00 AM), that will be interpreted as 1577836800 (January 1st, 2020 12:00 AM). The search results will then include Contacts created from January 2nd, 2020 12:00 AM onwards.\nIf you'd like to get contacts created on January 1st, 2020 you should search with a created_at value equal (=) to 1577836800 (January 1st, 2020 12:00 AM).\nThis behaviour applies only to timestamps used in search queries. The search results will still contain the full UNIX timestamp and be sorted accordingly.\n\n### Accepted Fields\n\nMost key listed as part of the Contacts Model are searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foorbar\"`).\n\n| Field                              | Type                           |\n| ---------------------------------- | ------------------------------ |\n| id                                 | String                         |\n| role                               | String<br>Accepts user or lead |\n| name                               | String                         |\n| avatar                             | String                         |\n| owner_id                           | Integer                        |\n| email                              | String                         |\n| email_domain                       | String                         |\n| phone                              | String                         |\n| formatted_phone                    | String                         |\n| external_id                        | String                         |\n| created_at                         | Date (UNIX Timestamp)          |\n| signed_up_at                       | Date (UNIX Timestamp)          |\n| updated_at                         | Date (UNIX Timestamp)          |\n| last_seen_at                       | Date (UNIX Timestamp)          |\n| last_contacted_at                  | Date (UNIX Timestamp)          |\n| last_replied_at                    | Date (UNIX Timestamp)          |\n| last_email_opened_at               | Date (UNIX Timestamp)          |\n| last_email_clicked_at              | Date (UNIX Timestamp)          |\n| language_override                  | String                         |\n| browser                            | String                         |\n| browser_language                   | String                         |\n| os                                 | String                         |\n| location.country                   | String                         |\n| location.region                    | String                         |\n| location.city                      | String                         |\n| unsubscribed_from_emails           | Boolean                        |\n| marked_email_as_spam               | Boolean                        |\n| has_hard_bounced                   | Boolean                        |\n| ios_last_seen_at                   | Date (UNIX Timestamp)          |\n| ios_app_version                    | String                         |\n| ios_device                         | String                         |\n| ios_app_device                     | String                         |\n| ios_os_version                     | String                         |\n| ios_app_name                       | String                         |\n| ios_sdk_version                    | String                         |\n| android_last_seen_at               | Date (UNIX Timestamp)          |\n| android_app_version                | String                         |\n| android_device                     | String                         |\n| android_app_name                   | String                         |\n| andoid_sdk_version                 | String                         |\n| segment_id                         | String                         |\n| tag_id                             | String                         |\n| custom_attributes.{attribute_name} | String                         |\n\n### Accepted Operators\n\n{% admonition type=\"attention\" name=\"Searching based on `created_at`\" %}\n  You cannot use the `<=` or `>=` operators to search by `created_at`.\n{% /admonition %}\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                      | Description                                                      |\n| :------- | :------------------------------- | :--------------------------------------------------------------- |\n| =        | All                              | Equals                                                           |\n| !=       | All                              | Doesn't Equal                                                    |\n| IN       | All                              | In<br>Shortcut for `OR` queries<br>Values must be in Array       |\n| NIN      | All                              | Not In<br>Shortcut for `OR !` queries<br>Values must be in Array |\n| >        | Integer<br>Date (UNIX Timestamp) | Greater than                                                     |\n| <       | Integer<br>Date (UNIX Timestamp) | Lower than                                                       |\n| ~        | String                           | Contains                                                         |\n| !~       | String                           | Doesn't Contain                                                  |\n| ^        | String                           | Starts With                                                      |\n| $        | String                           | Ends With                                                        |\n",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Search contacts",
       "operationId": "SearchContacts",
@@ -10129,7 +10129,7 @@
       "id": "endpoint_contacts.ListContacts",
       "description": "You can fetch a list of all contacts (ie. users or leads) in your workspace.\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `50` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "List all contacts",
       "operationId": "ListContacts",
@@ -10258,7 +10258,7 @@
       "id": "endpoint_contacts.CreateContact",
       "description": "You can create a new contact (ie. user or lead).",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Create contact",
       "operationId": "CreateContact",
@@ -10488,7 +10488,7 @@
       "id": "endpoint_contacts.ArchiveContact",
       "description": "You can archive a single contact.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Archive contact",
       "operationId": "ArchiveContact",
@@ -10615,7 +10615,7 @@
       "id": "endpoint_contacts.UnarchiveContact",
       "description": "You can unarchive a single contact.",
       "namespace": [
-        "subpackage_contacts"
+        "contacts"
       ],
       "displayName": "Unarchive contact",
       "operationId": "UnarchiveContact",
@@ -10742,7 +10742,7 @@
       "id": "endpoint_tags.attachTagToConversation",
       "description": "You can tag a specific conversation. This will return a tag object for the tag that was added to the conversation.",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Add tag to a conversation",
       "operationId": "attachTagToConversation",
@@ -11001,7 +11001,7 @@
       "id": "endpoint_tags.detachTagFromConversation",
       "description": "You can remove tag from a specific conversation. This will return a tag object for the tag that was removed from the conversation.",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Remove tag from a conversation",
       "operationId": "detachTagFromConversation",
@@ -11312,7 +11312,7 @@
       "id": "endpoint_conversations.listConversations",
       "description": "You can fetch a list of all conversations.\n\nYou can optionally request the result page size and the cursor to start after to fetch the result.\n{% admonition type=\"warning\" name=\"Pagination\" %}\n  You can use pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#pagination-for-list-apis) for more details on how to use the `starting_after` param.\n{% /admonition %}\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "List all conversations",
       "operationId": "listConversations",
@@ -11575,7 +11575,7 @@
       "id": "endpoint_conversations.createConversation",
       "description": "You can create a conversation that has been initiated by a contact (ie. user or lead).\nThe conversation can be an in-app message only.\n\n{% admonition type=\"info\" name=\"Sending for visitors\" %}\nYou can also send a message from a visitor by specifying their `user_id` or `id` value in the `from` field, along with a `type` field value of `contact`.\nThis visitor will be automatically converted to a contact with a lead role once the conversation is created.\n{% /admonition %}\n\nThis will return the Message model that has been created.\n\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Creates a conversation",
       "operationId": "createConversation",
@@ -11809,7 +11809,7 @@
       "id": "endpoint_conversations.retrieveConversation",
       "description": "\nYou can fetch the details of a single conversation.\n\nThis will return a single Conversation model with all its conversation parts.\n\n{% admonition type=\"warning\" name=\"Hard limit of 500 parts\" %}\nThe maximum number of conversation parts that can be returned via the API is 500. If you have more than that we will return the 500 most recent conversation parts.\n{% /admonition %}\n\nFor AI agent conversation metadata, please note that you need to have the agent enabled in your workspace, which is a [paid feature](https://www.intercom.com/help/en/articles/8205718-fin-resolutions#h_97f8c2e671).\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Retrieve a conversation",
       "operationId": "retrieveConversation",
@@ -12100,7 +12100,7 @@
       "id": "endpoint_conversations.updateConversation",
       "description": "\nYou can update an existing conversation.\n\n{% admonition type=\"info\" name=\"Replying and other actions\" %}\nIf you want to reply to a coveration or take an action such as assign, unassign, open, close or snooze, take a look at the reply and manage endpoints.\n{% /admonition %}\n\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Update a conversation",
       "operationId": "updateConversation",
@@ -12584,7 +12584,7 @@
       "id": "endpoint_conversations.searchConversations",
       "description": "You can search for multiple conversations by the value of their attributes in order to fetch exactly which ones you want.\n\nTo search for conversations, you need to send a `POST` request to `https://api.intercom.io/conversations/search`.\n\nThis will accept a query object in the body which will define your filters in order to search for conversations.\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `20` results per page and maximum is `150`.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiple's there can be:\n- There's a limit of max 2 nested filters\n- There's a limit of max 15 filters for each AND or OR group\n\n### Accepted Fields\n\nMost keys listed as part of the The conversation model is searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foorbar\"`).\n\n| Field                                     | Type                                                                                                                                                   |\n| :---------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- |\n| id                                        | String                                                                                                                                                 |\n| created_at                                | Date (UNIX timestamp)                                                                                                                                  |\n| updated_at                                | Date (UNIX timestamp)                                                                                                                                  |\n| source.type                               | String<br>Accepted fields are `conversation`, `email`, `facebook`, `instagram`, `phone_call`, `phone_switch`, `push`, `sms`, `twitter` and `whatsapp`. |\n| source.id                                 | String                                                                                                                                                 |\n| source.delivered_as                       | String                                                                                                                                                 |\n| source.subject                            | String                                                                                                                                                 |\n| source.body                               | String                                                                                                                                                 |\n| source.author.id                          | String                                                                                                                                                 |\n| source.author.type                        | String                                                                                                                                                 |\n| source.author.name                        | String                                                                                                                                                 |\n| source.author.email                       | String                                                                                                                                                 |\n| source.url                                | String                                                                                                                                                 |\n| contact_ids                               | String                                                                                                                                                 |\n| teammate_ids                              | String                                                                                                                                                 |\n| admin_assignee_id                         | String                                                                                                                                                 |\n| team_assignee_id                          | String                                                                                                                                                 |\n| channel_initiated                         | String                                                                                                                                                 |\n| open                                      | Boolean                                                                                                                                                |\n| read                                      | Boolean                                                                                                                                                |\n| state                                     | String                                                                                                                                                 |\n| waiting_since                             | Date (UNIX timestamp)                                                                                                                                  |\n| snoozed_until                             | Date (UNIX timestamp)                                                                                                                                  |\n| tag_ids                                   | String                                                                                                                                                 |\n| priority                                  | String                                                                                                                                                 |\n| statistics.time_to_assignment             | Integer                                                                                                                                                |\n| statistics.time_to_admin_reply            | Integer                                                                                                                                                |\n| statistics.time_to_first_close            | Integer                                                                                                                                                |\n| statistics.time_to_last_close             | Integer                                                                                                                                                |\n| statistics.median_time_to_reply           | Integer                                                                                                                                                |\n| statistics.first_contact_reply_at         | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_assignment_at            | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_admin_reply_at           | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.first_close_at                 | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_assignment_at             | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_assignment_admin_reply_at | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_contact_reply_at          | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_admin_reply_at            | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_close_at                  | Date (UNIX timestamp)                                                                                                                                  |\n| statistics.last_closed_by_id              | String                                                                                                                                                 |\n| statistics.count_reopens                  | Integer                                                                                                                                                |\n| statistics.count_assignments              | Integer                                                                                                                                                |\n| statistics.count_conversation_parts       | Integer                                                                                                                                                |\n| conversation_rating.requested_at          | Date (UNIX timestamp)                                                                                                                                  |\n| conversation_rating.replied_at            | Date (UNIX timestamp)                                                                                                                                  |\n| conversation_rating.score                 | Integer                                                                                                                                                |\n| conversation_rating.remark                | String                                                                                                                                                 |\n| conversation_rating.contact_id            | String                                                                                                                                                 |\n| conversation_rating.admin_d               | String                                                                                                                                                 |\n| ai_agent_participated                     | Boolean                                                                                                                                                |\n| ai_agent.resolution_state                 | String                                                                                                                                                 |\n| ai_agent.last_answer_type                 | String                                                                                                                                                 |\n| ai_agent.rating                           | Integer                                                                                                                                                |\n| ai_agent.rating_remark                    | String                                                                                                                                                 |\n| ai_agent.source_type                      | String                                                                                                                                                 |\n| ai_agent.source_title                     | String                                                                                                                                                 |\n\n### Accepted Operators\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type  (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                    | Description                                                  |\n| :------- | :----------------------------- | :----------------------------------------------------------- |\n| =        | All                            | Equals                                                       |\n| !=       | All                            | Doesn't Equal                                                |\n| IN       | All                            | In  Shortcut for `OR` queries  Values most be in Array       |\n| NIN      | All                            | Not In  Shortcut for `OR !` queries  Values must be in Array |\n| >        | Integer  Date (UNIX Timestamp) | Greater (or equal) than                                      |\n| <       | Integer  Date (UNIX Timestamp) | Lower (or equal) than                                        |\n| ~        | String                         | Contains                                                     |\n| !~       | String                         | Doesn't Contain                                              |\n| ^        | String                         | Starts With                                                  |\n| $        | String                         | Ends With                                                    |\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Search conversations",
       "operationId": "searchConversations",
@@ -12782,7 +12782,7 @@
       "id": "endpoint_conversations.replyConversation",
       "description": "You can reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Reply to a conversation",
       "operationId": "replyConversation",
@@ -13431,7 +13431,7 @@
       "id": "endpoint_conversations.manageConversation",
       "description": "For managing conversations you can:\n- Close a conversation\n- Snooze a conversation to reopen on a future date\n- Open a conversation which is `snoozed` or `closed`\n- Assign a conversation to an admin and/or team.\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Manage a conversation",
       "operationId": "manageConversation",
@@ -14177,7 +14177,7 @@
       "id": "endpoint_conversations.autoAssignConversation",
       "description": "You can let a conversation be automatically assigned following assignment rules.\n{% admonition type=\"attention\" name=\"When using workflows\" %}\nIt is not possible to use this endpoint with Workflows.\n{% /admonition %}\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Run Assignment Rules on a conversation",
       "operationId": "autoAssignConversation",
@@ -14478,7 +14478,7 @@
       "id": "endpoint_conversations.attachContactToConversation",
       "description": "You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.\n\n{% admonition type=\"attention\" name=\"Contacts without an email\" %}\nIf you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.\n{% /admonition %}\n\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Attach a contact to a conversation",
       "operationId": "attachContactToConversation",
@@ -14747,7 +14747,7 @@
       "id": "endpoint_conversations.detachContactFromConversation",
       "description": "You can add participants who are contacts to a conversation, on behalf of either another contact or an admin.\n\n{% admonition type=\"attention\" name=\"Contacts without an email\" %}\nIf you add a contact via the email parameter and there is no user/lead found on that workspace with he given email, then we will create a new contact with `role` set to `lead`.\n{% /admonition %}\n\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Detach a contact from a group conversation",
       "operationId": "detachContactFromConversation",
@@ -15143,7 +15143,7 @@
       "id": "endpoint_conversations.redactConversation",
       "description": "You can redact a conversation part or the source message of a conversation (as seen in the source object).\n\n{% admonition type=\"info\" name=\"Redacting parts and messages\" %}\nIf you are redacting a conversation part, it must have a `body`. If you are redacting a source message, it must have been created by a contact. We will return a `conversation_part_not_redactable` error if these criteria are not met.\n{% /admonition %}\n\n",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Redact a conversation part",
       "operationId": "redactConversation",
@@ -15515,7 +15515,7 @@
       "id": "endpoint_conversations.convertConversationToTicket",
       "description": "You can convert a conversation to a ticket.",
       "namespace": [
-        "subpackage_conversations"
+        "conversations"
       ],
       "displayName": "Convert a conversation to a ticket",
       "operationId": "convertConversationToTicket",
@@ -15907,7 +15907,7 @@
       "id": "endpoint_dataAttributes.lisDataAttributes",
       "description": "You can fetch a list of all data attributes belonging to a workspace for contacts, companies or conversations.",
       "namespace": [
-        "subpackage_dataAttributes"
+        "dataAttributes"
       ],
       "displayName": "List all data attributes",
       "operationId": "lisDataAttributes",
@@ -16317,7 +16317,7 @@
       "id": "endpoint_dataAttributes.createDataAttribute",
       "description": "You can create a data attributes for a `contact` or a `company`.",
       "namespace": [
-        "subpackage_dataAttributes"
+        "dataAttributes"
       ],
       "displayName": "Create a data attribute",
       "operationId": "createDataAttribute",
@@ -16735,7 +16735,7 @@
       "id": "endpoint_dataAttributes.updateDataAttribute",
       "description": "\nYou can update a data attribute.\n\n> 🚧 Updating the data type is not possible\n>\n> It is currently a dangerous action to execute changing a data attribute's type via the API. You will need to update the type via the UI instead.\n",
       "namespace": [
-        "subpackage_dataAttributes"
+        "dataAttributes"
       ],
       "displayName": "Update a data attribute",
       "operationId": "updateDataAttribute",
@@ -17149,7 +17149,7 @@
       "id": "endpoint_dataEvents.lisDataEvents",
       "description": "\n> 🚧\n>\n> Please note that you can only 'list' events that are less than 90 days old. Event counts and summaries will still include your events older than 90 days but you cannot 'list' these events individually if they are older than 90 days\n\nThe events belonging to a customer can be listed by sending a GET request to `https://api.intercom.io/events` with a user or lead identifier along with a `type` parameter. The identifier parameter can be one of `user_id`, `email` or `intercom_user_id`. The `type` parameter value must be `user`.\n\n- `https://api.intercom.io/events?type=user&user_id={user_id}`\n- `https://api.intercom.io/events?type=user&email={email}`\n- `https://api.intercom.io/events?type=user&intercom_user_id={id}` (this call can be used to list leads)\n\nThe `email` parameter value should be [url encoded](http://en.wikipedia.org/wiki/Percent-encoding) when sending.\n\nYou can optionally define the result page size as well with the `per_page` parameter.\n",
       "namespace": [
-        "subpackage_dataEvents"
+        "dataEvents"
       ],
       "displayName": "List all data events",
       "operationId": "lisDataEvents",
@@ -17388,7 +17388,7 @@
       "id": "endpoint_dataEvents.createDataEvent",
       "description": "\nYou will need an Access Token that has write permissions to send Events. Once you have a key you can submit events via POST to the Events resource, which is located at https://api.intercom.io/events, or you can send events using one of the client libraries. When working with the HTTP API directly a client should send the event with a `Content-Type` of `application/json`.\n\nWhen using the JavaScript API, [adding the code to your app](http://docs.intercom.io/configuring-Intercom/tracking-user-events-in-your-app) makes the Events API available. Once added, you can submit an event using the `trackEvent` method. This will associate the event with the Lead or currently logged-in user or logged-out visitor/lead and send it to Intercom. The final parameter is a map that can be used to send optional metadata about the event.\n\nWith the Ruby client you pass a hash describing the event to `Intercom::Event.create`, or call the `track_user` method directly on the current user object (e.g. `user.track_event`).\n\n**NB: For the JSON object types, please note that we do not currently support nested JSON structure.**\n\n| Type            | Description                                                                                                                                                                                                     | Example                                                                           |\n| :-------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |\n| String          | The value is a JSON String                                                                                                                                                                                      | `\"source\":\"desktop\"`                                                              |\n| Number          | The value is a JSON Number                                                                                                                                                                                      | `\"load\": 3.67`                                                                    |\n| Date            | The key ends with the String `_date` and the value is a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time), assumed to be in the [UTC](http://en.wikipedia.org/wiki/Coordinated_Universal_Time) timezone. | `\"contact_date\": 1392036272`                                                      |\n| Link            | The value is a HTTP or HTTPS URI.                                                                                                                                                                               | `\"article\": \"https://example.org/ab1de.html\"`                                     |\n| Rich Link       | The value is a JSON object that contains `url` and `value` keys.                                                                                                                                                | `\"article\": {\"url\": \"https://example.org/ab1de.html\", \"value\":\"the dude abides\"}` |\n| Monetary Amount | The value is a JSON object that contains `amount` and `currency` keys. The `amount` key is a positive integer representing the amount in cents. The price in the example to the right denotes €349.99.          | `\"price\": {\"amount\": 34999, \"currency\": \"eur\"}`                                   |\n\n**Lead Events**\n\nWhen submitting events for Leads, you will need to specify the Lead's `id`.\n\n**Metadata behaviour**\n\n- We currently limit the number of tracked metadata keys to 10 per event. Once the quota is reached, we ignore any further keys we receive. The first 10 metadata keys are determined by the order in which they are sent in with the event.\n- It is not possible to change the metadata keys once the event has been sent. A new event will need to be created with the new keys and you can archive the old one.\n- There might be up to 24 hrs delay when you send a new metadata for an existing event.\n\n**Event de-duplication**\n\nThe API may detect and ignore duplicate events. Each event is uniquely identified as a combination of the following data - the Workspace identifier, the Contact external identifier, the Data Event name and the Data Event created time. As a result, it is **strongly recommended** to send a second granularity Unix timestamp in the `created_at` field.\n\nDuplicated events are responded to using the normal `202 Accepted` code - an error is not thrown, however repeat requests will be counted against any rate limit that is in place.\n\n### HTTP API Responses\n\n- Successful responses to submitted events return `202 Accepted` with an empty body.\n- Unauthorised access will be rejected with a `401 Unauthorized` or `403 Forbidden` response code.\n- Events sent about users that cannot be found will return a `404 Not Found`.\n- Event lists containing duplicate events will have those duplicates ignored.\n- Server errors will return a `500` response code and may contain an error message in the body.\n\n",
       "namespace": [
-        "subpackage_dataEvents"
+        "dataEvents"
       ],
       "displayName": "Submit a data event",
       "operationId": "createDataEvent",
@@ -17510,7 +17510,7 @@
       "id": "endpoint_dataEvents.dataEventSummaries",
       "description": "Create event summaries for a user. Event summaries are used to track the number of times an event has occurred, the first time it occurred and the last time it occurred.\n\n",
       "namespace": [
-        "subpackage_dataEvents"
+        "dataEvents"
       ],
       "displayName": "Create event summaries",
       "operationId": "dataEventSummaries",
@@ -17652,7 +17652,7 @@
       "id": "endpoint_dataExport.createDataExport",
       "description": "To create your export job, you need to send a `POST` request to the export endpoint `https://api.intercom.io/export/content/data`.\n\nThe only parameters you need to provide are the range of dates that you want exported.\n\n>🚧 Limit of one active job\n>\n> You can only have one active job per workspace. You will receive a HTTP status code of 429 with the message Exceeded rate limit of 1 pending message data export jobs if you attempt to create a second concurrent job.\n\n>❗️ Updated_at not included\n>\n> It should be noted that the timeframe only includes messages sent during the time period and not messages that were only updated during this period. For example, if a message was updated yesterday but sent two days ago, you would need to set the created_at_after date before the message was sent to include that in your retrieval job.\n\n>📘 Date ranges are inclusive\n>\n> Requesting data for 2018-06-01 until 2018-06-30 will get all data for those days including those specified - e.g. 2018-06-01 00:00:00 until 2018-06-30 23:59:99.\n",
       "namespace": [
-        "subpackage_dataExport"
+        "dataExport"
       ],
       "displayName": "Create content data export",
       "operationId": "createDataExport",
@@ -17780,7 +17780,7 @@
       "id": "endpoint_dataExport.getDataExport",
       "description": "You can view the status of your job by sending a `GET` request to the URL\n`https://api.intercom.io/export/content/data/{job_identifier}` - the `{job_identifier}` is the value returned in the response when you first created the export job. More on it can be seen in the Export Job Model.\n\n> 🚧 Jobs expire after two days\n> All jobs that have completed processing (and are thus available to download from the provided URL) will have an expiry limit of two days from when the export ob completed. After this, the data will no longer be available.\n",
       "namespace": [
-        "subpackage_dataExport"
+        "dataExport"
       ],
       "displayName": "Show content data export",
       "operationId": "getDataExport",
@@ -17915,7 +17915,7 @@
       "id": "endpoint_dataExport.cancelDataExport",
       "description": "You can cancel your job",
       "namespace": [
-        "subpackage_dataExport"
+        "dataExport"
       ],
       "displayName": "Cancel content data export",
       "operationId": "cancelDataExport",
@@ -18042,7 +18042,7 @@
       "id": "endpoint_dataExport.downloadDataExport",
       "description": "When a job has a status of complete, and thus a filled download_url, you can download your data by hitting that provided URL, formatted like so: https://api.intercom.io/download/content/data/xyz1234.\n\nYour exported message data will be streamed continuously back down to you in a gzipped CSV format.\n\n> 📘 Octet header required\n>\n> You will have to specify the header Accept: `application/octet-stream` when hitting this endpoint.\n",
       "namespace": [
-        "subpackage_dataExport"
+        "dataExport"
       ],
       "displayName": "Download content data export",
       "operationId": "downloadDataExport",
@@ -18163,7 +18163,7 @@
       "id": "endpoint_messages.createMessage",
       "description": "You can create a message that has been initiated by an admin. The conversation can be either an in-app message or an email.\n\n> 🚧 Sending for visitors\n>\n> There can be a short delay between when a contact is created and when a contact becomes available to be messaged through the API. A 404 Not Found error will be returned in this case.\n\nThis will return the Message model that has been created.\n\n> 🚧 Retrieving Associated Conversations\n>\n> As this is a message, there will be no conversation present until the contact responds. Once they do, you will have to search for a contact's conversations with the id of the message.\n",
       "namespace": [
-        "subpackage_messages"
+        "messages"
       ],
       "displayName": "Create a message",
       "operationId": "createMessage",
@@ -18603,7 +18603,7 @@
       "id": "endpoint_news.listNewsItems",
       "description": "You can fetch a list of all news items",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "List all news items",
       "operationId": "listNewsItems",
@@ -18783,7 +18783,7 @@
       "id": "endpoint_news.createNewsItem",
       "description": "You can create a news item",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "Create a news item",
       "operationId": "createNewsItem",
@@ -18974,7 +18974,7 @@
       "id": "endpoint_news.retrieveNewsItem",
       "description": "You can fetch the details of a single news item.",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "Retrieve a news item",
       "operationId": "retrieveNewsItem",
@@ -19181,7 +19181,7 @@
     "endpoint_news.updateNewsItem": {
       "id": "endpoint_news.updateNewsItem",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "Update a news item",
       "operationId": "updateNewsItem",
@@ -19454,7 +19454,7 @@
       "id": "endpoint_news.deleteNewsItem",
       "description": "You can delete a single news item.",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "Delete a news item",
       "operationId": "deleteNewsItem",
@@ -19641,7 +19641,7 @@
       "id": "endpoint_news.listLiveNewsfeedItems",
       "description": "You can fetch a list of all news items that are live on a given newsfeed",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "List all live newsfeed items",
       "operationId": "listLiveNewsfeedItems",
@@ -19812,7 +19812,7 @@
       "id": "endpoint_news.listNewsfeeds",
       "description": "You can fetch a list of all newsfeeds",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "List all newsfeeds",
       "operationId": "listNewsfeeds",
@@ -19964,7 +19964,7 @@
       "id": "endpoint_news.retrieveNewsfeed",
       "description": "You can fetch the details of a single newsfeed",
       "namespace": [
-        "subpackage_news"
+        "news"
       ],
       "displayName": "Retrieve a newsfeed",
       "operationId": "retrieveNewsfeed",
@@ -20123,7 +20123,7 @@
       "id": "endpoint_notes.retrieveNote",
       "description": "You can fetch the details of a single note.",
       "namespace": [
-        "subpackage_notes"
+        "notes"
       ],
       "displayName": "Retrieve a note",
       "operationId": "retrieveNote",
@@ -20315,7 +20315,7 @@
       "id": "endpoint_segments.listSegments",
       "description": "You can fetch a list of all segments.",
       "namespace": [
-        "subpackage_segments"
+        "segments"
       ],
       "displayName": "List all segments",
       "operationId": "listSegments",
@@ -20475,7 +20475,7 @@
       "id": "endpoint_segments.retrieveSegment",
       "description": "You can fetch the details of a single segment.",
       "namespace": [
-        "subpackage_segments"
+        "segments"
       ],
       "displayName": "Retrieve a segment",
       "operationId": "retrieveSegment",
@@ -20657,7 +20657,7 @@
       "id": "endpoint_subscriptionTypes.listSubscriptionTypes",
       "description": "You can list all subscription types. A list of subscription type objects will be returned.",
       "namespace": [
-        "subpackage_subscriptionTypes"
+        "subscriptionTypes"
       ],
       "displayName": "List subscription types",
       "operationId": "listSubscriptionTypes",
@@ -20801,7 +20801,7 @@
       "id": "endpoint_switch.createPhoneSwitch",
       "description": "You can use the API to deflect phone calls to the Intercom Messenger.\nCalling this endpoint will send an SMS with a link to the Messenger to the phone number specified.\n\nIf custom attributes are specified, they will be added to the user or lead's custom data attributes.\n",
       "namespace": [
-        "subpackage_switch"
+        "switch"
       ],
       "displayName": "Create a phone Switch",
       "operationId": "createPhoneSwitch",
@@ -21011,7 +21011,7 @@
       "id": "endpoint_tags.listTags",
       "description": "You can fetch a list of all tags for a given workspace.\n\n",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "List all tags",
       "operationId": "listTags",
@@ -21139,7 +21139,7 @@
       "id": "endpoint_tags.createTag",
       "description": "You can use this endpoint to perform the following operations:\n\n  **1. Create a new tag:** You can create a new tag by passing in the tag name as specified in \"Create or Update Tag Request Payload\" described below.\n\n  **2. Update an existing tag:** You can update an existing tag by passing the id of the tag as specified in \"Create or Update Tag Request Payload\" described below.\n\n  **3. Tag Companies:** You can tag single company or a list of companies. You can tag a company by passing in the tag name and the company details as specified in \"Tag Company Request Payload\" described below. Also, if the tag doesn't exist then a new one will be created automatically.\n\n  **4. Untag Companies:** You can untag a single company or a list of companies. You can untag a company by passing in the tag id and the company details as specified in \"Untag Company Request Payload\" described below.\n\n  **5. Tag Multiple Users:** You can tag a list of users. You can tag the users by passing in the tag name and the user details as specified in \"Tag Users Request Payload\" described below.\n\nEach operation will return a tag object.\n",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Create or update a tag, Tag or untag companies, Tag contacts",
       "operationId": "createTag",
@@ -21423,7 +21423,7 @@
       "id": "endpoint_tags.findTag",
       "description": "You can fetch the details of tags that are on the workspace by their id.\nThis will return a tag object.\n",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Find a specific tag",
       "operationId": "findTag",
@@ -21602,7 +21602,7 @@
       "id": "endpoint_tags.deleteTag",
       "description": "You can delete the details of tags that are on the workspace by passing in the id.",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Delete tag",
       "operationId": "deleteTag",
@@ -21798,7 +21798,7 @@
       "id": "endpoint_teams.listTeams",
       "description": "This will return a list of team objects for the App.",
       "namespace": [
-        "subpackage_teams"
+        "teams"
       ],
       "displayName": "List all teams",
       "operationId": "listTeams",
@@ -21920,7 +21920,7 @@
       "id": "endpoint_teams.retrieveTeam",
       "description": "You can fetch the details of a single team, containing an array of admins that belong to this team.",
       "namespace": [
-        "subpackage_teams"
+        "teams"
       ],
       "displayName": "Retrieve a team",
       "operationId": "retrieveTeam",
@@ -22100,7 +22100,7 @@
       "id": "endpoint_ticketTypeAttributes.createTicketTypeAttribute",
       "description": "You can create a new attribute for a ticket type.",
       "namespace": [
-        "subpackage_ticketTypeAttributes"
+        "ticketTypeAttributes"
       ],
       "displayName": "Create a new attribute for a ticket type",
       "operationId": "createTicketTypeAttribute",
@@ -22294,7 +22294,7 @@
       "id": "endpoint_ticketTypeAttributes.updateTicketTypeAttribute",
       "description": "You can update an existing attribute for a ticket type.",
       "namespace": [
-        "subpackage_ticketTypeAttributes"
+        "ticketTypeAttributes"
       ],
       "displayName": "Update an existing attribute for a ticket type",
       "operationId": "updateTicketTypeAttribute",
@@ -22504,7 +22504,7 @@
       "id": "endpoint_ticketTypes.listTicketTypes",
       "description": "You can get a list of all ticket types for a workspace.",
       "namespace": [
-        "subpackage_ticketTypes"
+        "ticketTypes"
       ],
       "displayName": "List all ticket types",
       "operationId": "listTicketTypes",
@@ -22706,7 +22706,7 @@
       "id": "endpoint_ticketTypes.createTicketType",
       "description": "You can create a new ticket type.\n> 📘 Creating ticket types.\n>\n> Every ticket type will be created with two default attributes: _default_title_ and _default_description_.\n> For the `icon` propery, use an emoji from [Twemoji Cheatsheet](https://twemoji-cheatsheet.vercel.app/)\n",
       "namespace": [
-        "subpackage_ticketTypes"
+        "ticketTypes"
       ],
       "displayName": "Create a ticket type",
       "operationId": "createTicketType",
@@ -22905,7 +22905,7 @@
       "id": "endpoint_ticketTypes.getTicketType",
       "description": "You can fetch the details of a single ticket type.",
       "namespace": [
-        "subpackage_ticketTypes"
+        "ticketTypes"
       ],
       "displayName": "Retrieve a ticket type",
       "operationId": "getTicketType",
@@ -23128,7 +23128,7 @@
       "id": "endpoint_ticketTypes.updateTicketType",
       "description": "\nYou can update a ticket type.\n\n> 📘 Updating a ticket type.\n>\n> For the `icon` propery, use an emoji from [Twemoji Cheatsheet](https://twemoji-cheatsheet.vercel.app/)\n",
       "namespace": [
-        "subpackage_ticketTypes"
+        "ticketTypes"
       ],
       "displayName": "Update a ticket type",
       "operationId": "updateTicketType",
@@ -23369,7 +23369,7 @@
       "id": "endpoint_tickets.replyTicket",
       "description": "You can reply to a ticket with a message from an admin or on behalf of a contact, or with a note for admins.",
       "namespace": [
-        "subpackage_tickets"
+        "tickets"
       ],
       "displayName": "Reply to a ticket",
       "operationId": "replyTicket",
@@ -23731,7 +23731,7 @@
       "id": "endpoint_tags.attachTagToTicket",
       "description": "You can tag a specific ticket. This will return a tag object for the tag that was added to the ticket.",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Add tag to a ticket",
       "operationId": "attachTagToTicket",
@@ -23990,7 +23990,7 @@
       "id": "endpoint_tags.detachTagFromTicket",
       "description": "You can remove tag from a specific ticket. This will return a tag object for the tag that was removed from the ticket.",
       "namespace": [
-        "subpackage_tags"
+        "tags"
       ],
       "displayName": "Remove tag from a ticket",
       "operationId": "detachTagFromTicket",
@@ -24301,7 +24301,7 @@
       "id": "endpoint_tickets.createTicket",
       "description": "You can create a new ticket.",
       "namespace": [
-        "subpackage_tickets"
+        "tickets"
       ],
       "displayName": "Create a ticket",
       "operationId": "createTicket",
@@ -24560,7 +24560,7 @@
       "id": "endpoint_tickets.getTicket",
       "description": "You can fetch the details of a single ticket.",
       "namespace": [
-        "subpackage_tickets"
+        "tickets"
       ],
       "displayName": "Retrieve a ticket",
       "operationId": "getTicket",
@@ -24818,7 +24818,7 @@
       "id": "endpoint_tickets.updateTicket",
       "description": "You can update a ticket.",
       "namespace": [
-        "subpackage_tickets"
+        "tickets"
       ],
       "displayName": "Update a ticket",
       "operationId": "updateTicket",
@@ -25628,7 +25628,7 @@
       "id": "endpoint_tickets.searchTickets",
       "description": "You can search for multiple tickets by the value of their attributes in order to fetch exactly which ones you want.\n\nTo search for tickets, you send a `POST` request to `https://api.intercom.io/tickets/search`.\n\nThis will accept a query object in the body which will define your filters.\n{% admonition type=\"warning\" name=\"Optimizing search queries\" %}\n  Search queries can be complex, so optimizing them can help the performance of your search.\n  Use the `AND` and `OR` operators to combine multiple filters to get the exact results you need and utilize\n  pagination to limit the number of results returned. The default is `20` results per page.\n  See the [pagination section](https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/pagination/#example-search-conversations-request) for more details on how to use the `starting_after` param.\n{% /admonition %}\n\n### Nesting & Limitations\n\nYou can nest these filters in order to get even more granular insights that pinpoint exactly what you need. Example: (1 OR 2) AND (3 OR 4).\nThere are some limitations to the amount of multiples there can be:\n- There's a limit of max 2 nested filters\n- There's a limit of max 15 filters for each AND or OR group\n\n### Accepted Fields\n\nMost keys listed as part of the Ticket model are searchable, whether writeable or not. The value you search for has to match the accepted type, otherwise the query will fail (ie. as `created_at` accepts a date, the `value` cannot be a string such as `\"foobar\"`).\n\n| Field                                     | Type                                                                                     |\n| :---------------------------------------- | :--------------------------------------------------------------------------------------- |\n| id                                        | String                                                                                   |\n| created_at                                | Date (UNIX timestamp)                                                                    |\n| updated_at                                | Date (UNIX timestamp)                                                                    |\n| _default_title_                           | String                                                                                   |\n| _default_description_                     | String                                                                                   |\n| category                                  | String                                                                                   |\n| ticket_type_id                            | String                                                                                   |\n| contact_ids                               | String                                                                                   |\n| teammate_ids                              | String                                                                                   |\n| admin_assignee_id                         | String                                                                                   |\n| team_assignee_id                          | String                                                                                   |\n| open                                      | Boolean                                                                                  |\n| state                                     | String                                                                                   |\n| snoozed_until                             | Date (UNIX timestamp)                                                                    |\n| ticket_attribute.{id}                     | String or Boolean or Date (UNIX timestamp) or Float or Integer                           |\n\n### Accepted Operators\n\n{% admonition type=\"info\" name=\"Searching based on `created_at`\" %}\n  You may use the `<=` or `>=` operators to search by `created_at`.\n{% /admonition %}\n\nThe table below shows the operators you can use to define how you want to search for the value.  The operator should be put in as a string (`\"=\"`). The operator has to be compatible with the field's type  (eg. you cannot search with `>` for a given string value as it's only compatible for integer's and dates).\n\n| Operator | Valid Types                    | Description                                                  |\n| :------- | :----------------------------- | :----------------------------------------------------------- |\n| =        | All                            | Equals                                                       |\n| !=       | All                            | Doesn't Equal                                                |\n| IN       | All                            | In  Shortcut for `OR` queries  Values most be in Array       |\n| NIN      | All                            | Not In  Shortcut for `OR !` queries  Values must be in Array |\n| >        | Integer  Date (UNIX Timestamp) | Greater (or equal) than                                      |\n| <       | Integer  Date (UNIX Timestamp) | Lower (or equal) than                                        |\n| ~        | String                         | Contains                                                     |\n| !~       | String                         | Doesn't Contain                                              |\n| ^        | String                         | Starts With                                                  |\n| $        | String                         | Ends With                                                    |\n",
       "namespace": [
-        "subpackage_tickets"
+        "tickets"
       ],
       "displayName": "Search tickets",
       "operationId": "searchTickets",
@@ -25879,7 +25879,7 @@
       "id": "endpoint_visitors.retrieveVisitorWithUserId",
       "description": "You can fetch the details of a single visitor.",
       "namespace": [
-        "subpackage_visitors"
+        "visitors"
       ],
       "displayName": "Retrieve a visitor with User ID",
       "operationId": "retrieveVisitorWithUserId",
@@ -26095,7 +26095,7 @@
       "id": "endpoint_visitors.updateVisitor",
       "description": "Sending a PUT request to `/visitors` will result in an update of an existing Visitor.\n\n**Option 1.** You can update a visitor by passing in the `user_id` of the visitor in the Request body.\n\n**Option 2.** You can update a visitor by passing in the `id` of the visitor in the Request body.\n",
       "namespace": [
-        "subpackage_visitors"
+        "visitors"
       ],
       "displayName": "Update a visitor",
       "operationId": "updateVisitor",
@@ -26444,7 +26444,7 @@
       "id": "endpoint_visitors.convertVisitor",
       "description": "You can merge a Visitor to a Contact of role type `lead` or `user`.\n\n> 📘 What happens upon a visitor being converted?\n>\n> If the User exists, then the Visitor will be merged into it, the Visitor deleted and the User returned. If the User does not exist, the Visitor will be converted to a User, with the User identifiers replacing it's Visitor identifiers.\n",
       "namespace": [
-        "subpackage_visitors"
+        "visitors"
       ],
       "displayName": "Convert a visitor",
       "operationId": "convertVisitor",
@@ -26703,9 +26703,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -26714,62 +26720,92 @@
               {
                 "key": "performed_by",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "String representing the object's type. Always has the value `admin`."
+                        },
+                        {
+                          "key": "id",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The id representing the admin."
+                        },
+                        {
+                          "key": "email",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The email of the admin."
+                        },
+                        {
+                          "key": "ip",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The IP address of the admin."
                         }
-                      },
-                      "description": "String representing the object's type. Always has the value `admin`."
-                    },
-                    {
-                      "key": "id",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The id representing the admin."
-                    },
-                    {
-                      "key": "email",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The email of the admin."
-                    },
-                    {
-                      "key": "ip",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The IP address of the admin."
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "Details about the Admin involved in the activity."
               },
@@ -26778,8 +26814,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "activity_log_metadata"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "activity_log_metadata"
+                      }
+                    }
                   }
                 }
               },
@@ -26788,9 +26830,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -26799,210 +26847,216 @@
               {
                 "key": "activity_type",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "admin_assignment_limit_change"
-                    },
-                    {
-                      "value": "admin_away_mode_change"
-                    },
-                    {
-                      "value": "admin_deletion"
-                    },
-                    {
-                      "value": "admin_deprovisioned"
-                    },
-                    {
-                      "value": "admin_impersonation_end"
-                    },
-                    {
-                      "value": "admin_impersonation_start"
-                    },
-                    {
-                      "value": "admin_invite_change"
-                    },
-                    {
-                      "value": "admin_invite_creation"
-                    },
-                    {
-                      "value": "admin_invite_deletion"
-                    },
-                    {
-                      "value": "admin_login_failure"
-                    },
-                    {
-                      "value": "admin_login_success"
-                    },
-                    {
-                      "value": "admin_logout"
-                    },
-                    {
-                      "value": "admin_password_reset_request"
-                    },
-                    {
-                      "value": "admin_password_reset_success"
-                    },
-                    {
-                      "value": "admin_permission_change"
-                    },
-                    {
-                      "value": "admin_provisioned"
-                    },
-                    {
-                      "value": "admin_two_factor_auth_change"
-                    },
-                    {
-                      "value": "admin_unauthorized_sign_in_method"
-                    },
-                    {
-                      "value": "app_admin_join"
-                    },
-                    {
-                      "value": "app_authentication_method_change"
-                    },
-                    {
-                      "value": "app_data_deletion"
-                    },
-                    {
-                      "value": "app_data_export"
-                    },
-                    {
-                      "value": "app_google_sso_domain_change"
-                    },
-                    {
-                      "value": "app_identity_verification_change"
-                    },
-                    {
-                      "value": "app_name_change"
-                    },
-                    {
-                      "value": "app_outbound_address_change"
-                    },
-                    {
-                      "value": "app_package_installation"
-                    },
-                    {
-                      "value": "app_package_token_regeneration"
-                    },
-                    {
-                      "value": "app_package_uninstallation"
-                    },
-                    {
-                      "value": "app_team_creation"
-                    },
-                    {
-                      "value": "app_team_deletion"
-                    },
-                    {
-                      "value": "app_team_membership_modification"
-                    },
-                    {
-                      "value": "app_timezone_change"
-                    },
-                    {
-                      "value": "app_webhook_creation"
-                    },
-                    {
-                      "value": "app_webhook_deletion"
-                    },
-                    {
-                      "value": "articles_in_messenger_enabled_change"
-                    },
-                    {
-                      "value": "bulk_delete"
-                    },
-                    {
-                      "value": "bulk_export"
-                    },
-                    {
-                      "value": "campaign_deletion"
-                    },
-                    {
-                      "value": "campaign_state_change"
-                    },
-                    {
-                      "value": "conversation_part_deletion"
-                    },
-                    {
-                      "value": "conversation_topic_change"
-                    },
-                    {
-                      "value": "conversation_topic_creation"
-                    },
-                    {
-                      "value": "conversation_topic_deletion"
-                    },
-                    {
-                      "value": "help_center_settings_change"
-                    },
-                    {
-                      "value": "inbound_conversations_change"
-                    },
-                    {
-                      "value": "inbox_access_change"
-                    },
-                    {
-                      "value": "message_deletion"
-                    },
-                    {
-                      "value": "message_state_change"
-                    },
-                    {
-                      "value": "messenger_look_and_feel_change"
-                    },
-                    {
-                      "value": "messenger_search_required_change"
-                    },
-                    {
-                      "value": "messenger_spaces_change"
-                    },
-                    {
-                      "value": "office_hours_change"
-                    },
-                    {
-                      "value": "role_change"
-                    },
-                    {
-                      "value": "role_creation"
-                    },
-                    {
-                      "value": "role_deletion"
-                    },
-                    {
-                      "value": "ruleset_activation_title_preview"
-                    },
-                    {
-                      "value": "ruleset_creation"
-                    },
-                    {
-                      "value": "ruleset_deletion"
-                    },
-                    {
-                      "value": "search_browse_enabled_change"
-                    },
-                    {
-                      "value": "search_browse_required_change"
-                    },
-                    {
-                      "value": "seat_change"
-                    },
-                    {
-                      "value": "seat_revoke"
-                    },
-                    {
-                      "value": "security_settings_change"
-                    },
-                    {
-                      "value": "temporary_expectation_change"
-                    },
-                    {
-                      "value": "upfront_email_collection_change"
-                    },
-                    {
-                      "value": "welcome_message_change"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "admin_assignment_limit_change"
+                        },
+                        {
+                          "value": "admin_away_mode_change"
+                        },
+                        {
+                          "value": "admin_deletion"
+                        },
+                        {
+                          "value": "admin_deprovisioned"
+                        },
+                        {
+                          "value": "admin_impersonation_end"
+                        },
+                        {
+                          "value": "admin_impersonation_start"
+                        },
+                        {
+                          "value": "admin_invite_change"
+                        },
+                        {
+                          "value": "admin_invite_creation"
+                        },
+                        {
+                          "value": "admin_invite_deletion"
+                        },
+                        {
+                          "value": "admin_login_failure"
+                        },
+                        {
+                          "value": "admin_login_success"
+                        },
+                        {
+                          "value": "admin_logout"
+                        },
+                        {
+                          "value": "admin_password_reset_request"
+                        },
+                        {
+                          "value": "admin_password_reset_success"
+                        },
+                        {
+                          "value": "admin_permission_change"
+                        },
+                        {
+                          "value": "admin_provisioned"
+                        },
+                        {
+                          "value": "admin_two_factor_auth_change"
+                        },
+                        {
+                          "value": "admin_unauthorized_sign_in_method"
+                        },
+                        {
+                          "value": "app_admin_join"
+                        },
+                        {
+                          "value": "app_authentication_method_change"
+                        },
+                        {
+                          "value": "app_data_deletion"
+                        },
+                        {
+                          "value": "app_data_export"
+                        },
+                        {
+                          "value": "app_google_sso_domain_change"
+                        },
+                        {
+                          "value": "app_identity_verification_change"
+                        },
+                        {
+                          "value": "app_name_change"
+                        },
+                        {
+                          "value": "app_outbound_address_change"
+                        },
+                        {
+                          "value": "app_package_installation"
+                        },
+                        {
+                          "value": "app_package_token_regeneration"
+                        },
+                        {
+                          "value": "app_package_uninstallation"
+                        },
+                        {
+                          "value": "app_team_creation"
+                        },
+                        {
+                          "value": "app_team_deletion"
+                        },
+                        {
+                          "value": "app_team_membership_modification"
+                        },
+                        {
+                          "value": "app_timezone_change"
+                        },
+                        {
+                          "value": "app_webhook_creation"
+                        },
+                        {
+                          "value": "app_webhook_deletion"
+                        },
+                        {
+                          "value": "articles_in_messenger_enabled_change"
+                        },
+                        {
+                          "value": "bulk_delete"
+                        },
+                        {
+                          "value": "bulk_export"
+                        },
+                        {
+                          "value": "campaign_deletion"
+                        },
+                        {
+                          "value": "campaign_state_change"
+                        },
+                        {
+                          "value": "conversation_part_deletion"
+                        },
+                        {
+                          "value": "conversation_topic_change"
+                        },
+                        {
+                          "value": "conversation_topic_creation"
+                        },
+                        {
+                          "value": "conversation_topic_deletion"
+                        },
+                        {
+                          "value": "help_center_settings_change"
+                        },
+                        {
+                          "value": "inbound_conversations_change"
+                        },
+                        {
+                          "value": "inbox_access_change"
+                        },
+                        {
+                          "value": "message_deletion"
+                        },
+                        {
+                          "value": "message_state_change"
+                        },
+                        {
+                          "value": "messenger_look_and_feel_change"
+                        },
+                        {
+                          "value": "messenger_search_required_change"
+                        },
+                        {
+                          "value": "messenger_spaces_change"
+                        },
+                        {
+                          "value": "office_hours_change"
+                        },
+                        {
+                          "value": "role_change"
+                        },
+                        {
+                          "value": "role_creation"
+                        },
+                        {
+                          "value": "role_deletion"
+                        },
+                        {
+                          "value": "ruleset_activation_title_preview"
+                        },
+                        {
+                          "value": "ruleset_creation"
+                        },
+                        {
+                          "value": "ruleset_deletion"
+                        },
+                        {
+                          "value": "search_browse_enabled_change"
+                        },
+                        {
+                          "value": "search_browse_required_change"
+                        },
+                        {
+                          "value": "seat_change"
+                        },
+                        {
+                          "value": "seat_revoke"
+                        },
+                        {
+                          "value": "security_settings_change"
+                        },
+                        {
+                          "value": "temporary_expectation_change"
+                        },
+                        {
+                          "value": "upfront_email_collection_change"
+                        },
+                        {
+                          "value": "welcome_message_change"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
@@ -27010,9 +27064,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27035,9 +27095,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -27048,8 +27114,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           },
@@ -27058,12 +27130,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "activity_log"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "activity_log"
+                      }
+                    }
                   }
                 }
               }
@@ -27089,13 +27167,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -27108,13 +27192,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -27127,13 +27217,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "boolean"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "boolean"
+                            }
+                          }
                         }
                       }
                     }
@@ -27146,13 +27242,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -27165,13 +27267,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "boolean"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "boolean"
+                            }
+                          }
                         }
                       }
                     }
@@ -27184,13 +27292,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -27203,13 +27317,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -27222,13 +27342,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -27241,13 +27367,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -27272,10 +27404,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "uri"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
                 }
               }
             },
@@ -27286,9 +27424,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -27299,10 +27443,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "uri"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
                 }
               }
             },
@@ -27327,9 +27477,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27340,9 +27496,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27353,9 +27515,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27366,9 +27534,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27379,9 +27553,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27392,9 +27572,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -27405,9 +27591,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -27418,9 +27610,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -27431,13 +27629,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -27450,14 +27654,20 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string",
-                          "format": "uri"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string",
+                              "format": "uri"
+                            }
+                          }
                         }
                       }
                     }
@@ -27470,8 +27680,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "team_priority_level"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "team_priority_level"
+                      }
+                    }
                   }
                 }
               }
@@ -27492,9 +27708,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -27505,12 +27727,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "admin"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "admin"
+                      }
+                    }
                   }
                 }
               }
@@ -27536,13 +27764,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -27555,13 +27789,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -27888,9 +28128,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27901,9 +28147,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27914,9 +28166,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27927,9 +28185,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27940,9 +28204,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -27953,9 +28223,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -27966,9 +28242,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -27979,9 +28261,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -27992,13 +28280,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -28009,44 +28303,62 @@
               {
                 "key": "avatar",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string",
-                            "default": "avatar"
-                          }
-                        }
-                      },
-                      "description": "This is a string that identifies the type of the object. It will always have the value `avatar`."
-                    },
-                    {
-                      "key": "image_url",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "nullable",
-                          "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string",
-                                "format": "uri"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string",
+                                    "default": "avatar"
+                                  }
+                                }
                               }
                             }
-                          }
+                          },
+                          "description": "This is a string that identifies the type of the object. It will always have the value `avatar`."
+                        },
+                        {
+                          "key": "image_url",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "nullable",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "This object represents the avatar associated with the admin."
                         }
-                      },
-                      "description": "This object represents the avatar associated with the admin."
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "This object represents the avatar associated with the admin."
               },
@@ -28055,13 +28367,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "boolean"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "boolean"
+                            }
+                          }
                         }
                       }
                     }
@@ -28074,12 +28392,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "app"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "app"
+                          }
+                        }
                       }
                     }
                   }
@@ -28101,24 +28425,30 @@
           {
             "key": "source_type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "essentials_plan_setup"
-                },
-                {
-                  "value": "profile"
-                },
-                {
-                  "value": "workflow"
-                },
-                {
-                  "value": "workflow_preview"
-                },
-                {
-                  "value": "fin_preview"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "essentials_plan_setup"
+                    },
+                    {
+                      "value": "profile"
+                    },
+                    {
+                      "value": "workflow"
+                    },
+                    {
+                      "value": "workflow_preview"
+                    },
+                    {
+                      "value": "fin_preview"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the source that triggered AI Agent involvement in the conversation."
           },
@@ -28127,13 +28457,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -28146,10 +28482,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
-                  "type": "enum",
-                  "values": []
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "enum",
+                      "values": []
+                    }
+                  }
                 }
               }
             },
@@ -28160,23 +28502,29 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "assumed_resolution"
-                    },
-                    {
-                      "value": "confirmed_resolution"
-                    },
-                    {
-                      "value": "routed_to_team"
-                    },
-                    {
-                      "value": "abandoned"
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "assumed_resolution"
+                        },
+                        {
+                          "value": "confirmed_resolution"
+                        },
+                        {
+                          "value": "routed_to_team"
+                        },
+                        {
+                          "value": "abandoned"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             },
@@ -28187,13 +28535,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -28206,13 +28560,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -28225,8 +28585,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "content_sources_list"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "content_sources_list"
+                  }
+                }
               }
             }
           }
@@ -28249,10 +28615,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "default": "app"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "default": "app"
+                        }
+                      }
                     }
                   }
                 },
@@ -28263,9 +28635,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28276,9 +28654,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28289,9 +28673,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28302,9 +28692,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28315,9 +28711,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -28328,9 +28730,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -28355,12 +28763,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_statistics"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_statistics"
+                      }
+                    }
                   }
                 }
               }
@@ -28385,10 +28799,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
-                      "type": "enum",
-                      "values": []
+                      "type": "alias",
+                      "value": {
+                        "type": "nullable",
+                        "shape": {
+                          "type": "enum",
+                          "values": []
+                        }
+                      }
                     }
                   }
                 },
@@ -28399,9 +28819,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28412,9 +28838,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28425,9 +28857,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28438,9 +28876,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -28449,15 +28893,21 @@
               {
                 "key": "state",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "published"
-                    },
-                    {
-                      "value": "draft"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "published"
+                        },
+                        {
+                          "value": "draft"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "Whether the article is `published` or is a `draft` ."
               },
@@ -28466,9 +28916,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -28479,9 +28935,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -28492,9 +28954,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -28515,12 +28983,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object - `list`."
           },
@@ -28529,8 +29003,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           },
@@ -28539,9 +29019,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -28552,12 +29038,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_list_item"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_list_item"
+                      }
+                    }
                   }
                 }
               }
@@ -28577,13 +29069,20 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "article"
-                }
-              ],
-              "default": "article"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "article"
+                    }
+                  ],
+                  "default": "article"
+                },
+                "default": "article"
+              }
             },
             "description": "The type of object - `article`."
           },
@@ -28592,9 +29091,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -28605,9 +29110,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -28618,9 +29129,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -28631,13 +29148,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -28650,13 +29173,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -28669,9 +29198,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -28680,16 +29215,23 @@
           {
             "key": "state",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "published"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "published"
+                    },
+                    {
+                      "value": "draft"
+                    }
+                  ],
+                  "default": "draft"
                 },
-                {
-                  "value": "draft"
-                }
-              ],
-              "default": "draft"
+                "default": "draft"
+              }
             },
             "description": "Whether the article is `published` or is a `draft`. For multilingual articles, this will be the state of the default language's content."
           },
@@ -28698,9 +29240,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -28711,9 +29259,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -28724,13 +29278,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -28743,13 +29303,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -28762,13 +29328,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -28781,13 +29353,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -28800,9 +29378,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -28813,12 +29397,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_translated_content"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_translated_content"
+                      }
+                    }
                   }
                 }
               }
@@ -28839,9 +29429,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -28852,52 +29448,8 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "enum",
-                        "values": [
-                          {
-                            "value": "highlight"
-                          },
-                          {
-                            "value": "plain"
-                          }
-                        ]
-                      },
-                      "description": "The type of text - `highlight` or `plain`."
-                    },
-                    {
-                      "key": "text",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The text of the title."
-                    }
-                  ]
-                }
-              }
-            },
-            "description": "An Article title highlighted."
-          },
-          {
-            "key": "highlighted_summary",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
                     "type": "list",
@@ -28908,15 +29460,21 @@
                         {
                           "key": "type",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "highlight"
-                              },
-                              {
-                                "value": "plain"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "highlight"
+                                  },
+                                  {
+                                    "value": "plain"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "The type of text - `highlight` or `plain`."
                         },
@@ -28925,15 +29483,89 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
                               }
                             }
                           },
                           "description": "The text of the title."
                         }
                       ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "An Article title highlighted."
+          },
+          {
+            "key": "highlighted_summary",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "list",
+                        "itemShape": {
+                          "type": "object",
+                          "extends": [],
+                          "properties": [
+                            {
+                              "key": "type",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "enum",
+                                    "values": [
+                                      {
+                                        "value": "highlight"
+                                      },
+                                      {
+                                        "value": "plain"
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              "description": "The type of text - `highlight` or `plain`."
+                            },
+                            {
+                              "key": "text",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "The text of the title."
+                            }
+                          ]
+                        }
+                      }
                     }
                   }
                 }
@@ -28954,12 +29586,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object - `list`."
           },
@@ -28968,9 +29606,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -28979,44 +29623,62 @@
           {
             "key": "data",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "articles",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "list",
-                      "itemShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "articles",
+                      "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "article"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "list",
+                              "itemShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "id",
+                                  "id": "article"
+                                }
+                              }
+                            }
+                          }
                         }
-                      }
-                    }
-                  },
-                  "description": "An array of Article objects"
-                },
-                {
-                  "key": "highlights",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "list",
-                      "itemShape": {
+                      },
+                      "description": "An array of Article objects"
+                    },
+                    {
+                      "key": "highlights",
+                      "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "article_search_highlights"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "list",
+                              "itemShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "id",
+                                  "id": "article_search_highlights"
+                                }
+                              }
+                            }
+                          }
                         }
-                      }
+                      },
+                      "description": "A corresponding array of highlighted Article content"
                     }
-                  },
-                  "description": "A corresponding array of highlighted Article content"
+                  ]
                 }
-              ]
+              }
             },
             "description": "An object containing the results of the search."
           },
@@ -29025,8 +29687,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           }
@@ -29047,13 +29715,20 @@
               {
                 "key": "type",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "article_statistics"
-                    }
-                  ],
-                  "default": "article_statistics"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "article_statistics"
+                        }
+                      ],
+                      "default": "article_statistics"
+                    },
+                    "default": "article_statistics"
+                  }
                 },
                 "description": "The type of object - `article_statistics`."
               },
@@ -29062,9 +29737,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -29075,9 +29756,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -29088,9 +29775,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -29101,9 +29794,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -29114,9 +29813,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -29127,9 +29832,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -29156,10 +29867,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
-                      "type": "enum",
-                      "values": []
+                      "type": "alias",
+                      "value": {
+                        "type": "nullable",
+                        "shape": {
+                          "type": "enum",
+                          "values": []
+                        }
+                      }
                     }
                   }
                 },
@@ -29170,8 +29887,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Arabic"
@@ -29181,8 +29904,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Bulgarian"
@@ -29192,8 +29921,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Bosnian"
@@ -29203,8 +29938,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Catalan"
@@ -29214,8 +29955,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Czech"
@@ -29225,8 +29972,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Danish"
@@ -29236,8 +29989,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in German"
@@ -29247,8 +30006,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Greek"
@@ -29258,8 +30023,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in English"
@@ -29269,8 +30040,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Spanish"
@@ -29280,8 +30057,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Estonian"
@@ -29291,8 +30074,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Finnish"
@@ -29302,8 +30091,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in French"
@@ -29313,8 +30108,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Hebrew"
@@ -29324,8 +30125,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Croatian"
@@ -29335,8 +30142,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Hungarian"
@@ -29346,8 +30159,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Indonesian"
@@ -29357,8 +30176,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Italian"
@@ -29368,8 +30193,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Japanese"
@@ -29379,8 +30210,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Korean"
@@ -29390,8 +30227,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Lithuanian"
@@ -29401,8 +30244,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Latvian"
@@ -29412,8 +30261,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Mongolian"
@@ -29423,8 +30278,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Norwegian"
@@ -29434,8 +30295,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Dutch"
@@ -29445,8 +30312,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Polish"
@@ -29456,8 +30329,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Portuguese (Portugal)"
@@ -29467,8 +30346,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Romanian"
@@ -29478,8 +30363,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Russian"
@@ -29489,8 +30380,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Slovenian"
@@ -29500,8 +30397,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Serbian"
@@ -29511,8 +30414,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Swedish"
@@ -29522,8 +30431,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Turkish"
@@ -29533,8 +30448,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Vietnamese"
@@ -29544,8 +30465,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Portuguese (Brazil)"
@@ -29555,8 +30482,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Chinese (China)"
@@ -29566,8 +30499,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the article in Chinese (Taiwan)"
@@ -29669,9 +30608,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -29680,123 +30625,129 @@
           {
             "key": "customer",
             "valueShape": {
-              "type": "undiscriminatedUnion",
-              "variants": [
-                {
-                  "displayName": "Intercom User ID",
-                  "shape": {
-                    "type": "object",
-                    "extends": [],
-                    "properties": [
-                      {
-                        "key": "intercom_user_id",
-                        "valueShape": {
-                          "type": "alias",
-                          "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "description": "The identifier for the contact as given by Intercom."
-                      },
-                      {
-                        "key": "customer",
-                        "valueShape": {
-                          "type": "alias",
-                          "value": {
-                            "type": "optional",
-                            "shape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "undiscriminatedUnion",
+                  "variants": [
+                    {
+                      "displayName": "Intercom User ID",
+                      "shape": {
+                        "type": "object",
+                        "extends": [],
+                        "properties": [
+                          {
+                            "key": "intercom_user_id",
+                            "valueShape": {
                               "type": "alias",
                               "value": {
-                                "type": "id",
-                                "id": "customer_request"
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "description": "The identifier for the contact as given by Intercom."
+                          },
+                          {
+                            "key": "customer",
+                            "valueShape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "optional",
+                                "shape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "id",
+                                    "id": "customer_request"
+                                  }
+                                }
                               }
                             }
                           }
-                        }
+                        ]
                       }
-                    ]
-                  }
-                },
-                {
-                  "displayName": "User ID",
-                  "shape": {
-                    "type": "object",
-                    "extends": [],
-                    "properties": [
-                      {
-                        "key": "user_id",
-                        "valueShape": {
-                          "type": "alias",
-                          "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "description": "The external_id you have defined for the contact who is being added as a participant."
-                      },
-                      {
-                        "key": "customer",
-                        "valueShape": {
-                          "type": "alias",
-                          "value": {
-                            "type": "optional",
-                            "shape": {
+                    },
+                    {
+                      "displayName": "User ID",
+                      "shape": {
+                        "type": "object",
+                        "extends": [],
+                        "properties": [
+                          {
+                            "key": "user_id",
+                            "valueShape": {
                               "type": "alias",
                               "value": {
-                                "type": "id",
-                                "id": "customer_request"
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "description": "The external_id you have defined for the contact who is being added as a participant."
+                          },
+                          {
+                            "key": "customer",
+                            "valueShape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "optional",
+                                "shape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "id",
+                                    "id": "customer_request"
+                                  }
+                                }
                               }
                             }
                           }
-                        }
+                        ]
                       }
-                    ]
-                  }
-                },
-                {
-                  "displayName": "Email",
-                  "shape": {
-                    "type": "object",
-                    "extends": [],
-                    "properties": [
-                      {
-                        "key": "email",
-                        "valueShape": {
-                          "type": "alias",
-                          "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "description": "The email you have defined for the contact who is being added as a participant."
-                      },
-                      {
-                        "key": "customer",
-                        "valueShape": {
-                          "type": "alias",
-                          "value": {
-                            "type": "optional",
-                            "shape": {
+                    },
+                    {
+                      "displayName": "Email",
+                      "shape": {
+                        "type": "object",
+                        "extends": [],
+                        "properties": [
+                          {
+                            "key": "email",
+                            "valueShape": {
                               "type": "alias",
                               "value": {
-                                "type": "id",
-                                "id": "customer_request"
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "description": "The email you have defined for the contact who is being added as a participant."
+                          },
+                          {
+                            "key": "customer",
+                            "valueShape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "optional",
+                                "shape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "id",
+                                    "id": "customer_request"
+                                  }
+                                }
                               }
                             }
                           }
-                        }
+                        ]
                       }
-                    ]
-                  }
+                    }
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -29878,9 +30829,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -29891,9 +30848,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -29904,9 +30867,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -29917,13 +30886,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -29936,9 +30911,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -29949,9 +30930,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -29962,13 +30949,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -29981,13 +30974,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -30000,9 +30999,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30013,9 +31018,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30026,12 +31037,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_translated_content"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_translated_content"
+                      }
+                    }
                   }
                 }
               }
@@ -30042,13 +31059,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -30061,13 +31084,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -30088,12 +31117,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object - `list`."
           },
@@ -30102,8 +31137,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           },
@@ -30112,9 +31153,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30125,12 +31172,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "collection"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "collection"
+                      }
+                    }
                   }
                 }
               }
@@ -30150,12 +31203,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "company"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "company"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Value is `company`"
           },
@@ -30164,9 +31223,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30177,9 +31242,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30190,9 +31261,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30201,49 +31278,73 @@
           {
             "key": "plan",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "type",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "type",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "Value is always \"plan\""
+                    },
+                    {
+                      "key": "id",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The id of the plan"
+                    },
+                    {
+                      "key": "name",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The name of the plan"
                     }
-                  },
-                  "description": "Value is always \"plan\""
-                },
-                {
-                  "key": "id",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "description": "The id of the plan"
-                },
-                {
-                  "key": "name",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "description": "The name of the plan"
+                  ]
                 }
-              ]
+              }
             }
           },
           {
@@ -30251,9 +31352,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30264,9 +31371,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30277,9 +31390,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30290,9 +31409,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30303,9 +31428,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30316,9 +31447,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30329,9 +31466,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30342,9 +31485,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30355,9 +31504,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30368,9 +31523,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30381,9 +31542,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30394,22 +31561,28 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "map",
-                "keyShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "valueShape": {
-                  "type": "alias",
-                  "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "map",
+                    "keyShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "valueShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -30420,75 +31593,111 @@
           {
             "key": "tags",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "type",
-                  "valueShape": {
-                    "type": "enum",
-                    "values": [
-                      {
-                        "value": "tag.list"
-                      }
-                    ]
-                  },
-                  "description": "The type of the object"
-                },
-                {
-                  "key": "tags",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "list",
-                      "itemShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "type",
+                      "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "unknown"
+                          "type": "optional",
+                          "shape": {
+                            "type": "enum",
+                            "values": [
+                              {
+                                "value": "tag.list"
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "description": "The type of the object"
+                    },
+                    {
+                      "key": "tags",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "list",
+                              "itemShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "unknown"
+                                }
+                              }
+                            }
+                          }
                         }
                       }
                     }
-                  }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The list of tags associated with the company"
           },
           {
             "key": "segments",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "type",
-                  "valueShape": {
-                    "type": "enum",
-                    "values": [
-                      {
-                        "value": "segment.list"
-                      }
-                    ]
-                  },
-                  "description": "The type of the object"
-                },
-                {
-                  "key": "segments",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "list",
-                      "itemShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "type",
+                      "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "segment"
+                          "type": "optional",
+                          "shape": {
+                            "type": "enum",
+                            "values": [
+                              {
+                                "value": "segment.list"
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "description": "The type of the object"
+                    },
+                    {
+                      "key": "segments",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "list",
+                              "itemShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "id",
+                                  "id": "segment"
+                                }
+                              }
+                            }
+                          }
                         }
                       }
                     }
-                  }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The list of segments associated with the company"
           }
@@ -30505,12 +31714,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object - `list`"
           },
@@ -30519,12 +31734,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "contact"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "contact"
+                      }
+                    }
                   }
                 }
               }
@@ -30536,9 +31757,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30549,8 +31776,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           }
@@ -30567,12 +31800,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object - `list`"
           },
@@ -30581,12 +31820,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "segment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "segment"
+                      }
+                    }
                   }
                 }
               }
@@ -30606,12 +31851,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object - `list`."
           },
@@ -30620,8 +31871,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           },
@@ -30630,9 +31887,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30643,12 +31906,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "company"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "company"
+                      }
+                    }
                   }
                 }
               }
@@ -30672,12 +31941,18 @@
               {
                 "key": "type",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "list"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "list"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "The type of object - `list`"
               },
@@ -30686,12 +31961,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "company"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "company"
+                          }
+                        }
                       }
                     }
                   }
@@ -30702,8 +31983,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "cursor_pages"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "cursor_pages"
+                      }
+                    }
                   }
                 }
               },
@@ -30712,13 +31999,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -30731,9 +32024,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -30756,9 +32055,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30769,9 +32074,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30782,13 +32093,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -30801,9 +32118,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30814,9 +32137,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30827,9 +32156,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30840,9 +32175,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -30853,13 +32194,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -30872,13 +32219,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -30891,13 +32244,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -30910,13 +32269,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -30929,9 +32294,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -30942,9 +32313,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -30955,9 +32332,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -30968,9 +32351,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30981,9 +32370,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -30994,13 +32389,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31013,13 +32414,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31032,13 +32439,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31051,13 +32464,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31070,13 +32489,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31089,13 +32514,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31108,13 +32539,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31127,13 +32564,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31146,13 +32589,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31165,13 +32614,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31184,13 +32639,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31203,13 +32664,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31222,13 +32689,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31241,13 +32714,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31260,13 +32739,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31279,13 +32764,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31298,13 +32789,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31317,13 +32814,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31336,13 +32839,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31355,13 +32864,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31374,13 +32889,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31393,13 +32914,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31412,13 +32939,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -31429,9 +32962,15 @@
           {
             "key": "custom_attributes",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": []
+                }
+              }
             },
             "description": "The custom attributes which are set for the contact."
           },
@@ -31440,45 +32979,63 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The type of object"
-                    },
-                    {
-                      "key": "image_url",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "nullable",
-                          "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string",
-                                "format": "uri"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
                               }
                             }
-                          }
+                          },
+                          "description": "The type of object"
+                        },
+                        {
+                          "key": "image_url",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "nullable",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "An image URL containing the avatar of a contact."
                         }
-                      },
-                      "description": "An image URL containing the avatar of a contact."
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -31488,8 +33045,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "contact_tags"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "contact_tags"
+                  }
+                }
               }
             }
           },
@@ -31498,8 +33061,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "contact_notes"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "contact_notes"
+                  }
+                }
               }
             }
           },
@@ -31508,8 +33077,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "contact_companies"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "contact_companies"
+                  }
+                }
               }
             }
           },
@@ -31518,8 +33093,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "contact_location"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "contact_location"
+                  }
+                }
               }
             }
           },
@@ -31528,8 +33109,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "contact_social_profiles"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "contact_social_profiles"
+                  }
+                }
               }
             }
           }
@@ -31546,12 +33133,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "always contact"
           },
@@ -31560,9 +33153,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -31573,13 +33172,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31592,9 +33197,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -31613,12 +33224,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object"
           },
@@ -31627,12 +33244,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "company"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "company"
+                      }
+                    }
                   }
                 }
               }
@@ -31644,9 +33267,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -31657,8 +33286,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "pages_link"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "pages_link"
+                  }
+                }
               }
             }
           }
@@ -31677,10 +33312,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "uri"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
                 }
               }
             },
@@ -31691,9 +33332,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -31704,9 +33351,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -31725,12 +33378,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "always contact"
           },
@@ -31739,9 +33398,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -31752,13 +33417,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31771,9 +33442,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -31792,12 +33469,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Always list"
           },
@@ -31806,12 +33489,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "contact"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "contact"
+                      }
+                    }
                   }
                 }
               }
@@ -31823,9 +33512,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -31836,8 +33531,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           }
@@ -31856,13 +33557,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31875,13 +33582,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31894,13 +33607,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31913,13 +33632,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -31942,12 +33667,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "addressable_list"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "addressable_list"
+                      }
+                    }
                   }
                 }
               }
@@ -31959,10 +33690,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "uri"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
                 }
               }
             },
@@ -31973,9 +33710,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -31986,9 +33729,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -32007,12 +33756,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "always contact"
           },
@@ -32021,9 +33776,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32034,13 +33795,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -32445,12 +34212,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -32459,12 +34232,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "segment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "segment"
+                      }
+                    }
                   }
                 }
               }
@@ -32486,12 +34265,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "social_profile"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "social_profile"
+                      }
+                    }
                   }
                 }
               }
@@ -32513,12 +34298,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "addressable_list"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "addressable_list"
+                      }
+                    }
                   }
                 }
               }
@@ -32530,10 +34321,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "uri"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
                 }
               }
             },
@@ -32544,9 +34341,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -32557,9 +34360,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -32584,12 +34393,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "addressable_list"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "addressable_list"
+                          }
+                        }
                       }
                     }
                   }
@@ -32601,10 +34416,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "format": "uri"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      }
                     }
                   }
                 },
@@ -32615,9 +34436,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -32628,9 +34455,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -32651,12 +34484,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "always contact"
           },
@@ -32665,9 +34504,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32678,13 +34523,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -32697,9 +34548,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -32718,24 +34575,30 @@
           {
             "key": "content_type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "file"
-                },
-                {
-                  "value": "article"
-                },
-                {
-                  "value": "external_content"
-                },
-                {
-                  "value": "content_snippet"
-                },
-                {
-                  "value": "workflow_connector_action"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "file"
+                    },
+                    {
+                      "value": "article"
+                    },
+                    {
+                      "value": "external_content"
+                    },
+                    {
+                      "value": "content_snippet"
+                    },
+                    {
+                      "value": "workflow_connector_action"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the content source."
           },
@@ -32744,9 +34607,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32757,9 +34626,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32770,9 +34645,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32791,12 +34672,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "content_source.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "content_source.list"
+                    }
+                  ]
                 }
-              ]
+              }
             }
           },
           {
@@ -32804,9 +34691,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -32817,12 +34710,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "content_source"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "content_source"
+                      }
+                    }
                   }
                 }
               }
@@ -32843,9 +34742,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32856,9 +34761,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -32869,13 +34780,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -32888,9 +34805,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -32901,9 +34824,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -32914,13 +34843,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -32933,13 +34868,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -32952,9 +34893,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -32963,18 +34910,24 @@
           {
             "key": "state",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "open"
-                },
-                {
-                  "value": "closed"
-                },
-                {
-                  "value": "snoozed"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "open"
+                    },
+                    {
+                      "value": "closed"
+                    },
+                    {
+                      "value": "snoozed"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Can be set to \"open\", \"closed\" or \"snoozed\"."
           },
@@ -32983,9 +34936,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -32994,15 +34953,21 @@
           {
             "key": "priority",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "priority"
-                },
-                {
-                  "value": "not_priority"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "priority"
+                    },
+                    {
+                      "value": "not_priority"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "If marked as priority, it will return priority or else not_priority."
           },
@@ -33011,13 +34976,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -33030,13 +35001,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -33049,8 +35026,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "tags"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "tags"
+                  }
+                }
               }
             }
           },
@@ -33059,8 +35042,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_rating"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_rating"
+                  }
+                }
               }
             }
           },
@@ -33069,8 +35058,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_source"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_source"
+                  }
+                }
               }
             }
           },
@@ -33079,8 +35074,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_contacts"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_contacts"
+                  }
+                }
               }
             }
           },
@@ -33089,8 +35090,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_teammates"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_teammates"
+                  }
+                }
               }
             }
           },
@@ -33099,8 +35106,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "custom_attributes"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "custom_attributes"
+                  }
+                }
               }
             }
           },
@@ -33109,8 +35122,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_first_contact_reply"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_first_contact_reply"
+                  }
+                }
               }
             }
           },
@@ -33119,8 +35138,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "sla_applied"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "sla_applied"
+                  }
+                }
               }
             }
           },
@@ -33129,8 +35154,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_statistics"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_statistics"
+                  }
+                }
               }
             }
           },
@@ -33139,8 +35170,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_parts"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_parts"
+                  }
+                }
               }
             }
           },
@@ -33149,8 +35186,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "linked_object_list"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "linked_object_list"
+                  }
+                }
               }
             }
           },
@@ -33159,9 +35202,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -33172,12 +35221,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ai_agent"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ai_agent"
+                      }
+                    }
                   }
                 }
               }
@@ -33198,9 +35253,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33211,9 +35272,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33224,9 +35291,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33245,12 +35318,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": ""
           },
@@ -33259,12 +35338,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "contact_reference"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "contact_reference"
+                      }
+                    }
                   }
                 }
               }
@@ -33290,9 +35375,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33303,9 +35394,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -33316,13 +35413,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -33345,12 +35448,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "conversation.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "conversation.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Always conversation.list"
           },
@@ -33359,12 +35468,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "conversation"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "conversation"
+                      }
+                    }
                   }
                 }
               }
@@ -33376,9 +35491,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -33389,8 +35510,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           }
@@ -33409,9 +35536,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33422,9 +35555,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33435,9 +35574,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33448,13 +35593,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -33467,9 +35618,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -33480,9 +35637,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -33493,9 +35656,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -33506,12 +35675,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "reference"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "reference"
+                      }
+                    }
                   }
                 }
               }
@@ -33523,8 +35698,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_part_author"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_part_author"
+                  }
+                }
               }
             }
           },
@@ -33533,12 +35714,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "part_attachment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "part_attachment"
+                      }
+                    }
                   }
                 }
               }
@@ -33550,13 +35737,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -33569,9 +35762,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -33592,9 +35791,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33605,9 +35810,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33618,9 +35829,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33631,10 +35848,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "email"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "email"
+                    }
+                  }
                 }
               }
             },
@@ -33653,12 +35876,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "conversation_part.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "conversation_part.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": ""
           },
@@ -33667,12 +35896,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "conversation_part"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "conversation_part"
+                      }
+                    }
                   }
                 }
               }
@@ -33684,9 +35919,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -33711,9 +35952,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33724,9 +35971,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -33737,9 +35990,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33750,8 +36009,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "contact_reference"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "contact_reference"
+                      }
+                    }
                   }
                 }
               },
@@ -33760,8 +36025,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "reference"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "reference"
+                      }
+                    }
                   }
                 }
               }
@@ -33782,9 +36053,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33795,9 +36072,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33808,9 +36091,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33821,9 +36110,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33834,9 +36129,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -33847,8 +36148,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "conversation_part_author"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "conversation_part_author"
+                  }
+                }
               }
             }
           },
@@ -33857,12 +36164,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "part_attachment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "part_attachment"
+                      }
+                    }
                   }
                 }
               }
@@ -33874,13 +36187,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -33893,9 +36212,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -33920,9 +36245,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -33933,9 +36264,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33946,9 +36283,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33959,9 +36302,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33972,9 +36321,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33985,9 +36340,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -33998,9 +36359,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34011,9 +36378,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34024,9 +36397,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34037,9 +36416,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34050,9 +36435,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34063,9 +36454,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34076,9 +36473,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34089,9 +36492,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34102,9 +36511,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34115,9 +36530,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -34128,9 +36549,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34141,9 +36568,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34154,9 +36587,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -34183,9 +36622,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -34196,12 +36641,18 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "reference"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "reference"
+                          }
+                        }
                       }
                     }
                   }
@@ -34879,9 +37330,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -34890,62 +37347,92 @@
           {
             "key": "event_summaries",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "event_name",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "event_name",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The name of the event that occurred. A good event name is typically a past tense 'verb-noun' combination, to improve readability, for example `updated-plan`."
+                    },
+                    {
+                      "key": "count",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The number of times the event occurred."
+                    },
+                    {
+                      "key": "first",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The first time the event was sent"
+                    },
+                    {
+                      "key": "last",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The last time the event was sent"
                     }
-                  },
-                  "description": "The name of the event that occurred. A good event name is typically a past tense 'verb-noun' combination, to improve readability, for example `updated-plan`."
-                },
-                {
-                  "key": "count",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "integer"
-                      }
-                    }
-                  },
-                  "description": "The number of times the event occurred."
-                },
-                {
-                  "key": "first",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "integer"
-                      }
-                    }
-                  },
-                  "description": "The first time the event was sent"
-                },
-                {
-                  "key": "last",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "integer"
-                      }
-                    }
-                  },
-                  "description": "The last time the event was sent"
+                  ]
                 }
-              ]
+              }
             },
             "description": "A list of event summaries for the user. Each event summary should contain the event name, the time the event occurred, and the number of times the event occurred. The event name should be a past tense 'verb-noun' combination, to improve readability, for example `updated-plan`."
           }
@@ -35037,9 +37524,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35050,9 +37543,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35063,9 +37562,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35076,9 +37581,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -35089,9 +37600,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35102,9 +37619,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35115,22 +37638,28 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "map",
-                    "keyShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "valueShape": {
-                      "type": "alias",
-                      "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "map",
+                        "keyShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "valueShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -35143,9 +37672,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -35156,9 +37691,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -35771,12 +38312,18 @@
               {
                 "key": "type",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "pages"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "pages"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "the type of object `pages`."
               },
@@ -35785,9 +38332,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -35798,8 +38351,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "starting_after_paging"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "starting_after_paging"
+                      }
+                    }
                   }
                 }
               },
@@ -35808,9 +38367,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -35821,9 +38386,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -35838,9 +38409,45 @@
     "custom_attributes": {
       "name": "Custom Attributes",
       "shape": {
-        "type": "object",
-        "extends": [],
-        "properties": []
+        "type": "alias",
+        "value": {
+          "type": "map",
+          "keyShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "valueShape": {
+            "type": "undiscriminatedUnion",
+            "variants": [
+              {
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              {
+                "displayName": "Custom Object Instance",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "custom_object_instance"
+                  }
+                }
+              }
+            ]
+          }
+        }
       },
       "description": "An object containing the different custom attributes associated to the conversation as key-value pairs. For relationship attributes the value will be a list of custom object instance models."
     },
@@ -35859,9 +38466,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35872,9 +38485,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35885,9 +38504,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -35898,22 +38523,28 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "map",
-                    "keyShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "valueShape": {
-                      "type": "alias",
-                      "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "map",
+                        "keyShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "valueShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -36016,12 +38647,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "data_attribute"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "data_attribute"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Value is `data_attribute`."
           },
@@ -36030,9 +38667,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -36041,15 +38684,21 @@
           {
             "key": "model",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact"
-                },
-                {
-                  "value": "company"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact"
+                    },
+                    {
+                      "value": "company"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Value is `contact` for user/lead attributes and `company` for company attributes."
           },
@@ -36058,9 +38707,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36071,9 +38726,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36084,9 +38745,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36097,9 +38764,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36108,24 +38781,30 @@
           {
             "key": "data_type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "string"
-                },
-                {
-                  "value": "integer"
-                },
-                {
-                  "value": "float"
-                },
-                {
-                  "value": "boolean"
-                },
-                {
-                  "value": "date"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "string"
+                    },
+                    {
+                      "value": "integer"
+                    },
+                    {
+                      "value": "float"
+                    },
+                    {
+                      "value": "boolean"
+                    },
+                    {
+                      "value": "date"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The data type of the attribute."
           },
@@ -36134,13 +38813,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -36153,9 +38838,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -36166,9 +38857,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -36179,9 +38876,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -36192,9 +38895,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -36205,9 +38914,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -36218,9 +38933,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -36231,9 +38952,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -36244,9 +38971,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36265,12 +38998,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -36279,12 +39018,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "data_attribute"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "data_attribute"
+                      }
+                    }
                   }
                 }
               }
@@ -36468,12 +39213,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "event.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "event.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -36482,12 +39233,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "data_event"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "data_event"
+                      }
+                    }
                   }
                 }
               }
@@ -36497,34 +39254,52 @@
           {
             "key": "pages",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "next",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "next",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "key": "since",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
                       }
                     }
-                  }
-                },
-                {
-                  "key": "since",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Pagination"
           }
@@ -36541,12 +39316,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "event.summary"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "event.summary"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -36555,9 +39336,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36568,9 +39355,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36581,9 +39374,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36594,12 +39393,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "data_event_summary_item"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "data_event_summary_item"
+                      }
+                    }
                   }
                 }
               }
@@ -36625,9 +39430,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -36638,9 +39449,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -36651,9 +39468,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -36664,9 +39487,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -36677,9 +39506,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -36702,9 +39537,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36713,27 +39554,33 @@
           {
             "key": "status",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "pending"
-                },
-                {
-                  "value": "in_progress"
-                },
-                {
-                  "value": "failed"
-                },
-                {
-                  "value": "completed"
-                },
-                {
-                  "value": "no_data"
-                },
-                {
-                  "value": "canceled"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "pending"
+                    },
+                    {
+                      "value": "in_progress"
+                    },
+                    {
+                      "value": "failed"
+                    },
+                    {
+                      "value": "completed"
+                    },
+                    {
+                      "value": "no_data"
+                    },
+                    {
+                      "value": "canceled"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The current state of your job."
           },
@@ -36742,9 +39589,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36755,9 +39608,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36778,9 +39637,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36791,9 +39656,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36804,9 +39675,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36817,9 +39694,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36830,9 +39713,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36843,9 +39732,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36856,9 +39751,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36869,9 +39770,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36882,9 +39789,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36895,9 +39808,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36908,9 +39827,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36921,9 +39846,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -36934,9 +39865,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36947,9 +39884,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36960,9 +39903,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -36973,9 +39922,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -36986,9 +39941,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -36999,9 +39960,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37012,9 +39979,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37025,9 +39998,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37038,9 +40017,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37051,9 +40036,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37064,9 +40055,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37077,9 +40074,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37090,9 +40093,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37103,9 +40112,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37126,9 +40141,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37137,12 +40158,18 @@
           {
             "key": "object",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "article"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "article"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object which was deleted. - article"
           },
@@ -37151,9 +40178,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -37174,9 +40207,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37185,12 +40224,18 @@
           {
             "key": "object",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "collection"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "collection"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object which was deleted. - `collection`"
           },
@@ -37199,9 +40244,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -37222,9 +40273,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37233,12 +40290,18 @@
           {
             "key": "object",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "company"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "company"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object which was deleted. - `company`"
           },
@@ -37247,9 +40310,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -37270,9 +40339,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37281,12 +40356,18 @@
           {
             "key": "object",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "news-item"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "news-item"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object which was deleted - news-item."
           },
@@ -37295,9 +40376,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -37467,9 +40554,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -37479,9 +40572,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37492,9 +40591,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37505,9 +40610,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -37518,9 +40629,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37531,9 +40648,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37544,9 +40667,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -37571,10 +40700,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
-                      "type": "enum",
-                      "values": []
+                      "type": "alias",
+                      "value": {
+                        "type": "nullable",
+                        "shape": {
+                          "type": "enum",
+                          "values": []
+                        }
+                      }
                     }
                   }
                 },
@@ -37585,9 +40720,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -37598,9 +40739,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -37627,10 +40774,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
-                      "type": "enum",
-                      "values": []
+                      "type": "alias",
+                      "value": {
+                        "type": "nullable",
+                        "shape": {
+                          "type": "enum",
+                          "values": []
+                        }
+                      }
                     }
                   }
                 },
@@ -37641,8 +40794,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Arabic"
@@ -37652,8 +40811,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Bulgarian"
@@ -37663,8 +40828,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Bosnian"
@@ -37674,8 +40845,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Catalan"
@@ -37685,8 +40862,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Czech"
@@ -37696,8 +40879,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Danish"
@@ -37707,8 +40896,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in German"
@@ -37718,8 +40913,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Greek"
@@ -37729,8 +40930,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in English"
@@ -37740,8 +40947,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Spanish"
@@ -37751,8 +40964,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Estonian"
@@ -37762,8 +40981,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Finnish"
@@ -37773,8 +40998,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in French"
@@ -37784,8 +41015,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Hebrew"
@@ -37795,8 +41032,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Croatian"
@@ -37806,8 +41049,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Hungarian"
@@ -37817,8 +41066,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Indonesian"
@@ -37828,8 +41083,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Italian"
@@ -37839,8 +41100,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Japanese"
@@ -37850,8 +41117,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Korean"
@@ -37861,8 +41134,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Lithuanian"
@@ -37872,8 +41151,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Latvian"
@@ -37883,8 +41168,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Mongolian"
@@ -37894,8 +41185,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Norwegian"
@@ -37905,8 +41202,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Dutch"
@@ -37916,8 +41219,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Polish"
@@ -37927,8 +41236,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Portuguese (Portugal)"
@@ -37938,8 +41253,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Romanian"
@@ -37949,8 +41270,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Russian"
@@ -37960,8 +41287,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Slovenian"
@@ -37971,8 +41304,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Serbian"
@@ -37982,8 +41321,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Swedish"
@@ -37993,8 +41338,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Turkish"
@@ -38004,8 +41355,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Vietnamese"
@@ -38015,8 +41372,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Portuguese (Brazil)"
@@ -38026,8 +41389,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Chinese (China)"
@@ -38037,8 +41406,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_content"
+                      }
+                    }
                   }
                 },
                 "description": "The content of the group in Chinese (Taiwan)"
@@ -38060,9 +41435,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38073,9 +41454,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38086,9 +41473,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -38099,9 +41492,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -38112,9 +41511,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38125,9 +41530,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -38138,9 +41549,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38159,12 +41576,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object - `list`."
           },
@@ -38173,12 +41596,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "help_center"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "help_center"
+                      }
+                    }
                   }
                 }
               }
@@ -38262,15 +41691,21 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "ticket"
-                },
-                {
-                  "value": "conversation"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "ticket"
+                    },
+                    {
+                      "value": "conversation"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "ticket or conversation"
           },
@@ -38279,9 +41714,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38292,20 +41733,26 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "Customer"
-                    },
-                    {
-                      "value": "Back-office"
-                    },
-                    {
-                      "value": "Tracker"
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "Customer"
+                        },
+                        {
+                          "value": "Back-office"
+                        },
+                        {
+                          "value": "Tracker"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             },
@@ -38324,12 +41771,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Always list."
           },
@@ -38338,9 +41791,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -38351,9 +41810,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -38364,12 +41829,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "linked_object"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "linked_object"
+                      }
+                    }
                   }
                 }
               }
@@ -38391,9 +41862,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38404,9 +41881,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38546,58 +42029,70 @@
           {
             "key": "operator",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "AND"
-                },
-                {
-                  "value": "OR"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "AND"
+                    },
+                    {
+                      "value": "OR"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "An operator to allow boolean inspection between multiple fields."
           },
           {
             "key": "value",
             "valueShape": {
-              "type": "undiscriminatedUnion",
-              "variants": [
-                {
-                  "displayName": "multiple filter search request",
-                  "shape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "list",
-                      "itemShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "undiscriminatedUnion",
+                  "variants": [
+                    {
+                      "displayName": "multiple filter search request",
+                      "shape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "multiple_filter_search_request"
+                          "type": "list",
+                          "itemShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "multiple_filter_search_request"
+                            }
+                          }
                         }
-                      }
-                    }
-                  },
-                  "description": "Add mutiple filters."
-                },
-                {
-                  "displayName": "single filter search request",
-                  "shape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "list",
-                      "itemShape": {
+                      },
+                      "description": "Add mutiple filters."
+                    },
+                    {
+                      "displayName": "single filter search request",
+                      "shape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "single_filter_search_request"
+                          "type": "list",
+                          "itemShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "single_filter_search_request"
+                            }
+                          }
                         }
-                      }
+                      },
+                      "description": "Add a single filter field."
                     }
-                  },
-                  "description": "Add a single filter field."
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -38613,12 +42108,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "news-item"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "news-item"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object."
           },
@@ -38627,9 +42128,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38640,9 +42147,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38653,9 +42166,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38666,9 +42185,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -38679,9 +42204,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -38690,15 +42221,21 @@
           {
             "key": "state",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "draft"
-                },
-                {
-                  "value": "live"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "draft"
+                    },
+                    {
+                      "value": "live"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "News items will not be visible to your users in the assigned newsfeeds until they are set live."
           },
@@ -38707,12 +42244,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "newsfeed_assignment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "newsfeed_assignment"
+                      }
+                    }
                   }
                 }
               }
@@ -38724,17 +42267,23 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
-                    "shape": {
+                    "type": "list",
+                    "itemShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -38749,14 +42298,20 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "format": "uri"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      }
                     }
                   }
                 }
@@ -38769,17 +42324,23 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
-                    "shape": {
+                    "type": "list",
+                    "itemShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -38794,9 +42355,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -38807,9 +42374,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -38820,9 +42393,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39017,9 +42596,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39028,12 +42613,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "newsfeed"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "newsfeed"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object."
           },
@@ -39042,9 +42633,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39055,9 +42652,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39068,9 +42671,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39091,9 +42700,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39104,9 +42719,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39127,9 +42748,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39140,9 +42767,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39153,9 +42786,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39166,38 +42805,56 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "String representing the object's type. Always has the value `contact`."
+                        },
+                        {
+                          "key": "id",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The id of the contact."
                         }
-                      },
-                      "description": "String representing the object's type. Always has the value `contact`."
-                    },
-                    {
-                      "key": "id",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The id of the contact."
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             },
@@ -39208,8 +42865,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "admin"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "admin"
+                  }
+                }
               }
             },
             "description": "Optional. Represents the Admin that created the note."
@@ -39219,9 +42882,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39242,9 +42911,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39255,12 +42930,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "note"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "note"
+                      }
+                    }
                   }
                 }
               }
@@ -39272,9 +42953,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39285,8 +42972,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           }
@@ -39337,12 +43030,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "pages"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "pages"
+                    }
+                  ]
                 }
-              ]
+              }
             }
           },
           {
@@ -39350,9 +43049,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -39362,14 +43067,20 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "format": "uri"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      }
                     }
                   }
                 }
@@ -39382,9 +43093,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -39394,9 +43111,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -39414,15 +43137,21 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
-                },
-                {
-                  "value": "conversation.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    },
+                    {
+                      "value": "conversation.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object"
           },
@@ -39431,8 +43160,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           },
@@ -39441,9 +43176,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39454,31 +43195,37 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
-                  "type": "undiscriminatedUnion",
-                  "variants": [
-                    {
-                      "displayName": "News Item",
-                      "shape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "id",
-                          "id": "news_item"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "list",
+                    "itemShape": {
+                      "type": "undiscriminatedUnion",
+                      "variants": [
+                        {
+                          "displayName": "News Item",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "news_item"
+                            }
+                          }
+                        },
+                        {
+                          "displayName": "Newsfeed",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "newsfeed"
+                            }
+                          }
                         }
-                      }
-                    },
-                    {
-                      "displayName": "Newsfeed",
-                      "shape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "id",
-                          "id": "newsfeed"
-                        }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             },
@@ -39499,9 +43246,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39512,9 +43265,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39525,9 +43284,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39538,9 +43303,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39551,9 +43322,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39564,9 +43341,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39577,9 +43360,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39602,13 +43391,20 @@
               {
                 "key": "type",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "phone_call_redirect"
-                    }
-                  ],
-                  "default": "phone_call_redirect"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "phone_call_redirect"
+                        }
+                      ],
+                      "default": "phone_call_redirect"
+                    },
+                    "default": "phone_call_redirect"
+                  }
                 },
                 "description": ""
               },
@@ -39617,9 +43413,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -39746,9 +43548,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39759,13 +43567,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -39868,12 +43682,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "segment"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "segment"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object."
           },
@@ -39882,9 +43702,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39895,9 +43721,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -39908,9 +43740,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39921,9 +43759,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -39932,15 +43776,21 @@
           {
             "key": "person_type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact"
-                },
-                {
-                  "value": "user"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact"
+                    },
+                    {
+                      "value": "user"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Type of the contact: contact (lead) or user."
           },
@@ -39949,13 +43799,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -39976,12 +43832,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "segment.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "segment.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -39990,12 +43852,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "segment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "segment"
+                      }
+                    }
                   }
                 }
               }
@@ -40005,9 +43873,15 @@
           {
             "key": "pages",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": []
+                }
+              }
             },
             "description": "A pagination object, which may be empty, indicating no further pages to fetch."
           }
@@ -40026,9 +43900,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40037,39 +43917,45 @@
           {
             "key": "operator",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "="
-                },
-                {
-                  "value": "!="
-                },
-                {
-                  "value": "IN"
-                },
-                {
-                  "value": "NIN"
-                },
-                {
-                  "value": "<"
-                },
-                {
-                  "value": ">"
-                },
-                {
-                  "value": "~"
-                },
-                {
-                  "value": "!~"
-                },
-                {
-                  "value": "^"
-                },
-                {
-                  "value": "$"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "="
+                    },
+                    {
+                      "value": "!="
+                    },
+                    {
+                      "value": "IN"
+                    },
+                    {
+                      "value": "NIN"
+                    },
+                    {
+                      "value": "<"
+                    },
+                    {
+                      "value": ">"
+                    },
+                    {
+                      "value": "~"
+                    },
+                    {
+                      "value": "!~"
+                    },
+                    {
+                      "value": "^"
+                    },
+                    {
+                      "value": "$"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The accepted operators you can use to define how you want to search for the value."
           },
@@ -40078,9 +43964,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40105,9 +43997,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -40118,9 +44016,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -40129,21 +44033,27 @@
               {
                 "key": "sla_status",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "hit"
-                    },
-                    {
-                      "value": "missed"
-                    },
-                    {
-                      "value": "cancelled"
-                    },
-                    {
-                      "value": "active"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "hit"
+                        },
+                        {
+                          "value": "missed"
+                        },
+                        {
+                          "value": "cancelled"
+                        },
+                        {
+                          "value": "active"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "SLA statuses:\n            - `hit`: If there’s at least one hit event in the underlying sla_events table, and no “missed” or “canceled” events for the conversation.\n            - `missed`: If there are any missed sla_events for the conversation and no canceled events. If there’s even a single missed sla event, the status will always be missed. A missed status is not applied when the SLA expires, only the next time a teammate replies.\n            - `active`: An SLA has been applied to a conversation, but has not yet been fulfilled. SLA status is active only if there are no “hit, “missed”, or “canceled” events."
               }
@@ -40211,9 +44121,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40224,9 +44140,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40237,10 +44159,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "uri"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
                 }
               }
             },
@@ -40265,9 +44193,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -40278,13 +44212,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -40308,9 +44248,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40321,9 +44267,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40332,18 +44284,24 @@
           {
             "key": "state",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "live"
-                },
-                {
-                  "value": "draft"
-                },
-                {
-                  "value": "archived"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "live"
+                    },
+                    {
+                      "value": "draft"
+                    },
+                    {
+                      "value": "archived"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The state of the subscription type."
           },
@@ -40352,8 +44310,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "translation"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "translation"
+                  }
+                }
               }
             }
           },
@@ -40362,12 +44326,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "translation"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "translation"
+                      }
+                    }
                   }
                 }
               }
@@ -40377,15 +44347,21 @@
           {
             "key": "consent_type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "opt_out"
-                },
-                {
-                  "value": "opt_in"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "opt_out"
+                    },
+                    {
+                      "value": "opt_in"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Describes the type of consent."
           },
@@ -40394,17 +44370,23 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "email"
-                    },
-                    {
-                      "value": "sms_message"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "list",
+                    "itemShape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "email"
+                        },
+                        {
+                          "value": "sms_message"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             },
@@ -40423,12 +44405,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -40437,12 +44425,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "subscription_type"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "subscription_type"
+                      }
+                    }
                   }
                 }
               }
@@ -40464,9 +44458,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40477,9 +44477,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40490,9 +44496,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40503,9 +44515,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -40516,8 +44534,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "reference"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "reference"
+                  }
+                }
               }
             }
           }
@@ -40559,9 +44583,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
                           }
                         }
                       },
@@ -40572,9 +44602,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
                           }
                         }
                       },
@@ -40599,12 +44635,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -40613,12 +44655,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "tag"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "tag"
+                      }
+                    }
                   }
                 }
               }
@@ -40663,9 +44711,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
                           }
                         }
                       },
@@ -40689,12 +44743,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "tag.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "tag.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -40703,12 +44763,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "tag"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "tag"
+                      }
+                    }
                   }
                 }
               }
@@ -40730,9 +44796,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40743,9 +44815,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40756,9 +44834,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -40769,13 +44853,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -40788,8 +44878,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "admin_priority_level"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "admin_priority_level"
+                  }
+                }
               }
             }
           }
@@ -40806,12 +44902,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "team.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "team.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the object"
           },
@@ -40820,12 +44922,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "team"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "team"
+                      }
+                    }
                   }
                 }
               }
@@ -40851,13 +44959,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -40870,13 +44984,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -40903,13 +45023,20 @@
               {
                 "key": "type",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "ticket"
-                    }
-                  ],
-                  "default": "ticket"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "ticket"
+                        }
+                      ],
+                      "default": "ticket"
+                    },
+                    "default": "ticket"
+                  }
                 },
                 "description": "Always ticket"
               },
@@ -40918,9 +45045,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -40931,9 +45064,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -40942,18 +45081,24 @@
               {
                 "key": "category",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "Customer"
-                    },
-                    {
-                      "value": "Back-office"
-                    },
-                    {
-                      "value": "Tracker"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "Customer"
+                        },
+                        {
+                          "value": "Back-office"
+                        },
+                        {
+                          "value": "Tracker"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "Category of the Ticket."
               },
@@ -40962,29 +45107,41 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_custom_attributes"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_custom_attributes"
+                      }
+                    }
                   }
                 }
               },
               {
                 "key": "ticket_state",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "submitted"
-                    },
-                    {
-                      "value": "in_progress"
-                    },
-                    {
-                      "value": "waiting_on_customer"
-                    },
-                    {
-                      "value": "resolved"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "submitted"
+                        },
+                        {
+                          "value": "in_progress"
+                        },
+                        {
+                          "value": "waiting_on_customer"
+                        },
+                        {
+                          "value": "resolved"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "The state the ticket is currently in"
               },
@@ -40993,8 +45150,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_type"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_type"
+                      }
+                    }
                   }
                 }
               },
@@ -41003,8 +45166,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_contacts"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_contacts"
+                      }
+                    }
                   }
                 }
               },
@@ -41013,9 +45182,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41026,9 +45201,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41039,9 +45220,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -41052,9 +45239,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -41065,9 +45258,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -41078,9 +45277,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -41091,8 +45296,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "linked_object_list"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "linked_object_list"
+                      }
+                    }
                   }
                 }
               },
@@ -41101,8 +45312,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_parts"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_parts"
+                      }
+                    }
                   }
                 }
               },
@@ -41111,9 +45328,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -41124,9 +45347,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41137,9 +45366,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41160,12 +45395,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "contact.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "contact.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "always contact.list"
           },
@@ -41174,12 +45415,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "contact_reference"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "contact_reference"
+                      }
+                    }
                   }
                 }
               }
@@ -41193,9 +45440,73 @@
     "ticket_custom_attributes": {
       "name": "Ticket Attributes",
       "shape": {
-        "type": "object",
-        "extends": [],
-        "properties": []
+        "type": "alias",
+        "value": {
+          "type": "map",
+          "keyShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "valueShape": {
+            "type": "undiscriminatedUnion",
+            "variants": [
+              {
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
+                }
+              },
+              {
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              },
+              {
+                "displayName": "File Attribute",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "file_attribute"
+                  }
+                }
+              }
+            ]
+          }
+        }
       },
       "description": "An object containing the different attributes associated to the ticket as key-value pairs. For the default title and description attributes, the keys are `_default_title_` and `_default_description_`."
     },
@@ -41208,12 +45519,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "ticket.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "ticket.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Always ticket.list"
           },
@@ -41222,12 +45539,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket"
+                      }
+                    }
                   }
                 }
               }
@@ -41239,9 +45562,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -41252,8 +45581,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "cursor_pages"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "cursor_pages"
+                  }
+                }
               }
             }
           }
@@ -41272,46 +45607,7 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "Always ticket_part"
-          },
-          {
-            "key": "id",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "The id representing the ticket part."
-          },
-          {
-            "key": "part_type",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "The type of ticket part."
-          },
-          {
-            "key": "body",
-            "valueShape": {
-              "type": "alias",
-              "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
@@ -41323,47 +45619,122 @@
                 }
               }
             },
+            "description": "Always ticket_part"
+          },
+          {
+            "key": "id",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "The id representing the ticket part."
+          },
+          {
+            "key": "part_type",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "The type of ticket part."
+          },
+          {
+            "key": "body",
+            "valueShape": {
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "description": "The message body, which may contain HTML."
           },
           {
             "key": "previous_ticket_state",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "submitted"
-                },
-                {
-                  "value": "in_progress"
-                },
-                {
-                  "value": "waiting_on_customer"
-                },
-                {
-                  "value": "resolved"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "submitted"
+                    },
+                    {
+                      "value": "in_progress"
+                    },
+                    {
+                      "value": "waiting_on_customer"
+                    },
+                    {
+                      "value": "resolved"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The previous state of the ticket."
           },
           {
             "key": "ticket_state",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "submitted"
-                },
-                {
-                  "value": "in_progress"
-                },
-                {
-                  "value": "waiting_on_customer"
-                },
-                {
-                  "value": "resolved"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "submitted"
+                    },
+                    {
+                      "value": "in_progress"
+                    },
+                    {
+                      "value": "waiting_on_customer"
+                    },
+                    {
+                      "value": "resolved"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The state of the ticket."
           },
@@ -41372,9 +45743,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -41385,9 +45762,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -41398,12 +45781,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "reference"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "reference"
+                      }
+                    }
                   }
                 }
               }
@@ -41415,8 +45804,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ticket_part_author"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ticket_part_author"
+                  }
+                }
               }
             }
           },
@@ -41425,12 +45820,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "part_attachment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "part_attachment"
+                      }
+                    }
                   }
                 }
               }
@@ -41442,13 +45843,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -41461,9 +45868,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -41482,21 +45895,27 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "admin"
-                },
-                {
-                  "value": "bot"
-                },
-                {
-                  "value": "team"
-                },
-                {
-                  "value": "user"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "admin"
+                    },
+                    {
+                      "value": "bot"
+                    },
+                    {
+                      "value": "team"
+                    },
+                    {
+                      "value": "user"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of the author"
           },
@@ -41505,9 +45924,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -41518,13 +45943,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -41537,10 +45968,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "format": "email"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "format": "email"
+                    }
+                  }
                 }
               }
             },
@@ -41559,12 +45996,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "ticket_part.list"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "ticket_part.list"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": ""
           },
@@ -41573,12 +46016,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_part"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_part"
+                      }
+                    }
                   }
                 }
               }
@@ -41590,9 +46039,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -41611,12 +46066,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "ticket_part"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "ticket_part"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Always ticket_part"
           },
@@ -41625,9 +46086,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -41636,18 +46103,24 @@
           {
             "key": "part_type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "note"
-                },
-                {
-                  "value": "comment"
-                },
-                {
-                  "value": "quick_reply"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "note"
+                    },
+                    {
+                      "value": "comment"
+                    },
+                    {
+                      "value": "quick_reply"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Type of the part"
           },
@@ -41656,13 +46129,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -41675,9 +46154,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -41688,9 +46173,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -41701,8 +46192,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "ticket_part_author"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "ticket_part_author"
+                  }
+                }
               }
             }
           },
@@ -41711,12 +46208,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "part_attachment"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "part_attachment"
+                      }
+                    }
                   }
                 }
               }
@@ -41728,9 +46231,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -41743,9 +46252,63 @@
     "ticket_request_custom_attributes": {
       "name": "Ticket Attributes",
       "shape": {
-        "type": "object",
-        "extends": [],
-        "properties": []
+        "type": "alias",
+        "value": {
+          "type": "map",
+          "keyShape": {
+            "type": "alias",
+            "value": {
+              "type": "primitive",
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "valueShape": {
+            "type": "undiscriminatedUnion",
+            "variants": [
+              {
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
+                }
+              },
+              {
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
       },
       "description": "The attributes set on the ticket. When setting the default title and description attributes, the attribute keys that should be used are `_default_title_` and `_default_description_`. When setting ticket type attributes of the list attribute type, the key should be the attribute name and the value of the attribute should be the list item id, obtainable by [listing the ticket type](ref:get_ticket-types). For example, if the ticket type has an attribute called `priority` of type `list`, the key should be `priority` and the value of the attribute should be the guid of the list item (e.g. `de1825a0-0164-4070-8ca6-13e22462fa7e`)."
     },
@@ -41764,9 +46327,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41777,9 +46346,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41788,18 +46363,24 @@
               {
                 "key": "category",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "Customer"
-                    },
-                    {
-                      "value": "Back-office"
-                    },
-                    {
-                      "value": "Tracker"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "Customer"
+                        },
+                        {
+                          "value": "Back-office"
+                        },
+                        {
+                          "value": "Tracker"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "Category of the Ticket Type."
               },
@@ -41808,9 +46389,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41821,9 +46408,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41834,9 +46427,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41847,9 +46446,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41860,8 +46465,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_type_attribute_list"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_type_attribute_list"
+                      }
+                    }
                   }
                 }
               },
@@ -41870,9 +46481,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -41883,9 +46500,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -41896,9 +46519,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -41925,9 +46554,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41938,9 +46573,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41951,9 +46592,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41964,9 +46611,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41977,9 +46630,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -41990,9 +46649,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -42001,9 +46666,15 @@
               {
                 "key": "input_options",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": []
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": []
+                    }
+                  }
                 },
                 "description": "Input options for the attribute"
               },
@@ -42012,9 +46683,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -42025,10 +46702,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean",
-                      "default": false
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean",
+                          "default": false
+                        }
+                      }
                     }
                   }
                 },
@@ -42039,10 +46722,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean",
-                      "default": false
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean",
+                          "default": false
+                        }
+                      }
                     }
                   }
                 },
@@ -42053,10 +46742,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean",
-                      "default": true
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean",
+                          "default": true
+                        }
+                      }
                     }
                   }
                 },
@@ -42067,10 +46762,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean",
-                      "default": true
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean",
+                          "default": true
+                        }
+                      }
                     }
                   }
                 },
@@ -42081,9 +46782,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -42094,9 +46801,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -42107,9 +46820,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -42120,9 +46839,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -42133,9 +46858,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -42158,9 +46889,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42171,12 +46908,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_type_attribute"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_type_attribute"
+                      }
+                    }
                   }
                 }
               }
@@ -42198,9 +46941,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42211,12 +46960,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ticket_type"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ticket_type"
+                      }
+                    }
                   }
                 }
               }
@@ -42238,9 +46993,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42251,9 +47012,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42264,9 +47031,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42310,9 +47083,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
                           }
                         }
                       },
@@ -42323,9 +47102,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
                           }
                         }
                       },
@@ -42336,9 +47121,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "boolean"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "boolean"
+                              }
+                            }
                           }
                         }
                       },
@@ -42369,9 +47160,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -42382,9 +47179,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -42395,9 +47198,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -42408,9 +47217,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -42419,15 +47234,21 @@
               {
                 "key": "state",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "published"
-                    },
-                    {
-                      "value": "draft"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "published"
+                        },
+                        {
+                          "value": "draft"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "Whether the article will be `published` or will be a `draft`. Defaults to draft. For multilingual articles, this will be the state of the default language's content."
               },
@@ -42436,9 +47257,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -42449,9 +47276,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -42462,8 +47295,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "article_translated_content"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "article_translated_content"
+                      }
+                    }
                   }
                 }
               }
@@ -42484,9 +47323,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42497,9 +47342,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42510,12 +47361,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "group_translated_content"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "group_translated_content"
+                      }
+                    }
                   }
                 }
               }
@@ -42526,13 +47383,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -42555,9 +47418,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42568,9 +47437,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42581,9 +47456,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42594,13 +47475,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -42613,13 +47500,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -42632,13 +47525,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -42651,13 +47550,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -42670,13 +47575,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -42689,13 +47600,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }
@@ -42708,13 +47625,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 }
@@ -42727,11 +47650,17 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": []
+                  "type": "alias",
+                  "value": {
+                    "type": "nullable",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": []
+                    }
+                  }
                 }
               }
             },
@@ -42752,9 +47681,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -42765,8 +47700,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "custom_attributes"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "custom_attributes"
+                  }
+                }
               }
             }
           }
@@ -42785,9 +47726,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -42798,9 +47745,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42811,13 +47764,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -42830,9 +47789,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -42851,27 +47816,39 @@
           {
             "key": "ticket_attributes",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": []
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": []
+                }
+              }
             },
             "description": "The attributes set on the ticket."
           },
           {
             "key": "state",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "in_progress"
-                },
-                {
-                  "value": "waiting_on_customer"
-                },
-                {
-                  "value": "resolved"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "in_progress"
+                    },
+                    {
+                      "value": "waiting_on_customer"
+                    },
+                    {
+                      "value": "resolved"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The state of the ticket."
           },
@@ -42880,9 +47857,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -42893,9 +47876,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -42906,9 +47895,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -42917,36 +47912,54 @@
           {
             "key": "assignment",
             "valueShape": {
-              "type": "object",
-              "extends": [],
-              "properties": [
-                {
-                  "key": "admin_id",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "object",
+                  "extends": [],
+                  "properties": [
+                    {
+                      "key": "admin_id",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The ID of the admin performing the action."
+                    },
+                    {
+                      "key": "assignee_id",
+                      "valueShape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "The ID of the admin or team to which the ticket is assigned. Set this 0 to unassign it."
                     }
-                  },
-                  "description": "The ID of the admin performing the action."
-                },
-                {
-                  "key": "assignee_id",
-                  "valueShape": {
-                    "type": "alias",
-                    "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "description": "The ID of the admin or team to which the ticket is assigned. Set this 0 to unassign it."
+                  ]
                 }
-              ]
+              }
             }
           }
         ]
@@ -42964,9 +47977,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42977,9 +47996,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -42990,10 +48015,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean",
-                  "default": false
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean",
+                      "default": false
+                    }
+                  }
                 }
               }
             },
@@ -43004,10 +48035,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean",
-                  "default": false
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean",
+                      "default": false
+                    }
+                  }
                 }
               }
             },
@@ -43018,10 +48055,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean",
-                  "default": true
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean",
+                      "default": true
+                    }
+                  }
                 }
               }
             },
@@ -43032,10 +48075,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean",
-                  "default": true
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean",
+                      "default": true
+                    }
+                  }
                 }
               }
             },
@@ -43046,9 +48095,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -43059,9 +48114,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -43072,9 +48133,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -43085,9 +48152,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -43112,9 +48185,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -43125,9 +48204,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -43136,18 +48221,24 @@
               {
                 "key": "category",
                 "valueShape": {
-                  "type": "enum",
-                  "values": [
-                    {
-                      "value": "Customer"
-                    },
-                    {
-                      "value": "Back-office"
-                    },
-                    {
-                      "value": "Tracker"
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "enum",
+                      "values": [
+                        {
+                          "value": "Customer"
+                        },
+                        {
+                          "value": "Back-office"
+                        },
+                        {
+                          "value": "Tracker"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "Category of the Ticket Type."
               },
@@ -43156,10 +48247,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "default": "🎟️"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "default": "🎟️"
+                        }
+                      }
                     }
                   }
                 },
@@ -43170,9 +48267,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -43183,10 +48286,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean",
-                      "default": false
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean",
+                          "default": false
+                        }
+                      }
                     }
                   }
                 },
@@ -43238,10 +48347,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "default": "visitor"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "default": "visitor"
+                        }
+                      }
                     }
                   }
                 },
@@ -43252,9 +48367,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -43265,9 +48386,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -43278,9 +48405,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -43291,10 +48424,16 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string",
-                      "format": "email"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string",
+                          "format": "email"
+                        }
+                      }
                     }
                   }
                 },
@@ -43305,13 +48444,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43324,13 +48469,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43343,13 +48494,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43360,44 +48517,62 @@
               {
                 "key": "avatar",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string",
-                            "default": "avatar"
-                          }
-                        }
-                      },
-                      "description": ""
-                    },
-                    {
-                      "key": "image_url",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "nullable",
-                          "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string",
-                                "format": "uri"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string",
+                                    "default": "avatar"
+                                  }
+                                }
                               }
                             }
-                          }
+                          },
+                          "description": ""
+                        },
+                        {
+                          "key": "image_url",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "nullable",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "This object represents the avatar associated with the visitor."
                         }
-                      },
-                      "description": "This object represents the avatar associated with the visitor."
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
@@ -43405,9 +48580,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -43416,152 +48597,224 @@
               {
                 "key": "companies",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "enum",
-                        "values": [
-                          {
-                            "value": "company.list"
-                          }
-                        ]
-                      },
-                      "description": "The type of the object"
-                    },
-                    {
-                      "key": "companies",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "list",
-                          "itemShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "id",
-                              "id": "company"
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "company.list"
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "description": "The type of the object"
+                        },
+                        {
+                          "key": "companies",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "list",
+                                  "itemShape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "id",
+                                      "id": "company"
+                                    }
+                                  }
+                                }
+                              }
                             }
                           }
                         }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
                 "key": "location_data",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string",
-                            "default": "location_data"
-                          }
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string",
+                                    "default": "location_data"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": ""
+                        },
+                        {
+                          "key": "city_name",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The city name of the visitor."
+                        },
+                        {
+                          "key": "continent_code",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The continent code of the visitor."
+                        },
+                        {
+                          "key": "country_code",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The country code of the visitor."
+                        },
+                        {
+                          "key": "country_name",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The country name of the visitor."
+                        },
+                        {
+                          "key": "postal_code",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The postal code of the visitor."
+                        },
+                        {
+                          "key": "region_name",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The region name of the visitor."
+                        },
+                        {
+                          "key": "timezone",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "The timezone of the visitor."
                         }
-                      },
-                      "description": ""
-                    },
-                    {
-                      "key": "city_name",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The city name of the visitor."
-                    },
-                    {
-                      "key": "continent_code",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The continent code of the visitor."
-                    },
-                    {
-                      "key": "country_code",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The country code of the visitor."
-                    },
-                    {
-                      "key": "country_name",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The country name of the visitor."
-                    },
-                    {
-                      "key": "postal_code",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The postal code of the visitor."
-                    },
-                    {
-                      "key": "region_name",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The region name of the visitor."
-                    },
-                    {
-                      "key": "timezone",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "The timezone of the visitor."
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
@@ -43569,9 +48822,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -43582,9 +48841,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -43595,9 +48860,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -43608,9 +48879,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -43621,9 +48898,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -43634,9 +48917,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -43645,40 +48934,58 @@
               {
                 "key": "social_profiles",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "enum",
-                        "values": [
-                          {
-                            "value": "social_profile.list"
-                          }
-                        ]
-                      },
-                      "description": "The type of the object"
-                    },
-                    {
-                      "key": "social_profiles",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "list",
-                          "itemShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "social_profile.list"
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "description": "The type of the object"
+                        },
+                        {
+                          "key": "social_profiles",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "list",
+                                  "itemShape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
                               }
                             }
                           }
                         }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
@@ -43686,13 +48993,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43705,9 +49018,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -43718,9 +49037,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -43731,9 +49056,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -43742,114 +49073,168 @@
               {
                 "key": "tags",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "enum",
-                        "values": [
-                          {
-                            "value": "tag.list"
-                          }
-                        ]
-                      },
-                      "description": "The type of the object"
-                    },
-                    {
-                      "key": "tags",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "list",
-                          "itemShape": {
-                            "type": "object",
-                            "extends": [],
-                            "properties": [
-                              {
-                                "key": "type",
-                                "valueShape": {
-                                  "type": "enum",
-                                  "values": [
-                                    {
-                                      "value": "tag"
-                                    }
-                                  ]
-                                },
-                                "description": "The type of the object"
-                              },
-                              {
-                                "key": "id",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "string"
-                                    }
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "tag.list"
                                   }
-                                },
-                                "description": "The id of the tag."
-                              },
-                              {
-                                "key": "name",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  }
-                                },
-                                "description": "The name of the tag."
+                                ]
                               }
-                            ]
+                            }
+                          },
+                          "description": "The type of the object"
+                        },
+                        {
+                          "key": "tags",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "list",
+                                  "itemShape": {
+                                    "type": "object",
+                                    "extends": [],
+                                    "properties": [
+                                      {
+                                        "key": "type",
+                                        "valueShape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "optional",
+                                            "shape": {
+                                              "type": "enum",
+                                              "values": [
+                                                {
+                                                  "value": "tag"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "description": "The type of the object"
+                                      },
+                                      {
+                                        "key": "id",
+                                        "valueShape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "optional",
+                                            "shape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "primitive",
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "description": "The id of the tag."
+                                      },
+                                      {
+                                        "key": "name",
+                                        "valueShape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "optional",
+                                            "shape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "primitive",
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "description": "The name of the tag."
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            }
                           }
                         }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
                 "key": "segments",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "type",
-                      "valueShape": {
-                        "type": "enum",
-                        "values": [
-                          {
-                            "value": "segment.list"
-                          }
-                        ]
-                      },
-                      "description": "The type of the object"
-                    },
-                    {
-                      "key": "segments",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "list",
-                          "itemShape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "type",
+                          "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "segment.list"
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "description": "The type of the object"
+                        },
+                        {
+                          "key": "segments",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "list",
+                                  "itemShape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
                               }
                             }
                           }
                         }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               },
               {
@@ -43857,22 +49242,28 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "map",
-                    "keyShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "valueShape": {
-                      "type": "alias",
-                      "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "map",
+                        "keyShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "valueShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43885,13 +49276,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43904,13 +49301,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43923,13 +49326,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43942,13 +49351,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43961,13 +49376,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43980,13 +49401,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -43999,13 +49426,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "boolean"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "boolean"
+                            }
+                          }
                         }
                       }
                     }
@@ -44030,9 +49463,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -44041,12 +49480,18 @@
           {
             "key": "type",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "visitor"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "visitor"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "The type of object which was deleted"
           },
@@ -44055,9 +49500,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -44193,108 +49644,108 @@
     }
   },
   "subpackages": {
-    "subpackage_admins": {
-      "id": "subpackage_admins",
+    "admins": {
+      "id": "admins",
       "name": "admins",
       "displayName": "Admins"
     },
-    "subpackage_articles": {
-      "id": "subpackage_articles",
+    "articles": {
+      "id": "articles",
       "name": "articles",
       "displayName": "Articles"
     },
-    "subpackage_helpCenter": {
-      "id": "subpackage_helpCenter",
+    "helpCenter": {
+      "id": "helpCenter",
       "name": "helpCenter",
       "displayName": "Help Center"
     },
-    "subpackage_companies": {
-      "id": "subpackage_companies",
+    "companies": {
+      "id": "companies",
       "name": "companies",
       "displayName": "Companies"
     },
-    "subpackage_contacts": {
-      "id": "subpackage_contacts",
+    "contacts": {
+      "id": "contacts",
       "name": "contacts",
       "displayName": "Contacts"
     },
-    "subpackage_notes": {
-      "id": "subpackage_notes",
+    "notes": {
+      "id": "notes",
       "name": "notes",
       "displayName": "Notes"
     },
-    "subpackage_subscriptionTypes": {
-      "id": "subpackage_subscriptionTypes",
+    "subscriptionTypes": {
+      "id": "subscriptionTypes",
       "name": "subscriptionTypes",
       "displayName": "Subscription Types"
     },
-    "subpackage_tags": {
-      "id": "subpackage_tags",
+    "tags": {
+      "id": "tags",
       "name": "tags",
       "displayName": "Tags"
     },
-    "subpackage_conversations": {
-      "id": "subpackage_conversations",
+    "conversations": {
+      "id": "conversations",
       "name": "conversations",
       "displayName": "Conversations"
     },
-    "subpackage_dataAttributes": {
-      "id": "subpackage_dataAttributes",
+    "dataAttributes": {
+      "id": "dataAttributes",
       "name": "dataAttributes",
       "displayName": "Data Attributes"
     },
-    "subpackage_dataEvents": {
-      "id": "subpackage_dataEvents",
+    "dataEvents": {
+      "id": "dataEvents",
       "name": "dataEvents",
       "displayName": "Data Events"
     },
-    "subpackage_dataExport": {
-      "id": "subpackage_dataExport",
+    "dataExport": {
+      "id": "dataExport",
       "name": "dataExport",
       "displayName": "Data Export"
     },
-    "subpackage_messages": {
-      "id": "subpackage_messages",
+    "messages": {
+      "id": "messages",
       "name": "messages",
       "displayName": "Messages"
     },
-    "subpackage_news": {
-      "id": "subpackage_news",
+    "news": {
+      "id": "news",
       "name": "news",
       "displayName": "News"
     },
-    "subpackage_segments": {
-      "id": "subpackage_segments",
+    "segments": {
+      "id": "segments",
       "name": "segments",
       "displayName": "Segments"
     },
-    "subpackage_switch": {
-      "id": "subpackage_switch",
+    "switch": {
+      "id": "switch",
       "name": "switch",
       "displayName": "Switch"
     },
-    "subpackage_teams": {
-      "id": "subpackage_teams",
+    "teams": {
+      "id": "teams",
       "name": "teams",
       "displayName": "Teams"
     },
-    "subpackage_ticketTypeAttributes": {
-      "id": "subpackage_ticketTypeAttributes",
+    "ticketTypeAttributes": {
+      "id": "ticketTypeAttributes",
       "name": "ticketTypeAttributes",
       "displayName": "Ticket Type Attributes"
     },
-    "subpackage_ticketTypes": {
-      "id": "subpackage_ticketTypes",
+    "ticketTypes": {
+      "id": "ticketTypes",
       "name": "ticketTypes",
       "displayName": "Ticket Types"
     },
-    "subpackage_tickets": {
-      "id": "subpackage_tickets",
+    "tickets": {
+      "id": "tickets",
       "name": "tickets",
       "displayName": "Tickets"
     },
-    "subpackage_visitors": {
-      "id": "subpackage_visitors",
+    "visitors": {
+      "id": "visitors",
       "name": "visitors",
       "displayName": "Visitors"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/petstore.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/petstore.json
@@ -5,7 +5,7 @@
       "id": "endpoint_pet.addPet",
       "description": "Add a new pet to the store",
       "namespace": [
-        "subpackage_pet"
+        "pet"
       ],
       "displayName": "Add a new pet to the store",
       "operationId": "addPet",
@@ -369,7 +369,7 @@
       "id": "endpoint_pet.updatePet",
       "description": "Update an existing pet by Id",
       "namespace": [
-        "subpackage_pet"
+        "pet"
       ],
       "displayName": "Update an existing pet",
       "operationId": "updatePet",
@@ -733,7 +733,7 @@
       "id": "endpoint_pets.getPetById",
       "description": "Returns a pet when 0 < ID <= 10.  ID > 10 or nonintegers will simulate API error conditions",
       "namespace": [
-        "subpackage_pets"
+        "pets"
       ],
       "displayName": "Find pet by ID",
       "operationId": "getPetById",
@@ -779,30 +779,7 @@
           "description": "ID of pet that needs to be fetched"
         }
       ],
-      "responses": [
-        {
-          "statusCode": null,
-          "body": {
-            "type": "alias",
-            "value": {
-              "type": "id",
-              "id": "Pet"
-            }
-          },
-          "description": "The pet"
-        },
-        {
-          "statusCode": null,
-          "body": {
-            "type": "alias",
-            "value": {
-              "type": "id",
-              "id": "Pet"
-            }
-          },
-          "description": "The pet"
-        }
-      ],
+      "responses": [],
       "errors": [
         {
           "statusCode": 400,
@@ -953,120 +930,7 @@
           ]
         }
       ],
-      "examples": [
-        {
-          "path": "/pet/0",
-          "responseStatusCode": null,
-          "pathParameters": {
-            "petId": 0
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "id": 10,
-              "name": "doggie",
-              "category": {
-                "id": 1,
-                "name": "Dogs"
-              },
-              "photoUrls": [
-                "photoUrls"
-              ],
-              "tags": [
-                {
-                  "id": 0,
-                  "name": "name"
-                }
-              ],
-              "status": "available"
-            }
-          }
-        },
-        {
-          "path": "/pet/0",
-          "responseStatusCode": null,
-          "pathParameters": {
-            "petId": 0
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "id": 10,
-              "name": "doggie",
-              "category": {
-                "id": 1,
-                "name": "Dogs"
-              },
-              "photoUrls": [
-                "photoUrls"
-              ],
-              "tags": [
-                {
-                  "id": 0,
-                  "name": "name"
-                }
-              ],
-              "status": "available"
-            }
-          }
-        },
-        {
-          "path": "/pet/0",
-          "responseStatusCode": null,
-          "pathParameters": {
-            "petId": 0
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "id": 10,
-              "name": "doggie",
-              "category": {
-                "id": 1,
-                "name": "Dogs"
-              },
-              "photoUrls": [
-                "photoUrls"
-              ],
-              "tags": [
-                {
-                  "id": 0,
-                  "name": "name"
-                }
-              ],
-              "status": "available"
-            }
-          }
-        },
-        {
-          "path": "/pet/0",
-          "responseStatusCode": null,
-          "pathParameters": {
-            "petId": 0
-          },
-          "responseBody": {
-            "type": "json",
-            "value": {
-              "id": 10,
-              "name": "doggie",
-              "category": {
-                "id": 1,
-                "name": "Dogs"
-              },
-              "photoUrls": [
-                "photoUrls"
-              ],
-              "tags": [
-                {
-                  "id": 0,
-                  "name": "name"
-                }
-              ],
-              "status": "available"
-            }
-          }
-        }
-      ],
+      "examples": [],
       "protocol": {
         "type": "rest"
       }
@@ -1086,9 +950,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "long"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "long"
+                    }
+                  }
                 }
               }
             }
@@ -1098,9 +968,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "long"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "long"
+                    }
+                  }
                 }
               }
             }
@@ -1110,9 +986,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -1122,9 +1004,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "datetime"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "datetime"
+                    }
+                  }
                 }
               }
             }
@@ -1132,18 +1020,24 @@
           {
             "key": "status",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "placed"
-                },
-                {
-                  "value": "approved"
-                },
-                {
-                  "value": "delivered"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "placed"
+                    },
+                    {
+                      "value": "approved"
+                    },
+                    {
+                      "value": "delivered"
+                    }
+                  ]
                 }
-              ]
+              }
             },
             "description": "Order Status"
           },
@@ -1152,9 +1046,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -1173,9 +1073,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "long"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "long"
+                    }
+                  }
                 }
               }
             }
@@ -1185,9 +1091,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1197,12 +1109,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Address"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Address"
+                      }
+                    }
                   }
                 }
               }
@@ -1222,9 +1140,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1234,9 +1158,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1246,9 +1176,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1258,9 +1194,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1279,9 +1221,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "long"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "long"
+                    }
+                  }
                 }
               }
             }
@@ -1291,9 +1239,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1312,9 +1266,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "long"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "long"
+                    }
+                  }
                 }
               }
             }
@@ -1324,9 +1284,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1336,9 +1302,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1348,9 +1320,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1360,9 +1338,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1372,9 +1356,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1384,9 +1374,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1396,9 +1392,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             },
@@ -1418,9 +1420,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "long"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "long"
+                    }
+                  }
                 }
               }
             }
@@ -1430,9 +1438,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1570,9 +1584,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -1582,9 +1602,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1594,9 +1620,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -1606,13 +1638,13 @@
     }
   },
   "subpackages": {
-    "subpackage_pet": {
-      "id": "subpackage_pet",
+    "pet": {
+      "id": "pet",
       "name": "pet",
       "displayName": "Pet"
     },
-    "subpackage_pets": {
-      "id": "subpackage_pets",
+    "pets": {
+      "id": "pets",
       "name": "pets",
       "displayName": "Pets"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/petstore.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/petstore.json
@@ -1,12 +1,9 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_pet.addPet": {
-      "id": "endpoint_pet.addPet",
+    "endpoint_.addPet": {
+      "id": "endpoint_.addPet",
       "description": "Add a new pet to the store",
-      "namespace": [
-        "pet"
-      ],
       "displayName": "Add a new pet to the store",
       "operationId": "addPet",
       "method": "POST",
@@ -365,12 +362,9 @@
         "type": "rest"
       }
     },
-    "endpoint_pet.updatePet": {
-      "id": "endpoint_pet.updatePet",
+    "endpoint_.updatePet": {
+      "id": "endpoint_.updatePet",
       "description": "Update an existing pet by Id",
-      "namespace": [
-        "pet"
-      ],
       "displayName": "Update an existing pet",
       "operationId": "updatePet",
       "method": "PUT",
@@ -729,12 +723,9 @@
         "type": "rest"
       }
     },
-    "endpoint_pets.getPetById": {
-      "id": "endpoint_pets.getPetById",
+    "endpoint_.getPetById": {
+      "id": "endpoint_.getPetById",
       "description": "Returns a pet when 0 < ID <= 10.  ID > 10 or nonintegers will simulate API error conditions",
-      "namespace": [
-        "pets"
-      ],
       "displayName": "Find pet by ID",
       "operationId": "getPetById",
       "method": "GET",
@@ -1605,17 +1596,6 @@
       }
     }
   },
-  "subpackages": {
-    "pet": {
-      "id": "pet",
-      "name": "pet",
-      "displayName": "pet"
-    },
-    "pets": {
-      "id": "pets",
-      "name": "pets",
-      "displayName": "pets"
-    }
-  },
+  "subpackages": {},
   "auths": {}
 }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/petstore.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/petstore.json
@@ -1,9 +1,12 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.addPet": {
-      "id": "endpoint_.addPet",
+    "endpoint_pet.addPet": {
+      "id": "endpoint_pet.addPet",
       "description": "Add a new pet to the store",
+      "namespace": [
+        "subpackage_pet"
+      ],
       "displayName": "Add a new pet to the store",
       "operationId": "addPet",
       "method": "POST",
@@ -362,9 +365,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.updatePet": {
-      "id": "endpoint_.updatePet",
+    "endpoint_pet.updatePet": {
+      "id": "endpoint_pet.updatePet",
       "description": "Update an existing pet by Id",
+      "namespace": [
+        "subpackage_pet"
+      ],
       "displayName": "Update an existing pet",
       "operationId": "updatePet",
       "method": "PUT",
@@ -723,9 +729,12 @@
         "type": "rest"
       }
     },
-    "endpoint_.getPetById": {
-      "id": "endpoint_.getPetById",
+    "endpoint_pets.getPetById": {
+      "id": "endpoint_pets.getPetById",
       "description": "Returns a pet when 0 < ID <= 10.  ID > 10 or nonintegers will simulate API error conditions",
+      "namespace": [
+        "subpackage_pets"
+      ],
       "displayName": "Find pet by ID",
       "operationId": "getPetById",
       "method": "GET",
@@ -1596,6 +1605,17 @@
       }
     }
   },
-  "subpackages": {},
+  "subpackages": {
+    "subpackage_pet": {
+      "id": "subpackage_pet",
+      "name": "pet",
+      "displayName": "Pet"
+    },
+    "subpackage_pets": {
+      "id": "subpackage_pets",
+      "name": "pets",
+      "displayName": "Pets"
+    }
+  },
   "auths": {}
 }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/query-params.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/query-params.json
@@ -32,9 +32,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -44,9 +50,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -54,67 +66,103 @@
                   {
                     "key": "location",
                     "valueShape": {
-                      "type": "object",
-                      "extends": [],
-                      "properties": [
-                        {
-                          "key": "city",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "key": "country",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        {
-                          "key": "coordinates",
-                          "valueShape": {
-                            "type": "object",
-                            "extends": [],
-                            "properties": [
-                              {
-                                "key": "latitude",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
+                      "type": "alias",
+                      "value": {
+                        "type": "optional",
+                        "shape": {
+                          "type": "object",
+                          "extends": [],
+                          "properties": [
+                            {
+                              "key": "city",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
                                     "value": {
-                                      "type": "double"
-                                    }
-                                  }
-                                }
-                              },
-                              {
-                                "key": "longitude",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "double"
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
                                     }
                                   }
                                 }
                               }
-                            ]
-                          }
+                            },
+                            {
+                              "key": "country",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "key": "coordinates",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "object",
+                                    "extends": [],
+                                    "properties": [
+                                      {
+                                        "key": "latitude",
+                                        "valueShape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "optional",
+                                            "shape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "primitive",
+                                                "value": {
+                                                  "type": "double"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "key": "longitude",
+                                        "valueShape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "optional",
+                                            "shape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "primitive",
+                                                "value": {
+                                                  "type": "double"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ]
                         }
-                      ]
+                      }
                     }
                   }
                 ]
@@ -199,13 +247,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/readonly.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/readonly.json
@@ -181,9 +181,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -193,9 +199,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -205,8 +217,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "UserSettings"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "UserSettings"
+                  }
+                }
               }
             }
           }
@@ -224,9 +242,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -236,9 +260,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -248,9 +278,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -260,9 +296,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "datetime"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "datetime"
+                    }
+                  }
                 }
               }
             }
@@ -272,8 +314,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "UserSettings"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "UserSettings"
+                  }
+                }
               }
             }
           },
@@ -282,8 +330,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "UserStats"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "UserStats"
+                  }
+                }
               }
             }
           }
@@ -301,9 +355,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -313,9 +373,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -325,9 +391,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "datetime"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "datetime"
+                    }
+                  }
                 }
               }
             }
@@ -346,9 +418,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -358,9 +436,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "datetime"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "datetime"
+                    }
+                  }
                 }
               }
             }
@@ -368,18 +452,24 @@
           {
             "key": "accountStatus",
             "valueShape": {
-              "type": "enum",
-              "values": [
-                {
-                  "value": "active"
-                },
-                {
-                  "value": "suspended"
-                },
-                {
-                  "value": "deleted"
+              "type": "alias",
+              "value": {
+                "type": "optional",
+                "shape": {
+                  "type": "enum",
+                  "values": [
+                    {
+                      "value": "active"
+                    },
+                    {
+                      "value": "suspended"
+                    },
+                    {
+                      "value": "deleted"
+                    }
+                  ]
                 }
-              ]
+              }
             }
           }
         ]

--- a/packages/parsers/src/openapi/__test__/__snapshots__/request-response-description.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/request-response-description.json
@@ -62,9 +62,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -74,9 +80,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/rules.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/rules.json
@@ -80,12 +80,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer",
-                  "minimum": 10,
-                  "maximum": 100,
-                  "default": 50
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer",
+                      "minimum": 10,
+                      "maximum": 100,
+                      "default": 50
+                    }
+                  }
                 }
               }
             },
@@ -96,12 +102,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer",
-                  "minimum": -2147483649,
-                  "maximum": 2147483648,
-                  "default": 50
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer",
+                      "minimum": -2147483649,
+                      "maximum": 2147483648,
+                      "default": 50
+                    }
+                  }
                 }
               }
             },
@@ -112,13 +124,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "regex": "^[a-zA-Z0-9]*$",
-                  "minLength": 3,
-                  "maxLength": 10,
-                  "default": "type"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "regex": "^[a-zA-Z0-9]*$",
+                      "minLength": 3,
+                      "maxLength": 10,
+                      "default": "type"
+                    }
+                  }
                 }
               }
             },
@@ -129,12 +147,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double",
-                  "minimum": 1.1,
-                  "maximum": 2.2,
-                  "default": 1.1
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double",
+                      "minimum": 1.1,
+                      "maximum": 2.2,
+                      "default": 1.1
+                    }
+                  }
                 }
               }
             },
@@ -159,6 +183,7 @@
             }
           },
           {
+            "displayName": "Response Body 2",
             "shape": {
               "type": "object",
               "extends": [],
@@ -168,9 +193,15 @@
                   "valueShape": {
                     "type": "alias",
                     "value": {
-                      "type": "primitive",
-                      "value": {
-                        "type": "string"
+                      "type": "optional",
+                      "shape": {
+                        "type": "alias",
+                        "value": {
+                          "type": "primitive",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/streaming.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/streaming.json
@@ -36,9 +36,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -119,9 +125,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -202,9 +214,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -265,9 +283,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }
@@ -286,9 +310,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/uint.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/uint.json
@@ -81,9 +81,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             }
@@ -93,9 +99,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             }
@@ -115,9 +127,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             }
@@ -127,9 +145,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "double"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "double"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/union-extension.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/union-extension.json
@@ -44,13 +44,19 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -71,12 +77,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "nullable",
+                "type": "optional",
                 "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Other"
+                    "type": "nullable",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Other"
+                      }
+                    }
                   }
                 }
               }
@@ -96,9 +108,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -108,9 +126,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -131,9 +155,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/webhooks.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/webhooks.json
@@ -3,8 +3,8 @@
   "endpoints": {},
   "websockets": {},
   "webhooks": {
-    "webhook_.GetPet": {
-      "id": "webhook_.GetPet",
+    "subpackage_.GetPet": {
+      "id": "subpackage_.GetPet",
       "operationId": "GetPet",
       "method": "GET",
       "path": [
@@ -33,8 +33,8 @@
       ],
       "examples": []
     },
-    "webhook_.CreatePet": {
-      "id": "webhook_.CreatePet",
+    "subpackage_.CreatePet": {
+      "id": "subpackage_.CreatePet",
       "operationId": "CreatePet",
       "method": "POST",
       "path": [

--- a/packages/parsers/src/openapi/__test__/__snapshots__/webhooks.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/webhooks.json
@@ -3,8 +3,8 @@
   "endpoints": {},
   "websockets": {},
   "webhooks": {
-    "subpackage_.GetPet": {
-      "id": "subpackage_.GetPet",
+    "webhook_.GetPet": {
+      "id": "webhook_.GetPet",
       "operationId": "GetPet",
       "method": "GET",
       "path": [
@@ -33,8 +33,8 @@
       ],
       "examples": []
     },
-    "subpackage_.CreatePet": {
-      "id": "subpackage_.CreatePet",
+    "webhook_.CreatePet": {
+      "id": "webhook_.CreatePet",
       "operationId": "CreatePet",
       "method": "POST",
       "path": [

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-audiences.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-audiences.json
@@ -45,9 +45,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -57,9 +63,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -100,9 +112,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-global-headers.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-global-headers.json
@@ -4,7 +4,7 @@
     "endpoint_user.get": {
       "id": "endpoint_user.get",
       "namespace": [
-        "user"
+        "subpackage_user"
       ],
       "operationId": "get",
       "method": "POST",
@@ -231,10 +231,10 @@
     }
   },
   "subpackages": {
-    "user": {
-      "id": "user",
+    "subpackage_user": {
+      "id": "subpackage_user",
       "name": "user",
-      "displayName": "user"
+      "displayName": "User"
     }
   },
   "auths": {},

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-global-headers.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-global-headers.json
@@ -4,7 +4,7 @@
     "endpoint_user.get": {
       "id": "endpoint_user.get",
       "namespace": [
-        "subpackage_user"
+        "user"
       ],
       "operationId": "get",
       "method": "POST",
@@ -103,9 +103,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 }
@@ -174,9 +180,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }
@@ -186,9 +198,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -207,9 +225,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }
@@ -219,9 +243,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -231,8 +261,8 @@
     }
   },
   "subpackages": {
-    "subpackage_user": {
-      "id": "subpackage_user",
+    "user": {
+      "id": "user",
       "name": "user",
       "displayName": "User"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-idempotency-headers.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-idempotency-headers.json
@@ -27,9 +27,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-ignore.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-ignore.json
@@ -147,9 +147,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -168,8 +174,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Meta"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Meta"
+                  }
+                }
               }
             }
           },
@@ -178,12 +190,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "User"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "User"
+                      }
+                    }
                   }
                 }
               }
@@ -203,9 +221,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }
@@ -215,9 +239,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -227,9 +257,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -239,9 +275,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-pagination.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-pagination.json
@@ -111,9 +111,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -132,8 +138,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Meta"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Meta"
+                  }
+                }
               }
             }
           },
@@ -142,12 +154,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "User"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "User"
+                      }
+                    }
                   }
                 }
               }
@@ -167,9 +185,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }
@@ -179,9 +203,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -191,9 +221,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -203,9 +239,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-property-name.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-property-name.json
@@ -15,9 +15,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-sdk-group-name-with-streaming.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-sdk-group-name-with-streaming.json
@@ -4,7 +4,7 @@
     "endpoint_user.get": {
       "id": "endpoint_user.get",
       "namespace": [
-        "subpackage_user"
+        "user"
       ],
       "operationId": "get",
       "method": "POST",
@@ -53,9 +53,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 }
@@ -118,9 +124,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }
@@ -130,9 +142,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -151,9 +169,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }
@@ -163,9 +187,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -175,8 +205,8 @@
     }
   },
   "subpackages": {
-    "subpackage_user": {
-      "id": "subpackage_user",
+    "user": {
+      "id": "user",
       "name": "user",
       "displayName": "User"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-sdk-group-name-with-streaming.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-sdk-group-name-with-streaming.json
@@ -4,7 +4,7 @@
     "endpoint_user.get": {
       "id": "endpoint_user.get",
       "namespace": [
-        "user"
+        "subpackage_user"
       ],
       "operationId": "get",
       "method": "POST",
@@ -175,10 +175,10 @@
     }
   },
   "subpackages": {
-    "user": {
-      "id": "user",
+    "subpackage_user": {
+      "id": "subpackage_user",
       "name": "user",
-      "displayName": "user"
+      "displayName": "User"
     }
   },
   "auths": {}

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-sdk-group-name.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-sdk-group-name.json
@@ -39,9 +39,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }
@@ -51,12 +57,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Person"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Person"
+                      }
+                    }
                   }
                 }
               }
@@ -77,9 +89,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-audiences.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-audiences.json
@@ -4,7 +4,7 @@
     "endpoint_user.get": {
       "id": "endpoint_user.get",
       "namespace": [
-        "user"
+        "subpackage_user"
       ],
       "operationId": "get",
       "method": "GET",
@@ -175,10 +175,10 @@
     }
   },
   "subpackages": {
-    "user": {
-      "id": "user",
+    "subpackage_user": {
+      "id": "subpackage_user",
       "name": "user",
-      "displayName": "user"
+      "displayName": "User"
     }
   },
   "auths": {}

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-audiences.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-audiences.json
@@ -4,7 +4,7 @@
     "endpoint_user.get": {
       "id": "endpoint_user.get",
       "namespace": [
-        "subpackage_user"
+        "user"
       ],
       "operationId": "get",
       "method": "GET",
@@ -53,9 +53,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 }
@@ -118,9 +124,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }
@@ -130,9 +142,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -151,9 +169,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "uuid"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "uuid"
+                    }
+                  }
                 }
               }
             }
@@ -163,9 +187,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -175,8 +205,8 @@
     }
   },
   "subpackages": {
-    "subpackage_user": {
-      "id": "subpackage_user",
+    "user": {
+      "id": "user",
       "name": "user",
       "displayName": "User"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-reference.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-reference.json
@@ -4,7 +4,7 @@
     "endpoint_chatCompletions.create": {
       "id": "endpoint_chatCompletions.create",
       "namespace": [
-        "chatCompletions"
+        "subpackage_chatCompletions"
       ],
       "method": "POST",
       "path": [
@@ -162,10 +162,10 @@
     }
   },
   "subpackages": {
-    "chatCompletions": {
-      "id": "chatCompletions",
+    "subpackage_chatCompletions": {
+      "id": "subpackage_chatCompletions",
       "name": "chatCompletions",
-      "displayName": "chatCompletions"
+      "displayName": "Chat Completions"
     }
   },
   "auths": {}

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-reference.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-reference.json
@@ -4,7 +4,7 @@
     "endpoint_chatCompletions.create": {
       "id": "endpoint_chatCompletions.create",
       "namespace": [
-        "subpackage_chatCompletions"
+        "chatCompletions"
       ],
       "method": "POST",
       "path": [
@@ -129,9 +129,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -150,9 +156,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -162,8 +174,8 @@
     }
   },
   "subpackages": {
-    "subpackage_chatCompletions": {
-      "id": "subpackage_chatCompletions",
+    "chatCompletions": {
+      "id": "chatCompletions",
       "name": "chatCompletions",
       "displayName": "Chat Completions"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-sse.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-sse.json
@@ -4,7 +4,7 @@
     "endpoint_chatCompletions.create": {
       "id": "endpoint_chatCompletions.create",
       "namespace": [
-        "chatCompletions"
+        "subpackage_chatCompletions"
       ],
       "method": "POST",
       "path": [
@@ -162,10 +162,10 @@
     }
   },
   "subpackages": {
-    "chatCompletions": {
-      "id": "chatCompletions",
+    "subpackage_chatCompletions": {
+      "id": "subpackage_chatCompletions",
       "name": "chatCompletions",
-      "displayName": "chatCompletions"
+      "displayName": "Chat Completions"
     }
   },
   "auths": {}

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-sse.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-sse.json
@@ -4,7 +4,7 @@
     "endpoint_chatCompletions.create": {
       "id": "endpoint_chatCompletions.create",
       "namespace": [
-        "subpackage_chatCompletions"
+        "chatCompletions"
       ],
       "method": "POST",
       "path": [
@@ -129,9 +129,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -150,9 +156,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -162,8 +174,8 @@
     }
   },
   "subpackages": {
-    "subpackage_chatCompletions": {
-      "id": "subpackage_chatCompletions",
+    "chatCompletions": {
+      "id": "chatCompletions",
       "name": "chatCompletions",
       "displayName": "Chat Completions"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-stream-condition.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-stream-condition.json
@@ -1,12 +1,9 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_chats.chat": {
-      "id": "endpoint_chats.chat",
+    "endpoint_.chat": {
+      "id": "endpoint_.chat",
       "description": "Create a chat while specifying the default retrieval parameters used by the prompt.",
-      "namespace": [
-        "Chats"
-      ],
       "displayName": "Start a chat",
       "operationId": "createChat",
       "method": "POST",
@@ -311,12 +308,6 @@
       "description": "An individual event when the response is streamed."
     }
   },
-  "subpackages": {
-    "chats": {
-      "id": "chats",
-      "name": "Chats",
-      "displayName": "Chats"
-    }
-  },
+  "subpackages": {},
   "auths": {}
 }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-stream-condition.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-stream-condition.json
@@ -1,9 +1,12 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.chat": {
-      "id": "endpoint_.chat",
+    "endpoint_chats.chat": {
+      "id": "endpoint_chats.chat",
       "description": "Create a chat while specifying the default retrieval parameters used by the prompt.",
+      "namespace": [
+        "subpackage_chats"
+      ],
       "displayName": "Start a chat",
       "operationId": "createChat",
       "method": "POST",
@@ -308,6 +311,12 @@
       "description": "An individual event when the response is streamed."
     }
   },
-  "subpackages": {},
+  "subpackages": {
+    "subpackage_chats": {
+      "id": "subpackage_chats",
+      "name": "chats",
+      "displayName": "Chats"
+    }
+  },
   "auths": {}
 }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-stream-condition.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-streaming-with-stream-condition.json
@@ -5,7 +5,7 @@
       "id": "endpoint_chats.chat",
       "description": "Create a chat while specifying the default retrieval parameters used by the prompt.",
       "namespace": [
-        "subpackage_chats"
+        "chats"
       ],
       "displayName": "Start a chat",
       "operationId": "createChat",
@@ -249,9 +249,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -262,9 +268,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -275,9 +287,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -298,9 +316,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -312,8 +336,8 @@
     }
   },
   "subpackages": {
-    "subpackage_chats": {
-      "id": "subpackage_chats",
+    "chats": {
+      "id": "chats",
       "name": "chats",
       "displayName": "Chats"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-token-variable-name.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-token-variable-name.json
@@ -4,7 +4,7 @@
     "endpoint_chatCompletions.create": {
       "id": "endpoint_chatCompletions.create",
       "namespace": [
-        "chatCompletions"
+        "subpackage_chatCompletions"
       ],
       "method": "POST",
       "path": [
@@ -162,10 +162,10 @@
     }
   },
   "subpackages": {
-    "chatCompletions": {
-      "id": "chatCompletions",
+    "subpackage_chatCompletions": {
+      "id": "subpackage_chatCompletions",
       "name": "chatCompletions",
-      "displayName": "chatCompletions"
+      "displayName": "Chat Completions"
     }
   },
   "auths": {

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-token-variable-name.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-token-variable-name.json
@@ -4,7 +4,7 @@
     "endpoint_chatCompletions.create": {
       "id": "endpoint_chatCompletions.create",
       "namespace": [
-        "subpackage_chatCompletions"
+        "chatCompletions"
       ],
       "method": "POST",
       "path": [
@@ -129,9 +129,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -150,9 +156,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -162,8 +174,8 @@
     }
   },
   "subpackages": {
-    "subpackage_chatCompletions": {
-      "id": "subpackage_chatCompletions",
+    "chatCompletions": {
+      "id": "chatCompletions",
       "name": "chatCompletions",
       "displayName": "Chat Completions"
     }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-version.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-version.json
@@ -4,7 +4,7 @@
     "endpoint_chatCompletions.create": {
       "id": "endpoint_chatCompletions.create",
       "namespace": [
-        "chatCompletions"
+        "subpackage_chatCompletions"
       ],
       "method": "POST",
       "path": [
@@ -162,10 +162,10 @@
     }
   },
   "subpackages": {
-    "chatCompletions": {
-      "id": "chatCompletions",
+    "subpackage_chatCompletions": {
+      "id": "subpackage_chatCompletions",
       "name": "chatCompletions",
-      "displayName": "chatCompletions"
+      "displayName": "Chat Completions"
     }
   },
   "auths": {

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-version.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-version.json
@@ -4,7 +4,7 @@
     "endpoint_chatCompletions.create": {
       "id": "endpoint_chatCompletions.create",
       "namespace": [
-        "subpackage_chatCompletions"
+        "chatCompletions"
       ],
       "method": "POST",
       "path": [
@@ -129,9 +129,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -150,9 +156,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -162,8 +174,8 @@
     }
   },
   "subpackages": {
-    "subpackage_chatCompletions": {
-      "id": "subpackage_chatCompletions",
+    "chatCompletions": {
+      "id": "chatCompletions",
       "name": "chatCompletions",
       "displayName": "Chat Completions"
     }

--- a/packages/parsers/src/openapi/utils/3.1/convertToObjectProperties.ts
+++ b/packages/parsers/src/openapi/utils/3.1/convertToObjectProperties.ts
@@ -4,6 +4,7 @@ import {
   ParameterBaseObjectConverterNode,
   SchemaConverterNode,
 } from "../../3.1";
+import { isRequired } from "../isRequired";
 import { maybeSingleValueToArray } from "../maybeSingleValueToArray";
 import { wrapOptional } from "../wrapOptional";
 
@@ -23,7 +24,10 @@ export function convertToObjectProperties(
 
       return maybeValueShapes
         ?.map((valueShape) => {
-          if (requiredProperties != null && !requiredProperties.includes(key)) {
+          if (
+            (requiredProperties != null && !requiredProperties.includes(key)) ||
+            (requiredProperties == null && !isRequired(node))
+          ) {
             valueShape = wrapOptional(
               valueShape,
               valueShape.type === "enum" ? valueShape.default : undefined

--- a/packages/parsers/src/openapi/utils/__test__/3.1/convertToObjectProperties.test.ts
+++ b/packages/parsers/src/openapi/utils/__test__/3.1/convertToObjectProperties.test.ts
@@ -15,14 +15,22 @@ describe("convertToObjectProperties", () => {
     const mockTypeShape: FernRegistry.api.latest.TypeShape = {
       type: "alias",
       value: {
-        type: "primitive",
-        value: {
-          type: "string",
-          regex: undefined,
-          minLength: undefined,
-          maxLength: undefined,
-          default: undefined,
+        type: "optional",
+        shape: {
+          type: "alias",
+          value: {
+            type: "primitive",
+            value: {
+              type: "string",
+              regex: undefined,
+              format: undefined,
+              minLength: undefined,
+              maxLength: undefined,
+              default: undefined,
+            },
+          },
         },
+        default: undefined,
       },
     };
 
@@ -37,6 +45,8 @@ describe("convertToObjectProperties", () => {
       accessPath: [],
       pathId: "",
       seenSchemas: new Set(),
+      nullable: undefined,
+      schemaName: undefined,
     });
     nameSchemaConverterNode.availability = new AvailabilityConverterNode({
       input: {
@@ -57,6 +67,8 @@ describe("convertToObjectProperties", () => {
         accessPath: [],
         pathId: "",
         seenSchemas: new Set(),
+        nullable: undefined,
+        schemaName: undefined,
       }),
     };
 
@@ -84,14 +96,22 @@ describe("convertToObjectProperties", () => {
     const mockTypeShape: FernRegistry.api.latest.TypeShape = {
       type: "alias",
       value: {
-        type: "primitive",
-        value: {
-          type: "string",
-          regex: undefined,
-          minLength: undefined,
-          maxLength: undefined,
-          default: undefined,
+        type: "optional",
+        shape: {
+          type: "alias",
+          value: {
+            type: "primitive",
+            value: {
+              type: "string",
+              format: undefined,
+              regex: undefined,
+              minLength: undefined,
+              maxLength: undefined,
+              default: undefined,
+            },
+          },
         },
+        default: undefined,
       },
     };
 
@@ -103,6 +123,8 @@ describe("convertToObjectProperties", () => {
       accessPath: [],
       pathId: "",
       seenSchemas: new Set(),
+      nullable: undefined,
+      schemaName: undefined,
     });
 
     const properties = {

--- a/packages/parsers/src/openapi/utils/__test__/getEndpointId.test.ts
+++ b/packages/parsers/src/openapi/utils/__test__/getEndpointId.test.ts
@@ -16,7 +16,7 @@ describe("getEndpointId", () => {
   it("handles array namespace", () => {
     expect(
       getEndpointId(["pets", "v1"], "/pets/get", "getById", undefined)
-    ).toBe("endpoint_petsV1.getByIdPetsGet");
+    ).toBe("endpoint_pets.v1.getByIdPetsGet");
   });
 
   it("handles undefined namespace", () => {

--- a/packages/parsers/src/openapi/utils/__test__/getEndpointId.test.ts
+++ b/packages/parsers/src/openapi/utils/__test__/getEndpointId.test.ts
@@ -3,48 +3,92 @@ import { getEndpointId } from "../getEndpointId";
 describe("getEndpointId", () => {
   it("returns undefined when path is undefined", () => {
     expect(
-      getEndpointId("namespace", undefined, "method", "opId")
+      getEndpointId({
+        namespace: "namespace",
+        path: undefined,
+        method: "method",
+        sdkMethodName: "opId",
+        operationId: undefined,
+        isWebhook: undefined,
+      })
     ).toBeUndefined();
   });
 
   it("handles string namespace", () => {
-    expect(getEndpointId("pets", "/pets/get", "getById", undefined)).toBe(
-      "endpoint_pets.getByIdPetsGet"
-    );
+    expect(
+      getEndpointId({
+        namespace: "pets",
+        path: "/pets/get",
+        method: "getById",
+        sdkMethodName: undefined,
+        operationId: undefined,
+        isWebhook: undefined,
+      })
+    ).toBe("endpoint_pets.getByIdPetsGet");
   });
 
   it("handles array namespace", () => {
     expect(
-      getEndpointId(["pets", "v1"], "/pets/get", "getById", undefined)
+      getEndpointId({
+        namespace: ["pets", "v1"],
+        path: "/pets/get",
+        method: "getById",
+        sdkMethodName: undefined,
+        operationId: undefined,
+        isWebhook: undefined,
+      })
     ).toBe("endpoint_pets.v1.getByIdPetsGet");
   });
 
   it("handles undefined namespace", () => {
-    expect(getEndpointId(undefined, "/pets/get", "getById", undefined)).toBe(
-      "endpoint_.getByIdPetsGet"
-    );
+    expect(
+      getEndpointId({
+        namespace: undefined,
+        path: "/pets/get",
+        method: "getById",
+        sdkMethodName: undefined,
+        operationId: undefined,
+        isWebhook: undefined,
+      })
+    ).toBe("endpoint_.getByIdPetsGet");
   });
 
   it("uses operationId when sdkMethodName is undefined", () => {
-    expect(getEndpointId("pets", "/pets/get", undefined, "getPetById")).toBe(
-      "endpoint_pets.getPetById"
-    );
+    expect(
+      getEndpointId({
+        namespace: "pets",
+        path: "/pets/get",
+        method: undefined,
+        sdkMethodName: undefined,
+        operationId: "getPetById",
+        isWebhook: undefined,
+      })
+    ).toBe("endpoint_pets.getPetById");
   });
 
   it("falls back to path endpoint when no sdkMethodName or operationId", () => {
-    expect(getEndpointId("pets", "/pets/get", undefined, undefined)).toBe(
-      "endpoint_pets.petsGet"
-    );
+    expect(
+      getEndpointId({
+        namespace: "pets",
+        path: "/pets/get",
+        method: undefined,
+        sdkMethodName: undefined,
+        operationId: undefined,
+        isWebhook: undefined,
+      })
+    ).toBe("endpoint_pets.petsGet");
   });
 
   it("handles complex paths", () => {
     expect(
-      getEndpointId(
-        "pets",
-        "/api/v1/pets/{petId}/details",
-        "getDetails",
-        undefined
-      )
+      getEndpointId({
+        namespace: "pets",
+        path: "/api/v1/pets/{petId}/details",
+        method: "getDetails",
+        sdkMethodName: undefined,
+        operationId: undefined,
+        isWebhook: undefined,
+      })
     ).toBe("endpoint_pets.getDetailsApiV1PetsPetIdDetails");
   });
 });

--- a/packages/parsers/src/openapi/utils/getEndpointId.ts
+++ b/packages/parsers/src/openapi/utils/getEndpointId.ts
@@ -1,14 +1,21 @@
 import { camelCase } from "es-toolkit";
 import { maybeSingleValueToArray } from "./maybeSingleValueToArray";
 
-export function getEndpointId(
-  namespace: string | string[] | undefined,
-  path: string | undefined,
-  method: string | undefined,
-  sdkMethodName: string | undefined,
-  operationId: string | undefined,
-  isWebhook: boolean | undefined
-): string | undefined {
+export function getEndpointId({
+  namespace,
+  path,
+  method,
+  sdkMethodName,
+  operationId,
+  isWebhook,
+}: {
+  namespace: string | string[] | undefined;
+  path: string | undefined;
+  method: string | undefined;
+  sdkMethodName: string | undefined;
+  operationId: string | undefined;
+  isWebhook: boolean | undefined;
+}): string | undefined {
   if (path == null) {
     return undefined;
   }
@@ -21,11 +28,29 @@ export function getEndpointId(
   if (endpointName == null) {
     return undefined;
   }
-  return `${isWebhook ? "subpackage_" : "endpoint_"}${
-    namespace != null
-      ? maybeSingleValueToArray(namespace)
-          ?.map((member) => camelCase(member))
-          .join(".")
-      : ""
-  }.${camelCase(sdkMethodName ?? "") || operationId || camelCase(endpointName)}`;
+  return `${getPrefix(isWebhook)}${getFullyQualifiedNamespace(namespace)}.${getEndpointName(sdkMethodName, operationId, endpointName)}`;
+}
+
+function getPrefix(isWebhook: boolean | undefined): string {
+  return isWebhook ? "subpackage_" : "endpoint_";
+}
+
+function getFullyQualifiedNamespace(
+  namespace: string | string[] | undefined
+): string | undefined {
+  return namespace != null
+    ? maybeSingleValueToArray(namespace)
+        ?.map((member) => camelCase(member))
+        .join(".")
+    : "";
+}
+
+function getEndpointName(
+  sdkMethodName: string | undefined,
+  operationId: string | undefined,
+  endpointName: string
+): string | undefined {
+  return (
+    camelCase(sdkMethodName ?? "") || operationId || camelCase(endpointName)
+  );
 }

--- a/packages/parsers/src/openapi/utils/getEndpointId.ts
+++ b/packages/parsers/src/openapi/utils/getEndpointId.ts
@@ -1,4 +1,5 @@
 import { camelCase } from "es-toolkit";
+import { maybeSingleValueToArray } from "./maybeSingleValueToArray";
 
 export function getEndpointId(
   namespace: string | string[] | undefined,
@@ -20,5 +21,11 @@ export function getEndpointId(
   if (endpointName == null) {
     return undefined;
   }
-  return `${isWebhook ? "webhook_" : "endpoint_"}${camelCase(namespace != null ? (typeof namespace === "string" ? namespace : namespace.join("_")) : "")}.${camelCase(sdkMethodName ?? "") || operationId || camelCase(endpointName)}`;
+  return `${isWebhook ? "subpackage_" : "endpoint_"}${
+    namespace != null
+      ? maybeSingleValueToArray(namespace)
+          ?.map((member) => camelCase(member))
+          .join(".")
+      : ""
+  }.${camelCase(sdkMethodName ?? "") || operationId || camelCase(endpointName)}`;
 }

--- a/packages/parsers/src/openapi/utils/getEndpointId.ts
+++ b/packages/parsers/src/openapi/utils/getEndpointId.ts
@@ -32,7 +32,7 @@ export function getEndpointId({
 }
 
 function getPrefix(isWebhook: boolean | undefined): string {
-  return isWebhook ? "subpackage_" : "endpoint_";
+  return isWebhook ? "webhook_" : "endpoint_";
 }
 
 function getFullyQualifiedNamespace(

--- a/packages/parsers/src/openapi/utils/isRequired.ts
+++ b/packages/parsers/src/openapi/utils/isRequired.ts
@@ -1,0 +1,5 @@
+export function isRequired(object: object): boolean {
+  return "required" in object && typeof object.required === "boolean"
+    ? object.required
+    : false;
+}

--- a/packages/parsers/src/openrpc/1.x/MethodConverter.node.ts
+++ b/packages/parsers/src/openrpc/1.x/MethodConverter.node.ts
@@ -72,6 +72,8 @@ export class MethodConverterNode extends BaseOpenrpcConverterNode<
             accessPath: this.accessPath,
             pathId: "result",
             seenSchemas: new Set(),
+            nullable: undefined,
+            schemaName: "Result",
           }).convert()
         : undefined;
 
@@ -91,6 +93,8 @@ export class MethodConverterNode extends BaseOpenrpcConverterNode<
               accessPath: this.accessPath,
               pathId: ["params", param.name],
               seenSchemas: new Set(),
+              nullable: undefined,
+              schemaName: param.name,
             }).convert();
 
             if (!schema) return undefined;

--- a/packages/parsers/src/openrpc/__test__/__snapshots__/ethereum.json
+++ b/packages/parsers/src/openrpc/__test__/__snapshots__/ethereum.json
@@ -38,8 +38,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "StorageProofKey"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "StorageProofKey"
+                      }
+                    }
                   }
                 }
               },
@@ -48,8 +54,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Integer"
+                      }
+                    }
                   }
                 },
                 "description": "The value of the storage slot in its account tree"
@@ -59,8 +71,14 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "ProofNodes"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "ProofNodes"
+                      }
+                    }
                   }
                 }
               }
@@ -425,8 +443,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Address"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Address"
+                  }
+                }
               }
             },
             "description": "Sender of the transaction"
@@ -436,8 +460,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "BlockHash"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "BlockHash"
+                  }
+                }
               }
             }
           },
@@ -446,8 +476,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "BlockNumber"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "BlockNumber"
+                  }
+                }
               }
             }
           },
@@ -456,8 +492,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Bytes"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Bytes"
+                  }
+                }
               }
             },
             "description": "The data/input string sent along with the transaction"
@@ -467,8 +509,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Integer"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Integer"
+                  }
+                }
               }
             },
             "description": "The index of the event within its transaction, null when its pending"
@@ -478,9 +526,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "boolean"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },
@@ -491,8 +545,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Topics"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Topics"
+                  }
+                }
               }
             }
           },
@@ -501,8 +561,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "TransactionHash"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "TransactionHash"
+                  }
+                }
               }
             }
           },
@@ -511,8 +577,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "TransactionIndex"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "TransactionIndex"
+                  }
+                }
               }
             }
           }
@@ -643,8 +715,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "BlockNumberOrNull"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "BlockNumberOrNull"
+                  }
+                }
               }
             }
           },
@@ -653,8 +731,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "BlockHashOrNull"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "BlockHashOrNull"
+                  }
+                }
               }
             }
           },
@@ -663,8 +747,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "BlockHash"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "BlockHash"
+                  }
+                }
               }
             }
           },
@@ -673,8 +763,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "NonceOrNull"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "NonceOrNull"
+                  }
+                }
               }
             }
           },
@@ -683,8 +779,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Keccak"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Keccak"
+                  }
+                }
               }
             },
             "description": "Keccak hash of the uncles data in the block"
@@ -694,10 +796,16 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string",
-                  "regex": "^0x[a-fA-F\\d]+$"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string",
+                      "regex": "^0x[a-fA-F\\d]+$"
+                    }
+                  }
                 }
               }
             },
@@ -708,8 +816,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Keccak"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Keccak"
+                  }
+                }
               }
             },
             "description": "The root of the transactions trie of the block."
@@ -719,8 +833,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Keccak"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Keccak"
+                  }
+                }
               }
             },
             "description": "The root of the final state trie of the block"
@@ -730,8 +850,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "Keccak"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "Keccak"
+                  }
+                }
               }
             },
             "description": "The root of the receipts trie of the block"
@@ -741,8 +867,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "AddressOrNull"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "AddressOrNull"
+                  }
+                }
               }
             }
           },
@@ -751,9 +883,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -764,8 +902,14 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "id",
-                "id": "IntegerOrNull"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "id",
+                    "id": "IntegerOrNull"
+                  }
+                }
               }
             },
             "description": "Integer of the total difficulty of the chain until this block"
@@ -775,9 +919,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -788,9 +938,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -801,9 +957,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -814,9 +976,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -827,9 +995,15 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "primitive",
-                "value": {
-                  "type": "string"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "primitive",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -840,31 +1014,37 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
-                  "type": "undiscriminatedUnion",
-                  "variants": [
-                    {
-                      "displayName": "Transaction",
-                      "shape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "id",
-                          "id": "Transaction"
+                "type": "optional",
+                "shape": {
+                  "type": "alias",
+                  "value": {
+                    "type": "list",
+                    "itemShape": {
+                      "type": "undiscriminatedUnion",
+                      "variants": [
+                        {
+                          "displayName": "Transaction",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "Transaction"
+                            }
+                          }
+                        },
+                        {
+                          "displayName": "Transaction Hash",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "TransactionHash"
+                            }
+                          }
                         }
-                      }
-                    },
-                    {
-                      "displayName": "Transaction Hash",
-                      "shape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "id",
-                          "id": "TransactionHash"
-                        }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             },
@@ -875,12 +1055,18 @@
             "valueShape": {
               "type": "alias",
               "value": {
-                "type": "list",
-                "itemShape": {
+                "type": "optional",
+                "shape": {
                   "type": "alias",
                   "value": {
-                    "type": "id",
-                    "id": "Keccak"
+                    "type": "list",
+                    "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "id",
+                        "id": "Keccak"
+                      }
+                    }
                   }
                 }
               }
@@ -3286,8 +3472,14 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "BlockNumber"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "BlockNumber"
+                            }
+                          }
                         }
                       }
                     },
@@ -3296,37 +3488,49 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "BlockNumber"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "BlockNumber"
+                            }
+                          }
                         }
                       }
                     },
                     {
                       "key": "address",
                       "valueShape": {
-                        "type": "undiscriminatedUnion",
-                        "variants": [
-                          {
-                            "displayName": "Address",
-                            "shape": {
-                              "type": "alias",
-                              "value": {
-                                "type": "id",
-                                "id": "Address"
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "undiscriminatedUnion",
+                            "variants": [
+                              {
+                                "displayName": "Address",
+                                "shape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "id",
+                                    "id": "Address"
+                                  }
+                                }
+                              },
+                              {
+                                "displayName": "Addresses",
+                                "shape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "id",
+                                    "id": "Addresses"
+                                  }
+                                }
                               }
-                            }
-                          },
-                          {
-                            "displayName": "Addresses",
-                            "shape": {
-                              "type": "alias",
-                              "value": {
-                                "type": "id",
-                                "id": "Addresses"
-                              }
-                            }
+                            ]
                           }
-                        ]
+                        }
                       }
                     },
                     {
@@ -3334,8 +3538,14 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "Topics"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "Topics"
+                            }
+                          }
                         }
                       }
                     }
@@ -4548,8 +4758,14 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "Address"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "Address"
+                          }
+                        }
                       }
                     },
                     "description": "The address of the account or contract of the request"
@@ -4559,8 +4775,14 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "ProofNodes"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "ProofNodes"
+                          }
+                        }
                       }
                     }
                   },
@@ -4569,8 +4791,14 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "Integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "Integer"
+                          }
+                        }
                       }
                     },
                     "description": "The Ether balance of the account or contract of the request"
@@ -4580,8 +4808,14 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "Keccak"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "Keccak"
+                          }
+                        }
                       }
                     },
                     "description": "The code hash of the contract of the request (keccak(NULL) if external account)"
@@ -4591,8 +4825,14 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "Nonce"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "Nonce"
+                          }
+                        }
                       }
                     },
                     "description": "The transaction count of the account or contract of the request"
@@ -4602,8 +4842,14 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "Keccak"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "Keccak"
+                          }
+                        }
                       }
                     },
                     "description": "The storage hash of the contract of the request (keccak(rlp(NULL)) if external account)"
@@ -4613,8 +4859,14 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "id",
-                        "id": "StorageProof"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "id",
+                            "id": "StorageProof"
+                          }
+                        }
                       }
                     }
                   }
@@ -4995,8 +5247,14 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "BlockNumber"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "BlockNumber"
+                            }
+                          }
                         }
                       }
                     },
@@ -5005,37 +5263,49 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "BlockNumber"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "BlockNumber"
+                            }
+                          }
                         }
                       }
                     },
                     {
                       "key": "address",
                       "valueShape": {
-                        "type": "undiscriminatedUnion",
-                        "variants": [
-                          {
-                            "displayName": "Address",
-                            "shape": {
-                              "type": "alias",
-                              "value": {
-                                "type": "id",
-                                "id": "Address"
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "undiscriminatedUnion",
+                            "variants": [
+                              {
+                                "displayName": "Address",
+                                "shape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "id",
+                                    "id": "Address"
+                                  }
+                                }
+                              },
+                              {
+                                "displayName": "Addresses",
+                                "shape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "id",
+                                    "id": "Addresses"
+                                  }
+                                }
                               }
-                            }
-                          },
-                          {
-                            "displayName": "Addresses",
-                            "shape": {
-                              "type": "alias",
-                              "value": {
-                                "type": "id",
-                                "id": "Addresses"
-                              }
-                            }
+                            ]
                           }
-                        ]
+                        }
                       }
                     },
                     {
@@ -5043,8 +5313,14 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "id",
-                          "id": "Topics"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "id",
+                              "id": "Topics"
+                            }
+                          }
                         }
                       }
                     }

--- a/packages/parsers/src/openrpc/__test__/__snapshots__/petstore.json
+++ b/packages/parsers/src/openrpc/__test__/__snapshots__/petstore.json
@@ -429,8 +429,8 @@
   "websockets": {},
   "webhooks": {},
   "subpackages": {
-    "subpackage_pets": {
-      "id": "subpackage_pets",
+    "pets": {
+      "id": "pets",
       "name": "pets",
       "displayName": "Pets"
     }

--- a/packages/parsers/src/openrpc/__test__/__snapshots__/petstore.json
+++ b/packages/parsers/src/openrpc/__test__/__snapshots__/petstore.json
@@ -429,10 +429,10 @@
   "websockets": {},
   "webhooks": {},
   "subpackages": {
-    "pets": {
-      "id": "pets",
+    "subpackage_pets": {
+      "id": "subpackage_pets",
       "name": "pets",
-      "displayName": "pets"
+      "displayName": "Pets"
     }
   },
   "auths": {},

--- a/packages/parsers/src/openrpc/__test__/__snapshots__/solana.json
+++ b/packages/parsers/src/openrpc/__test__/__snapshots__/solana.json
@@ -64,75 +64,105 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
                         {
                           "key": "encoding",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "base58"
-                              },
-                              {
-                                "value": "base64"
-                              },
-                              {
-                                "value": "base64+zstd"
-                              },
-                              {
-                                "value": "jsonParsed"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "base58"
+                                  },
+                                  {
+                                    "value": "base64"
+                                  },
+                                  {
+                                    "value": "base64+zstd"
+                                  },
+                                  {
+                                    "value": "jsonParsed"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Encoding format for account data."
                         },
                         {
                           "key": "dataSlice",
                           "valueShape": {
-                            "type": "object",
-                            "extends": [],
-                            "properties": [
-                              {
-                                "key": "length",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "integer"
-                                    }
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "object",
+                                "extends": [],
+                                "properties": [
+                                  {
+                                    "key": "length",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "primitive",
+                                            "value": {
+                                              "type": "integer"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "description": "Number of bytes to return."
+                                  },
+                                  {
+                                    "key": "offset",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "primitive",
+                                            "value": {
+                                              "type": "integer"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "description": "Byte offset from which to start reading."
                                   }
-                                },
-                                "description": "Number of bytes to return."
-                              },
-                              {
-                                "key": "offset",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "integer"
-                                    }
-                                  }
-                                },
-                                "description": "Byte offset from which to start reading."
+                                ]
                               }
-                            ]
+                            }
                           }
                         },
                         {
@@ -140,9 +170,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -170,9 +206,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -183,9 +225,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -196,13 +244,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -215,9 +269,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -228,9 +288,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -241,9 +307,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -360,18 +432,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -380,9 +458,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -505,63 +589,84 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ],
+                                "default": "finalized"
                               },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
-                              }
-                            ],
-                            "default": "finalized"
+                              "default": "finalized"
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
                         {
                           "key": "encoding",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "json"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "json"
+                                  },
+                                  {
+                                    "value": "jsonParsed"
+                                  },
+                                  {
+                                    "value": "base58"
+                                  },
+                                  {
+                                    "value": "base64"
+                                  }
+                                ],
+                                "default": "json"
                               },
-                              {
-                                "value": "jsonParsed"
-                              },
-                              {
-                                "value": "base58"
-                              },
-                              {
-                                "value": "base64"
-                              }
-                            ],
-                            "default": "json"
+                              "default": "json"
+                            }
                           },
                           "description": "Encoding format for transactions."
                         },
                         {
                           "key": "transactionDetails",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "full"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "full"
+                                  },
+                                  {
+                                    "value": "accounts"
+                                  },
+                                  {
+                                    "value": "signatures"
+                                  },
+                                  {
+                                    "value": "none"
+                                  }
+                                ],
+                                "default": "full"
                               },
-                              {
-                                "value": "accounts"
-                              },
-                              {
-                                "value": "signatures"
-                              },
-                              {
-                                "value": "none"
-                              }
-                            ],
-                            "default": "full"
+                              "default": "full"
+                            }
                           },
                           "description": "Level of transaction detail to return."
                         },
@@ -570,9 +675,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -583,10 +694,16 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "boolean",
-                                "default": true
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "boolean",
+                                    "default": true
+                                  }
+                                }
                               }
                             }
                           },
@@ -614,9 +731,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -627,9 +750,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -640,9 +769,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -653,135 +788,376 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
-                      "type": "object",
-                      "extends": [],
-                      "properties": [
-                        {
-                          "key": "slot",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "The slot this transaction was processed in."
-                        },
-                        {
-                          "key": "transaction",
-                          "valueShape": {
-                            "type": "object",
-                            "extends": [],
-                            "properties": [
-                              {
-                                "key": "signatures",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "list",
-                                    "itemShape": {
-                                      "type": "alias",
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "list",
+                        "itemShape": {
+                          "type": "object",
+                          "extends": [],
+                          "properties": [
+                            {
+                              "key": "slot",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
                                       "value": {
-                                        "type": "primitive",
+                                        "type": "integer"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "The slot this transaction was processed in."
+                            },
+                            {
+                              "key": "transaction",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "object",
+                                    "extends": [],
+                                    "properties": [
+                                      {
+                                        "key": "signatures",
+                                        "valueShape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "optional",
+                                            "shape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "list",
+                                                "itemShape": {
+                                                  "type": "alias",
+                                                  "value": {
+                                                    "type": "primitive",
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "description": "An array of signatures applied to the transaction."
+                                      },
+                                      {
+                                        "key": "message",
+                                        "valueShape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "optional",
+                                            "shape": {
+                                              "type": "object",
+                                              "extends": [],
+                                              "properties": [
+                                                {
+                                                  "key": "accountKeys",
+                                                  "valueShape": {
+                                                    "type": "alias",
+                                                    "value": {
+                                                      "type": "optional",
+                                                      "shape": {
+                                                        "type": "alias",
+                                                        "value": {
+                                                          "type": "list",
+                                                          "itemShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "primitive",
+                                                              "value": {
+                                                                "type": "string"
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "description": "An array of account keys used by the transaction."
+                                                },
+                                                {
+                                                  "key": "header",
+                                                  "valueShape": {
+                                                    "type": "alias",
+                                                    "value": {
+                                                      "type": "optional",
+                                                      "shape": {
+                                                        "type": "object",
+                                                        "extends": [],
+                                                        "properties": [
+                                                          {
+                                                            "key": "numRequiredSignatures",
+                                                            "valueShape": {
+                                                              "type": "alias",
+                                                              "value": {
+                                                                "type": "optional",
+                                                                "shape": {
+                                                                  "type": "alias",
+                                                                  "value": {
+                                                                    "type": "primitive",
+                                                                    "value": {
+                                                                      "type": "integer"
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            },
+                                                            "description": "The number of signatures required for the transaction."
+                                                          },
+                                                          {
+                                                            "key": "numReadonlySignedAccounts",
+                                                            "valueShape": {
+                                                              "type": "alias",
+                                                              "value": {
+                                                                "type": "optional",
+                                                                "shape": {
+                                                                  "type": "alias",
+                                                                  "value": {
+                                                                    "type": "primitive",
+                                                                    "value": {
+                                                                      "type": "integer"
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            },
+                                                            "description": "Number of read-only signed accounts."
+                                                          },
+                                                          {
+                                                            "key": "numReadonlyUnsignedAccounts",
+                                                            "valueShape": {
+                                                              "type": "alias",
+                                                              "value": {
+                                                                "type": "optional",
+                                                                "shape": {
+                                                                  "type": "alias",
+                                                                  "value": {
+                                                                    "type": "primitive",
+                                                                    "value": {
+                                                                      "type": "integer"
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            },
+                                                            "description": "Number of read-only unsigned accounts."
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "key": "instructions",
+                                                  "valueShape": {
+                                                    "type": "alias",
+                                                    "value": {
+                                                      "type": "optional",
+                                                      "shape": {
+                                                        "type": "alias",
+                                                        "value": {
+                                                          "type": "list",
+                                                          "itemShape": {
+                                                            "type": "object",
+                                                            "extends": [],
+                                                            "properties": [
+                                                              {
+                                                                "key": "accounts",
+                                                                "valueShape": {
+                                                                  "type": "alias",
+                                                                  "value": {
+                                                                    "type": "optional",
+                                                                    "shape": {
+                                                                      "type": "alias",
+                                                                      "value": {
+                                                                        "type": "list",
+                                                                        "itemShape": {
+                                                                          "type": "alias",
+                                                                          "value": {
+                                                                            "type": "primitive",
+                                                                            "value": {
+                                                                              "type": "integer"
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "description": "List of account indices to be passed to the program."
+                                                              },
+                                                              {
+                                                                "key": "data",
+                                                                "valueShape": {
+                                                                  "type": "alias",
+                                                                  "value": {
+                                                                    "type": "optional",
+                                                                    "shape": {
+                                                                      "type": "alias",
+                                                                      "value": {
+                                                                        "type": "primitive",
+                                                                        "value": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "description": "The program input data encoded as a base-58 string."
+                                                              },
+                                                              {
+                                                                "key": "programIdIndex",
+                                                                "valueShape": {
+                                                                  "type": "alias",
+                                                                  "value": {
+                                                                    "type": "optional",
+                                                                    "shape": {
+                                                                      "type": "alias",
+                                                                      "value": {
+                                                                        "type": "primitive",
+                                                                        "value": {
+                                                                          "type": "integer"
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "description": "Index into the message.accountKeys array indicating the program account."
+                                                              }
+                                                            ]
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "key": "recentBlockhash",
+                                                  "valueShape": {
+                                                    "type": "alias",
+                                                    "value": {
+                                                      "type": "optional",
+                                                      "shape": {
+                                                        "type": "alias",
+                                                        "value": {
+                                                          "type": "primitive",
+                                                          "value": {
+                                                            "type": "string"
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "description": "The recent blockhash used by the transaction."
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              "description": "The transaction details, either in JSON format or encoded binary data, depending on the encoding parameter."
+                            },
+                            {
+                              "key": "blockTime",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "nullable",
+                                      "shape": {
+                                        "type": "alias",
                                         "value": {
-                                          "type": "string"
+                                          "type": "primitive",
+                                          "value": {
+                                            "type": "integer"
+                                          }
                                         }
                                       }
                                     }
                                   }
-                                },
-                                "description": "An array of signatures applied to the transaction."
+                                }
                               },
-                              {
-                                "key": "message",
-                                "valueShape": {
-                                  "type": "object",
-                                  "extends": [],
-                                  "properties": [
-                                    {
-                                      "key": "accountKeys",
-                                      "valueShape": {
-                                        "type": "alias",
-                                        "value": {
-                                          "type": "list",
-                                          "itemShape": {
-                                            "type": "alias",
-                                            "value": {
-                                              "type": "primitive",
-                                              "value": {
-                                                "type": "string"
-                                              }
-                                            }
-                                          }
-                                        }
-                                      },
-                                      "description": "An array of account keys used by the transaction."
-                                    },
-                                    {
-                                      "key": "header",
-                                      "valueShape": {
+                              "description": "Estimated production time as a Unix timestamp. Null if not available."
+                            },
+                            {
+                              "key": "meta",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "nullable",
+                                      "shape": {
                                         "type": "object",
                                         "extends": [],
                                         "properties": [
                                           {
-                                            "key": "numRequiredSignatures",
+                                            "key": "err",
                                             "valueShape": {
                                               "type": "alias",
                                               "value": {
-                                                "type": "primitive",
-                                                "value": {
-                                                  "type": "integer"
+                                                "type": "optional",
+                                                "shape": {
+                                                  "type": "alias",
+                                                  "value": {
+                                                    "type": "nullable",
+                                                    "shape": {
+                                                      "type": "object",
+                                                      "extends": [],
+                                                      "properties": []
+                                                    }
+                                                  }
                                                 }
                                               }
                                             },
-                                            "description": "The number of signatures required for the transaction."
+                                            "description": "Error if the transaction failed, null if it succeeded."
                                           },
                                           {
-                                            "key": "numReadonlySignedAccounts",
+                                            "key": "fee",
                                             "valueShape": {
                                               "type": "alias",
                                               "value": {
-                                                "type": "primitive",
-                                                "value": {
-                                                  "type": "integer"
+                                                "type": "optional",
+                                                "shape": {
+                                                  "type": "alias",
+                                                  "value": {
+                                                    "type": "primitive",
+                                                    "value": {
+                                                      "type": "integer"
+                                                    }
+                                                  }
                                                 }
                                               }
                                             },
-                                            "description": "Number of read-only signed accounts."
+                                            "description": "Fee charged for this transaction."
                                           },
                                           {
-                                            "key": "numReadonlyUnsignedAccounts",
+                                            "key": "preBalances",
                                             "valueShape": {
                                               "type": "alias",
                                               "value": {
-                                                "type": "primitive",
-                                                "value": {
-                                                  "type": "integer"
-                                                }
-                                              }
-                                            },
-                                            "description": "Number of read-only unsigned accounts."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "key": "instructions",
-                                      "valueShape": {
-                                        "type": "alias",
-                                        "value": {
-                                          "type": "list",
-                                          "itemShape": {
-                                            "type": "object",
-                                            "extends": [],
-                                            "properties": [
-                                              {
-                                                "key": "accounts",
-                                                "valueShape": {
+                                                "type": "optional",
+                                                "shape": {
                                                   "type": "alias",
                                                   "value": {
                                                     "type": "list",
@@ -795,43 +1171,611 @@
                                                       }
                                                     }
                                                   }
-                                                },
-                                                "description": "List of account indices to be passed to the program."
-                                              },
-                                              {
-                                                "key": "data",
-                                                "valueShape": {
-                                                  "type": "alias",
-                                                  "value": {
-                                                    "type": "primitive",
-                                                    "value": {
-                                                      "type": "string"
-                                                    }
-                                                  }
-                                                },
-                                                "description": "The program input data encoded as a base-58 string."
-                                              },
-                                              {
-                                                "key": "programIdIndex",
-                                                "valueShape": {
-                                                  "type": "alias",
-                                                  "value": {
-                                                    "type": "primitive",
-                                                    "value": {
-                                                      "type": "integer"
-                                                    }
-                                                  }
-                                                },
-                                                "description": "Index into the message.accountKeys array indicating the program account."
+                                                }
                                               }
-                                            ]
+                                            },
+                                            "description": "Array of u64 account balances before the transaction."
+                                          },
+                                          {
+                                            "key": "postBalances",
+                                            "valueShape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "optional",
+                                                "shape": {
+                                                  "type": "alias",
+                                                  "value": {
+                                                    "type": "list",
+                                                    "itemShape": {
+                                                      "type": "alias",
+                                                      "value": {
+                                                        "type": "primitive",
+                                                        "value": {
+                                                          "type": "integer"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "description": "Array of u64 account balances after the transaction."
+                                          },
+                                          {
+                                            "key": "innerInstructions",
+                                            "valueShape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "optional",
+                                                "shape": {
+                                                  "type": "alias",
+                                                  "value": {
+                                                    "type": "list",
+                                                    "itemShape": {
+                                                      "type": "object",
+                                                      "extends": [],
+                                                      "properties": [
+                                                        {
+                                                          "key": "index",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "alias",
+                                                                "value": {
+                                                                  "type": "primitive",
+                                                                  "value": {
+                                                                    "type": "integer"
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "description": "Index of the instruction in the transaction."
+                                                        },
+                                                        {
+                                                          "key": "instructions",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "alias",
+                                                                "value": {
+                                                                  "type": "list",
+                                                                  "itemShape": {
+                                                                    "type": "object",
+                                                                    "extends": [],
+                                                                    "properties": [
+                                                                      {
+                                                                        "key": "programId",
+                                                                        "valueShape": {
+                                                                          "type": "alias",
+                                                                          "value": {
+                                                                            "type": "optional",
+                                                                            "shape": {
+                                                                              "type": "alias",
+                                                                              "value": {
+                                                                                "type": "primitive",
+                                                                                "value": {
+                                                                                  "type": "string"
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "description": "Program ID invoked by this instruction."
+                                                                      },
+                                                                      {
+                                                                        "key": "accounts",
+                                                                        "valueShape": {
+                                                                          "type": "alias",
+                                                                          "value": {
+                                                                            "type": "optional",
+                                                                            "shape": {
+                                                                              "type": "alias",
+                                                                              "value": {
+                                                                                "type": "list",
+                                                                                "itemShape": {
+                                                                                  "type": "alias",
+                                                                                  "value": {
+                                                                                    "type": "primitive",
+                                                                                    "value": {
+                                                                                      "type": "string"
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "description": "Account addresses involved in this instruction."
+                                                                      },
+                                                                      {
+                                                                        "key": "data",
+                                                                        "valueShape": {
+                                                                          "type": "alias",
+                                                                          "value": {
+                                                                            "type": "optional",
+                                                                            "shape": {
+                                                                              "type": "alias",
+                                                                              "value": {
+                                                                                "type": "primitive",
+                                                                                "value": {
+                                                                                  "type": "string"
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "description": "The program input data encoded as a base-58 string."
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "description": "List of inner instructions or null if not enabled."
+                                          },
+                                          {
+                                            "key": "preTokenBalances",
+                                            "valueShape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "optional",
+                                                "shape": {
+                                                  "type": "alias",
+                                                  "value": {
+                                                    "type": "list",
+                                                    "itemShape": {
+                                                      "type": "object",
+                                                      "extends": [],
+                                                      "properties": [
+                                                        {
+                                                          "key": "amount",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "alias",
+                                                                "value": {
+                                                                  "type": "primitive",
+                                                                  "value": {
+                                                                    "type": "string"
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "description": "The raw balance without decimals, a string representation of u64."
+                                                        },
+                                                        {
+                                                          "key": "decimals",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "alias",
+                                                                "value": {
+                                                                  "type": "primitive",
+                                                                  "value": {
+                                                                    "type": "integer"
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "description": "Number of base-10 digits to the right of the decimal place."
+                                                        },
+                                                        {
+                                                          "key": "uiAmount",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "alias",
+                                                                "value": {
+                                                                  "type": "nullable",
+                                                                  "shape": {
+                                                                    "type": "alias",
+                                                                    "value": {
+                                                                      "type": "primitive",
+                                                                      "value": {
+                                                                        "type": "double"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "description": "The balance, using mint-prescribed decimals. **DEPRECATED**"
+                                                        },
+                                                        {
+                                                          "key": "uiAmountString",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "alias",
+                                                                "value": {
+                                                                  "type": "primitive",
+                                                                  "value": {
+                                                                    "type": "string"
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "description": "The balance as a string, using mint-prescribed decimals."
+                                                        }
+                                                      ]
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "description": "Token balances before the transaction, if available."
+                                          },
+                                          {
+                                            "key": "postTokenBalances",
+                                            "valueShape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "optional",
+                                                "shape": {
+                                                  "type": "alias",
+                                                  "value": {
+                                                    "type": "list",
+                                                    "itemShape": {
+                                                      "type": "object",
+                                                      "extends": [],
+                                                      "properties": [
+                                                        {
+                                                          "key": "amount",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "alias",
+                                                                "value": {
+                                                                  "type": "primitive",
+                                                                  "value": {
+                                                                    "type": "string"
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "description": "The raw balance without decimals, a string representation of u64."
+                                                        },
+                                                        {
+                                                          "key": "decimals",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "alias",
+                                                                "value": {
+                                                                  "type": "primitive",
+                                                                  "value": {
+                                                                    "type": "integer"
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "description": "Number of base-10 digits to the right of the decimal place."
+                                                        },
+                                                        {
+                                                          "key": "uiAmount",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "alias",
+                                                                "value": {
+                                                                  "type": "nullable",
+                                                                  "shape": {
+                                                                    "type": "alias",
+                                                                    "value": {
+                                                                      "type": "primitive",
+                                                                      "value": {
+                                                                        "type": "double"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "description": "The balance, using mint-prescribed decimals. **DEPRECATED**"
+                                                        },
+                                                        {
+                                                          "key": "uiAmountString",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "alias",
+                                                                "value": {
+                                                                  "type": "primitive",
+                                                                  "value": {
+                                                                    "type": "string"
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "description": "The balance as a string, using mint-prescribed decimals."
+                                                        }
+                                                      ]
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "description": "Token balances after the transaction, if available."
+                                          },
+                                          {
+                                            "key": "logMessages",
+                                            "valueShape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "optional",
+                                                "shape": {
+                                                  "type": "alias",
+                                                  "value": {
+                                                    "type": "list",
+                                                    "itemShape": {
+                                                      "type": "alias",
+                                                      "value": {
+                                                        "type": "primitive",
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "description": "Array of string log messages or null if not enabled."
+                                          },
+                                          {
+                                            "key": "rewards",
+                                            "valueShape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "optional",
+                                                "shape": {
+                                                  "type": "alias",
+                                                  "value": {
+                                                    "type": "list",
+                                                    "itemShape": {
+                                                      "type": "object",
+                                                      "extends": [],
+                                                      "properties": [
+                                                        {
+                                                          "key": "pubkey",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "alias",
+                                                                "value": {
+                                                                  "type": "primitive",
+                                                                  "value": {
+                                                                    "type": "string"
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "description": "The public key of the rewarded account."
+                                                        },
+                                                        {
+                                                          "key": "lamports",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "alias",
+                                                                "value": {
+                                                                  "type": "primitive",
+                                                                  "value": {
+                                                                    "type": "integer"
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "description": "The amount of reward in lamports."
+                                                        },
+                                                        {
+                                                          "key": "postBalance",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "alias",
+                                                                "value": {
+                                                                  "type": "primitive",
+                                                                  "value": {
+                                                                    "type": "integer"
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "description": "The balance of the account after the reward was applied."
+                                                        },
+                                                        {
+                                                          "key": "rewardType",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "enum",
+                                                                "values": [
+                                                                  {
+                                                                    "value": "fee"
+                                                                  },
+                                                                  {
+                                                                    "value": "rent"
+                                                                  },
+                                                                  {
+                                                                    "value": "voting"
+                                                                  },
+                                                                  {
+                                                                    "value": "staking"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            }
+                                                          },
+                                                          "description": "The type of reward."
+                                                        },
+                                                        {
+                                                          "key": "commission",
+                                                          "valueShape": {
+                                                            "type": "alias",
+                                                            "value": {
+                                                              "type": "optional",
+                                                              "shape": {
+                                                                "type": "alias",
+                                                                "value": {
+                                                                  "type": "nullable",
+                                                                  "shape": {
+                                                                    "type": "alias",
+                                                                    "value": {
+                                                                      "type": "primitive",
+                                                                      "value": {
+                                                                        "type": "integer"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "description": "The vote account commission when the reward was credited, if applicable."
+                                                        }
+                                                      ]
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "description": "Transaction-level rewards."
+                                          },
+                                          {
+                                            "key": "loadedAddresses",
+                                            "valueShape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "optional",
+                                                "shape": {
+                                                  "type": "alias",
+                                                  "value": {
+                                                    "type": "nullable",
+                                                    "shape": {
+                                                      "type": "object",
+                                                      "extends": [],
+                                                      "properties": []
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "description": "Transaction addresses loaded from address lookup tables."
+                                          },
+                                          {
+                                            "key": "returnData",
+                                            "valueShape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "optional",
+                                                "shape": {
+                                                  "type": "alias",
+                                                  "value": {
+                                                    "type": "nullable",
+                                                    "shape": {
+                                                      "type": "object",
+                                                      "extends": [],
+                                                      "properties": []
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "description": "Return data generated by an instruction in the transaction."
+                                          },
+                                          {
+                                            "key": "computeUnitsConsumed",
+                                            "valueShape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "optional",
+                                                "shape": {
+                                                  "type": "alias",
+                                                  "value": {
+                                                    "type": "nullable",
+                                                    "shape": {
+                                                      "type": "alias",
+                                                      "value": {
+                                                        "type": "primitive",
+                                                        "value": {
+                                                          "type": "integer"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "description": "Number of compute units consumed by the transaction."
                                           }
-                                        }
+                                        ]
                                       }
-                                    },
-                                    {
-                                      "key": "recentBlockhash",
-                                      "valueShape": {
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Transaction status metadata."
+                            },
+                            {
+                              "key": "version",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "nullable",
+                                      "shape": {
                                         "type": "alias",
                                         "value": {
                                           "type": "primitive",
@@ -839,537 +1783,16 @@
                                             "type": "string"
                                           }
                                         }
-                                      },
-                                      "description": "The recent blockhash used by the transaction."
+                                      }
                                     }
-                                  ]
-                                }
-                              }
-                            ]
-                          },
-                          "description": "The transaction details, either in JSON format or encoded binary data, depending on the encoding parameter."
-                        },
-                        {
-                          "key": "blockTime",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "nullable",
-                              "shape": {
-                                "type": "alias",
-                                "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "integer"
                                   }
                                 }
-                              }
+                              },
+                              "description": "Transaction version. Undefined if not set."
                             }
-                          },
-                          "description": "Estimated production time as a Unix timestamp. Null if not available."
-                        },
-                        {
-                          "key": "meta",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "nullable",
-                              "shape": {
-                                "type": "object",
-                                "extends": [],
-                                "properties": [
-                                  {
-                                    "key": "err",
-                                    "valueShape": {
-                                      "type": "alias",
-                                      "value": {
-                                        "type": "nullable",
-                                        "shape": {
-                                          "type": "object",
-                                          "extends": [],
-                                          "properties": []
-                                        }
-                                      }
-                                    },
-                                    "description": "Error if the transaction failed, null if it succeeded."
-                                  },
-                                  {
-                                    "key": "fee",
-                                    "valueShape": {
-                                      "type": "alias",
-                                      "value": {
-                                        "type": "primitive",
-                                        "value": {
-                                          "type": "integer"
-                                        }
-                                      }
-                                    },
-                                    "description": "Fee charged for this transaction."
-                                  },
-                                  {
-                                    "key": "preBalances",
-                                    "valueShape": {
-                                      "type": "alias",
-                                      "value": {
-                                        "type": "list",
-                                        "itemShape": {
-                                          "type": "alias",
-                                          "value": {
-                                            "type": "primitive",
-                                            "value": {
-                                              "type": "integer"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "description": "Array of u64 account balances before the transaction."
-                                  },
-                                  {
-                                    "key": "postBalances",
-                                    "valueShape": {
-                                      "type": "alias",
-                                      "value": {
-                                        "type": "list",
-                                        "itemShape": {
-                                          "type": "alias",
-                                          "value": {
-                                            "type": "primitive",
-                                            "value": {
-                                              "type": "integer"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "description": "Array of u64 account balances after the transaction."
-                                  },
-                                  {
-                                    "key": "innerInstructions",
-                                    "valueShape": {
-                                      "type": "alias",
-                                      "value": {
-                                        "type": "list",
-                                        "itemShape": {
-                                          "type": "object",
-                                          "extends": [],
-                                          "properties": [
-                                            {
-                                              "key": "index",
-                                              "valueShape": {
-                                                "type": "alias",
-                                                "value": {
-                                                  "type": "primitive",
-                                                  "value": {
-                                                    "type": "integer"
-                                                  }
-                                                }
-                                              },
-                                              "description": "Index of the instruction in the transaction."
-                                            },
-                                            {
-                                              "key": "instructions",
-                                              "valueShape": {
-                                                "type": "alias",
-                                                "value": {
-                                                  "type": "list",
-                                                  "itemShape": {
-                                                    "type": "object",
-                                                    "extends": [],
-                                                    "properties": [
-                                                      {
-                                                        "key": "programId",
-                                                        "valueShape": {
-                                                          "type": "alias",
-                                                          "value": {
-                                                            "type": "primitive",
-                                                            "value": {
-                                                              "type": "string"
-                                                            }
-                                                          }
-                                                        },
-                                                        "description": "Program ID invoked by this instruction."
-                                                      },
-                                                      {
-                                                        "key": "accounts",
-                                                        "valueShape": {
-                                                          "type": "alias",
-                                                          "value": {
-                                                            "type": "list",
-                                                            "itemShape": {
-                                                              "type": "alias",
-                                                              "value": {
-                                                                "type": "primitive",
-                                                                "value": {
-                                                                  "type": "string"
-                                                                }
-                                                              }
-                                                            }
-                                                          }
-                                                        },
-                                                        "description": "Account addresses involved in this instruction."
-                                                      },
-                                                      {
-                                                        "key": "data",
-                                                        "valueShape": {
-                                                          "type": "alias",
-                                                          "value": {
-                                                            "type": "primitive",
-                                                            "value": {
-                                                              "type": "string"
-                                                            }
-                                                          }
-                                                        },
-                                                        "description": "The program input data encoded as a base-58 string."
-                                                      }
-                                                    ]
-                                                  }
-                                                }
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    "description": "List of inner instructions or null if not enabled."
-                                  },
-                                  {
-                                    "key": "preTokenBalances",
-                                    "valueShape": {
-                                      "type": "alias",
-                                      "value": {
-                                        "type": "list",
-                                        "itemShape": {
-                                          "type": "object",
-                                          "extends": [],
-                                          "properties": [
-                                            {
-                                              "key": "amount",
-                                              "valueShape": {
-                                                "type": "alias",
-                                                "value": {
-                                                  "type": "primitive",
-                                                  "value": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              },
-                                              "description": "The raw balance without decimals, a string representation of u64."
-                                            },
-                                            {
-                                              "key": "decimals",
-                                              "valueShape": {
-                                                "type": "alias",
-                                                "value": {
-                                                  "type": "primitive",
-                                                  "value": {
-                                                    "type": "integer"
-                                                  }
-                                                }
-                                              },
-                                              "description": "Number of base-10 digits to the right of the decimal place."
-                                            },
-                                            {
-                                              "key": "uiAmount",
-                                              "valueShape": {
-                                                "type": "alias",
-                                                "value": {
-                                                  "type": "nullable",
-                                                  "shape": {
-                                                    "type": "alias",
-                                                    "value": {
-                                                      "type": "primitive",
-                                                      "value": {
-                                                        "type": "double"
-                                                      }
-                                                    }
-                                                  }
-                                                }
-                                              },
-                                              "description": "The balance, using mint-prescribed decimals. **DEPRECATED**"
-                                            },
-                                            {
-                                              "key": "uiAmountString",
-                                              "valueShape": {
-                                                "type": "alias",
-                                                "value": {
-                                                  "type": "primitive",
-                                                  "value": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              },
-                                              "description": "The balance as a string, using mint-prescribed decimals."
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    "description": "Token balances before the transaction, if available."
-                                  },
-                                  {
-                                    "key": "postTokenBalances",
-                                    "valueShape": {
-                                      "type": "alias",
-                                      "value": {
-                                        "type": "list",
-                                        "itemShape": {
-                                          "type": "object",
-                                          "extends": [],
-                                          "properties": [
-                                            {
-                                              "key": "amount",
-                                              "valueShape": {
-                                                "type": "alias",
-                                                "value": {
-                                                  "type": "primitive",
-                                                  "value": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              },
-                                              "description": "The raw balance without decimals, a string representation of u64."
-                                            },
-                                            {
-                                              "key": "decimals",
-                                              "valueShape": {
-                                                "type": "alias",
-                                                "value": {
-                                                  "type": "primitive",
-                                                  "value": {
-                                                    "type": "integer"
-                                                  }
-                                                }
-                                              },
-                                              "description": "Number of base-10 digits to the right of the decimal place."
-                                            },
-                                            {
-                                              "key": "uiAmount",
-                                              "valueShape": {
-                                                "type": "alias",
-                                                "value": {
-                                                  "type": "nullable",
-                                                  "shape": {
-                                                    "type": "alias",
-                                                    "value": {
-                                                      "type": "primitive",
-                                                      "value": {
-                                                        "type": "double"
-                                                      }
-                                                    }
-                                                  }
-                                                }
-                                              },
-                                              "description": "The balance, using mint-prescribed decimals. **DEPRECATED**"
-                                            },
-                                            {
-                                              "key": "uiAmountString",
-                                              "valueShape": {
-                                                "type": "alias",
-                                                "value": {
-                                                  "type": "primitive",
-                                                  "value": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              },
-                                              "description": "The balance as a string, using mint-prescribed decimals."
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    "description": "Token balances after the transaction, if available."
-                                  },
-                                  {
-                                    "key": "logMessages",
-                                    "valueShape": {
-                                      "type": "alias",
-                                      "value": {
-                                        "type": "list",
-                                        "itemShape": {
-                                          "type": "alias",
-                                          "value": {
-                                            "type": "primitive",
-                                            "value": {
-                                              "type": "string"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "description": "Array of string log messages or null if not enabled."
-                                  },
-                                  {
-                                    "key": "rewards",
-                                    "valueShape": {
-                                      "type": "alias",
-                                      "value": {
-                                        "type": "list",
-                                        "itemShape": {
-                                          "type": "object",
-                                          "extends": [],
-                                          "properties": [
-                                            {
-                                              "key": "pubkey",
-                                              "valueShape": {
-                                                "type": "alias",
-                                                "value": {
-                                                  "type": "primitive",
-                                                  "value": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              },
-                                              "description": "The public key of the rewarded account."
-                                            },
-                                            {
-                                              "key": "lamports",
-                                              "valueShape": {
-                                                "type": "alias",
-                                                "value": {
-                                                  "type": "primitive",
-                                                  "value": {
-                                                    "type": "integer"
-                                                  }
-                                                }
-                                              },
-                                              "description": "The amount of reward in lamports."
-                                            },
-                                            {
-                                              "key": "postBalance",
-                                              "valueShape": {
-                                                "type": "alias",
-                                                "value": {
-                                                  "type": "primitive",
-                                                  "value": {
-                                                    "type": "integer"
-                                                  }
-                                                }
-                                              },
-                                              "description": "The balance of the account after the reward was applied."
-                                            },
-                                            {
-                                              "key": "rewardType",
-                                              "valueShape": {
-                                                "type": "enum",
-                                                "values": [
-                                                  {
-                                                    "value": "fee"
-                                                  },
-                                                  {
-                                                    "value": "rent"
-                                                  },
-                                                  {
-                                                    "value": "voting"
-                                                  },
-                                                  {
-                                                    "value": "staking"
-                                                  }
-                                                ]
-                                              },
-                                              "description": "The type of reward."
-                                            },
-                                            {
-                                              "key": "commission",
-                                              "valueShape": {
-                                                "type": "alias",
-                                                "value": {
-                                                  "type": "nullable",
-                                                  "shape": {
-                                                    "type": "alias",
-                                                    "value": {
-                                                      "type": "primitive",
-                                                      "value": {
-                                                        "type": "integer"
-                                                      }
-                                                    }
-                                                  }
-                                                }
-                                              },
-                                              "description": "The vote account commission when the reward was credited, if applicable."
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    "description": "Transaction-level rewards."
-                                  },
-                                  {
-                                    "key": "loadedAddresses",
-                                    "valueShape": {
-                                      "type": "alias",
-                                      "value": {
-                                        "type": "nullable",
-                                        "shape": {
-                                          "type": "object",
-                                          "extends": [],
-                                          "properties": []
-                                        }
-                                      }
-                                    },
-                                    "description": "Transaction addresses loaded from address lookup tables."
-                                  },
-                                  {
-                                    "key": "returnData",
-                                    "valueShape": {
-                                      "type": "alias",
-                                      "value": {
-                                        "type": "nullable",
-                                        "shape": {
-                                          "type": "object",
-                                          "extends": [],
-                                          "properties": []
-                                        }
-                                      }
-                                    },
-                                    "description": "Return data generated by an instruction in the transaction."
-                                  },
-                                  {
-                                    "key": "computeUnitsConsumed",
-                                    "valueShape": {
-                                      "type": "alias",
-                                      "value": {
-                                        "type": "nullable",
-                                        "shape": {
-                                          "type": "alias",
-                                          "value": {
-                                            "type": "primitive",
-                                            "value": {
-                                              "type": "integer"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "description": "Number of compute units consumed by the transaction."
-                                  }
-                                ]
-                              }
-                            }
-                          },
-                          "description": "Transaction status metadata."
-                        },
-                        {
-                          "key": "version",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "nullable",
-                              "shape": {
-                                "type": "alias",
-                                "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            }
-                          },
-                          "description": "Transaction version. Undefined if not set."
+                          ]
                         }
-                      ]
+                      }
                     }
                   }
                 },
@@ -1380,13 +1803,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -1399,91 +1828,127 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
-                      "type": "object",
-                      "extends": [],
-                      "properties": [
-                        {
-                          "key": "pubkey",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "description": "The public key of the rewarded account."
-                        },
-                        {
-                          "key": "lamports",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "The amount of reward in lamports."
-                        },
-                        {
-                          "key": "postBalance",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "The balance of the account after the reward was applied."
-                        },
-                        {
-                          "key": "rewardType",
-                          "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "fee"
-                              },
-                              {
-                                "value": "rent"
-                              },
-                              {
-                                "value": "voting"
-                              },
-                              {
-                                "value": "staking"
-                              }
-                            ]
-                          },
-                          "description": "The type of reward."
-                        },
-                        {
-                          "key": "commission",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "nullable",
-                              "shape": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "list",
+                        "itemShape": {
+                          "type": "object",
+                          "extends": [],
+                          "properties": [
+                            {
+                              "key": "pubkey",
+                              "valueShape": {
                                 "type": "alias",
                                 "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "integer"
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
                                   }
                                 }
-                              }
+                              },
+                              "description": "The public key of the rewarded account."
+                            },
+                            {
+                              "key": "lamports",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "The amount of reward in lamports."
+                            },
+                            {
+                              "key": "postBalance",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "The balance of the account after the reward was applied."
+                            },
+                            {
+                              "key": "rewardType",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "enum",
+                                    "values": [
+                                      {
+                                        "value": "fee"
+                                      },
+                                      {
+                                        "value": "rent"
+                                      },
+                                      {
+                                        "value": "voting"
+                                      },
+                                      {
+                                        "value": "staking"
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              "description": "The type of reward."
+                            },
+                            {
+                              "key": "commission",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "nullable",
+                                      "shape": {
+                                        "type": "alias",
+                                        "value": {
+                                          "type": "primitive",
+                                          "value": {
+                                            "type": "integer"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "The vote account commission when the reward was credited, if applicable."
                             }
-                          },
-                          "description": "The vote account commission when the reward was credited, if applicable."
+                          ]
                         }
-                      ]
+                      }
                     }
                   }
                 },
@@ -1494,9 +1959,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -1507,9 +1978,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -1723,13 +2200,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -1742,9 +2225,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -1835,18 +2324,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -1855,9 +2350,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -1966,18 +2467,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -1986,9 +2493,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
                               }
                             }
                           },
@@ -1997,36 +2510,54 @@
                         {
                           "key": "range",
                           "valueShape": {
-                            "type": "object",
-                            "extends": [],
-                            "properties": [
-                              {
-                                "key": "firstSlot",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "integer"
-                                    }
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "object",
+                                "extends": [],
+                                "properties": [
+                                  {
+                                    "key": "firstSlot",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "primitive",
+                                            "value": {
+                                              "type": "integer"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "description": "First slot to return block production for."
+                                  },
+                                  {
+                                    "key": "lastSlot",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "primitive",
+                                            "value": {
+                                              "type": "integer"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "description": "Last slot to return block production for."
                                   }
-                                },
-                                "description": "First slot to return block production for."
-                              },
-                              {
-                                "key": "lastSlot",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "integer"
-                                    }
-                                  }
-                                },
-                                "description": "Last slot to return block production for."
+                                ]
                               }
-                            ]
+                            }
                           }
                         }
                       ]
@@ -2051,26 +2582,32 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "map",
-                    "keyShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "valueShape": {
-                      "type": "alias",
-                      "value": {
-                        "type": "list",
-                        "itemShape": {
+                        "type": "map",
+                        "keyShape": {
                           "type": "alias",
                           "value": {
                             "type": "primitive",
                             "value": {
-                              "type": "integer"
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "valueShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "list",
+                            "itemShape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "integer"
+                                }
+                              }
                             }
                           }
                         }
@@ -2083,36 +2620,54 @@
               {
                 "key": "range",
                 "valueShape": {
-                  "type": "object",
-                  "extends": [],
-                  "properties": [
-                    {
-                      "key": "firstSlot",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "integer"
-                          }
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "object",
+                      "extends": [],
+                      "properties": [
+                        {
+                          "key": "firstSlot",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "First slot to return block production for."
+                        },
+                        {
+                          "key": "lastSlot",
+                          "valueShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "description": "Last slot to return block production for."
                         }
-                      },
-                      "description": "First slot to return block production for."
-                    },
-                    {
-                      "key": "lastSlot",
-                      "valueShape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "integer"
-                          }
-                        }
-                      },
-                      "description": "Last slot to return block production for."
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             ]
@@ -2240,19 +2795,26 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ],
+                                "default": "finalized"
                               },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
-                              }
-                            ],
-                            "default": "finalized"
+                              "default": "finalized"
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         }
@@ -2394,19 +2956,26 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ],
+                                "default": "finalized"
                               },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
-                              }
-                            ],
-                            "default": "finalized"
+                              "default": "finalized"
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         }
@@ -2520,9 +3089,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "integer"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "integer"
+                              }
+                            }
                           }
                         }
                       },
@@ -2624,9 +3199,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     },
@@ -2637,13 +3218,19 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "nullable",
+                        "type": "optional",
                         "shape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
+                            "type": "nullable",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
                             }
                           }
                         }
@@ -2656,13 +3243,19 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "nullable",
+                        "type": "optional",
                         "shape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
+                            "type": "nullable",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
                             }
                           }
                         }
@@ -2675,13 +3268,19 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "nullable",
+                        "type": "optional",
                         "shape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
+                            "type": "nullable",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
                             }
                           }
                         }
@@ -2694,13 +3293,19 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "nullable",
+                        "type": "optional",
                         "shape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
+                            "type": "nullable",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
                             }
                           }
                         }
@@ -2713,13 +3318,19 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "nullable",
+                        "type": "optional",
                         "shape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "integer"
+                            "type": "nullable",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "integer"
+                                }
+                              }
                             }
                           }
                         }
@@ -2732,13 +3343,19 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "nullable",
+                        "type": "optional",
                         "shape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "integer"
+                            "type": "nullable",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "integer"
+                                }
+                              }
                             }
                           }
                         }
@@ -2836,18 +3453,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -2856,9 +3479,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -2886,9 +3515,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -2899,9 +3534,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -2912,9 +3553,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -2925,9 +3572,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -2938,9 +3591,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -2951,13 +3610,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -3047,9 +3712,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -3060,9 +3731,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -3073,9 +3750,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "boolean"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 },
@@ -3086,9 +3769,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -3099,9 +3788,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -3189,9 +3884,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
                           }
                         }
                       },
@@ -3214,18 +3915,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -3234,9 +3941,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -3537,9 +4250,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -3550,13 +4269,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -3637,9 +4362,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -3725,18 +4456,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -3745,9 +4482,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -3775,9 +4518,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -3788,9 +4537,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -3801,9 +4556,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -3814,9 +4575,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -3827,9 +4594,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -3916,9 +4689,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -3929,9 +4708,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -3942,9 +4727,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "double"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "double"
+                        }
+                      }
                     }
                   }
                 },
@@ -3955,9 +4746,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -4044,13 +4841,19 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "list",
-                          "itemShape": {
+                          "type": "optional",
+                          "shape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                              "type": "list",
+                              "itemShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
                               }
                             }
                           }
@@ -4061,18 +4864,24 @@
                     {
                       "key": "commitment",
                       "valueShape": {
-                        "type": "enum",
-                        "values": [
-                          {
-                            "value": "processed"
-                          },
-                          {
-                            "value": "confirmed"
-                          },
-                          {
-                            "value": "finalized"
+                        "type": "alias",
+                        "value": {
+                          "type": "optional",
+                          "shape": {
+                            "type": "enum",
+                            "values": [
+                              {
+                                "value": "processed"
+                              },
+                              {
+                                "value": "confirmed"
+                              },
+                              {
+                                "value": "finalized"
+                              }
+                            ]
                           }
-                        ]
+                        }
                       },
                       "description": "Configures the state commitment for querying."
                     },
@@ -4081,9 +4890,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "integer"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "integer"
+                              }
+                            }
                           }
                         }
                       },
@@ -4094,9 +4909,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "integer"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "integer"
+                              }
+                            }
                           }
                         }
                       },
@@ -4130,9 +4951,15 @@
                         "valueShape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "integer"
+                            "type": "optional",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "integer"
+                                }
+                              }
                             }
                           }
                         },
@@ -4143,9 +4970,15 @@
                         "valueShape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "integer"
+                            "type": "optional",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "integer"
+                                }
+                              }
                             }
                           }
                         },
@@ -4156,9 +4989,15 @@
                         "valueShape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "integer"
+                            "type": "optional",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "integer"
+                                }
+                              }
                             }
                           }
                         },
@@ -4169,9 +5008,15 @@
                         "valueShape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "integer"
+                            "type": "optional",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "integer"
+                                }
+                              }
                             }
                           }
                         },
@@ -4182,13 +5027,19 @@
                         "valueShape": {
                           "type": "alias",
                           "value": {
-                            "type": "nullable",
+                            "type": "optional",
                             "shape": {
                               "type": "alias",
                               "value": {
-                                "type": "primitive",
-                                "value": {
-                                  "type": "integer"
+                                "type": "nullable",
+                                "shape": {
+                                  "type": "alias",
+                                  "value": {
+                                    "type": "primitive",
+                                    "value": {
+                                      "type": "integer"
+                                    }
+                                  }
                                 }
                               }
                             }
@@ -4295,33 +5146,45 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
                         {
                           "key": "filter",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "circulating"
-                              },
-                              {
-                                "value": "nonCirculating"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "circulating"
+                                  },
+                                  {
+                                    "value": "nonCirculating"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Filter results by account type."
                         }
@@ -4351,9 +5214,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     },
@@ -4364,9 +5233,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     },
@@ -4462,18 +5337,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -4482,9 +5363,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -4512,9 +5399,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -4525,9 +5418,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -4753,9 +5652,15 @@
                       "valueShape": {
                         "type": "alias",
                         "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "integer"
+                          "type": "optional",
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "integer"
+                              }
+                            }
                           }
                         }
                       },
@@ -4778,18 +5683,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         }
@@ -4917,18 +5828,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -4937,9 +5854,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -4948,57 +5871,82 @@
                         {
                           "key": "dataSlice",
                           "valueShape": {
-                            "type": "object",
-                            "extends": [],
-                            "properties": [
-                              {
-                                "key": "length",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "integer"
-                                    }
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "object",
+                                "extends": [],
+                                "properties": [
+                                  {
+                                    "key": "length",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "primitive",
+                                            "value": {
+                                              "type": "integer"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "description": "Number of bytes to return."
+                                  },
+                                  {
+                                    "key": "offset",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "primitive",
+                                            "value": {
+                                              "type": "integer"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "description": "Byte offset from which to start reading."
                                   }
-                                },
-                                "description": "Number of bytes to return."
-                              },
-                              {
-                                "key": "offset",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "integer"
-                                    }
-                                  }
-                                },
-                                "description": "Byte offset from which to start reading."
+                                ]
                               }
-                            ]
+                            }
                           }
                         },
                         {
                           "key": "encoding",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "base58"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "base58"
+                                  },
+                                  {
+                                    "value": "base64"
+                                  },
+                                  {
+                                    "value": "base64+zstd"
+                                  },
+                                  {
+                                    "value": "jsonParsed"
+                                  }
+                                ],
+                                "default": "base64"
                               },
-                              {
-                                "value": "base64"
-                              },
-                              {
-                                "value": "base64+zstd"
-                              },
-                              {
-                                "value": "jsonParsed"
-                              }
-                            ],
-                            "default": "base64"
+                              "default": "base64"
+                            }
                           },
                           "description": "Encoding format for data."
                         }
@@ -5028,9 +5976,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     },
@@ -5041,9 +5995,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     },
@@ -5054,13 +6014,19 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "list",
-                        "itemShape": {
+                        "type": "optional",
+                        "shape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
+                            "type": "list",
+                            "itemShape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
                             }
                           }
                         }
@@ -5073,9 +6039,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "boolean"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "boolean"
+                            }
+                          }
                         }
                       }
                     },
@@ -5086,9 +6058,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     },
@@ -5099,9 +6077,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     },
@@ -5224,18 +6208,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -5244,9 +6234,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -5257,9 +6253,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "boolean"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "boolean"
+                                  }
+                                }
                               }
                             }
                           },
@@ -5268,58 +6270,83 @@
                         {
                           "key": "encoding",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "base58"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "base58"
+                                  },
+                                  {
+                                    "value": "base64"
+                                  },
+                                  {
+                                    "value": "base64+zstd"
+                                  },
+                                  {
+                                    "value": "jsonParsed"
+                                  }
+                                ],
+                                "default": "json"
                               },
-                              {
-                                "value": "base64"
-                              },
-                              {
-                                "value": "base64+zstd"
-                              },
-                              {
-                                "value": "jsonParsed"
-                              }
-                            ],
-                            "default": "json"
+                              "default": "json"
+                            }
                           },
                           "description": "Encoding format for data."
                         },
                         {
                           "key": "dataSlice",
                           "valueShape": {
-                            "type": "object",
-                            "extends": [],
-                            "properties": [
-                              {
-                                "key": "length",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "integer"
-                                    }
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "object",
+                                "extends": [],
+                                "properties": [
+                                  {
+                                    "key": "length",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "primitive",
+                                            "value": {
+                                              "type": "integer"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "description": "Number of bytes to return."
+                                  },
+                                  {
+                                    "key": "offset",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "primitive",
+                                            "value": {
+                                              "type": "integer"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "description": "Byte offset from which to start reading."
                                   }
-                                },
-                                "description": "Number of bytes to return."
-                              },
-                              {
-                                "key": "offset",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "integer"
-                                    }
-                                  }
-                                },
-                                "description": "Byte offset from which to start reading."
+                                ]
                               }
-                            ]
+                            }
                           }
                         }
                       ]
@@ -5348,9 +6375,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     },
@@ -5359,94 +6392,136 @@
                   {
                     "key": "account",
                     "valueShape": {
-                      "type": "object",
-                      "extends": [],
-                      "properties": [
-                        {
-                          "key": "lamports",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "Number of lamports assigned to this account."
-                        },
-                        {
-                          "key": "owner",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "description": "Program owner of this account."
-                        },
-                        {
-                          "key": "data",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "list",
-                              "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "optional",
+                        "shape": {
+                          "type": "object",
+                          "extends": [],
+                          "properties": [
+                            {
+                              "key": "lamports",
+                              "valueShape": {
                                 "type": "alias",
                                 "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "string"
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
                                   }
                                 }
-                              }
+                              },
+                              "description": "Number of lamports assigned to this account."
+                            },
+                            {
+                              "key": "owner",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Program owner of this account."
+                            },
+                            {
+                              "key": "data",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "list",
+                                      "itemShape": {
+                                        "type": "alias",
+                                        "value": {
+                                          "type": "primitive",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Account data in the specified encoding format."
+                            },
+                            {
+                              "key": "executable",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "boolean"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Indicates if the account contains a program."
+                            },
+                            {
+                              "key": "rentEpoch",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "The epoch at which this account will next owe rent."
+                            },
+                            {
+                              "key": "size",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "The data size of the account."
                             }
-                          },
-                          "description": "Account data in the specified encoding format."
-                        },
-                        {
-                          "key": "executable",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "boolean"
-                              }
-                            }
-                          },
-                          "description": "Indicates if the account contains a program."
-                        },
-                        {
-                          "key": "rentEpoch",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "The epoch at which this account will next owe rent."
-                        },
-                        {
-                          "key": "size",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "The data size of the account."
+                          ]
                         }
-                      ]
+                      }
                     }
                   }
                 ]
@@ -5582,9 +6657,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     },
@@ -5595,9 +6676,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     },
@@ -5608,9 +6695,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     },
@@ -5621,9 +6714,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     },
@@ -5634,9 +6733,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     },
@@ -5764,9 +6869,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     },
@@ -5777,9 +6888,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     },
@@ -5887,18 +7004,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -5907,9 +7030,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -5920,10 +7049,16 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer",
-                                "default": 1000
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer",
+                                    "default": 1000
+                                  }
+                                }
                               }
                             }
                           },
@@ -5934,9 +7069,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
                               }
                             }
                           },
@@ -5947,9 +7088,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
                               }
                             }
                           },
@@ -5981,9 +7128,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     },
@@ -5994,9 +7147,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     },
@@ -6007,11 +7166,17 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "nullable",
+                        "type": "optional",
                         "shape": {
-                          "type": "object",
-                          "extends": [],
-                          "properties": []
+                          "type": "alias",
+                          "value": {
+                            "type": "nullable",
+                            "shape": {
+                              "type": "object",
+                              "extends": [],
+                              "properties": []
+                            }
+                          }
                         }
                       }
                     },
@@ -6022,13 +7187,19 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "nullable",
+                        "type": "optional",
                         "shape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
+                            "type": "nullable",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
                             }
                           }
                         }
@@ -6041,13 +7212,19 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "nullable",
+                        "type": "optional",
                         "shape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "integer"
+                            "type": "nullable",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "integer"
+                                }
+                              }
                             }
                           }
                         }
@@ -6060,13 +7237,19 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "nullable",
+                        "type": "optional",
                         "shape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
+                            "type": "nullable",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
                             }
                           }
                         }
@@ -6193,9 +7376,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "boolean"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "boolean"
+                                  }
+                                }
                               }
                             }
                           },
@@ -6227,9 +7416,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     },
@@ -6240,13 +7435,19 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "nullable",
+                        "type": "optional",
                         "shape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "integer"
+                            "type": "nullable",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "integer"
+                                }
+                              }
                             }
                           }
                         }
@@ -6259,11 +7460,17 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "nullable",
+                        "type": "optional",
                         "shape": {
-                          "type": "object",
-                          "extends": [],
-                          "properties": []
+                          "type": "alias",
+                          "value": {
+                            "type": "nullable",
+                            "shape": {
+                              "type": "object",
+                              "extends": [],
+                              "properties": []
+                            }
+                          }
                         }
                       }
                     },
@@ -6274,13 +7481,19 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "nullable",
+                        "type": "optional",
                         "shape": {
                           "type": "alias",
                           "value": {
-                            "type": "primitive",
-                            "value": {
-                              "type": "string"
+                            "type": "nullable",
+                            "shape": {
+                              "type": "alias",
+                              "value": {
+                                "type": "primitive",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
                             }
                           }
                         }
@@ -6291,9 +7504,15 @@
                   {
                     "key": "status",
                     "valueShape": {
-                      "type": "object",
-                      "extends": [],
-                      "properties": []
+                      "type": "alias",
+                      "value": {
+                        "type": "optional",
+                        "shape": {
+                          "type": "object",
+                          "extends": [],
+                          "properties": []
+                        }
+                      }
                     },
                     "description": "DEPRECATED. The transaction status."
                   }
@@ -6392,18 +7611,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -6412,9 +7637,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -6523,18 +7754,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -6543,9 +7780,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -6770,18 +8013,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -6790,9 +8039,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "boolean"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "boolean"
+                                  }
+                                }
                               }
                             }
                           },
@@ -6820,9 +8075,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -6833,9 +8094,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -6846,9 +8113,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -6859,13 +8132,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -6976,18 +8255,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         }
@@ -7013,9 +8298,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -7026,9 +8317,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -7039,13 +8336,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "double"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "double"
+                            }
+                          }
                         }
                       }
                     }
@@ -7058,9 +8361,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -7169,9 +8478,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
                               }
                             }
                           },
@@ -7182,9 +8497,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
                               }
                             }
                           },
@@ -7209,18 +8530,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -7229,9 +8556,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -7240,56 +8573,80 @@
                         {
                           "key": "dataSlice",
                           "valueShape": {
-                            "type": "object",
-                            "extends": [],
-                            "properties": [
-                              {
-                                "key": "length",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "integer"
-                                    }
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "object",
+                                "extends": [],
+                                "properties": [
+                                  {
+                                    "key": "length",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "primitive",
+                                            "value": {
+                                              "type": "integer"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "description": "Number of bytes to return."
+                                  },
+                                  {
+                                    "key": "offset",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "primitive",
+                                            "value": {
+                                              "type": "integer"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "description": "Byte offset from which to start reading."
                                   }
-                                },
-                                "description": "Number of bytes to return."
-                              },
-                              {
-                                "key": "offset",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "primitive",
-                                    "value": {
-                                      "type": "integer"
-                                    }
-                                  }
-                                },
-                                "description": "Byte offset from which to start reading."
+                                ]
                               }
-                            ]
+                            }
                           }
                         },
                         {
                           "key": "encoding",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "base58"
-                              },
-                              {
-                                "value": "base64"
-                              },
-                              {
-                                "value": "base64+zstd"
-                              },
-                              {
-                                "value": "jsonParsed"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "base58"
+                                  },
+                                  {
+                                    "value": "base64"
+                                  },
+                                  {
+                                    "value": "base64+zstd"
+                                  },
+                                  {
+                                    "value": "jsonParsed"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Encoding format for account data."
                         }
@@ -7319,9 +8676,15 @@
                     "valueShape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "optional",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     },
@@ -7330,94 +8693,136 @@
                   {
                     "key": "account",
                     "valueShape": {
-                      "type": "object",
-                      "extends": [],
-                      "properties": [
-                        {
-                          "key": "lamports",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "Number of lamports assigned to this account."
-                        },
-                        {
-                          "key": "owner",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "description": "Program owner of this account."
-                        },
-                        {
-                          "key": "data",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "list",
-                              "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "optional",
+                        "shape": {
+                          "type": "object",
+                          "extends": [],
+                          "properties": [
+                            {
+                              "key": "lamports",
+                              "valueShape": {
                                 "type": "alias",
                                 "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "string"
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
                                   }
                                 }
-                              }
+                              },
+                              "description": "Number of lamports assigned to this account."
+                            },
+                            {
+                              "key": "owner",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Program owner of this account."
+                            },
+                            {
+                              "key": "data",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "list",
+                                      "itemShape": {
+                                        "type": "alias",
+                                        "value": {
+                                          "type": "primitive",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Account data in the specified encoding format."
+                            },
+                            {
+                              "key": "executable",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "boolean"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Indicates if the account contains a program."
+                            },
+                            {
+                              "key": "rentEpoch",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "The epoch at which this account will next owe rent."
+                            },
+                            {
+                              "key": "size",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "The data size of the account."
                             }
-                          },
-                          "description": "Account data in the specified encoding format."
-                        },
-                        {
-                          "key": "executable",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "boolean"
-                              }
-                            }
-                          },
-                          "description": "Indicates if the account contains a program."
-                        },
-                        {
-                          "key": "rentEpoch",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "The epoch at which this account will next owe rent."
-                        },
-                        {
-                          "key": "size",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "The data size of the account."
+                          ]
                         }
-                      ]
+                      }
                     }
                   }
                 ]
@@ -7542,18 +8947,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         }
@@ -7579,9 +8990,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -7592,9 +9009,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -7605,13 +9028,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "double"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "double"
+                            }
+                          }
                         }
                       }
                     }
@@ -7624,9 +9053,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -7733,18 +9168,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Commitment level to use. `Processed` is not supported."
                         },
@@ -7753,9 +9194,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -7764,21 +9211,27 @@
                         {
                           "key": "encoding",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "json"
-                              },
-                              {
-                                "value": "jsonParsed"
-                              },
-                              {
-                                "value": "base64"
-                              },
-                              {
-                                "value": "base58"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "json"
+                                  },
+                                  {
+                                    "value": "jsonParsed"
+                                  },
+                                  {
+                                    "value": "base64"
+                                  },
+                                  {
+                                    "value": "base58"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Encoding format for the returned transaction."
                         }
@@ -7804,9 +9257,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -7815,29 +9274,36 @@
               {
                 "key": "transaction",
                 "valueShape": {
-                  "type": "undiscriminatedUnion",
-                  "variants": [
-                    {
-                      "shape": {
-                        "type": "object",
-                        "extends": [],
-                        "properties": []
-                      },
-                      "description": "The transaction details in JSON format."
-                    },
-                    {
-                      "shape": {
-                        "type": "alias",
-                        "value": {
-                          "type": "primitive",
-                          "value": {
-                            "type": "string"
-                          }
+                  "type": "alias",
+                  "value": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "undiscriminatedUnion",
+                      "variants": [
+                        {
+                          "displayName": "Result 1",
+                          "shape": {
+                            "type": "object",
+                            "extends": [],
+                            "properties": []
+                          },
+                          "description": "The transaction details in JSON format."
+                        },
+                        {
+                          "shape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "primitive",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "description": "The transaction details as encoded binary data."
                         }
-                      },
-                      "description": "The transaction details as encoded binary data."
+                      ]
                     }
-                  ]
+                  }
                 },
                 "description": "The transaction details, either in JSON format or encoded binary data."
               },
@@ -7846,13 +9312,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "integer"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
                         }
                       }
                     }
@@ -7865,11 +9337,17 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
-                      "type": "object",
-                      "extends": [],
-                      "properties": []
+                      "type": "alias",
+                      "value": {
+                        "type": "nullable",
+                        "shape": {
+                          "type": "object",
+                          "extends": [],
+                          "properties": []
+                        }
+                      }
                     }
                   }
                 },
@@ -7880,33 +9358,39 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
-                      "type": "undiscriminatedUnion",
-                      "variants": [
-                        {
-                          "shape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                      "type": "alias",
+                      "value": {
+                        "type": "nullable",
+                        "shape": {
+                          "type": "undiscriminatedUnion",
+                          "variants": [
+                            {
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "double"
+                                  }
+                                }
                               }
                             }
-                          }
-                        },
-                        {
-                          "shape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "double"
-                              }
-                            }
-                          }
+                          ]
                         }
-                      ]
+                      }
                     }
                   }
                 },
@@ -7995,9 +9479,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "string"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 },
@@ -8008,9 +9498,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -8097,18 +9593,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -8117,9 +9619,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
                               }
                             }
                           },
@@ -8130,9 +9638,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "boolean"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "boolean"
+                                  }
+                                }
                               }
                             }
                           },
@@ -8143,9 +9657,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -8173,100 +9693,60 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
-                      "type": "object",
-                      "extends": [],
-                      "properties": [
-                        {
-                          "key": "votePubkey",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "description": "Vote account address."
-                        },
-                        {
-                          "key": "nodePubkey",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "description": "Validator identity."
-                        },
-                        {
-                          "key": "activatedStake",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "Active stake in lamports delegated to this vote account."
-                        },
-                        {
-                          "key": "epochVoteAccount",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "boolean"
-                              }
-                            }
-                          },
-                          "description": "Whether the vote account is staked for this epoch."
-                        },
-                        {
-                          "key": "commission",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "double"
-                              }
-                            }
-                          },
-                          "description": "Percentage of rewards payout owed to the vote account."
-                        },
-                        {
-                          "key": "lastVote",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "Most recent slot voted on by this vote account."
-                        },
-                        {
-                          "key": "epochCredits",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "list",
-                              "itemShape": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "list",
+                        "itemShape": {
+                          "type": "object",
+                          "extends": [],
+                          "properties": [
+                            {
+                              "key": "votePubkey",
+                              "valueShape": {
                                 "type": "alias",
                                 "value": {
-                                  "type": "list",
-                                  "itemShape": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Vote account address."
+                            },
+                            {
+                              "key": "nodePubkey",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Validator identity."
+                            },
+                            {
+                              "key": "activatedStake",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
                                     "type": "alias",
                                     "value": {
                                       "type": "primitive",
@@ -8276,25 +9756,119 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "description": "Active stake in lamports delegated to this vote account."
+                            },
+                            {
+                              "key": "epochVoteAccount",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "boolean"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Whether the vote account is staked for this epoch."
+                            },
+                            {
+                              "key": "commission",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "double"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Percentage of rewards payout owed to the vote account."
+                            },
+                            {
+                              "key": "lastVote",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Most recent slot voted on by this vote account."
+                            },
+                            {
+                              "key": "epochCredits",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "list",
+                                      "itemShape": {
+                                        "type": "alias",
+                                        "value": {
+                                          "type": "list",
+                                          "itemShape": {
+                                            "type": "alias",
+                                            "value": {
+                                              "type": "primitive",
+                                              "value": {
+                                                "type": "integer"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "History of earned credits for up to five epochs."
+                            },
+                            {
+                              "key": "rootSlot",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Current root slot for this vote account."
                             }
-                          },
-                          "description": "History of earned credits for up to five epochs."
-                        },
-                        {
-                          "key": "rootSlot",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "Current root slot for this vote account."
+                          ]
                         }
-                      ]
+                      }
                     }
                   }
                 },
@@ -8305,100 +9879,60 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
-                      "type": "object",
-                      "extends": [],
-                      "properties": [
-                        {
-                          "key": "votePubkey",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "description": "Vote account address."
-                        },
-                        {
-                          "key": "nodePubkey",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "description": "Validator identity."
-                        },
-                        {
-                          "key": "activatedStake",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "Active stake in lamports delegated to this vote account."
-                        },
-                        {
-                          "key": "epochVoteAccount",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "boolean"
-                              }
-                            }
-                          },
-                          "description": "Whether the vote account is staked for this epoch."
-                        },
-                        {
-                          "key": "commission",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "double"
-                              }
-                            }
-                          },
-                          "description": "Percentage of rewards payout owed to the vote account."
-                        },
-                        {
-                          "key": "lastVote",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "Most recent slot voted on by this vote account."
-                        },
-                        {
-                          "key": "epochCredits",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "list",
-                              "itemShape": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "list",
+                        "itemShape": {
+                          "type": "object",
+                          "extends": [],
+                          "properties": [
+                            {
+                              "key": "votePubkey",
+                              "valueShape": {
                                 "type": "alias",
                                 "value": {
-                                  "type": "list",
-                                  "itemShape": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Vote account address."
+                            },
+                            {
+                              "key": "nodePubkey",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Validator identity."
+                            },
+                            {
+                              "key": "activatedStake",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
                                     "type": "alias",
                                     "value": {
                                       "type": "primitive",
@@ -8408,25 +9942,119 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "description": "Active stake in lamports delegated to this vote account."
+                            },
+                            {
+                              "key": "epochVoteAccount",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "boolean"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Whether the vote account is staked for this epoch."
+                            },
+                            {
+                              "key": "commission",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "double"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Percentage of rewards payout owed to the vote account."
+                            },
+                            {
+                              "key": "lastVote",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Most recent slot voted on by this vote account."
+                            },
+                            {
+                              "key": "epochCredits",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "list",
+                                      "itemShape": {
+                                        "type": "alias",
+                                        "value": {
+                                          "type": "list",
+                                          "itemShape": {
+                                            "type": "alias",
+                                            "value": {
+                                              "type": "primitive",
+                                              "value": {
+                                                "type": "integer"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "History of earned credits for up to five epochs."
+                            },
+                            {
+                              "key": "rootSlot",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Current root slot for this vote account."
                             }
-                          },
-                          "description": "History of earned credits for up to five epochs."
-                        },
-                        {
-                          "key": "rootSlot",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "Current root slot for this vote account."
+                          ]
                         }
-                      ]
+                      }
                     }
                   }
                 },
@@ -8565,9 +10193,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
                               }
                             }
                           },
@@ -8576,18 +10210,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -8596,9 +10236,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -8803,18 +10449,24 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
-                              },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         }
@@ -8935,16 +10587,23 @@
                         {
                           "key": "encoding",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "base58"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "base58"
+                                  },
+                                  {
+                                    "value": "base64"
+                                  }
+                                ],
+                                "default": "base58"
                               },
-                              {
-                                "value": "base64"
-                              }
-                            ],
-                            "default": "base58"
+                              "default": "base58"
+                            }
                           },
                           "description": "Encoding used for the transaction data."
                         },
@@ -8953,10 +10612,16 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "boolean",
-                                "default": false
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "boolean",
+                                    "default": false
+                                  }
+                                }
                               }
                             }
                           },
@@ -8965,19 +10630,26 @@
                         {
                           "key": "preflightCommitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ],
+                                "default": "finalized"
                               },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
-                              }
-                            ],
-                            "default": "finalized"
+                              "default": "finalized"
+                            }
                           },
                           "description": "Commitment level to use for preflight."
                         },
@@ -8986,9 +10658,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -8999,9 +10677,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -9127,19 +10811,26 @@
                         {
                           "key": "commitment",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "processed"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "processed"
+                                  },
+                                  {
+                                    "value": "confirmed"
+                                  },
+                                  {
+                                    "value": "finalized"
+                                  }
+                                ],
+                                "default": "finalized"
                               },
-                              {
-                                "value": "confirmed"
-                              },
-                              {
-                                "value": "finalized"
-                              }
-                            ],
-                            "default": "finalized"
+                              "default": "finalized"
+                            }
                           },
                           "description": "Configures the state commitment for querying."
                         },
@@ -9148,10 +10839,16 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "boolean",
-                                "default": false
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "boolean",
+                                    "default": false
+                                  }
+                                }
                               }
                             }
                           },
@@ -9162,10 +10859,16 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "boolean",
-                                "default": false
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "boolean",
+                                    "default": false
+                                  }
+                                }
                               }
                             }
                           },
@@ -9176,9 +10879,15 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "integer"
+                                  }
+                                }
                               }
                             }
                           },
@@ -9187,16 +10896,23 @@
                         {
                           "key": "encoding",
                           "valueShape": {
-                            "type": "enum",
-                            "values": [
-                              {
-                                "value": "base58"
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "enum",
+                                "values": [
+                                  {
+                                    "value": "base58"
+                                  },
+                                  {
+                                    "value": "base64"
+                                  }
+                                ],
+                                "default": "base58"
                               },
-                              {
-                                "value": "base64"
-                              }
-                            ],
-                            "default": "base58"
+                              "default": "base58"
+                            }
                           },
                           "description": "Encoding used for the transaction data."
                         },
@@ -9205,10 +10921,16 @@
                           "valueShape": {
                             "type": "alias",
                             "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "boolean",
-                                "default": false
+                              "type": "optional",
+                              "shape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "primitive",
+                                  "value": {
+                                    "type": "boolean",
+                                    "default": false
+                                  }
+                                }
                               }
                             }
                           },
@@ -9217,51 +10939,70 @@
                         {
                           "key": "accounts",
                           "valueShape": {
-                            "type": "object",
-                            "extends": [],
-                            "properties": [
-                              {
-                                "key": "addresses",
-                                "valueShape": {
-                                  "type": "alias",
-                                  "value": {
-                                    "type": "list",
-                                    "itemShape": {
+                            "type": "alias",
+                            "value": {
+                              "type": "optional",
+                              "shape": {
+                                "type": "object",
+                                "extends": [],
+                                "properties": [
+                                  {
+                                    "key": "addresses",
+                                    "valueShape": {
                                       "type": "alias",
                                       "value": {
-                                        "type": "primitive",
-                                        "value": {
-                                          "type": "string"
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "alias",
+                                          "value": {
+                                            "type": "list",
+                                            "itemShape": {
+                                              "type": "alias",
+                                              "value": {
+                                                "type": "primitive",
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
                                         }
                                       }
-                                    }
+                                    },
+                                    "description": "An array of account Pubkeys to return."
+                                  },
+                                  {
+                                    "key": "encoding",
+                                    "valueShape": {
+                                      "type": "alias",
+                                      "value": {
+                                        "type": "optional",
+                                        "shape": {
+                                          "type": "enum",
+                                          "values": [
+                                            {
+                                              "value": "base58"
+                                            },
+                                            {
+                                              "value": "base64"
+                                            },
+                                            {
+                                              "value": "base64+zstd"
+                                            },
+                                            {
+                                              "value": "jsonParsed"
+                                            }
+                                          ],
+                                          "default": "base64"
+                                        },
+                                        "default": "base64"
+                                      }
+                                    },
+                                    "description": "Encoding for returned account data."
                                   }
-                                },
-                                "description": "An array of account Pubkeys to return."
-                              },
-                              {
-                                "key": "encoding",
-                                "valueShape": {
-                                  "type": "enum",
-                                  "values": [
-                                    {
-                                      "value": "base58"
-                                    },
-                                    {
-                                      "value": "base64"
-                                    },
-                                    {
-                                      "value": "base64+zstd"
-                                    },
-                                    {
-                                      "value": "jsonParsed"
-                                    }
-                                  ],
-                                  "default": "base64"
-                                },
-                                "description": "Encoding for returned account data."
+                                ]
                               }
-                            ]
+                            }
                           }
                         }
                       ]
@@ -9286,13 +11027,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "nullable",
+                        "shape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -9305,13 +11052,19 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
+                    "type": "optional",
+                    "shape": {
                       "type": "alias",
                       "value": {
-                        "type": "primitive",
-                        "value": {
-                          "type": "string"
+                        "type": "list",
+                        "itemShape": {
+                          "type": "alias",
+                          "value": {
+                            "type": "primitive",
+                            "value": {
+                              "type": "string"
+                            }
+                          }
                         }
                       }
                     }
@@ -9324,96 +11077,138 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "list",
-                    "itemShape": {
-                      "type": "object",
-                      "extends": [],
-                      "properties": [
-                        {
-                          "key": "lamports",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "Number of lamports assigned to this account."
-                        },
-                        {
-                          "key": "owner",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "description": "Program owner of this account."
-                        },
-                        {
-                          "key": "data",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "list",
-                              "itemShape": {
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "list",
+                        "itemShape": {
+                          "type": "object",
+                          "extends": [],
+                          "properties": [
+                            {
+                              "key": "lamports",
+                              "valueShape": {
                                 "type": "alias",
                                 "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "string"
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
                                   }
                                 }
-                              }
+                              },
+                              "description": "Number of lamports assigned to this account."
+                            },
+                            {
+                              "key": "owner",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Program owner of this account."
+                            },
+                            {
+                              "key": "data",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "list",
+                                      "itemShape": {
+                                        "type": "alias",
+                                        "value": {
+                                          "type": "primitive",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Account data in the specified encoding format."
+                            },
+                            {
+                              "key": "executable",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "boolean"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Indicates if the account contains a program."
+                            },
+                            {
+                              "key": "rentEpoch",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "The epoch at which this account will next owe rent."
+                            },
+                            {
+                              "key": "size",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "integer"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "The data size of the account."
                             }
-                          },
-                          "description": "Account data in the specified encoding format."
-                        },
-                        {
-                          "key": "executable",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "boolean"
-                              }
-                            }
-                          },
-                          "description": "Indicates if the account contains a program."
-                        },
-                        {
-                          "key": "rentEpoch",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "The epoch at which this account will next owe rent."
-                        },
-                        {
-                          "key": "size",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "integer"
-                              }
-                            }
-                          },
-                          "description": "The data size of the account."
+                          ]
                         }
-                      ]
+                      }
                     }
                   }
                 },
@@ -9424,9 +11219,15 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "primitive",
-                    "value": {
-                      "type": "integer"
+                    "type": "optional",
+                    "shape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "primitive",
+                        "value": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 },
@@ -9437,44 +11238,62 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
-                      "type": "object",
-                      "extends": [],
-                      "properties": [
-                        {
-                          "key": "programId",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "primitive",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "description": "Program that generated the return data."
-                        },
-                        {
-                          "key": "data",
-                          "valueShape": {
-                            "type": "alias",
-                            "value": {
-                              "type": "list",
-                              "itemShape": {
+                      "type": "alias",
+                      "value": {
+                        "type": "nullable",
+                        "shape": {
+                          "type": "object",
+                          "extends": [],
+                          "properties": [
+                            {
+                              "key": "programId",
+                              "valueShape": {
                                 "type": "alias",
                                 "value": {
-                                  "type": "primitive",
-                                  "value": {
-                                    "type": "string"
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "primitive",
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
                                   }
                                 }
-                              }
+                              },
+                              "description": "Program that generated the return data."
+                            },
+                            {
+                              "key": "data",
+                              "valueShape": {
+                                "type": "alias",
+                                "value": {
+                                  "type": "optional",
+                                  "shape": {
+                                    "type": "alias",
+                                    "value": {
+                                      "type": "list",
+                                      "itemShape": {
+                                        "type": "alias",
+                                        "value": {
+                                          "type": "primitive",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Return data as base-64 encoded binary data."
                             }
-                          },
-                          "description": "Return data as base-64 encoded binary data."
+                          ]
                         }
-                      ]
+                      }
                     }
                   }
                 }
@@ -9484,11 +11303,17 @@
                 "valueShape": {
                   "type": "alias",
                   "value": {
-                    "type": "nullable",
+                    "type": "optional",
                     "shape": {
-                      "type": "object",
-                      "extends": [],
-                      "properties": []
+                      "type": "alias",
+                      "value": {
+                        "type": "nullable",
+                        "shape": {
+                          "type": "object",
+                          "extends": [],
+                          "properties": []
+                        }
+                      }
                     }
                   }
                 },

--- a/packages/parsers/src/utils/computeSubpackages.ts
+++ b/packages/parsers/src/utils/computeSubpackages.ts
@@ -1,4 +1,4 @@
-import { camelCase } from "es-toolkit";
+import { titleCase } from "@fern-api/ui-core-utils";
 import { FernRegistry } from "../client/generated";
 
 export declare namespace ComputeSubpackages {
@@ -26,33 +26,25 @@ export function computeSubpackages({
     FernRegistry.api.latest.SubpackageMetadata
   > = {};
 
-  if (endpoints != null) {
-    Object.values(endpoints).forEach((endpoint) =>
-      endpoint.namespace?.forEach((subpackage) => {
-        const qualifiedPath: string[] = [];
-        subpackages[FernRegistry.api.v1.SubpackageId(camelCase(subpackage))] = {
-          id: FernRegistry.api.v1.SubpackageId(camelCase(subpackage)),
-          name: [...qualifiedPath, subpackage].join("/"),
-          displayName: subpackage,
-        };
-        qualifiedPath.push(subpackage);
-      })
-    );
-  }
-
-  if (webhookEndpoints != null) {
-    Object.values(webhookEndpoints).forEach((webhook) =>
-      webhook.namespace?.forEach((subpackage) => {
-        const qualifiedPath: string[] = [];
-        subpackages[FernRegistry.api.v1.SubpackageId(camelCase(subpackage))] = {
-          id: FernRegistry.api.v1.SubpackageId(camelCase(subpackage)),
-          name: [...qualifiedPath, subpackage].join("/"),
-          displayName: subpackage,
-        };
-        qualifiedPath.push(subpackage);
-      })
-    );
-  }
+  Object.values({
+    ...endpoints,
+    ...webhookEndpoints,
+  }).forEach((endpoint) => {
+    const qualifiedPath: string[] = [];
+    return endpoint.namespace?.forEach((subpackage) => {
+      const prunedSubpackage = subpackage.replace(/subpackage_/, "");
+      const qualifiedSubpackagePath = [...qualifiedPath, prunedSubpackage];
+      const fullyQualifiedSubpackageId = FernRegistry.api.v1.SubpackageId(
+        `subpackage_${qualifiedSubpackagePath.join(".")}`
+      );
+      subpackages[fullyQualifiedSubpackageId] = {
+        id: fullyQualifiedSubpackageId,
+        name: qualifiedSubpackagePath.join("/"),
+        displayName: titleCase(prunedSubpackage),
+      };
+      qualifiedPath.push(prunedSubpackage);
+    });
+  });
 
   return subpackages;
 }

--- a/packages/parsers/src/utils/computeSubpackages.ts
+++ b/packages/parsers/src/utils/computeSubpackages.ts
@@ -32,10 +32,11 @@ export function computeSubpackages({
   }).forEach((endpoint) => {
     const qualifiedPath: string[] = [];
     return endpoint.namespace?.forEach((subpackage) => {
-      const prunedSubpackage = subpackage.replace(/subpackage_/, "");
+      const prunedSubpackage = subpackage;
+      // subpackage.replace(/subpackage_/, "");
       const qualifiedSubpackagePath = [...qualifiedPath, prunedSubpackage];
       const fullyQualifiedSubpackageId = FernRegistry.api.v1.SubpackageId(
-        `subpackage_${qualifiedSubpackagePath.join(".")}`
+        qualifiedSubpackagePath.join(".")
       );
       subpackages[fullyQualifiedSubpackageId] = {
         id: fullyQualifiedSubpackageId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -794,7 +794,7 @@ importers:
         version: 5.13.0
       braintrust:
         specifier: ^0.0.182
-        version: 0.0.182(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.723.0))(react@18.3.1)(sswr@2.1.0(svelte@5.19.2))(svelte@5.19.2)(vue@3.5.13(typescript@5.7.2))(zod@3.24.1)
+        version: 0.0.182(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.682.0))(react@18.3.1)(sswr@2.1.0(svelte@5.19.2))(svelte@5.19.2)(vue@3.5.13(typescript@5.7.2))(zod@3.24.1)
       cssnano:
         specifier: ^6.0.3
         version: 6.1.2(postcss@8.4.31)
@@ -2554,9 +2554,6 @@ importers:
       '@fern-platform/configs':
         specifier: workspace:*
         version: link:../configs
-      '@types/jest':
-        specifier: ^29.5.14
-        version: 29.5.14
       '@types/uuid':
         specifier: ^9.0.1
         version: 9.0.8
@@ -7974,9 +7971,6 @@ packages:
 
   '@types/jest@29.5.12':
     resolution: {integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==}
-
-  '@types/jest@29.5.14':
-    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
@@ -14251,9 +14245,6 @@ packages:
   pkg-types@1.0.3:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
 
-  pkg-types@1.2.1:
-    resolution: {integrity: sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==}
-
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -18863,6 +18854,16 @@ snapshots:
       '@smithy/property-provider': 3.1.8
       '@smithy/types': 3.6.0
       tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.682.0)':
+    dependencies:
+      '@aws-sdk/client-sts': 3.682.0
+      '@aws-sdk/core': 3.723.0
+      '@aws-sdk/types': 3.723.0
+      '@smithy/property-provider': 4.0.0
+      '@smithy/types': 4.1.0
+      tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.723.0)':
     dependencies:
@@ -24686,11 +24687,6 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.7.0
 
-  '@types/jest@29.5.14':
-    dependencies:
-      expect: 29.7.0
-      pretty-format: 29.7.0
-
   '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
@@ -25100,9 +25096,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@vercel/functions@1.5.2(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.723.0))':
+  '@vercel/functions@1.5.2(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.682.0))':
     optionalDependencies:
-      '@aws-sdk/credential-provider-web-identity': 3.723.0(@aws-sdk/client-sts@3.723.0)
+      '@aws-sdk/credential-provider-web-identity': 3.723.0(@aws-sdk/client-sts@3.682.0)
 
   '@vercel/kv@2.0.0':
     dependencies:
@@ -26988,12 +26984,12 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braintrust@0.0.182(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.723.0))(react@18.3.1)(sswr@2.1.0(svelte@5.19.2))(svelte@5.19.2)(vue@3.5.13(typescript@5.7.2))(zod@3.24.1):
+  braintrust@0.0.182(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.682.0))(react@18.3.1)(sswr@2.1.0(svelte@5.19.2))(svelte@5.19.2)(vue@3.5.13(typescript@5.7.2))(zod@3.24.1):
     dependencies:
       '@ai-sdk/provider': 1.0.4
       '@braintrust/core': 0.0.76
       '@next/env': 14.2.9
-      '@vercel/functions': 1.5.2(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.723.0))
+      '@vercel/functions': 1.5.2(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.682.0))
       ai: 3.4.33(react@18.3.1)(sswr@2.1.0(svelte@5.19.2))(svelte@5.19.2)(vue@3.5.13(typescript@5.7.2))(zod@3.24.1)
       argparse: 2.0.1
       chalk: 4.1.2
@@ -31447,7 +31443,7 @@ snapshots:
   local-pkg@0.5.0:
     dependencies:
       mlly: 1.7.4
-      pkg-types: 1.2.1
+      pkg-types: 1.3.1
 
   localforage@1.10.0:
     dependencies:
@@ -32505,7 +32501,7 @@ snapshots:
     dependencies:
       acorn: 8.14.0
       pathe: 1.1.2
-      pkg-types: 1.2.1
+      pkg-types: 1.3.1
       ufo: 1.5.4
 
   mlly@1.7.4:
@@ -33170,12 +33166,6 @@ snapshots:
   pkg-types@1.0.3:
     dependencies:
       jsonc-parser: 3.3.1
-      mlly: 1.7.4
-      pathe: 1.1.2
-
-  pkg-types@1.2.1:
-    dependencies:
-      confbox: 0.1.8
       mlly: 1.7.4
       pathe: 1.1.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,10 +68,10 @@ importers:
         version: 1.47.1
       '@tailwindcss/forms':
         specifier: ^0.5.7
-        version: 0.5.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))
+        version: 0.5.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)))
       '@tailwindcss/typography':
         specifier: ^0.5.10
-        version: 0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))
+        version: 0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)))
       '@types/express':
         specifier: ^4.17.13
         version: 4.17.21
@@ -131,7 +131,7 @@ importers:
         version: 5.1.0(eslint@9.17.0(jiti@1.21.7))
       eslint-plugin-tailwindcss:
         specifier: ^3.17.5
-        version: 3.17.5(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))
+        version: 3.17.5(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)))
       eslint-plugin-vitest:
         specifier: ^0.5.4
         version: 0.5.4(@typescript-eslint/eslint-plugin@8.18.1(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.7.2))(eslint@9.17.0(jiti@1.21.7))(typescript@5.7.2))(eslint@9.17.0(jiti@1.21.7))(typescript@5.7.2)(vitest@2.1.9(@edge-runtime/vm@5.0.0)(@types/node@18.19.33)(jsdom@24.0.0)(less@4.2.0)(sass@1.77.0)(stylus@0.62.0)(terser@5.31.0))
@@ -197,16 +197,16 @@ importers:
         version: 13.1.0(postcss@8.4.31)(stylelint@16.5.0(typescript@5.7.2))
       stylelint-config-tailwindcss:
         specifier: ^0.0.7
-        version: 0.0.7(stylelint@16.5.0(typescript@5.7.2))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))
+        version: 0.0.7(stylelint@16.5.0(typescript@5.7.2))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)))
       stylelint-scss:
         specifier: ^6.0.0
         version: 6.3.0(stylelint@16.5.0(typescript@5.7.2))
       tailwindcss:
         specifier: 3.4.17
-        version: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+        version: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)
+        version: 10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)
       tsx:
         specifier: ^4.19.2
         version: 4.19.2
@@ -221,7 +221,7 @@ importers:
         version: 8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.7.2)
       typescript-plugin-css-modules:
         specifier: ^5.1.0
-        version: 5.1.0(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))(typescript@5.7.2)
+        version: 5.1.0(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))(typescript@5.7.2)
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@edge-runtime/vm@5.0.0)(@types/node@18.19.33)(jsdom@24.0.0)(less@4.2.0)(sass@1.77.0)(stylus@0.62.0)(terser@5.31.0)
@@ -273,7 +273,7 @@ importers:
         version: 3.0.3
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@swc/core@1.5.7)(jiti@1.21.7)(postcss@8.4.31)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.7.0)
+        version: 8.3.5(@swc/core@1.5.7(@swc/helpers@0.5.15))(jiti@1.21.7)(postcss@8.4.31)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.7.0)
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -794,7 +794,7 @@ importers:
         version: 5.13.0
       braintrust:
         specifier: ^0.0.182
-        version: 0.0.182(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.682.0))(react@18.3.1)(sswr@2.1.0(svelte@5.19.2))(svelte@5.19.2)(vue@3.5.13(typescript@5.7.2))(zod@3.24.1)
+        version: 0.0.182(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.723.0))(react@18.3.1)(sswr@2.1.0(svelte@5.19.2))(svelte@5.19.2)(vue@3.5.13(typescript@5.7.2))(zod@3.24.1)
       cssnano:
         specifier: ^6.0.3
         version: 6.1.2(postcss@8.4.31)
@@ -871,10 +871,10 @@ importers:
         version: 14.2.9
       '@tailwindcss/forms':
         specifier: ^0.5.7
-        version: 0.5.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))
+        version: 0.5.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)))
       '@tailwindcss/typography':
         specifier: ^0.5.10
-        version: 0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))
+        version: 0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)))
       '@types/node':
         specifier: ^18.7.18
         version: 18.19.33
@@ -907,7 +907,7 @@ importers:
         version: 3.4.2
       raw-loader:
         specifier: ^4.0.2
-        version: 4.0.2(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
+        version: 4.0.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
       sass:
         specifier: ^1.74.1
         version: 1.77.0
@@ -916,7 +916,7 @@ importers:
         version: 16.5.0(typescript@5.7.2)
       tailwindcss:
         specifier: 3.4.17
-        version: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+        version: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -1116,10 +1116,10 @@ importers:
         version: 8.4.4(storybook@8.4.4(prettier@3.4.2))
       '@tailwindcss/forms':
         specifier: ^0.5.7
-        version: 0.5.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))
+        version: 0.5.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)))
       '@tailwindcss/typography':
         specifier: ^0.5.10
-        version: 0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))
+        version: 0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)))
       '@testing-library/jest-dom':
         specifier: ^6.4.2
         version: 6.5.0
@@ -1179,7 +1179,7 @@ importers:
         version: 16.5.0(typescript@5.7.2)
       tailwindcss:
         specifier: 3.4.17
-        version: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+        version: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -1409,10 +1409,10 @@ importers:
         version: 14.2.9
       '@tailwindcss/forms':
         specifier: ^0.5.7
-        version: 0.5.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))
+        version: 0.5.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)))
       '@tailwindcss/typography':
         specifier: ^0.5.10
-        version: 0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))
+        version: 0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)))
       '@types/node':
         specifier: ^18.7.18
         version: 18.19.33
@@ -1451,7 +1451,7 @@ importers:
         version: 3.4.2
       raw-loader:
         specifier: ^4.0.2
-        version: 4.0.2(webpack@5.94.0(@swc/core@1.5.7))
+        version: 4.0.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
       sass:
         specifier: ^1.74.1
         version: 1.77.0
@@ -1460,7 +1460,7 @@ importers:
         version: 16.5.0(typescript@5.7.2)
       tailwindcss:
         specifier: 3.4.17
-        version: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+        version: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -1841,7 +1841,7 @@ importers:
         version: 8.4.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))
       '@storybook/nextjs':
         specifier: ^8.4.4
-        version: 8.4.4(@fern-api/next@14.2.9-fork.2(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0))(@swc/core@1.5.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0)(storybook@8.4.4(prettier@3.4.2))(type-fest@4.21.0)(typescript@5.7.2)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7))
+        version: 8.4.4(@fern-api/next@14.2.9-fork.2(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0))(@swc/core@1.5.7(@swc/helpers@0.5.15))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0)(storybook@8.4.4(prettier@3.4.2))(type-fest@4.21.0)(typescript@5.7.2)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
       '@storybook/react':
         specifier: ^8.4.4
         version: 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)
@@ -1850,7 +1850,7 @@ importers:
         version: 8.4.4(storybook@8.4.4(prettier@3.4.2))
       '@tailwindcss/typography':
         specifier: ^0.5.10
-        version: 0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))
+        version: 0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@22.5.5)(typescript@5.7.2)))
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -1892,10 +1892,10 @@ importers:
         version: 2.2.5(react@18.3.1)
       tailwindcss:
         specifier: 3.4.17
-        version: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+        version: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@22.5.5)(typescript@5.7.2))
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))
+        version: 1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@22.5.5)(typescript@5.7.2)))
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -2322,7 +2322,7 @@ importers:
         version: 8.4.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))
       '@storybook/nextjs':
         specifier: ^8.4.4
-        version: 8.4.4(@fern-api/next@14.2.9-fork.2(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0))(@swc/core@1.5.7)(esbuild@0.24.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0)(storybook@8.4.4(prettier@3.4.2))(type-fest@4.21.0)(typescript@5.7.2)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
+        version: 8.4.4(@fern-api/next@14.2.9-fork.2(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0))(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0)(storybook@8.4.4(prettier@3.4.2))(type-fest@4.21.0)(typescript@5.7.2)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
       '@storybook/react':
         specifier: ^8.4.4
         version: 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)
@@ -2331,10 +2331,10 @@ importers:
         version: 8.4.4(storybook@8.4.4(prettier@3.4.2))
       '@tailwindcss/forms':
         specifier: ^0.5.7
-        version: 0.5.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))
+        version: 0.5.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)))
       '@tailwindcss/typography':
         specifier: ^0.5.10
-        version: 0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))
+        version: 0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)))
       '@testing-library/jest-dom':
         specifier: ^6.4.2
         version: 6.5.0
@@ -2409,7 +2409,7 @@ importers:
         version: 16.5.0(typescript@5.7.2)
       tailwindcss:
         specifier: 3.4.17
-        version: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+        version: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
       ts-essentials:
         specifier: ^10.0.1
         version: 10.0.1(typescript@5.7.2)
@@ -2510,7 +2510,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@swc/core@1.5.7)(jiti@1.21.7)(postcss@8.4.31)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.7.0)
+        version: 8.3.5(@swc/core@1.5.7(@swc/helpers@0.5.15))(jiti@1.21.7)(postcss@8.4.31)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.7.0)
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -2554,6 +2554,9 @@ importers:
       '@fern-platform/configs':
         specifier: workspace:*
         version: link:../configs
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
       '@types/uuid':
         specifier: ^9.0.1
         version: 9.0.8
@@ -2639,7 +2642,7 @@ importers:
         version: 9.17.0(jiti@1.21.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+        version: 29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -2924,7 +2927,7 @@ importers:
         version: 2.1.2
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)
+        version: 10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -3042,7 +3045,7 @@ importers:
         version: 1.54.6(esbuild@0.24.2)
       ts-node:
         specifier: ^10.4.0
-        version: 10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)
+        version: 10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)
       tsconfig-paths:
         specifier: ^3.9.0
         version: 3.15.0
@@ -7971,6 +7974,9 @@ packages:
 
   '@types/jest@29.5.12':
     resolution: {integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==}
+
+  '@types/jest@29.5.14':
+    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
@@ -13643,9 +13649,6 @@ packages:
   mlly@1.7.2:
     resolution: {integrity: sha512-tN3dvVHYVz4DhSXinXIk7u9syPYaJvio118uomkovAtWBT+RdbP6Lfh/5Lvo519YMmwBafwlh20IPTXIStscpA==}
 
-  mlly@1.7.3:
-    resolution: {integrity: sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==}
-
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
 
@@ -18861,16 +18864,6 @@ snapshots:
       '@smithy/types': 3.6.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.682.0)':
-    dependencies:
-      '@aws-sdk/client-sts': 3.682.0
-      '@aws-sdk/core': 3.723.0
-      '@aws-sdk/types': 3.723.0
-      '@smithy/property-provider': 4.0.0
-      '@smithy/types': 4.1.0
-      tslib: 2.8.1
-    optional: true
-
   '@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.723.0)':
     dependencies:
       '@aws-sdk/client-sts': 3.723.0
@@ -21082,7 +21075,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -21096,7 +21089,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.12)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+      jest-config: 29.7.0(@types/node@20.12.12)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -21938,7 +21931,7 @@ snapshots:
     dependencies:
       playwright: 1.47.1
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.13(react-refresh@0.14.2)(type-fest@4.21.0)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.13(react-refresh@0.14.2)(type-fest@4.21.0)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))':
     dependencies:
       ansi-html-community: 0.0.8
       core-js-pure: 3.37.0
@@ -21948,12 +21941,12 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
     optionalDependencies:
       type-fest: 4.21.0
       webpack-hot-middleware: 2.26.1
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.13(react-refresh@0.14.2)(type-fest@4.21.0)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.13(react-refresh@0.14.2)(type-fest@4.21.0)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))':
     dependencies:
       ansi-html-community: 0.0.8
       core-js-pure: 3.37.0
@@ -21963,7 +21956,7 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
     optionalDependencies:
       type-fest: 4.21.0
       webpack-hot-middleware: 2.26.1
@@ -23887,7 +23880,7 @@ snapshots:
     transitivePeerDependencies:
       - webpack-sources
 
-  '@storybook/builder-webpack5@8.4.4(@swc/core@1.5.7)(esbuild@0.24.2)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)':
+  '@storybook/builder-webpack5@8.4.4(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)':
     dependencies:
       '@storybook/core-webpack': 8.4.4(storybook@8.4.4(prettier@3.4.2))
       '@types/node': 22.5.5
@@ -23896,23 +23889,23 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.3.1
       constants-browserify: 1.0.0
-      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
+      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
       es-module-lexer: 1.5.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
-      html-webpack-plugin: 5.6.0(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
+      html-webpack-plugin: 5.6.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
       storybook: 8.4.4(prettier@3.4.2)
-      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
-      terser-webpack-plugin: 5.3.10(@swc/core@1.5.7)(esbuild@0.24.2)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
+      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
-      webpack-dev-middleware: 6.1.3(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
+      webpack-dev-middleware: 6.1.3(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -23924,7 +23917,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/builder-webpack5@8.4.4(@swc/core@1.5.7)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)':
+  '@storybook/builder-webpack5@8.4.4(@swc/core@1.5.7(@swc/helpers@0.5.15))(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)':
     dependencies:
       '@storybook/core-webpack': 8.4.4(storybook@8.4.4(prettier@3.4.2))
       '@types/node': 22.5.5
@@ -23933,23 +23926,23 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.3.1
       constants-browserify: 1.0.0
-      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.5.7))
+      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
       es-module-lexer: 1.5.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7))
-      html-webpack-plugin: 5.6.0(webpack@5.94.0(@swc/core@1.5.7))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
+      html-webpack-plugin: 5.6.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
       storybook: 8.4.4(prettier@3.4.2)
-      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.5.7))
-      terser-webpack-plugin: 5.3.10(@swc/core@1.5.7)(webpack@5.94.0(@swc/core@1.5.7))
+      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.15))(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.94.0(@swc/core@1.5.7)
-      webpack-dev-middleware: 6.1.3(webpack@5.94.0(@swc/core@1.5.7))
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
+      webpack-dev-middleware: 6.1.3(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -24045,7 +24038,7 @@ snapshots:
     dependencies:
       storybook: 8.4.4(prettier@3.4.2)
 
-  '@storybook/nextjs@8.4.4(@fern-api/next@14.2.9-fork.2(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0))(@swc/core@1.5.7)(esbuild@0.24.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0)(storybook@8.4.4(prettier@3.4.2))(type-fest@4.21.0)(typescript@5.7.2)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))':
+  '@storybook/nextjs@8.4.4(@fern-api/next@14.2.9-fork.2(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0))(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0)(storybook@8.4.4(prettier@3.4.2))(type-fest@4.21.0)(typescript@5.7.2)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.26.0)
@@ -24060,31 +24053,31 @@ snapshots:
       '@babel/preset-react': 7.25.9(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
       '@babel/runtime': 7.26.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.13(react-refresh@0.14.2)(type-fest@4.21.0)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
-      '@storybook/builder-webpack5': 8.4.4(@swc/core@1.5.7)(esbuild@0.24.2)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)
-      '@storybook/preset-react-webpack': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.4.2)))(@swc/core@1.5.7)(esbuild@0.24.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.13(react-refresh@0.14.2)(type-fest@4.21.0)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
+      '@storybook/builder-webpack5': 8.4.4(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)
+      '@storybook/preset-react-webpack': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.4.2)))(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)
       '@storybook/react': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)
       '@storybook/test': 8.4.4(storybook@8.4.4(prettier@3.4.2))
       '@types/node': 22.5.5
       '@types/semver': 7.5.8
-      babel-loader: 9.1.3(@babel/core@7.26.0)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
-      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
+      babel-loader: 9.1.3(@babel/core@7.26.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
+      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
       find-up: 5.0.0
       image-size: 1.1.1
       loader-utils: 3.2.1
       next: '@fern-api/next@14.2.9-fork.2(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0)'
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
       pnp-webpack-plugin: 1.7.0(typescript@5.7.2)
       postcss: 8.4.31
-      postcss-loader: 8.1.1(postcss@8.4.31)(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
+      postcss-loader: 8.1.1(postcss@8.4.31)(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 13.3.3(sass@1.77.0)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
+      sass-loader: 13.3.3(sass@1.77.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
       semver: 7.6.3
       storybook: 8.4.4(prettier@3.4.2)
-      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
+      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
       styled-jsx: 5.1.6(@babel/core@7.26.0)(react@18.3.1)
       ts-dedent: 2.2.0
       tsconfig-paths: 4.2.0
@@ -24092,7 +24085,7 @@ snapshots:
     optionalDependencies:
       sharp: 0.33.3
       typescript: 5.7.2
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -24112,7 +24105,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/nextjs@8.4.4(@fern-api/next@14.2.9-fork.2(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0))(@swc/core@1.5.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0)(storybook@8.4.4(prettier@3.4.2))(type-fest@4.21.0)(typescript@5.7.2)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7))':
+  '@storybook/nextjs@8.4.4(@fern-api/next@14.2.9-fork.2(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0))(@swc/core@1.5.7(@swc/helpers@0.5.15))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0)(storybook@8.4.4(prettier@3.4.2))(type-fest@4.21.0)(typescript@5.7.2)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.26.0)
@@ -24127,31 +24120,31 @@ snapshots:
       '@babel/preset-react': 7.25.9(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
       '@babel/runtime': 7.26.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.13(react-refresh@0.14.2)(type-fest@4.21.0)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7))
-      '@storybook/builder-webpack5': 8.4.4(@swc/core@1.5.7)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)
-      '@storybook/preset-react-webpack': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.4.2)))(@swc/core@1.5.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.13(react-refresh@0.14.2)(type-fest@4.21.0)(webpack-hot-middleware@2.26.1)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
+      '@storybook/builder-webpack5': 8.4.4(@swc/core@1.5.7(@swc/helpers@0.5.15))(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)
+      '@storybook/preset-react-webpack': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.4.2)))(@swc/core@1.5.7(@swc/helpers@0.5.15))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)
       '@storybook/react': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)
       '@storybook/test': 8.4.4(storybook@8.4.4(prettier@3.4.2))
       '@types/node': 22.5.5
       '@types/semver': 7.5.8
-      babel-loader: 9.1.3(@babel/core@7.26.0)(webpack@5.94.0(@swc/core@1.5.7))
-      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.5.7))
+      babel-loader: 9.1.3(@babel/core@7.26.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
+      css-loader: 6.11.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
       find-up: 5.0.0
       image-size: 1.1.1
       loader-utils: 3.2.1
       next: '@fern-api/next@14.2.9-fork.2(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.0)'
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.94.0(@swc/core@1.5.7))
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
       pnp-webpack-plugin: 1.7.0(typescript@5.7.2)
       postcss: 8.4.31
-      postcss-loader: 8.1.1(postcss@8.4.31)(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7))
+      postcss-loader: 8.1.1(postcss@8.4.31)(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 13.3.3(sass@1.77.0)(webpack@5.94.0(@swc/core@1.5.7))
+      sass-loader: 13.3.3(sass@1.77.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
       semver: 7.6.3
       storybook: 8.4.4(prettier@3.4.2)
-      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.5.7))
+      style-loader: 3.3.4(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
       styled-jsx: 5.1.6(@babel/core@7.26.0)(react@18.3.1)
       ts-dedent: 2.2.0
       tsconfig-paths: 4.2.0
@@ -24159,7 +24152,7 @@ snapshots:
     optionalDependencies:
       sharp: 0.33.3
       typescript: 5.7.2
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -24179,11 +24172,11 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.4.2)))(@swc/core@1.5.7)(esbuild@0.24.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)':
+  '@storybook/preset-react-webpack@8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.4.2)))(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)':
     dependencies:
       '@storybook/core-webpack': 8.4.4(storybook@8.4.4(prettier@3.4.2))
       '@storybook/react': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
       '@types/node': 22.5.5
       '@types/semver': 7.5.8
       find-up: 5.0.0
@@ -24195,7 +24188,7 @@ snapshots:
       semver: 7.6.3
       storybook: 8.4.4(prettier@3.4.2)
       tsconfig-paths: 4.2.0
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
     optionalDependencies:
       typescript: 5.7.2
     transitivePeerDependencies:
@@ -24206,11 +24199,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/preset-react-webpack@8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.4.2)))(@swc/core@1.5.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)':
+  '@storybook/preset-react-webpack@8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.4.2)))(@swc/core@1.5.7(@swc/helpers@0.5.15))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)':
     dependencies:
       '@storybook/core-webpack': 8.4.4(storybook@8.4.4(prettier@3.4.2))
       '@storybook/react': 8.4.4(@storybook/test@8.4.4(storybook@8.4.4(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.4.2))(typescript@5.7.2)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
       '@types/node': 22.5.5
       '@types/semver': 7.5.8
       find-up: 5.0.0
@@ -24222,7 +24215,7 @@ snapshots:
       semver: 7.6.3
       storybook: 8.4.4(prettier@3.4.2)
       tsconfig-paths: 4.2.0
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
     optionalDependencies:
       typescript: 5.7.2
     transitivePeerDependencies:
@@ -24254,7 +24247,7 @@ snapshots:
     dependencies:
       storybook: 8.4.4(prettier@3.4.2)
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))':
     dependencies:
       debug: 4.4.0
       endent: 2.1.0
@@ -24264,11 +24257,11 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.7.2)
       tslib: 2.8.1
       typescript: 5.7.2
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))':
     dependencies:
       debug: 4.4.0
       endent: 2.1.0
@@ -24278,7 +24271,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.7.2)
       tslib: 2.8.1
       typescript: 5.7.2
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
     transitivePeerDependencies:
       - supports-color
 
@@ -24378,7 +24371,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.5.7':
     optional: true
 
-  '@swc/core@1.5.7':
+  '@swc/core@1.5.7(@swc/helpers@0.5.15)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.7
@@ -24393,6 +24386,7 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.5.7
       '@swc/core-win32-ia32-msvc': 1.5.7
       '@swc/core-win32-x64-msvc': 1.5.7
+      '@swc/helpers': 0.5.15
     optional: true
 
   '@swc/counter@0.1.3': {}
@@ -24415,18 +24409,26 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tailwindcss/forms@0.5.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))':
+  '@tailwindcss/forms@0.5.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)))':
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+      tailwindcss: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
 
-  '@tailwindcss/typography@0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)))':
+  '@tailwindcss/typography@0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)))':
     dependencies:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+      tailwindcss: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
+
+  '@tailwindcss/typography@0.5.13(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@22.5.5)(typescript@5.7.2)))':
+    dependencies:
+      lodash.castarray: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@22.5.5)(typescript@5.7.2))
 
   '@tanem/svg-injector@10.1.68':
     dependencies:
@@ -24680,6 +24682,11 @@ snapshots:
       '@types/istanbul-lib-report': 3.0.3
 
   '@types/jest@29.5.12':
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
+
+  '@types/jest@29.5.14':
     dependencies:
       expect: 29.7.0
       pretty-format: 29.7.0
@@ -25093,9 +25100,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@vercel/functions@1.5.2(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.682.0))':
+  '@vercel/functions@1.5.2(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.723.0))':
     optionalDependencies:
-      '@aws-sdk/credential-provider-web-identity': 3.723.0(@aws-sdk/client-sts@3.682.0)
+      '@aws-sdk/credential-provider-web-identity': 3.723.0(@aws-sdk/client-sts@3.723.0)
 
   '@vercel/kv@2.0.0':
     dependencies:
@@ -26810,19 +26817,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.1.3(@babel/core@7.26.0)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)):
+  babel-loader@9.1.3(@babel/core@7.26.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       '@babel/core': 7.26.0
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
 
-  babel-loader@9.1.3(@babel/core@7.26.0)(webpack@5.94.0(@swc/core@1.5.7)):
+  babel-loader@9.1.3(@babel/core@7.26.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))):
     dependencies:
       '@babel/core': 7.26.0
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
@@ -26981,12 +26988,12 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braintrust@0.0.182(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.682.0))(react@18.3.1)(sswr@2.1.0(svelte@5.19.2))(svelte@5.19.2)(vue@3.5.13(typescript@5.7.2))(zod@3.24.1):
+  braintrust@0.0.182(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.723.0))(react@18.3.1)(sswr@2.1.0(svelte@5.19.2))(svelte@5.19.2)(vue@3.5.13(typescript@5.7.2))(zod@3.24.1):
     dependencies:
       '@ai-sdk/provider': 1.0.4
       '@braintrust/core': 0.0.76
       '@next/env': 14.2.9
-      '@vercel/functions': 1.5.2(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.682.0))
+      '@vercel/functions': 1.5.2(@aws-sdk/credential-provider-web-identity@3.723.0(@aws-sdk/client-sts@3.723.0))
       ai: 3.4.33(react@18.3.1)(sswr@2.1.0(svelte@5.19.2))(svelte@5.19.2)(vue@3.5.13(typescript@5.7.2))(zod@3.24.1)
       argparse: 2.0.1
       chalk: 4.1.2
@@ -27626,13 +27633,13 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
-  create-jest@29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)):
+  create-jest@29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+      jest-config: 29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -27679,7 +27686,7 @@ snapshots:
 
   css-functions-list@3.2.2: {}
 
-  css-loader@6.11.0(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)):
+  css-loader@6.11.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -27690,9 +27697,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
 
-  css-loader@6.11.0(webpack@5.94.0(@swc/core@1.5.7)):
+  css-loader@6.11.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -27703,7 +27710,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
 
   css-select@4.3.0:
     dependencies:
@@ -28741,7 +28748,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@1.21.7)))(eslint@9.17.0(jiti@1.21.7)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.17.0(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -28773,7 +28780,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.17.0(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@1.21.7)))(eslint@9.17.0(jiti@1.21.7))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.18.1(eslint@9.17.0(jiti@1.21.7))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.17.0(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.0
       is-glob: 4.0.3
@@ -28847,11 +28854,11 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-tailwindcss@3.17.5(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))):
+  eslint-plugin-tailwindcss@3.17.5(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))):
     dependencies:
       fast-glob: 3.3.2
       postcss: 8.4.31
-      tailwindcss: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+      tailwindcss: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
 
   eslint-plugin-turbo@2.3.3(eslint@9.17.0(jiti@1.21.7)):
     dependencies:
@@ -29392,7 +29399,7 @@ snapshots:
       cross-spawn: 7.0.5
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       '@babel/code-frame': 7.26.2
       chalk: 4.1.2
@@ -29407,9 +29414,9 @@ snapshots:
       semver: 7.6.3
       tapable: 2.2.1
       typescript: 5.7.2
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))):
     dependencies:
       '@babel/code-frame': 7.26.2
       chalk: 4.1.2
@@ -29424,7 +29431,7 @@ snapshots:
       semver: 7.6.3
       tapable: 2.2.1
       typescript: 5.7.2
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
 
   form-data@2.5.1:
     dependencies:
@@ -30121,7 +30128,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.0(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)):
+  html-webpack-plugin@5.6.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -30129,9 +30136,9 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
 
-  html-webpack-plugin@5.6.0(webpack@5.94.0(@swc/core@1.5.7)):
+  html-webpack-plugin@5.6.0(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -30139,7 +30146,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
 
   htmlparser2@6.1.0:
     dependencies:
@@ -30770,16 +30777,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)):
+  jest-cli@29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+      create-jest: 29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+      jest-config: 29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -30789,7 +30796,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)):
+  jest-config@29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -30815,12 +30822,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.19.33
-      ts-node: 10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)
+      ts-node: 10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.12.12)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)):
+  jest-config@29.7.0(@types/node@20.12.12)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -30846,7 +30853,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.12.12
-      ts-node: 10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)
+      ts-node: 10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -31072,12 +31079,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)):
+  jest@29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+      jest-cli: 29.7.0(@types/node@18.19.33)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -31439,7 +31446,7 @@ snapshots:
 
   local-pkg@0.5.0:
     dependencies:
-      mlly: 1.7.3
+      mlly: 1.7.4
       pkg-types: 1.2.1
 
   localforage@1.10.0:
@@ -32501,13 +32508,6 @@ snapshots:
       pkg-types: 1.2.1
       ufo: 1.5.4
 
-  mlly@1.7.3:
-    dependencies:
-      acorn: 8.14.0
-      pathe: 1.1.2
-      pkg-types: 1.2.1
-      ufo: 1.5.4
-
   mlly@1.7.4:
     dependencies:
       acorn: 8.14.0
@@ -32673,7 +32673,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -32700,9 +32700,9 @@ snapshots:
       url: 0.11.3
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.94.0(@swc/core@1.5.7)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -32729,7 +32729,7 @@ snapshots:
       url: 0.11.3
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
 
   node-releases@2.0.18: {}
 
@@ -33275,21 +33275,29 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.31
 
-  postcss-load-config@3.1.4(postcss@8.4.31)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)):
+  postcss-load-config@3.1.4(postcss@8.4.31)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
       postcss: 8.4.31
-      ts-node: 10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)
+      ts-node: 10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)
 
-  postcss-load-config@4.0.2(postcss@8.4.31)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)):
+  postcss-load-config@4.0.2(postcss@8.4.31)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.4.2
     optionalDependencies:
       postcss: 8.4.31
-      ts-node: 10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)
+      ts-node: 10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)
+
+  postcss-load-config@4.0.2(postcss@8.4.31)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@22.5.5)(typescript@5.7.2)):
+    dependencies:
+      lilconfig: 3.1.3
+      yaml: 2.4.2
+    optionalDependencies:
+      postcss: 8.4.31
+      ts-node: 10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@22.5.5)(typescript@5.7.2)
 
   postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.4.31)(tsx@4.19.2)(yaml@2.7.0):
     dependencies:
@@ -33300,25 +33308,25 @@ snapshots:
       tsx: 4.19.2
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.4.31)(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)):
+  postcss-loader@8.1.1(postcss@8.4.31)(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.7.2)
       jiti: 1.21.0
       postcss: 8.4.31
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
     transitivePeerDependencies:
       - typescript
 
-  postcss-loader@8.1.1(postcss@8.4.31)(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7)):
+  postcss-loader@8.1.1(postcss@8.4.31)(typescript@5.7.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.7.2)
       jiti: 1.21.0
       postcss: 8.4.31
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
     transitivePeerDependencies:
       - typescript
 
@@ -33709,17 +33717,17 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  raw-loader@4.0.2(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)):
+  raw-loader@4.0.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
 
-  raw-loader@4.0.2(webpack@5.94.0(@swc/core@1.5.7)):
+  raw-loader@4.0.2(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
 
   rc@1.2.8:
     dependencies:
@@ -34552,17 +34560,17 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@13.3.3(sass@1.77.0)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)):
+  sass-loader@13.3.3(sass@1.77.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       neo-async: 2.6.2
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
     optionalDependencies:
       sass: 1.77.0
 
-  sass-loader@13.3.3(sass@1.77.0)(webpack@5.94.0(@swc/core@1.5.7)):
+  sass-loader@13.3.3(sass@1.77.0)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))):
     dependencies:
       neo-async: 2.6.2
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
     optionalDependencies:
       sass: 1.77.0
 
@@ -35211,13 +35219,13 @@ snapshots:
       '@tokenizer/token': 0.3.0
       peek-readable: 4.1.0
 
-  style-loader@3.3.4(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)):
+  style-loader@3.3.4(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
 
-  style-loader@3.3.4(webpack@5.94.0(@swc/core@1.5.7)):
+  style-loader@3.3.4(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))):
     dependencies:
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
 
   style-to-js@1.1.3:
     dependencies:
@@ -35288,10 +35296,10 @@ snapshots:
       stylelint: 16.5.0(typescript@5.7.2)
       stylelint-config-recommended: 14.0.0(stylelint@16.5.0(typescript@5.7.2))
 
-  stylelint-config-tailwindcss@0.0.7(stylelint@16.5.0(typescript@5.7.2))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))):
+  stylelint-config-tailwindcss@0.0.7(stylelint@16.5.0(typescript@5.7.2))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))):
     dependencies:
       stylelint: 16.5.0(typescript@5.7.2)
-      tailwindcss: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+      tailwindcss: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
 
   stylelint-scss@6.3.0(stylelint@16.5.0(typescript@5.7.2)):
     dependencies:
@@ -35468,11 +35476,11 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.0
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@22.5.5)(typescript@5.7.2))):
     dependencies:
-      tailwindcss: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+      tailwindcss: 3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@22.5.5)(typescript@5.7.2))
 
-  tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2)):
+  tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -35491,7 +35499,34 @@ snapshots:
       postcss: 8.4.31
       postcss-import: 15.1.0(postcss@8.4.31)
       postcss-js: 4.0.1(postcss@8.4.31)
-      postcss-load-config: 4.0.2(postcss@8.4.31)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+      postcss-load-config: 4.0.2(postcss@8.4.31)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
+      postcss-nested: 6.2.0(postcss@8.4.31)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.8
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
+
+  tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@22.5.5)(typescript@5.7.2)):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.2
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.4.31
+      postcss-import: 15.1.0(postcss@8.4.31)
+      postcss-js: 4.0.1(postcss@8.4.31)
+      postcss-load-config: 4.0.2(postcss@8.4.31)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@22.5.5)(typescript@5.7.2))
       postcss-nested: 6.2.0(postcss@8.4.31)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -35538,28 +35573,28 @@ snapshots:
     dependencies:
       memoizerific: 1.11.3
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.5.7)(esbuild@0.24.2)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.0
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
     optionalDependencies:
-      '@swc/core': 1.5.7
+      '@swc/core': 1.5.7(@swc/helpers@0.5.15)
       esbuild: 0.24.2
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.5.7)(webpack@5.94.0(@swc/core@1.5.7)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.15))(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.0
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
     optionalDependencies:
-      '@swc/core': 1.5.7
+      '@swc/core': 1.5.7(@swc/helpers@0.5.15)
 
   terser@5.31.0:
     dependencies:
@@ -35773,7 +35808,7 @@ snapshots:
       '@ts-morph/common': 0.20.0
       code-block-writer: 12.0.0
 
-  ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2):
+  ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -35791,7 +35826,28 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
-      '@swc/core': 1.5.7
+      '@swc/core': 1.5.7(@swc/helpers@0.5.15)
+
+  ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@22.5.5)(typescript@5.7.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.5.5
+      acorn: 8.14.0
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.7.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.5.7(@swc/helpers@0.5.15)
+    optional: true
 
   ts-pattern@5.0.5: {}
 
@@ -35832,7 +35888,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.3.5(@swc/core@1.5.7)(jiti@1.21.7)(postcss@8.4.31)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.7.0):
+  tsup@8.3.5(@swc/core@1.5.7(@swc/helpers@0.5.15))(jiti@1.21.7)(postcss@8.4.31)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.7.0):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.24.2)
       cac: 6.7.14
@@ -35851,7 +35907,7 @@ snapshots:
       tinyglobby: 0.2.10
       tree-kill: 1.2.2
     optionalDependencies:
-      '@swc/core': 1.5.7
+      '@swc/core': 1.5.7(@swc/helpers@0.5.15)
       postcss: 8.4.31
       typescript: 5.7.2
     transitivePeerDependencies:
@@ -36009,7 +36065,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript-plugin-css-modules@5.1.0(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))(typescript@5.7.2):
+  typescript-plugin-css-modules@5.1.0(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))(typescript@5.7.2):
     dependencies:
       '@types/postcss-modules-local-by-default': 4.0.2
       '@types/postcss-modules-scope': 3.0.4
@@ -36018,7 +36074,7 @@ snapshots:
       less: 4.2.0
       lodash.camelcase: 4.3.0
       postcss: 8.4.31
-      postcss-load-config: 3.1.4(postcss@8.4.31)(ts-node@10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.7.2))
+      postcss-load-config: 3.1.4(postcss@8.4.31)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.15))(@types/node@18.19.33)(typescript@5.7.2))
       postcss-modules-extract-imports: 3.1.0(postcss@8.4.31)
       postcss-modules-local-by-default: 4.0.5(postcss@8.4.31)
       postcss-modules-scope: 3.2.0(postcss@8.4.31)
@@ -36627,7 +36683,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@6.1.3(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)):
+  webpack-dev-middleware@6.1.3(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -36635,9 +36691,9 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)
 
-  webpack-dev-middleware@6.1.3(webpack@5.94.0(@swc/core@1.5.7)):
+  webpack-dev-middleware@6.1.3(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -36645,7 +36701,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.94.0(@swc/core@1.5.7)
+      webpack: 5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -36657,7 +36713,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.94.0(@swc/core@1.5.7):
+  webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)):
     dependencies:
       '@types/estree': 1.0.6
       '@webassemblyjs/ast': 1.12.1
@@ -36679,7 +36735,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.5.7)(webpack@5.94.0(@swc/core@1.5.7))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.15))(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15)))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -36687,7 +36743,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2):
+  webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2):
     dependencies:
       '@types/estree': 1.0.6
       '@webassemblyjs/ast': 1.12.1
@@ -36709,7 +36765,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.5.7)(esbuild@0.24.2)(webpack@5.94.0(@swc/core@1.5.7)(esbuild@0.24.2))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2)(webpack@5.94.0(@swc/core@1.5.7(@swc/helpers@0.5.15))(esbuild@0.24.2))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/servers/fdr/src/__test__/local/services/api.test.ts
+++ b/servers/fdr/src/__test__/local/services/api.test.ts
@@ -114,6 +114,7 @@ it("register api latest", async () => {
     await fdr.api.v1.register.registerApiDefinition({
       orgId: FdrAPI.OrgId("fern"),
       apiId: FdrAPI.ApiId("api"),
+      definition: EMPTY_REGISTER_API_DEFINITION,
       definitionV2: EMPTY_REGISTER_API_LATEST_DEFINITION,
     })
   );
@@ -144,6 +145,7 @@ it("register api latest", async () => {
     await fdr.api.v1.register.registerApiDefinition({
       orgId: FdrAPI.OrgId("fern"),
       apiId: FdrAPI.ApiId("api"),
+      definition: MOCK_REGISTER_API_DEFINITION,
       definitionV2: MOCK_REGISTER_API_LATEST_DEFINITION,
     })
   );

--- a/servers/fdr/src/__test__/local/services/api.test.ts
+++ b/servers/fdr/src/__test__/local/services/api.test.ts
@@ -114,7 +114,6 @@ it("register api latest", async () => {
     await fdr.api.v1.register.registerApiDefinition({
       orgId: FdrAPI.OrgId("fern"),
       apiId: FdrAPI.ApiId("api"),
-      definition: EMPTY_REGISTER_API_DEFINITION,
       definitionV2: EMPTY_REGISTER_API_LATEST_DEFINITION,
     })
   );
@@ -145,7 +144,6 @@ it("register api latest", async () => {
     await fdr.api.v1.register.registerApiDefinition({
       orgId: FdrAPI.OrgId("fern"),
       apiId: FdrAPI.ApiId("api"),
-      definition: MOCK_REGISTER_API_DEFINITION,
       definitionV2: MOCK_REGISTER_API_LATEST_DEFINITION,
     })
   );

--- a/servers/fdr/src/controllers/api/getRegisterApiService.ts
+++ b/servers/fdr/src/controllers/api/getRegisterApiService.ts
@@ -7,7 +7,6 @@ import {
 } from "@fern-api/fdr-sdk";
 import { v4 as uuidv4 } from "uuid";
 import { APIV1WriteService } from "../../api";
-import { FernRegistry } from "../../api/generated";
 import { SdkRequest } from "../../api/generated/api";
 import type { FdrApplication } from "../../app";
 import { LOGGER } from "../../app/FdrApplication";
@@ -111,13 +110,16 @@ export function getRegisterApiService(app: FdrApplication): APIV1WriteService {
         );
       }
 
-      // TODO: we need to keep this until dynamic snippets are implemented
       let isLatest = false;
-      if (req.body.definitionV2 != null && transformedApiDefinition != null) {
-        transformedApiDefinition = mergeEndpointSnippets(
-          req.body.definitionV2,
-          transformedApiDefinition as APIV1Db.DbApiDefinition
-        );
+      if (transformedApiDefinition == null) {
+        if (
+          req.body.definitionV2 == null ||
+          (req.body.definitionV2 != null &&
+            Object.keys(req.body.definitionV2).length === 0)
+        ) {
+          throw new Error("No latest definition provided");
+        }
+        transformedApiDefinition = req.body.definitionV2;
         isLatest = true;
         apiDefinitionId = transformedApiDefinition.id;
       }
@@ -166,101 +168,6 @@ export function getRegisterApiService(app: FdrApplication): APIV1WriteService {
       });
     },
   });
-}
-
-function stringifyPathParts(path: FernRegistry.api.latest.PathPart[]) {
-  return path
-    .map((part) => {
-      if (part.type === "literal") {
-        return part.value;
-      } else if (part.type === "pathParameter") {
-        return `{${part}}`;
-      } else {
-        return "";
-      }
-    })
-    .join("/");
-}
-
-function mergeEndpointSnippets(
-  definitionV2: FernRegistry.api.latest.ApiDefinition,
-  definition: APIV1Db.DbApiDefinition
-) {
-  for (const vLatestEndpoint of Object.values(definitionV2.endpoints)) {
-    for (const v1Endpoint of definition.rootPackage.endpoints) {
-      if (
-        stringifyPathParts(vLatestEndpoint.path) ===
-          stringifyPathParts(v1Endpoint.path.parts) &&
-        vLatestEndpoint.method === v1Endpoint.method
-      ) {
-        for (const v1Example of v1Endpoint.examples) {
-          for (const vLatestExample of vLatestEndpoint.examples ?? []) {
-            if (v1Example.name === vLatestExample.name) {
-              vLatestExample.snippets ??= {};
-              if (v1Example.codeExamples.goSdk != null) {
-                vLatestExample.snippets.go ??= [];
-                vLatestExample.snippets.go.push({
-                  language: "go",
-                  name: v1Example.name,
-                  code: v1Example.codeExamples.goSdk.client,
-                  install: v1Example.codeExamples.goSdk.install,
-                  generated: true,
-                  description: v1Example.description,
-                });
-              }
-
-              if (v1Example.codeExamples.typescriptSdk != null) {
-                vLatestExample.snippets.typescriptSdk ??= [];
-                vLatestExample.snippets.typescriptSdk.push({
-                  language: "typescript",
-                  name: v1Example.name,
-                  code: v1Example.codeExamples.typescriptSdk.client,
-                  install: v1Example.codeExamples.typescriptSdk.install,
-                  generated: true,
-                  description: v1Example.description,
-                });
-              }
-
-              if (v1Example.codeExamples.pythonSdk != null) {
-                vLatestExample.snippets.pythonSdk ??= [];
-                vLatestExample.snippets.pythonSdk.push({
-                  language: "python",
-                  name: v1Example.name,
-                  code: v1Example.codeExamples.pythonSdk.async_client,
-                  install: v1Example.codeExamples.pythonSdk.install,
-                  generated: true,
-                  description: v1Example.description,
-                });
-                vLatestExample.snippets.pythonSdk.push({
-                  language: "python",
-                  name: v1Example.name,
-                  code: v1Example.codeExamples.pythonSdk.sync_client,
-                  install: v1Example.codeExamples.pythonSdk.install,
-                  generated: true,
-                  description: v1Example.description,
-                });
-              }
-
-              if (v1Example.codeExamples.rubySdk != null) {
-                vLatestExample.snippets.rubySdk ??= [];
-                vLatestExample.snippets.rubySdk.push({
-                  language: "ruby",
-                  name: v1Example.name,
-                  code: v1Example.codeExamples.rubySdk.client,
-                  install: v1Example.codeExamples.rubySdk.install,
-                  generated: true,
-                  description: v1Example.description,
-                });
-              }
-            }
-          }
-        }
-        vLatestEndpoint.snippetTemplates = v1Endpoint.snippetTemplates;
-      }
-    }
-  }
-
-  return definitionV2;
 }
 
 function getSnippetSdkRequests({


### PR DESCRIPTION
## Short description of the changes made

* Changes the output ids for endpoints, webhooks and subpackages to better conform with Nav converter in CLI
* Respect default optional object parameters
* Begin to transition to kwargs for extra arguments
* Add names for undiscriminated union variants

## What was the motivation & context behind this PR?

* Go lives

## How has this PR been tested?

Snapshots
