### PR TITLE
chore: fail gracefully on endpoint url display

### DIFF
--- a/packages/fern-docs/ui/src/components/MaybeEnvironmentDropdown.tsx
+++ b/packages/fern-docs/ui/src/components/MaybeEnvironmentDropdown.tsx
@@ -81,12 +81,18 @@ export function MaybeEnvironmentDropdown({
     parse(inputValue).host != null &&
     parse(inputValue).protocol != null;
 
-  const urlProtocol = url ? url.protocol : "";
-  const fullyQualifiedDomainAndBasePath = url
-    ? url.pathname != null && url.pathname !== "/"
-      ? `${url.host}${url.pathname}`
-      : url.host
-    : "";
+  // convert the empty string to null for ease of conditionals
+  const urlProtocol = typeof url === "string" ? null : url?.protocol;
+  const fullyQualifiedDomainAndBasePath =
+    typeof url === "string"
+      ? null
+      : url
+        ? url.pathname != null && url.pathname !== "/"
+          ? url.host
+            ? `${url.host}${url.pathname}`
+            : url.pathname
+          : url.host
+        : null;
 
   return (
     <>
@@ -183,12 +189,16 @@ export function MaybeEnvironmentDropdown({
                       key="protocol"
                       className="whitespace-nowrap max-sm:hidden"
                     >
-                      <span
-                        className={protocolTextStyle}
-                      >{`${urlProtocol}//`}</span>
-                      <span className={urlTextStyle}>
-                        {fullyQualifiedDomainAndBasePath ?? ""}
-                      </span>
+                      {urlProtocol && (
+                        <span
+                          className={protocolTextStyle}
+                        >{`${urlProtocol}//`}</span>
+                      )}
+                      {fullyQualifiedDomainAndBasePath && (
+                        <span className={urlTextStyle}>
+                          {fullyQualifiedDomainAndBasePath}
+                        </span>
+                      )}
                     </span>
                   }
                   size={small ? "small" : "normal"}
@@ -226,7 +236,8 @@ export function MaybeEnvironmentDropdown({
                         : () => undefined
                     }
                   >
-                    {`${urlProtocol}//${fullyQualifiedDomainAndBasePath}`}
+                    {urlProtocol && `${urlProtocol}//`}
+                    {fullyQualifiedDomainAndBasePath}
                   </span>
                 ) : (
                   <>
@@ -236,10 +247,10 @@ export function MaybeEnvironmentDropdown({
                         small ? "text-xs" : "text-sm"
                       )}
                     >
-                      {`${urlProtocol}//`}
+                      {urlProtocol && `${urlProtocol}//`}
                     </span>
                     <span className={urlTextStyle}>
-                      {fullyQualifiedDomainAndBasePath}
+                      {fullyQualifiedDomainAndBasePath ?? ""}
                     </span>
                   </>
                 )}


### PR DESCRIPTION
This PR handles some of the possibly null values in the Environment to fail more gracefully when protocols or hosts aren't set. 

Before:
![Screenshot 2025-02-17 at 12 32 19 PM](https://github.com/user-attachments/assets/2538b9e5-1e0d-4008-b339-d425b49d819d)

After:
![Screenshot 2025-02-17 at 12 30 52 PM](https://github.com/user-attachments/assets/3b66a806-7498-4629-9dd3-5f5b70d9a764)

