### PR TITLE
add undiscriminated union wrapper to various responses

### DIFF
--- a/packages/fern-docs/ui/src/api-reference/endpoints/EndpointRequestSection.tsx
+++ b/packages/fern-docs/ui/src/api-reference/endpoints/EndpointRequestSection.tsx
@@ -8,10 +8,26 @@ import { renderTypeShorthand } from "../../type-shorthand";
 import { JsonPropertyPath } from "../examples/JsonPropertyPath";
 import { TypeComponentSeparator } from "../types/TypeComponentSeparator";
 import { TypeReferenceDefinitions } from "../types/type-reference/TypeReferenceDefinitions";
+import { maybeWrapTypeWithUndiscriminatedUnion } from "../utils/maybeWrapTypeWithUndiscriminatedUnion";
 import {
   EndpointParameter,
   EndpointParameterContent,
 } from "./EndpointParameter";
+
+const FORM_DATA_BYTES_SHAPE: ApiDefinition.TypeShape = {
+  type: "alias",
+  value: {
+    type: "primitive",
+    value: {
+      type: "string",
+      format: "binary",
+      regex: undefined,
+      minLength: undefined,
+      maxLength: undefined,
+      default: undefined,
+    },
+  },
+};
 
 export declare namespace EndpointRequestSection {
   export interface Props {
@@ -108,7 +124,21 @@ export const EndpointRequestSection: React.FC<EndpointRequestSection.Props> = ({
               })}
             </Fragment>
           )),
-        bytes: () => null,
+        bytes: () => (
+          <TypeReferenceDefinitions
+            shape={maybeWrapTypeWithUndiscriminatedUnion(
+              FORM_DATA_BYTES_SHAPE,
+              types,
+              "Binary"
+            )}
+            isCollapsible={false}
+            onHoverProperty={onHoverProperty}
+            anchorIdParts={anchorIdParts}
+            slug={slug}
+            applyErrorStyles={false}
+            types={types}
+          />
+        ),
         object: (obj) => (
           <TypeReferenceDefinitions
             shape={obj}
@@ -122,7 +152,7 @@ export const EndpointRequestSection: React.FC<EndpointRequestSection.Props> = ({
         ),
         alias: (alias) => (
           <TypeReferenceDefinitions
-            shape={alias}
+            shape={maybeWrapTypeWithUndiscriminatedUnion(alias, types)}
             isCollapsible={false}
             onHoverProperty={onHoverProperty}
             anchorIdParts={anchorIdParts}

--- a/packages/fern-docs/ui/src/api-reference/endpoints/EndpointResponseSection.tsx
+++ b/packages/fern-docs/ui/src/api-reference/endpoints/EndpointResponseSection.tsx
@@ -5,6 +5,42 @@ import { Markdown } from "../../mdx/Markdown";
 import { renderTypeShorthand } from "../../type-shorthand";
 import { JsonPropertyPath } from "../examples/JsonPropertyPath";
 import { TypeReferenceDefinitions } from "../types/type-reference/TypeReferenceDefinitions";
+import { maybeWrapTypeWithUndiscriminatedUnion } from "../utils/maybeWrapTypeWithUndiscriminatedUnion";
+
+const STREAMING_TEXT_SHAPE: ApiDefinition.TypeShape = {
+  type: "alias",
+  value: {
+    type: "primitive",
+    value: {
+      type: "string",
+      format: "text",
+      default: undefined,
+      regex: undefined,
+      minLength: undefined,
+      maxLength: undefined,
+    },
+  },
+};
+
+const FILE_DOWNLOAD_SHAPE: ApiDefinition.TypeShape = {
+  type: "alias",
+  value: {
+    type: "primitive",
+    value: {
+      type: "base64",
+      default: undefined,
+      mimeType: undefined,
+    },
+  },
+};
+
+export const NO_CONTENT_SHAPE: ApiDefinition.TypeShape = {
+  type: "alias",
+  value: {
+    type: "unknown",
+    displayName: "No Content",
+  },
+};
 
 export declare namespace EndpointResponseSection {
   export interface Props {
@@ -75,9 +111,51 @@ function EndpointResponseSectionContent({
 }: EndpointResponseSectionContentProps) {
   switch (body.type) {
     case "empty":
+      return (
+        <TypeReferenceDefinitions
+          shape={maybeWrapTypeWithUndiscriminatedUnion(NO_CONTENT_SHAPE, types)}
+          isCollapsible={false}
+          onHoverProperty={onHoverProperty}
+          anchorIdParts={anchorIdParts}
+          slug={slug}
+          applyErrorStyles={false}
+          types={types}
+        />
+      );
     case "fileDownload":
+      return (
+        <TypeReferenceDefinitions
+          shape={maybeWrapTypeWithUndiscriminatedUnion(
+            FILE_DOWNLOAD_SHAPE,
+            types,
+            "File Download"
+          )}
+          isCollapsible={false}
+          onHoverProperty={onHoverProperty}
+          anchorIdParts={anchorIdParts}
+          slug={slug}
+          applyErrorStyles={false}
+          types={types}
+          isResponse={true}
+        />
+      );
     case "streamingText":
-      return null;
+      return (
+        <TypeReferenceDefinitions
+          shape={maybeWrapTypeWithUndiscriminatedUnion(
+            STREAMING_TEXT_SHAPE,
+            types,
+            "Streaming Text"
+          )}
+          isCollapsible={false}
+          onHoverProperty={onHoverProperty}
+          anchorIdParts={anchorIdParts}
+          slug={slug}
+          applyErrorStyles={false}
+          types={types}
+          isResponse={true}
+        />
+      );
     case "stream":
       return (
         <TypeReferenceDefinitions
@@ -91,10 +169,10 @@ function EndpointResponseSectionContent({
           isResponse={true}
         />
       );
-    default:
+    default: {
       return (
         <TypeReferenceDefinitions
-          shape={body}
+          shape={maybeWrapTypeWithUndiscriminatedUnion(body, types)}
           isCollapsible={false}
           onHoverProperty={onHoverProperty}
           anchorIdParts={anchorIdParts}
@@ -104,6 +182,7 @@ function EndpointResponseSectionContent({
           isResponse={true}
         />
       );
+    }
   }
 }
 

--- a/packages/fern-docs/ui/src/api-reference/endpoints/EndpointResponseSection.tsx
+++ b/packages/fern-docs/ui/src/api-reference/endpoints/EndpointResponseSection.tsx
@@ -34,14 +34,6 @@ const FILE_DOWNLOAD_SHAPE: ApiDefinition.TypeShape = {
   },
 };
 
-export const NO_CONTENT_SHAPE: ApiDefinition.TypeShape = {
-  type: "alias",
-  value: {
-    type: "unknown",
-    displayName: "No Content",
-  },
-};
-
 export declare namespace EndpointResponseSection {
   export interface Props {
     response: ApiDefinition.HttpResponse;
@@ -112,15 +104,9 @@ function EndpointResponseSectionContent({
   switch (body.type) {
     case "empty":
       return (
-        <TypeReferenceDefinitions
-          shape={maybeWrapTypeWithUndiscriminatedUnion(NO_CONTENT_SHAPE, types)}
-          isCollapsible={false}
-          onHoverProperty={onHoverProperty}
-          anchorIdParts={anchorIdParts}
-          slug={slug}
-          applyErrorStyles={false}
-          types={types}
-        />
+        <span className="t-muted my-4 inline-flex items-baseline gap-2 text-xs">
+          No content
+        </span>
       );
     case "fileDownload":
       return (

--- a/packages/fern-docs/ui/src/api-reference/utils/__test__/maybeWrapTypeWithUndiscriminatedUnion.test.ts
+++ b/packages/fern-docs/ui/src/api-reference/utils/__test__/maybeWrapTypeWithUndiscriminatedUnion.test.ts
@@ -1,0 +1,89 @@
+import { ApiDefinition } from "@fern-api/fdr-sdk";
+import { maybeWrapTypeWithUndiscriminatedUnion } from "../maybeWrapTypeWithUndiscriminatedUnion";
+
+describe("maybeWrapTypeWithUndiscriminatedUnion", () => {
+  const types: Record<string, ApiDefinition.TypeDefinition> = {};
+
+  it("wraps primitive types in undiscriminated union", () => {
+    const stringShape: ApiDefinition.TypeShape = {
+      type: "alias",
+      value: {
+        type: "primitive",
+        value: {
+          type: "string",
+          format: undefined,
+          regex: undefined,
+          minLength: undefined,
+          maxLength: undefined,
+          default: undefined,
+        },
+      },
+    };
+
+    const result = maybeWrapTypeWithUndiscriminatedUnion(
+      stringShape,
+      types,
+      "String Type"
+    );
+
+    expect(result).toEqual({
+      type: "undiscriminatedUnion",
+      variants: [
+        {
+          displayName: "String Type",
+          description: undefined,
+          shape: stringShape,
+          availability: undefined,
+        },
+      ],
+    });
+  });
+
+  it("does not wrap object types", () => {
+    const objectShape: ApiDefinition.TypeShape = {
+      type: "object",
+      properties: [],
+      extends: [],
+      extraProperties: undefined,
+    };
+
+    const result = maybeWrapTypeWithUndiscriminatedUnion(objectShape, types);
+
+    expect(result).toBe(objectShape);
+  });
+
+  it("does not wrap enum types", () => {
+    const enumShape: ApiDefinition.TypeShape = {
+      type: "enum",
+      values: [],
+      default: undefined,
+    };
+
+    const result = maybeWrapTypeWithUndiscriminatedUnion(enumShape, types);
+
+    expect(result).toBe(enumShape);
+  });
+
+  it("does not wrap discriminated union types", () => {
+    const unionShape: ApiDefinition.TypeShape = {
+      type: "discriminatedUnion",
+      discriminant: ApiDefinition.PropertyKey("type"),
+      variants: [],
+    };
+
+    const result = maybeWrapTypeWithUndiscriminatedUnion(unionShape, types);
+
+    expect(result).toBe(unionShape);
+  });
+
+  it("does not wrap undiscriminated union types", () => {
+    const unionShape: ApiDefinition.TypeShape = {
+      type: "undiscriminatedUnion",
+      variants: [],
+    };
+
+    const result = maybeWrapTypeWithUndiscriminatedUnion(unionShape, types);
+
+    expect(result).toBe(unionShape);
+  });
+});

--- a/packages/fern-docs/ui/src/api-reference/utils/maybeWrapTypeWithUndiscriminatedUnion.ts
+++ b/packages/fern-docs/ui/src/api-reference/utils/maybeWrapTypeWithUndiscriminatedUnion.ts
@@ -1,0 +1,28 @@
+import { ApiDefinition } from "@fern-api/fdr-sdk";
+
+export function maybeWrapTypeWithUndiscriminatedUnion(
+  shape: ApiDefinition.TypeShape,
+  types: Record<string, ApiDefinition.TypeDefinition>,
+  displayName?: string
+): ApiDefinition.TypeShapeOrReference {
+  const unwrapped = ApiDefinition.unwrapReference(shape, types);
+  if (
+    unwrapped.shape.type !== "object" &&
+    unwrapped.shape.type !== "undiscriminatedUnion" &&
+    unwrapped.shape.type !== "discriminatedUnion" &&
+    unwrapped.shape.type !== "enum"
+  ) {
+    return {
+      type: "undiscriminatedUnion",
+      variants: [
+        {
+          displayName,
+          description: undefined,
+          shape,
+          availability: undefined,
+        },
+      ],
+    };
+  }
+  return shape;
+}


### PR DESCRIPTION
## Short description of the changes made

* Adds support for displaying non-containing types as schemas underneath requests and responses if specified as such

## What was the motivation & context behind this PR?

* Customer requests

## How has this PR been tested?

Unit tests and manually:

<img width="474" alt="Screenshot 2025-02-17 at 1 05 31 PM" src="https://github.com/user-attachments/assets/2e2c537c-90bb-4e2d-af8c-d2291ba6daf9" />

<img width="447" alt="Screenshot 2025-02-17 at 1 06 17 PM" src="https://github.com/user-attachments/assets/bb75dba2-2f83-48a3-9b6b-02a3fbc14b5d" />

