### PR TITLE
feat: schema snippet alpha

### DIFF
--- a/packages/fern-docs/ui/src/mdx/components/index.tsx
+++ b/packages/fern-docs/ui/src/mdx/components/index.tsx
@@ -40,7 +40,11 @@ import { Json } from "./json";
 import { Mermaid } from "./mermaid";
 import { ParamField } from "./mintlify";
 import { ReferenceLayoutAside, ReferenceLayoutMain } from "./reference-layout";
-import { EndpointRequestSnippet, EndpointResponseSnippet } from "./snippets";
+import {
+  EndpointRequestSnippet,
+  EndpointResponseSnippet,
+  EndpointSchemaSnippet,
+} from "./snippets";
 import { Step, StepGroup } from "./steps";
 import { TabGroup } from "./tabs";
 import { Tooltip } from "./tooltip";
@@ -67,6 +71,7 @@ const FERN_COMPONENTS = {
   Download,
   EndpointRequestSnippet,
   EndpointResponseSnippet,
+  EndpointSchemaSnippet,
   Feature,
   Frame,
   Icon: RemoteFontAwesomeIcon,

--- a/packages/fern-docs/ui/src/mdx/components/snippets/EndpointSchemaSnippet.tsx
+++ b/packages/fern-docs/ui/src/mdx/components/snippets/EndpointSchemaSnippet.tsx
@@ -75,7 +75,9 @@ function EndpointSchemaSnippetInternal({
 
   return (
     <div>
-      {(selector == null || selector === "request.path") &&
+      {(selector == null ||
+        selector === "request" ||
+        selector === "request.path") &&
         endpoint.pathParameters &&
         endpoint.pathParameters.length > 0 && (
           <EndpointSection
@@ -139,7 +141,9 @@ function EndpointSchemaSnippetInternal({
             </div>
           </EndpointSection>
         )} */}
-      {(selector == null || selector === "request.query") &&
+      {(selector == null ||
+        selector === "request" ||
+        selector === "request.query") &&
         endpoint.queryParameters &&
         endpoint.queryParameters.length > 0 && (
           <EndpointSection
@@ -169,7 +173,9 @@ function EndpointSchemaSnippetInternal({
             </div>
           </EndpointSection>
         )}
-      {(selector == null || selector === "request.body") &&
+      {(selector == null ||
+        selector === "request" ||
+        selector === "request.body") &&
         endpoint.requests?.[0] != null && (
           <EndpointSection
             key={endpoint.requests[0].contentType}
@@ -185,7 +191,9 @@ function EndpointSchemaSnippetInternal({
             />
           </EndpointSection>
         )}
-      {(selector == null || selector === "response.body") &&
+      {(selector == null ||
+        selector === "response" ||
+        selector === "response.body") &&
         endpoint.responses?.[0] != null && (
           <EndpointSection
             title="Response"

--- a/packages/fern-docs/ui/src/mdx/components/snippets/EndpointSchemaSnippet.tsx
+++ b/packages/fern-docs/ui/src/mdx/components/snippets/EndpointSchemaSnippet.tsx
@@ -51,9 +51,11 @@ const REQUEST = ["request"];
 const RESPONSE = ["response"];
 const REQUEST_PATH = ["request", "path"];
 const REQUEST_QUERY = ["request", "query"];
+// todo: finish implementation
 // const REQUEST_HEADER = ["request", "header"];
 const REQUEST_BODY = ["request", "body"];
 const RESPONSE_BODY = ["response", "body"];
+// out of scope for now
 // const RESPONSE_ERROR = ["response", "error"];
 
 function EndpointSchemaSnippetInternal({
@@ -66,10 +68,6 @@ function EndpointSchemaSnippetInternal({
   selector: string | undefined;
 }) {
   const currentSlug = useAtomValue(SLUG_ATOM);
-
-  // const types = Object.entries(types).reduce<
-  //   Record<string, ApiDefinition.TypeDefinition>
-  // >((acc, [key, type]) => ({ ...acc, [`type_:${key}`]: type }), {});
 
   if (endpoint == null) {
     return null;
@@ -107,6 +105,40 @@ function EndpointSchemaSnippetInternal({
             </div>
           </EndpointSection>
         )}
+      {/* {(selector == null || selector === "request.header") &&
+        headers &&
+        headers.length > 0 && (
+          <EndpointSection
+            title="Headers"
+            anchorIdParts={REQUEST_HEADER}
+            slug={currentSlug}
+          >
+            <div>
+              {headers.map((parameter) => {
+                return (
+                  <div key={parameter.key} className="relative">
+                    <TypeComponentSeparator />
+                    <EndpointParameter
+                      name={parameter.key}
+                      shape={parameter.valueShape}
+                      anchorIdParts={[...REQUEST_HEADER, parameter.key]}
+                      slug={currentSlug}
+                      description={parameter.description}
+                      additionalDescriptions={
+                        ApiDefinition.unwrapReference(
+                          parameter.valueShape,
+                          types
+                        ).descriptions
+                      }
+                      availability={parameter.availability}
+                      types={types}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </EndpointSection>
+        )} */}
       {(selector == null || selector === "request.query") &&
         endpoint.queryParameters &&
         endpoint.queryParameters.length > 0 && (

--- a/packages/fern-docs/ui/src/mdx/components/snippets/EndpointSchemaSnippet.tsx
+++ b/packages/fern-docs/ui/src/mdx/components/snippets/EndpointSchemaSnippet.tsx
@@ -1,5 +1,3 @@
-import { useExampleSelection } from "../../../api-reference/endpoints/useExampleSelection";
-import { CodeSnippetExample } from "../../../api-reference/examples/CodeSnippetExample";
 import { SchemaSnippet } from "./types";
 import { useFindEndpoint } from "./useFindEndpoint";
 import { extractEndpointPathAndMethod } from "./utils";
@@ -34,34 +32,22 @@ function EndpointSchemaSnippetInternal({
   }
 
   return (
-    <EndpointSchemaSnippetRenderer endpoint={endpoint} selector={selector} />
+    <EndpointSchemaSnippetRenderer
+      path={path}
+      method={method}
+      selector={selector}
+    />
   );
 }
 
 function EndpointSchemaSnippetRenderer({
-  endpoint,
+  path,
+  method,
   selector,
 }: SchemaSnippet.InternalProps) {
-  const { selectedExample } = useExampleSelection(endpoint, selector);
+  console.log("path", path);
+  console.log("method", method);
+  console.log("selector", selector);
 
-  const responseJson = selectedExample?.exampleCall.responseBody?.value;
-
-  if (responseJson == null) {
-    return null;
-  }
-
-  const responseJsonString = JSON.stringify(responseJson, null, 2);
-
-  return (
-    <div className="mb-5 mt-3">
-      <CodeSnippetExample
-        title="Response"
-        // actions={undefined}
-        code={responseJsonString}
-        language="json"
-        json={responseJson}
-        scrollAreaStyle={{ maxHeight: "500px" }}
-      />
-    </div>
-  );
+  return <div className="mb-5 mt-3">Snippet!</div>;
 }

--- a/packages/fern-docs/ui/src/mdx/components/snippets/EndpointSchemaSnippet.tsx
+++ b/packages/fern-docs/ui/src/mdx/components/snippets/EndpointSchemaSnippet.tsx
@@ -1,5 +1,13 @@
+import * as ApiDefinition from "@fern-api/fdr-sdk/api-definition";
+import { useAtomValue } from "jotai";
+import { EndpointParameter } from "../../../api-reference/endpoints/EndpointParameter";
+import { EndpointRequestSection } from "../../../api-reference/endpoints/EndpointRequestSection";
+import { EndpointResponseSection } from "../../../api-reference/endpoints/EndpointResponseSection";
+import { EndpointSection } from "../../../api-reference/endpoints/EndpointSection";
+import { TypeComponentSeparator } from "../../../api-reference/types/TypeComponentSeparator";
+import { SLUG_ATOM } from "../../../atoms";
 import { SchemaSnippet } from "./types";
-import { useFindEndpoint } from "./useFindEndpoint";
+import { useFindEndpoint, useFindTypes } from "./useFindEndpoint";
 import { extractEndpointPathAndMethod } from "./utils";
 
 export const EndpointSchemaSnippet: React.FC<
@@ -12,7 +20,7 @@ export const EndpointSchemaSnippet: React.FC<
   }
 
   return (
-    <EndpointSchemaSnippetInternal
+    <EndpointSchemaSnippetRenderer
       method={method}
       path={path}
       selector={selector}
@@ -20,34 +28,147 @@ export const EndpointSchemaSnippet: React.FC<
   );
 };
 
-function EndpointSchemaSnippetInternal({
-  path,
-  method,
-  selector,
-}: SchemaSnippet.InternalProps) {
-  const endpoint = useFindEndpoint(method, path, selector);
+const EndpointSchemaSnippetRenderer: React.FC<
+  React.PropsWithChildren<SchemaSnippet.InternalProps>
+> = ({ method, path, selector }) => {
+  const endpoint = useFindEndpoint(method, path, undefined);
+  const types = useFindTypes(method, path);
 
   if (endpoint == null) {
     return null;
   }
 
   return (
-    <EndpointSchemaSnippetRenderer
-      path={path}
-      method={method}
+    <EndpointSchemaSnippetInternal
+      endpoint={endpoint}
+      types={types ?? {}}
       selector={selector}
     />
   );
-}
+};
 
-function EndpointSchemaSnippetRenderer({
-  path,
-  method,
+const REQUEST = ["request"];
+const RESPONSE = ["response"];
+const REQUEST_PATH = ["request", "path"];
+const REQUEST_QUERY = ["request", "query"];
+// const REQUEST_HEADER = ["request", "header"];
+const REQUEST_BODY = ["request", "body"];
+const RESPONSE_BODY = ["response", "body"];
+// const RESPONSE_ERROR = ["response", "error"];
+
+function EndpointSchemaSnippetInternal({
+  endpoint,
+  types,
   selector,
-}: SchemaSnippet.InternalProps) {
-  console.log("path", path);
-  console.log("method", method);
-  console.log("selector", selector);
+}: {
+  endpoint: ApiDefinition.EndpointDefinition;
+  types: Record<string, ApiDefinition.TypeDefinition>;
+  selector: string | undefined;
+}) {
+  const currentSlug = useAtomValue(SLUG_ATOM);
 
-  return <div className="mb-5 mt-3">Snippet!</div>;
+  // const types = Object.entries(types).reduce<
+  //   Record<string, ApiDefinition.TypeDefinition>
+  // >((acc, [key, type]) => ({ ...acc, [`type_:${key}`]: type }), {});
+
+  if (endpoint == null) {
+    return null;
+  }
+
+  return (
+    <div>
+      {(selector == null || selector === "request.path") &&
+        endpoint.pathParameters &&
+        endpoint.pathParameters.length > 0 && (
+          <EndpointSection
+            title="Path parameters"
+            anchorIdParts={REQUEST_PATH}
+            slug={currentSlug}
+          >
+            <div>
+              {endpoint.pathParameters.map((parameter) => (
+                <div key={parameter.key}>
+                  <TypeComponentSeparator />
+                  <EndpointParameter
+                    name={parameter.key}
+                    shape={parameter.valueShape}
+                    anchorIdParts={[...REQUEST_PATH, parameter.key]}
+                    slug={currentSlug}
+                    description={parameter.description}
+                    additionalDescriptions={
+                      ApiDefinition.unwrapReference(parameter.valueShape, types)
+                        .descriptions
+                    }
+                    availability={parameter.availability}
+                    types={types}
+                  />
+                </div>
+              ))}
+            </div>
+          </EndpointSection>
+        )}
+      {(selector == null || selector === "request.query") &&
+        endpoint.queryParameters &&
+        endpoint.queryParameters.length > 0 && (
+          <EndpointSection
+            title="Query parameters"
+            anchorIdParts={REQUEST_QUERY}
+            slug={currentSlug}
+          >
+            <div>
+              {endpoint.queryParameters.map((parameter) => (
+                <div key={parameter.key}>
+                  <TypeComponentSeparator />
+                  <EndpointParameter
+                    name={parameter.key}
+                    shape={parameter.valueShape}
+                    anchorIdParts={[...REQUEST_QUERY, parameter.key]}
+                    slug={currentSlug}
+                    description={parameter.description}
+                    additionalDescriptions={
+                      ApiDefinition.unwrapReference(parameter.valueShape, types)
+                        .descriptions
+                    }
+                    availability={parameter.availability}
+                    types={types}
+                  />
+                </div>
+              ))}
+            </div>
+          </EndpointSection>
+        )}
+      {(selector == null || selector === "request.body") &&
+        endpoint.requests?.[0] != null && (
+          <EndpointSection
+            key={endpoint.requests[0].contentType}
+            title="Request"
+            anchorIdParts={REQUEST}
+            slug={currentSlug}
+          >
+            <EndpointRequestSection
+              request={endpoint.requests[0]}
+              anchorIdParts={REQUEST_BODY}
+              slug={currentSlug}
+              types={types}
+            />
+          </EndpointSection>
+        )}
+      {(selector == null || selector === "response.body") &&
+        endpoint.responses?.[0] != null && (
+          <EndpointSection
+            title="Response"
+            anchorIdParts={RESPONSE}
+            slug={currentSlug}
+          >
+            <EndpointResponseSection
+              response={endpoint.responses[0]}
+              anchorIdParts={RESPONSE_BODY}
+              exampleResponseBody={undefined}
+              slug={currentSlug}
+              types={types}
+            />
+          </EndpointSection>
+        )}
+    </div>
+  );
 }

--- a/packages/fern-docs/ui/src/mdx/components/snippets/EndpointSchemaSnippet.tsx
+++ b/packages/fern-docs/ui/src/mdx/components/snippets/EndpointSchemaSnippet.tsx
@@ -1,0 +1,67 @@
+import { useExampleSelection } from "../../../api-reference/endpoints/useExampleSelection";
+import { CodeSnippetExample } from "../../../api-reference/examples/CodeSnippetExample";
+import { SchemaSnippet } from "./types";
+import { useFindEndpoint } from "./useFindEndpoint";
+import { extractEndpointPathAndMethod } from "./utils";
+
+export const EndpointSchemaSnippet: React.FC<
+  React.PropsWithChildren<SchemaSnippet.Props>
+> = ({ endpoint: endpointLocator, selector }) => {
+  const [method, path] = extractEndpointPathAndMethod(endpointLocator);
+
+  if (method == null || path == null) {
+    return null;
+  }
+
+  return (
+    <EndpointSchemaSnippetInternal
+      method={method}
+      path={path}
+      selector={selector}
+    />
+  );
+};
+
+function EndpointSchemaSnippetInternal({
+  path,
+  method,
+  selector,
+}: SchemaSnippet.InternalProps) {
+  const endpoint = useFindEndpoint(method, path, selector);
+
+  if (endpoint == null) {
+    return null;
+  }
+
+  return (
+    <EndpointSchemaSnippetRenderer endpoint={endpoint} selector={selector} />
+  );
+}
+
+function EndpointSchemaSnippetRenderer({
+  endpoint,
+  selector,
+}: SchemaSnippet.InternalProps) {
+  const { selectedExample } = useExampleSelection(endpoint, selector);
+
+  const responseJson = selectedExample?.exampleCall.responseBody?.value;
+
+  if (responseJson == null) {
+    return null;
+  }
+
+  const responseJsonString = JSON.stringify(responseJson, null, 2);
+
+  return (
+    <div className="mb-5 mt-3">
+      <CodeSnippetExample
+        title="Response"
+        // actions={undefined}
+        code={responseJsonString}
+        language="json"
+        json={responseJson}
+        scrollAreaStyle={{ maxHeight: "500px" }}
+      />
+    </div>
+  );
+}

--- a/packages/fern-docs/ui/src/mdx/components/snippets/EndpointSchemaSnippet.tsx
+++ b/packages/fern-docs/ui/src/mdx/components/snippets/EndpointSchemaSnippet.tsx
@@ -1,3 +1,5 @@
+import { useExampleSelection } from "../../../api-reference/endpoints/useExampleSelection";
+import { CodeSnippetExample } from "../../../api-reference/examples/CodeSnippetExample";
 import { SchemaSnippet } from "./types";
 import { useFindEndpoint } from "./useFindEndpoint";
 import { extractEndpointPathAndMethod } from "./utils";
@@ -32,22 +34,34 @@ function EndpointSchemaSnippetInternal({
   }
 
   return (
-    <EndpointSchemaSnippetRenderer
-      path={path}
-      method={method}
-      selector={selector}
-    />
+    <EndpointSchemaSnippetRenderer endpoint={endpoint} selector={selector} />
   );
 }
 
 function EndpointSchemaSnippetRenderer({
-  path,
-  method,
+  endpoint,
   selector,
 }: SchemaSnippet.InternalProps) {
-  console.log("path", path);
-  console.log("method", method);
-  console.log("selector", selector);
+  const { selectedExample } = useExampleSelection(endpoint, selector);
 
-  return <div className="mb-5 mt-3">Snippet!</div>;
+  const responseJson = selectedExample?.exampleCall.responseBody?.value;
+
+  if (responseJson == null) {
+    return null;
+  }
+
+  const responseJsonString = JSON.stringify(responseJson, null, 2);
+
+  return (
+    <div className="mb-5 mt-3">
+      <CodeSnippetExample
+        title="Response"
+        // actions={undefined}
+        code={responseJsonString}
+        language="json"
+        json={responseJson}
+        scrollAreaStyle={{ maxHeight: "500px" }}
+      />
+    </div>
+  );
 }

--- a/packages/fern-docs/ui/src/mdx/components/snippets/index.ts
+++ b/packages/fern-docs/ui/src/mdx/components/snippets/index.ts
@@ -1,2 +1,3 @@
 export * from "./EndpointRequestSnippet";
 export * from "./EndpointResponseSnippet";
+export * from "./EndpointSchemaSnippet";

--- a/packages/fern-docs/ui/src/mdx/components/snippets/types.ts
+++ b/packages/fern-docs/ui/src/mdx/components/snippets/types.ts
@@ -11,3 +11,16 @@ export declare namespace RequestSnippet {
     example: string | undefined;
   }
 }
+
+export declare namespace SchemaSnippet {
+  export interface Props {
+    endpoint: string;
+    selector?: string;
+  }
+
+  export interface InternalProps {
+    path: string;
+    method: APIV1Read.HttpMethod;
+    selector: string | undefined;
+  }
+}

--- a/packages/fern-docs/ui/src/mdx/components/snippets/useFindEndpoint.tsx
+++ b/packages/fern-docs/ui/src/mdx/components/snippets/useFindEndpoint.tsx
@@ -1,4 +1,7 @@
-import { EndpointDefinition } from "@fern-api/fdr-sdk/api-definition";
+import {
+  EndpointDefinition,
+  TypeDefinition,
+} from "@fern-api/fdr-sdk/api-definition";
 import { atom, useAtomValue } from "jotai";
 import { useMemoOne } from "use-memo-one";
 import { READ_APIS_ATOM } from "../../../atoms";
@@ -28,6 +31,33 @@ export function useFindEndpoint(
           return endpoint;
         }),
       [example, method, path]
+    )
+  );
+}
+
+export function useFindTypes(
+  method: string,
+  path: string
+): Record<string, TypeDefinition> | undefined {
+  return useAtomValue(
+    useMemoOne(
+      () =>
+        atom((get) => {
+          const apis = get(READ_APIS_ATOM);
+          for (const apiDefinition of Object.values(apis)) {
+            const endpoint = findEndpoint({
+              apiDefinition,
+              path,
+              method,
+              example: undefined,
+            });
+            if (endpoint) {
+              return { ...apiDefinition.types };
+            }
+          }
+          return {};
+        }),
+      [method, path]
     )
   );
 }

--- a/packages/fern-docs/ui/src/mdx/components/snippets/useFindEndpoint.tsx
+++ b/packages/fern-docs/ui/src/mdx/components/snippets/useFindEndpoint.tsx
@@ -1,5 +1,6 @@
 import {
   EndpointDefinition,
+  ObjectProperty,
   TypeDefinition,
 } from "@fern-api/fdr-sdk/api-definition";
 import { atom, useAtomValue } from "jotai";
@@ -56,6 +57,33 @@ export function useFindTypes(
             }
           }
           return {};
+        }),
+      [method, path]
+    )
+  );
+}
+
+export function useGlobalHeaders(
+  method: string,
+  path: string
+): ObjectProperty[] | undefined {
+  return useAtomValue(
+    useMemoOne(
+      () =>
+        atom((get) => {
+          const apis = get(READ_APIS_ATOM);
+          for (const apiDefinition of Object.values(apis)) {
+            const endpoint = findEndpoint({
+              apiDefinition,
+              path,
+              method,
+              example: undefined,
+            });
+            if (endpoint) {
+              return apiDefinition.globalHeaders || [];
+            }
+          }
+          return [];
         }),
       [method, path]
     )

--- a/packages/fern-docs/ui/src/resolver/resolveMarkdownPage.ts
+++ b/packages/fern-docs/ui/src/resolver/resolveMarkdownPage.ts
@@ -20,7 +20,8 @@ function shouldFetchApiRef(markdown: FernDocs.MarkdownText): boolean {
   if (typeof markdown === "string") {
     return (
       markdown.includes("EndpointRequestSnippet") ||
-      markdown.includes("EndpointResponseSnippet")
+      markdown.includes("EndpointResponseSnippet") ||
+      markdown.includes("EndpointSchemaSnippet")
     );
   } else {
     return shouldFetchApiRef(markdown.code);


### PR DESCRIPTION
This PR sets up an alpha version of the `<EndpointSchemaSnippet />` component

**Not included:**
- Endpoint headers
- Endpoint errors (out of scope until this feature is requested)
- Selecting a specific property within a given schema shape