### PR TITLE
fix: OpenApi Parser v2 return auths if types are nullish

### DIFF
--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fern-api/docs-parsers",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern-platform.git",

--- a/packages/parsers/src/openapi/3.1/OpenApiDocumentConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/OpenApiDocumentConverter.node.ts
@@ -138,6 +138,7 @@ export class OpenApiDocumentConverterNode extends BaseOpenApiV3_1ConverterNode<
     > = computeSubpackages({ endpoints, webhookEndpoints: webhooks });
 
     const { types, auths } = this.components?.convert() ?? {};
+    console.log(types, auths);
 
     return {
       id: FernRegistry.ApiDefinitionId(apiDefinitionId),

--- a/packages/parsers/src/openapi/3.1/OpenApiDocumentConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/OpenApiDocumentConverter.node.ts
@@ -138,7 +138,6 @@ export class OpenApiDocumentConverterNode extends BaseOpenApiV3_1ConverterNode<
     > = computeSubpackages({ endpoints, webhookEndpoints: webhooks });
 
     const { types, auths } = this.components?.convert() ?? {};
-    console.log(types, auths);
 
     return {
       id: FernRegistry.ApiDefinitionId(apiDefinitionId),

--- a/packages/parsers/src/openapi/3.1/paths/response/ResponseMediaTypeObjectConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/paths/response/ResponseMediaTypeObjectConverter.node.ts
@@ -502,11 +502,17 @@ export class ResponseMediaTypeObjectConverterNode extends BaseOpenApiV3_1Convert
         exampleName !== GLOBAL_EXAMPLE_NAME
     );
 
-    // Match based on index, saturating examples at the end of lists if mismatched
-    this.matchExamplesByIndex(
-      filteredRequestExamples,
-      filteredResponseExamples
-    );
+    if (
+      !Object.keys(responseExamples).every(
+        (exampleName) => exampleName === GLOBAL_EXAMPLE_NAME
+      )
+    ) {
+      // Match based on index, saturating examples at the end of lists if mismatched
+      this.matchExamplesByIndex(
+        filteredRequestExamples,
+        filteredResponseExamples
+      );
+    }
 
     // Fallback to a generated example if no examples were matched
     if (

--- a/packages/parsers/src/openapi/3.1/schemas/ComponentsConverter.node.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/ComponentsConverter.node.ts
@@ -97,44 +97,46 @@ export class ComponentsConverterNode extends BaseOpenApiV3_1ConverterNode<
   }
 
   convert(): ComponentsConverterNode.Output | undefined {
-    if (this.typeSchemas == null) {
-      return undefined;
-    }
-
     return {
-      auths: Object.fromEntries(
-        Object.entries(this.securitySchemes ?? {})
-          .map(([key, value]) => {
-            const maybeAuth = value.convert();
-            if (maybeAuth == null) {
-              return undefined;
-            }
-            return [FernRegistry.api.latest.AuthSchemeId(key), maybeAuth];
-          })
-          .filter(isNonNullish)
-      ),
-      types: Object.fromEntries(
-        Object.entries(this.typeSchemas)
-          .map(([key, value]) => {
-            const name = value.name ?? key;
-            const maybeShapes = maybeSingleValueToArray(value.convert());
+      auths:
+        this.securitySchemes != null
+          ? Object.fromEntries(
+              Object.entries(this.securitySchemes ?? {})
+                .map(([key, value]) => {
+                  const maybeAuth = value.convert();
+                  if (maybeAuth == null) {
+                    return undefined;
+                  }
+                  return [FernRegistry.api.latest.AuthSchemeId(key), maybeAuth];
+                })
+                .filter(isNonNullish)
+            )
+          : undefined,
+      types:
+        this.typeSchemas != null
+          ? Object.fromEntries(
+              Object.entries(this.typeSchemas)
+                .map(([key, value]) => {
+                  const name = value.name ?? key;
+                  const maybeShapes = maybeSingleValueToArray(value.convert());
 
-            if (maybeShapes == null) {
-              return [key, undefined];
-            }
+                  if (maybeShapes == null) {
+                    return [key, undefined];
+                  }
 
-            return [
-              FernRegistry.TypeId(key),
-              {
-                name,
-                shape: maybeShapes[0],
-                description: value.description,
-                availability: undefined,
-              },
-            ];
-          })
-          .filter(([_, value]) => isNonNullish(value))
-      ),
+                  return [
+                    FernRegistry.TypeId(key),
+                    {
+                      name,
+                      shape: maybeShapes[0],
+                      description: value.description,
+                      availability: undefined,
+                    },
+                  ];
+                })
+                .filter(([_, value]) => isNonNullish(value))
+            )
+          : undefined,
     };
   }
 }

--- a/packages/parsers/src/openapi/3.1/schemas/__test__/ComponentsConverter.node.test.ts
+++ b/packages/parsers/src/openapi/3.1/schemas/__test__/ComponentsConverter.node.test.ts
@@ -52,7 +52,8 @@ describe("ComponentsConverterNode", () => {
       pathId: "test",
     });
     const result = converter.convert();
-    expect(result).toBeUndefined();
+    expect(result?.types).toBeUndefined();
+    expect(result?.auths).toBeUndefined();
   });
 
   it("should use schema name if available, otherwise use key", () => {

--- a/packages/parsers/src/openapi/__test__/__snapshots__/oauth.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/oauth.json
@@ -273,5 +273,9 @@
       "displayName": "Auth"
     }
   },
-  "auths": {}
+  "auths": {
+    "oauth2": {
+      "type": "bearerAuth"
+    }
+  }
 }

--- a/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-auth-variables.json
+++ b/packages/parsers/src/openapi/__test__/__snapshots__/x-fern-auth-variables.json
@@ -148,5 +148,11 @@
       "displayName": "User"
     }
   },
-  "auths": {}
+  "auths": {
+    "BasicAuth": {
+      "type": "basicAuth",
+      "usernameName": "username",
+      "passwordName": "password"
+    }
+  }
 }


### PR DESCRIPTION
## Short description of the changes made

* Previously, auths were not propagating if there were no schemas. Now they do

## What was the motivation & context behind this PR?

* Customer edge case

## How has this PR been tested?

* Snapshot test
