### PR TITLE
docs/ask-ai: reduce max number of docs inlined in system prompt

### DIFF
--- a/packages/fern-docs/bundle/src/app/api/fern-docs/search/v2/chat/route.ts
+++ b/packages/fern-docs/bundle/src/app/api/fern-docs/search/v2/chat/route.ts
@@ -197,7 +197,7 @@ async function runQueryTurbopuffer(
     : await queryTurbopuffer(query, {
         namespace: opts.namespace,
         apiKey: turbopufferApiKey(),
-        topK: opts.topK ?? 20,
+        topK: opts.topK ?? 10,
         vectorizer: async (text) => {
           const embedding = await embed({
             model: opts.embeddingModel,


### PR DESCRIPTION
FER-4458

## Short description of the changes made

Reduce the default topK number of docs inlined into the system prompt for Ask AI.

## What was the motivation & context behind this PR?

This is an attempt to mitigate the Bedrock throttling errors we've been seeing. See context in [slack thread](https://buildwithfern.slack.com/archives/C05E0S0A9SN/p1739894908205249?thread_ts=1739834073.265809&cid=C05E0S0A9SN)

## How has this PR been tested?

Ran `pnpm docs:dev` locally and verified that Ask AI feature works as expected. Didn't try to invoke a throttling error since it should be less likely now (didn't occur after ~3 attempts).