### PR TITLE
fix: OpenApi Parser v2 single element array types

### DIFF
--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fern-api/docs-parsers",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern-platform.git",

--- a/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/SchemaConverter.node.ts
@@ -83,6 +83,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
       accessPath: this.accessPath,
       pathId: "x-fern-availability",
     });
+
     // check if nullable is set. If nullable is false, we will set it, otherwise we will ignore it
     if (isNonArraySchema(this.input) && isNullableSchema(this.input)) {
       this.nullable =
@@ -123,6 +124,7 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
       // If the object is not a reference object, then it is a schema object, gather all appropriate variables
       this.name = this.input.title;
       this.examples = this.input.example;
+
       if (this.input.const != null) {
         this.typeShapeNode = new ConstConverterNode({
           input: this.input,
@@ -172,89 +174,100 @@ export class SchemaConverterNode extends BaseOpenApiV3_1ConverterNodeWithTrackin
         });
       }
       // We assume that if one of is defined, it is an object node
-      else if (typeof this.input.type === "string") {
-        switch (this.input.type) {
-          case "object":
-            if (isObjectSchema(this.input)) {
-              this.typeShapeNode = new ObjectConverterNode({
-                input: this.input,
-                context: this.context,
-                accessPath: this.accessPath,
-                pathId: this.pathId,
-                seenSchemas: this.seenSchemas,
-                schemaName: this.schemaName,
-              });
-            }
-            break;
-          case "array":
-            if (isArraySchema(this.input)) {
-              this.typeShapeNode = new ArrayConverterNode({
-                input: this.input,
-                context: this.context,
-                accessPath: this.accessPath,
-                pathId: this.pathId,
-                seenSchemas: this.seenSchemas,
-                schemaName: this.schemaName,
-              });
-            }
-            break;
-          case "boolean":
-            if (isBooleanSchema(this.input)) {
-              this.typeShapeNode = new BooleanConverterNode({
-                input: this.input,
-                context: this.context,
-                accessPath: this.accessPath,
-                pathId: this.pathId,
-                nullable: this.nullable,
-              });
-            }
-            break;
-          case "integer":
-            if (isIntegerSchema(this.input)) {
-              this.typeShapeNode = new IntegerConverterNode({
-                input: this.input,
-                context: this.context,
-                accessPath: this.accessPath,
-                pathId: this.pathId,
-                nullable: this.nullable,
-              });
-            }
-            break;
-          case "number":
-            if (isNumberSchema(this.input)) {
-              this.typeShapeNode = new NumberConverterNode({
-                input: this.input,
-                context: this.context,
-                accessPath: this.accessPath,
-                pathId: this.pathId,
-                nullable: this.nullable,
-              });
-            }
-            break;
-          case "string":
-            if (isStringSchema(this.input)) {
-              this.typeShapeNode = new StringConverterNode({
-                input: this.input,
-                context: this.context,
-                accessPath: this.accessPath,
-                pathId: this.pathId,
-                nullable: this.nullable,
-              });
-            }
-            break;
-          case "null":
-            if (isNullSchema(this.input)) {
-              this.typeShapeNode = new NullConverterNode({
-                input: this.input,
-                context: this.context,
-                accessPath: this.accessPath,
-                pathId: this.pathId,
-              });
-            }
-            break;
-          default:
-            new UnreachableCaseError(this.input.type);
-            break;
+      else if (
+        typeof this.input.type === "string" ||
+        (Array.isArray(this.input.type) && this.input.type.length === 1)
+      ) {
+        this.input.type = Array.isArray(this.input.type)
+          ? this.input.type[0]
+          : this.input.type;
+
+        if (!Array.isArray(this.input.type)) {
+          switch (this.input.type) {
+            case "object":
+              if (isObjectSchema(this.input)) {
+                this.typeShapeNode = new ObjectConverterNode({
+                  input: this.input,
+                  context: this.context,
+                  accessPath: this.accessPath,
+                  pathId: this.pathId,
+                  seenSchemas: this.seenSchemas,
+                  schemaName: this.schemaName,
+                });
+              }
+              break;
+            case "array":
+              if (isArraySchema(this.input)) {
+                this.typeShapeNode = new ArrayConverterNode({
+                  input: this.input,
+                  context: this.context,
+                  accessPath: this.accessPath,
+                  pathId: this.pathId,
+                  seenSchemas: this.seenSchemas,
+                  schemaName: this.schemaName,
+                });
+              }
+              break;
+            case "boolean":
+              if (isBooleanSchema(this.input)) {
+                this.typeShapeNode = new BooleanConverterNode({
+                  input: this.input,
+                  context: this.context,
+                  accessPath: this.accessPath,
+                  pathId: this.pathId,
+                  nullable: this.nullable,
+                });
+              }
+              break;
+            case "integer":
+              if (isIntegerSchema(this.input)) {
+                this.typeShapeNode = new IntegerConverterNode({
+                  input: this.input,
+                  context: this.context,
+                  accessPath: this.accessPath,
+                  pathId: this.pathId,
+                  nullable: this.nullable,
+                });
+              }
+              break;
+            case "number":
+              if (isNumberSchema(this.input)) {
+                this.typeShapeNode = new NumberConverterNode({
+                  input: this.input,
+                  context: this.context,
+                  accessPath: this.accessPath,
+                  pathId: this.pathId,
+                  nullable: this.nullable,
+                });
+              }
+              break;
+            case "string":
+              if (isStringSchema(this.input)) {
+                this.typeShapeNode = new StringConverterNode({
+                  input: this.input,
+                  context: this.context,
+                  accessPath: this.accessPath,
+                  pathId: this.pathId,
+                  nullable: this.nullable,
+                });
+              }
+              break;
+            case "null":
+              if (isNullSchema(this.input)) {
+                this.typeShapeNode = new NullConverterNode({
+                  input: this.input,
+                  context: this.context,
+                  accessPath: this.accessPath,
+                  pathId: this.pathId,
+                });
+              }
+              break;
+            case undefined:
+              break;
+            default:
+              new UnreachableCaseError(this.input.type);
+              break;
+          }
         }
       } else if (
         Array.isArray(this.input.type) &&

--- a/packages/parsers/src/openapi/__test__/__snapshots__/pathing/warnings/single-element-type.txt
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/pathing/warnings/single-element-type.txt
@@ -1,0 +1,6 @@
+[
+  {
+    "message": "Expected 'paths' or 'webhooks' property to be specified",
+    "path": [],
+  },
+]

--- a/packages/parsers/src/openapi/__test__/__snapshots__/single-element-type.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/single-element-type.json
@@ -1,0 +1,22 @@
+{
+  "id": "test-uuid-replacement",
+  "endpoints": {},
+  "websockets": {},
+  "webhooks": {},
+  "types": {
+    "Test": {
+      "name": "Test",
+      "shape": {
+        "type": "alias",
+        "value": {
+          "type": "primitive",
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "subpackages": {},
+  "auths": {}
+}

--- a/packages/parsers/src/openapi/__test__/fixtures/single-element-type/openapi.yml
+++ b/packages/parsers/src/openapi/__test__/fixtures/single-element-type/openapi.yml
@@ -1,0 +1,11 @@
+openapi: 3.1.0
+info:
+  title: Single Element Type
+  description: Single Element Type
+  version: 1.0.0
+components:
+  schemas:
+    Test:
+      type: 
+        - string
+        


### PR DESCRIPTION
## Short description of the changes made

* Previously, types that were single value arrays were not being parsed correctly. Now they are

## What was the motivation & context behind this PR?

* Customer spec review

## How has this PR been tested?

* Fixture test
