### PR TITLE
chore: playground passes query params as search params so ignore from…

### DIFF
--- a/packages/fern-docs/ui/src/playground/code-snippets/builders/types.ts
+++ b/packages/fern-docs/ui/src/playground/code-snippets/builders/types.ts
@@ -17,7 +17,7 @@ export abstract class PlaygroundCodeSnippetBuilder {
     this.url = buildEndpointUrl({
       endpoint: context.endpoint,
       pathParameters: formState.pathParameters,
-      queryParameters: formState.queryParameters,
+      queryParameters: {},
       baseUrl,
     });
   }


### PR DESCRIPTION
## Short description of the changes made
API Playground passes query params as `searchParams` already so ignore from building the url

## What was the motivation & context behind this PR?
Stop repeating query params. 

## How has this PR been tested?
Preview
