### PR TITLE
fix: encode markdown record ids

### DIFF
--- a/packages/fern-docs/search-server/src/turbopuffer/records/create-markdown-records.ts
+++ b/packages/fern-docs/search-server/src/turbopuffer/records/create-markdown-records.ts
@@ -111,7 +111,9 @@ export async function createMarkdownRecords({
   const rootRecords = chunked_code_snippets.map((chunk, i) => {
     return {
       ...base_root_markdown_record,
-      id: `${base_root_markdown_record.id}-chunk:${i}`,
+      id: createHash("sha256")
+        .update(`${base_root_markdown_record.id}-chunk:${i}`)
+        .digest("hex"),
       attributes: {
         ...base_root_markdown_record.attributes,
         chunk,


### PR DESCRIPTION
Fixes FER-

## Short description of the changes made

Markdown record ids need to be less than 64 bytes 

## What was the motivation & context behind this PR?
Failing to index records for a customer. Same issue as on the[ base record fixed in PR](https://github.com/fern-api/fern-platform/pull/2159)

## How has this PR been tested?
@dsinghvi Any testing I need here? 