### PR TITLE
fix: OpenApi Parser v2 Server parsing logic and webhook subpackage resolution

### DIFF
--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fern-api/docs-parsers",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern-platform.git",

--- a/packages/parsers/src/openapi/3.1/OpenApiDocumentConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/OpenApiDocumentConverter.node.ts
@@ -127,10 +127,15 @@ export class OpenApiDocumentConverterNode extends BaseOpenApiV3_1ConverterNode<
 
     const { webhookEndpoints, endpoints } = this.paths?.convert() ?? {};
 
+    const webhooks = {
+      ...(this.webhooks?.convert() ?? {}),
+      ...(webhookEndpoints ?? {}),
+    };
+
     const subpackages: Record<
       FernRegistry.api.v1.SubpackageId,
       FernRegistry.api.latest.SubpackageMetadata
-    > = computeSubpackages({ endpoints, webhookEndpoints });
+    > = computeSubpackages({ endpoints, webhookEndpoints: webhooks });
 
     const { types, auths } = this.components?.convert() ?? {};
 
@@ -139,10 +144,7 @@ export class OpenApiDocumentConverterNode extends BaseOpenApiV3_1ConverterNode<
       endpoints: endpoints ?? {},
       // Websockets are not implemented in OAS, but are in AsyncAPI
       websockets: {},
-      webhooks: {
-        ...(this.webhooks?.convert() ?? {}),
-        ...(webhookEndpoints ?? {}),
-      },
+      webhooks,
       types:
         types != null
           ? {

--- a/packages/parsers/src/openapi/3.1/paths/ServerObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/ServerObjectConverter.node.ts
@@ -21,7 +21,10 @@ export class ServerObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
   }
 
   parse(): void {
-    this.url = this.input.url;
+    this.url =
+      Object.entries(this.input.variables ?? {}).reduce((url, [key, value]) => {
+        return url.replace(`{${key}}`, value.default);
+      }, this.input.url) ?? this.input.url;
     this.serverName = new XFernServerNameConverterNode({
       input: this.input,
       context: this.context,
@@ -37,7 +40,6 @@ export class ServerObjectConverterNode extends BaseOpenApiV3_1ConverterNode<
     }
 
     return {
-      // TODO: url validation here
       id: FernRegistry.EnvironmentId(serverName),
       baseUrl: this.url,
     };

--- a/packages/parsers/src/openapi/3.1/paths/__test__/ServerObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/ServerObjectConverter.node.test.ts
@@ -38,5 +38,26 @@ describe("ServerObjectConverterNode", () => {
         baseUrl: "https://api.example.com",
       });
     });
+
+    it("should replace variables in url", () => {
+      const input: OpenAPIV3_1.ServerObject = {
+        url: "https://api.example.com/{foo}/{bar}",
+        variables: {
+          foo: { default: "bar" },
+          bar: { default: "baz" },
+        },
+      };
+      const node = new ServerObjectConverterNode({
+        input,
+        context: mockContext,
+        accessPath: [],
+        pathId: "test",
+      });
+      const result = node.convert();
+      expect(result).toEqual({
+        id: FernRegistry.EnvironmentId("https://api.example.com/bar/baz"),
+        baseUrl: "https://api.example.com/bar/baz",
+      });
+    });
   });
 });


### PR DESCRIPTION
## Short description of the changes made

* fixes two papercuts from testing on customer specs:
1. server parsing with variables
2. webhook subpackage resolution when listing under webhooks

## What was the motivation & context behind this PR?

* customer tests

## How has this PR been tested?

* unit tests and manual testing with cli
