### PR TITLE
fix: OpenApi Parser v2 Conform to legacy ids for snippet matching

### DIFF
--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fern-api/docs-parsers",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern-platform.git",

--- a/packages/parsers/src/openapi/3.1/auth/__test__/OAuth2SecuritySchemeConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/auth/__test__/OAuth2SecuritySchemeConverter.node.test.ts
@@ -35,7 +35,7 @@ describe("OAuth2SecuritySchemeConverterNode", () => {
         type: "clientCredentials",
         value: {
           type: "referencedEndpoint",
-          endpointId: "endpoint_.postHttpsApiExampleComOauthToken",
+          endpointId: "endpoint_.post-https-api-example-com-oauth-token",
           accessTokenLocator: "$.access_token",
           headerName: "Authorization",
           tokenPrefix: "Bearer",

--- a/packages/parsers/src/openapi/3.1/auth/__test__/SecuritySchemeConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/auth/__test__/SecuritySchemeConverter.node.test.ts
@@ -223,7 +223,7 @@ describe("SecuritySchemeConverterNode", () => {
           type: "clientCredentials",
           value: {
             type: "referencedEndpoint",
-            endpointId: "endpoint_.postHttpsApiExampleComOauthToken",
+            endpointId: "endpoint_.post-https-api-example-com-oauth-token",
             accessTokenLocator: "$.body.access_token",
             headerName: "Authorization",
           },

--- a/packages/parsers/src/openapi/3.1/paths/__test__/OperationObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/OperationObjectConverter.node.test.ts
@@ -52,7 +52,7 @@ describe("OperationObjectConverterNode", () => {
               },
             },
           ],
-          id: "endpoint_.getPetsPetId",
+          id: "endpoint_.get-pets-pet-id",
           method: "GET",
           namespace: undefined,
           operationId: undefined,

--- a/packages/parsers/src/openapi/3.1/paths/__test__/PathItemObjectConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/paths/__test__/PathItemObjectConverter.node.test.ts
@@ -65,7 +65,7 @@ describe("PathItemObjectConverterNode", () => {
             responseStatusCode: 200,
           },
         ],
-        id: "endpoint_.getPetsPetId",
+        id: "endpoint_.get-pets-pet-id",
         method: "GET",
         namespace: undefined,
         operationId: undefined,
@@ -135,7 +135,7 @@ describe("PathItemObjectConverterNode", () => {
       });
       expect(result?.[1]).toMatchObject({
         description: "Create a pet",
-        id: "endpoint_.postPetsPetId",
+        id: "endpoint_.post-pets-pet-id",
         method: "POST",
         path: [
           {

--- a/packages/parsers/src/openapi/__test__/__snapshots__/application-json.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/application-json.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.getVndFernUserJsonVersion1": {
-      "id": "endpoint_.getVndFernUserJsonVersion1",
+    "endpoint_.get-vnd-fern-user-json-version-1": {
+      "id": "endpoint_.get-vnd-fern-user-json-version-1",
       "method": "GET",
       "path": [
         {
@@ -46,8 +46,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.getApplicationJson": {
-      "id": "endpoint_.getApplicationJson",
+    "endpoint_.get-application-json": {
+      "id": "endpoint_.get-application-json",
       "method": "GET",
       "path": [
         {

--- a/packages/parsers/src/openapi/__test__/__snapshots__/availability.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/availability.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.getCollectionIdActiveIdDeprecatedRefIdXFernAvailabilityPathParam": {
-      "id": "endpoint_.getCollectionIdActiveIdDeprecatedRefIdXFernAvailabilityPathParam",
+    "endpoint_.get-collection-id-active-id-deprecated-ref-id-x-fern-availability-path-param": {
+      "id": "endpoint_.get-collection-id-active-id-deprecated-ref-id-x-fern-availability-path-param",
       "method": "GET",
       "path": [
         {
@@ -280,8 +280,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.postSuccessRef": {
-      "id": "endpoint_.postSuccessRef",
+    "endpoint_.post-success-ref": {
+      "id": "endpoint_.post-success-ref",
       "method": "POST",
       "path": [
         {
@@ -342,8 +342,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.postSuccessInlinePropertyDeprecation": {
-      "id": "endpoint_.postSuccessInlinePropertyDeprecation",
+    "endpoint_.post-success-inline-property-deprecation": {
+      "id": "endpoint_.post-success-inline-property-deprecation",
       "method": "POST",
       "path": [
         {
@@ -440,8 +440,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.postSuccessInlineObjectDeprecation": {
-      "id": "endpoint_.postSuccessInlineObjectDeprecation",
+    "endpoint_.post-success-inline-object-deprecation": {
+      "id": "endpoint_.post-success-inline-object-deprecation",
       "availability": "Deprecated",
       "method": "POST",
       "path": [
@@ -514,8 +514,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.postSuccessInlineBetaBody": {
-      "id": "endpoint_.postSuccessInlineBetaBody",
+    "endpoint_.post-success-inline-beta-body": {
+      "id": "endpoint_.post-success-inline-beta-body",
       "availability": "Beta",
       "method": "POST",
       "path": [

--- a/packages/parsers/src/openapi/__test__/__snapshots__/cohere.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/cohere.json
@@ -19692,8 +19692,8 @@
         "type": "rest"
       }
     },
-    "endpoint_datasets.getUsage": {
-      "id": "endpoint_datasets.getUsage",
+    "endpoint_datasets.get-usage": {
+      "id": "endpoint_datasets.get-usage",
       "description": "View the dataset storage usage for your Organization. Each Organization can have up to 10GB of storage across all their users.",
       "namespace": [
         "datasets"
@@ -27139,8 +27139,8 @@
         "type": "rest"
       }
     },
-    "endpoint_connectors.oAuthAuthorize": {
-      "id": "endpoint_connectors.oAuthAuthorize",
+    "endpoint_connectors.o-auth-authorize": {
+      "id": "endpoint_connectors.o-auth-authorize",
       "description": "Authorize the connector with the given ID for the connector oauth app.  See ['Connector Authentication'](https://docs.cohere.com/docs/connector-authentication) for more information.",
       "namespace": [
         "connectors"

--- a/packages/parsers/src/openapi/__test__/__snapshots__/content-type.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/content-type.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.postTest": {
-      "id": "endpoint_.postTest",
+    "endpoint_.post-test": {
+      "id": "endpoint_.post-test",
       "description": "Test multipart request with different content types.\n",
       "displayName": "Test upload",
       "method": "POST",

--- a/packages/parsers/src/openapi/__test__/__snapshots__/deeptune.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/deeptune.json
@@ -86,8 +86,8 @@
         "type": "rest"
       }
     },
-    "endpoint_textToSpeech.generateFromPrompt": {
-      "id": "endpoint_textToSpeech.generateFromPrompt",
+    "endpoint_textToSpeech.generate-from-prompt": {
+      "id": "endpoint_textToSpeech.generate-from-prompt",
       "description": "If you prefer to manage voices on your own, you can use your own audio file as a reference for the voice clone.x",
       "namespace": [
         "textToSpeech"

--- a/packages/parsers/src/openapi/__test__/__snapshots__/defaults.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/defaults.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.getTest": {
-      "id": "endpoint_.getTest",
+    "endpoint_.get-test": {
+      "id": "endpoint_.get-test",
       "method": "GET",
       "path": [
         {

--- a/packages/parsers/src/openapi/__test__/__snapshots__/enum-casing.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/enum-casing.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.getExample": {
-      "id": "endpoint_.getExample",
+    "endpoint_.get-example": {
+      "id": "endpoint_.get-example",
       "displayName": "Get Example",
       "method": "GET",
       "path": [

--- a/packages/parsers/src/openapi/__test__/__snapshots__/examples.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/examples.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.postMatchingExamples": {
-      "id": "endpoint_.postMatchingExamples",
+    "endpoint_.post-matching-examples": {
+      "id": "endpoint_.post-matching-examples",
       "method": "POST",
       "path": [
         {
@@ -103,8 +103,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.postNonMatchingExamples": {
-      "id": "endpoint_.postNonMatchingExamples",
+    "endpoint_.post-non-matching-examples": {
+      "id": "endpoint_.post-non-matching-examples",
       "method": "POST",
       "path": [
         {
@@ -205,8 +205,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.postMoreRequests": {
-      "id": "endpoint_.postMoreRequests",
+    "endpoint_.post-more-requests": {
+      "id": "endpoint_.post-more-requests",
       "method": "POST",
       "path": [
         {
@@ -307,8 +307,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.postMoreResponses": {
-      "id": "endpoint_.postMoreResponses",
+    "endpoint_.post-more-responses": {
+      "id": "endpoint_.post-more-responses",
       "method": "POST",
       "path": [
         {
@@ -409,8 +409,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.postPostEmptyResponse": {
-      "id": "endpoint_.postPostEmptyResponse",
+    "endpoint_.post-post-empty-response": {
+      "id": "endpoint_.post-post-empty-response",
       "description": "empty response",
       "method": "POST",
       "path": [
@@ -464,8 +464,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.postSingleExample": {
-      "id": "endpoint_.postSingleExample",
+    "endpoint_.post-single-example": {
+      "id": "endpoint_.post-single-example",
       "method": "POST",
       "path": [
         {
@@ -548,8 +548,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.postRequestBodyReference": {
-      "id": "endpoint_.postRequestBodyReference",
+    "endpoint_.post-request-body-reference": {
+      "id": "endpoint_.post-request-body-reference",
       "method": "POST",
       "path": [
         {

--- a/packages/parsers/src/openapi/__test__/__snapshots__/inline-schema-reference.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/inline-schema-reference.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.getExample": {
-      "id": "endpoint_.getExample",
+    "endpoint_.get-example": {
+      "id": "endpoint_.get-example",
       "displayName": "Get Example",
       "method": "GET",
       "path": [

--- a/packages/parsers/src/openapi/__test__/__snapshots__/multi-url-generators-yml.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/multi-url-generators-yml.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.getUsers": {
-      "id": "endpoint_.getUsers",
+    "endpoint_.get-users": {
+      "id": "endpoint_.get-users",
       "description": "List information about all users",
       "displayName": "List Users",
       "method": "GET",
@@ -56,8 +56,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.getUsersUserId": {
-      "id": "endpoint_.getUsersUserId",
+    "endpoint_.get-users-user-id": {
+      "id": "endpoint_.get-users-user-id",
       "description": "Retrieve detailed information about a specific user",
       "displayName": "Get user information",
       "method": "GET",
@@ -136,8 +136,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.getToken": {
-      "id": "endpoint_.getToken",
+    "endpoint_.get-token": {
+      "id": "endpoint_.get-token",
       "description": "Retrieve an authentication token for the API",
       "displayName": "Get authentication token",
       "method": "GET",

--- a/packages/parsers/src/openapi/__test__/__snapshots__/nested-array-object.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/nested-array-object.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.postTestNestedArrayObject": {
-      "id": "endpoint_.postTestNestedArrayObject",
+    "endpoint_.post-test-nested-array-object": {
+      "id": "endpoint_.post-test-nested-array-object",
       "method": "POST",
       "path": [
         {

--- a/packages/parsers/src/openapi/__test__/__snapshots__/non-alphanumeric-characters.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/non-alphanumeric-characters.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.patchSettings": {
-      "id": "endpoint_.patchSettings",
+    "endpoint_.patch-settings": {
+      "id": "endpoint_.patch-settings",
       "method": "PATCH",
       "path": [
         {

--- a/packages/parsers/src/openapi/__test__/__snapshots__/nullable.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/nullable.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.postUsers": {
-      "id": "endpoint_.postUsers",
+    "endpoint_.post-users": {
+      "id": "endpoint_.post-users",
       "displayName": "Create a user",
       "method": "POST",
       "path": [
@@ -83,8 +83,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.putUsers": {
-      "id": "endpoint_.putUsers",
+    "endpoint_.put-users": {
+      "id": "endpoint_.put-users",
       "displayName": "Update a user",
       "method": "PUT",
       "path": [
@@ -165,8 +165,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.getUsersUserId": {
-      "id": "endpoint_.getUsersUserId",
+    "endpoint_.get-users-user-id": {
+      "id": "endpoint_.get-users-user-id",
       "displayName": "Get a user",
       "method": "GET",
       "path": [

--- a/packages/parsers/src/openapi/__test__/__snapshots__/oauth.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/oauth.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_auth.getToken": {
-      "id": "endpoint_auth.getToken",
+    "endpoint_auth.get-token": {
+      "id": "endpoint_auth.get-token",
       "description": "Exchange credentials or refresh token for an access token",
       "namespace": [
         "auth"

--- a/packages/parsers/src/openapi/__test__/__snapshots__/readonly.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/readonly.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.postUsers": {
-      "id": "endpoint_.postUsers",
+    "endpoint_.post-users": {
+      "id": "endpoint_.post-users",
       "displayName": "Create a user",
       "method": "POST",
       "path": [
@@ -83,8 +83,8 @@
         "type": "rest"
       }
     },
-    "endpoint_.getUsersUserId": {
-      "id": "endpoint_.getUsersUserId",
+    "endpoint_.get-users-user-id": {
+      "id": "endpoint_.get-users-user-id",
       "displayName": "Get a user",
       "method": "GET",
       "path": [

--- a/packages/parsers/src/openapi/__test__/__snapshots__/request-response-description.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/request-response-description.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.getExample": {
-      "id": "endpoint_.getExample",
+    "endpoint_.get-example": {
+      "id": "endpoint_.get-example",
       "displayName": "Get Example",
       "method": "GET",
       "path": [

--- a/packages/parsers/src/openapi/__test__/__snapshots__/rules.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/rules.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.getExample": {
-      "id": "endpoint_.getExample",
+    "endpoint_.get-example": {
+      "id": "endpoint_.get-example",
       "displayName": "Default and validation rules",
       "method": "GET",
       "path": [

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-audiences.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-audiences.json
@@ -1,8 +1,8 @@
 {
   "id": "test-uuid-replacement",
   "endpoints": {
-    "endpoint_.postV1Users": {
-      "id": "endpoint_.postV1Users",
+    "endpoint_.post-v-1-users": {
+      "id": "endpoint_.post-v-1-users",
       "method": "POST",
       "path": [
         {

--- a/packages/parsers/src/openapi/utils/__test__/getEndpointId.test.ts
+++ b/packages/parsers/src/openapi/utils/__test__/getEndpointId.test.ts
@@ -24,7 +24,7 @@ describe("getEndpointId", () => {
         operationId: undefined,
         isWebhook: undefined,
       })
-    ).toBe("endpoint_pets.getByIdPetsGet");
+    ).toBe("endpoint_pets.get-by-id-pets-get");
   });
 
   it("handles array namespace", () => {
@@ -37,7 +37,7 @@ describe("getEndpointId", () => {
         operationId: undefined,
         isWebhook: undefined,
       })
-    ).toBe("endpoint_pets.v1.getByIdPetsGet");
+    ).toBe("endpoint_pets/v1.get-by-id-pets-get");
   });
 
   it("handles undefined namespace", () => {
@@ -50,7 +50,7 @@ describe("getEndpointId", () => {
         operationId: undefined,
         isWebhook: undefined,
       })
-    ).toBe("endpoint_.getByIdPetsGet");
+    ).toBe("endpoint_.get-by-id-pets-get");
   });
 
   it("uses operationId when sdkMethodName is undefined", () => {
@@ -76,7 +76,7 @@ describe("getEndpointId", () => {
         operationId: undefined,
         isWebhook: undefined,
       })
-    ).toBe("endpoint_pets.petsGet");
+    ).toBe("endpoint_pets.pets-get");
   });
 
   it("handles complex paths", () => {
@@ -89,6 +89,6 @@ describe("getEndpointId", () => {
         operationId: undefined,
         isWebhook: undefined,
       })
-    ).toBe("endpoint_pets.getDetailsApiV1PetsPetIdDetails");
+    ).toBe("endpoint_pets.get-details-api-v-1-pets-pet-id-details");
   });
 });

--- a/packages/parsers/src/openapi/utils/getEndpointId.ts
+++ b/packages/parsers/src/openapi/utils/getEndpointId.ts
@@ -1,4 +1,4 @@
-import { camelCase } from "es-toolkit";
+import { camelCase, kebabCase } from "es-toolkit";
 import { maybeSingleValueToArray } from "./maybeSingleValueToArray";
 
 export function getEndpointId({
@@ -41,7 +41,7 @@ function getFullyQualifiedNamespace(
   return namespace != null
     ? maybeSingleValueToArray(namespace)
         ?.map((member) => camelCase(member))
-        .join(".")
+        .join("/")
     : "";
 }
 
@@ -51,6 +51,6 @@ function getEndpointName(
   endpointName: string
 ): string | undefined {
   return (
-    camelCase(sdkMethodName ?? "") || operationId || camelCase(endpointName)
+    kebabCase(sdkMethodName ?? "") || operationId || kebabCase(endpointName)
   );
 }

--- a/packages/parsers/src/utils/computeSubpackages.ts
+++ b/packages/parsers/src/utils/computeSubpackages.ts
@@ -31,19 +31,17 @@ export function computeSubpackages({
     ...webhookEndpoints,
   }).forEach((endpoint) => {
     const qualifiedPath: string[] = [];
-    return endpoint.namespace?.forEach((subpackage) => {
-      const prunedSubpackage = subpackage;
-      // subpackage.replace(/subpackage_/, "");
-      const qualifiedSubpackagePath = [...qualifiedPath, prunedSubpackage];
+    endpoint.namespace?.forEach((subpackage) => {
+      const qualifiedSubpackagePath = [...qualifiedPath, subpackage];
       const fullyQualifiedSubpackageId = FernRegistry.api.v1.SubpackageId(
         qualifiedSubpackagePath.join(".")
       );
       subpackages[fullyQualifiedSubpackageId] = {
         id: fullyQualifiedSubpackageId,
         name: qualifiedSubpackagePath.join("/"),
-        displayName: titleCase(prunedSubpackage),
+        displayName: titleCase(subpackage),
       };
-      qualifiedPath.push(prunedSubpackage);
+      qualifiedPath.push(subpackage);
     });
   });
 

--- a/servers/fdr/src/controllers/api/getRegisterApiService.ts
+++ b/servers/fdr/src/controllers/api/getRegisterApiService.ts
@@ -5,8 +5,8 @@ import {
   FdrAPI,
   SDKSnippetHolder,
 } from "@fern-api/fdr-sdk";
+import urlJoin from "url-join";
 import { v4 as uuidv4 } from "uuid";
-import { stringifyEndpointPathParts } from "../../../../../packages/fdr-sdk/src/navigation/utils/stringifyEndpointPathParts";
 import { APIV1WriteService } from "../../api";
 import { SdkRequest } from "../../api/generated/api";
 import type { FdrApplication } from "../../app";
@@ -181,6 +181,16 @@ export function getRegisterApiService(app: FdrApplication): APIV1WriteService {
   });
 }
 
+function stringifyEndpointPathParts(
+  path: FdrAPI.api.latest.PathPart[]
+): string {
+  return urlJoin(
+    ...path.map((part) =>
+      part.type === "literal" ? part.value : `{${part.value}}`
+    )
+  );
+}
+
 function enrichApiLatestDefinitionWithSnippets(
   definition: FdrAPI.api.latest.ApiDefinition,
   snippetHolder: SDKSnippetHolder
@@ -191,45 +201,44 @@ function enrichApiLatestDefinitionWithSnippets(
         stringifyEndpointPathParts(endpoint.path)
       ),
       endpointMethod: endpoint.method,
-      endpointId: undefined,
+      endpointId: endpoint.id,
     });
 
-    const goSnippet = snippetHolder.getGoCodeSnippetForEndpoint({
-      endpointPath: FdrAPI.EndpointPathLiteral(
-        stringifyEndpointPathParts(endpoint.path)
-      ),
-      endpointMethod: endpoint.method,
-      endpointId: undefined,
-      exampleId: undefined,
-    });
-    const pythonSnippet = snippetHolder.getPythonCodeSnippetForEndpoint({
-      endpointPath: FdrAPI.EndpointPathLiteral(
-        stringifyEndpointPathParts(endpoint.path)
-      ),
-      endpointMethod: endpoint.method,
-      endpointId: undefined,
-      exampleId: undefined,
-    });
-    const rubySnippet = snippetHolder.getRubyCodeSnippetForEndpoint({
-      endpointPath: FdrAPI.EndpointPathLiteral(
-        stringifyEndpointPathParts(endpoint.path)
-      ),
-      endpointMethod: endpoint.method,
-      endpointId: undefined,
-      exampleId: undefined,
-    });
-    const typescriptSnippet = snippetHolder.getTypeScriptCodeSnippetForEndpoint(
-      {
+    endpoint.examples?.forEach((example) => {
+      const goSnippet = snippetHolder.getGoCodeSnippetForEndpoint({
         endpointPath: FdrAPI.EndpointPathLiteral(
           stringifyEndpointPathParts(endpoint.path)
         ),
         endpointMethod: endpoint.method,
-        endpointId: undefined,
-        exampleId: undefined,
-      }
-    );
+        endpointId: endpoint.id,
+        exampleId: example.name,
+      });
+      const pythonSnippet = snippetHolder.getPythonCodeSnippetForEndpoint({
+        endpointPath: FdrAPI.EndpointPathLiteral(
+          stringifyEndpointPathParts(endpoint.path)
+        ),
+        endpointMethod: endpoint.method,
+        endpointId: endpoint.id,
+        exampleId: example.name,
+      });
+      const rubySnippet = snippetHolder.getRubyCodeSnippetForEndpoint({
+        endpointPath: FdrAPI.EndpointPathLiteral(
+          stringifyEndpointPathParts(endpoint.path)
+        ),
+        endpointMethod: endpoint.method,
+        endpointId: endpoint.id,
+        exampleId: example.name,
+      });
+      const typescriptSnippet =
+        snippetHolder.getTypeScriptCodeSnippetForEndpoint({
+          endpointPath: FdrAPI.EndpointPathLiteral(
+            stringifyEndpointPathParts(endpoint.path)
+          ),
+          endpointMethod: endpoint.method,
+          endpointId: endpoint.id,
+          exampleId: example.name,
+        });
 
-    endpoint.examples?.forEach((example) => {
       if (goSnippet != null) {
         example.snippets ??= {};
         example.snippets.go ??= [];


### PR DESCRIPTION
## Short description of the changes made

* Previously, we generated a new version of unique ids for endpoints, so that they were cleaner in the resulting payload. Now we generate the legacy apis
* Previously, we only tried to match on endpoint path -- upon closer inspection, it looks like the stringifying function appended an erroneous `/` and did not conform to the path parameter specification as in the table. Now we stringify properly, and use the legacy id to be more robust when matching

## What was the motivation & context behind this PR?

* Make sure that snippets properly match

## How has this PR been tested?

*. To be tested with dev cli
