### PR TITLE
docs/ask-ai: tell user to retry when error occurs

### DIFF
--- a/packages/fern-docs/search-ui/src/components/desktop/desktop-ask-ai.tsx
+++ b/packages/fern-docs/search-ui/src/components/desktop/desktop-ask-ai.tsx
@@ -249,6 +249,7 @@ const DesktopAskAIContent = (props: {
 };
 
 const initialConversationAtom = atom<Message[]>([]);
+const chatErrorAtom = atom(false);
 
 const DesktopAskAIChat = ({
   onReturnToSearch,
@@ -282,6 +283,8 @@ const DesktopAskAIChat = ({
   const [initialConversation, setInitialConversation] = useAtom(
     initialConversationAtom
   );
+  const [chatError, setChatError] = useAtom(chatErrorAtom);
+
   const chat = useChat({
     id: chatId,
     initialInput,
@@ -292,6 +295,10 @@ const DesktopAskAIChat = ({
     onFinish: useEventCallback(() => {
       setInitialConversation(chat.messages);
     }),
+    onError: (error) => {
+      console.error(error);
+      setChatError(true);
+    },
   });
 
   // Reset userScrolled when the chat is loading
@@ -312,6 +319,7 @@ const DesktopAskAIChat = ({
         );
         return;
       }
+      setChatError(false); // reset any previous chat error
       void chat.append({ role: "user", content: message });
       chat.setInput("");
     },
@@ -580,6 +588,7 @@ const AskAICommandItems = memo<{
     domain,
     renderActions,
   }): ReactElement => {
+    const [chatError, _] = useAtom(chatErrorAtom);
     const squeezedMessages = squeezeMessages(messages);
 
     const lastConversationRef = useRef<Element | null>(null);
@@ -610,6 +619,15 @@ const AskAICommandItems = memo<{
         });
       }
     });
+
+    if (chatError) {
+      console.log("chatError, sq msgs", squeezedMessages);
+      let asst = squeezedMessages.at(-1)?.assistant;
+      if (asst != null) {
+        asst.content =
+          "I wasn't able to complete your request. Please try again in a few seconds.";
+      }
+    }
 
     if (squeezedMessages.length === 0) {
       return (

--- a/packages/fern-docs/search-ui/src/components/desktop/desktop-ask-ai.tsx
+++ b/packages/fern-docs/search-ui/src/components/desktop/desktop-ask-ai.tsx
@@ -283,7 +283,7 @@ const DesktopAskAIChat = ({
   const [initialConversation, setInitialConversation] = useAtom(
     initialConversationAtom
   );
-  const [chatError, setChatError] = useAtom(chatErrorAtom);
+  const [_, setChatError] = useAtom(chatErrorAtom);
 
   const chat = useChat({
     id: chatId,
@@ -621,11 +621,13 @@ const AskAICommandItems = memo<{
     });
 
     if (chatError) {
-      console.log("chatError, sq msgs", squeezedMessages);
-      let asst = squeezedMessages.at(-1)?.assistant;
-      if (asst != null) {
-        asst.content =
-          "I wasn't able to complete your request. Please try again in a few seconds.";
+      let lastConvo = squeezedMessages.at(-1);
+      if (lastConvo != null && lastConvo.assistant == null) {
+        lastConvo.assistant = {
+          id: "error-msg-id",
+          content:
+            "I wasn't able to complete your request. Please try again in a few seconds.",
+        };
       }
     }
 


### PR DESCRIPTION
## Short description of the changes made

Provide an `onError` handler to `useChat` that updates a bool atom. This state can then be used to show a useful error message rather than a blank response.

## What was the motivation & context behind this PR?

It's useful to show users a message rather than a blank response when an error occurs.

## How has this PR been tested?

Tested locally: invoked an error and verified that the new error message was displayed.

![Screenshot 2025-02-18 at 3 25 38 PM](https://github.com/user-attachments/assets/6b69abd5-534f-4015-a275-fac083fed81d)
