### PR TITLE
feat(api): add flag to disable playground

### DIFF
--- a/fern/apis/fdr/definition/navigation/latest/__package__.yml
+++ b/fern/apis/fdr/definition/navigation/latest/__package__.yml
@@ -249,6 +249,9 @@ types:
 
   PlaygroundSettings:
     properties:
+      disabled: 
+        type: optional<boolean>
+        docs: Whether the playground is disabled. Defaults to false.
       environments:
         type: optional<list<commons.EnvironmentId>>
         docs: |

--- a/fern/apis/fdr/definition/navigation/v1/__package__.yml
+++ b/fern/apis/fdr/definition/navigation/v1/__package__.yml
@@ -250,6 +250,9 @@ types:
 
   PlaygroundSettings:
     properties:
+      disabled: 
+        type: optional<boolean>
+        docs: Whether the playground is disabled. Defaults to false. 
       environments:
         type: optional<list<commons.EnvironmentId>>
         docs: |

--- a/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/latest/types/PlaygroundSettings.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/latest/types/PlaygroundSettings.ts
@@ -5,6 +5,8 @@
 import * as FernRegistry from "../../../../../index";
 
 export interface PlaygroundSettings {
+    /** Whether the playground is disabled. Defaults to false. */
+    disabled: boolean | undefined;
     /**
      * A list of environment IDs that are allowed to be used in the playground.
      * If not provided, all environments are allowed. And if the provided list is empty, the playground should be disabled.

--- a/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/v1/types/PlaygroundSettings.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/navigation/resources/v1/types/PlaygroundSettings.ts
@@ -5,6 +5,8 @@
 import * as FernRegistry from "../../../../../index";
 
 export interface PlaygroundSettings {
+    /** Whether the playground is disabled. Defaults to false. */
+    disabled: boolean | undefined;
     /**
      * A list of environment IDs that are allowed to be used in the playground.
      * If not provided, all environments are allowed. And if the provided list is empty, the playground should be disabled.

--- a/packages/fern-docs/ui/src/playground/PlaygroundButton.tsx
+++ b/packages/fern-docs/ui/src/playground/PlaygroundButton.tsx
@@ -15,9 +15,9 @@ export const PlaygroundButton: FC<{
 }> = ({ state }) => {
   const openPlayground = useOpenPlayground();
   const isPlaygroundEnabled = useAtomValue(IS_PLAYGROUND_ENABLED_ATOM);
-  const settings = usePlaygroundSettings(state.id);
+  const settings = usePlaygroundSettings(state.id ?? state);
 
-  if (!isPlaygroundEnabled) {
+  if (!isPlaygroundEnabled || settings?.disabled) {
     return null;
   }
 

--- a/packages/parsers/src/client/generated/api/resources/navigation/resources/latest/types/PlaygroundSettings.ts
+++ b/packages/parsers/src/client/generated/api/resources/navigation/resources/latest/types/PlaygroundSettings.ts
@@ -5,6 +5,8 @@
 import * as FernRegistry from "../../../../../index";
 
 export interface PlaygroundSettings {
+    /** Whether the playground is disabled. Defaults to false. */
+    disabled: boolean | undefined;
     /**
      * A list of environment IDs that are allowed to be used in the playground.
      * If not provided, all environments are allowed. And if the provided list is empty, the playground should be disabled.

--- a/packages/parsers/src/client/generated/api/resources/navigation/resources/v1/types/PlaygroundSettings.ts
+++ b/packages/parsers/src/client/generated/api/resources/navigation/resources/v1/types/PlaygroundSettings.ts
@@ -5,6 +5,8 @@
 import * as FernRegistry from "../../../../../index";
 
 export interface PlaygroundSettings {
+    /** Whether the playground is disabled. Defaults to false. */
+    disabled: boolean | undefined;
     /**
      * A list of environment IDs that are allowed to be used in the playground.
      * If not provided, all environments are allowed. And if the provided list is empty, the playground should be disabled.

--- a/servers/fdr/src/api/generated/api/resources/navigation/resources/latest/types/PlaygroundSettings.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/navigation/resources/latest/types/PlaygroundSettings.d.ts
@@ -3,6 +3,8 @@
  */
 import * as FernRegistry from "../../../../../index";
 export interface PlaygroundSettings {
+    /** Whether the playground is disabled. Defaults to false. */
+    disabled: boolean | undefined;
     /**
      * A list of environment IDs that are allowed to be used in the playground.
      * If not provided, all environments are allowed. And if the provided list is empty, the playground should be disabled.

--- a/servers/fdr/src/api/generated/api/resources/navigation/resources/v1/types/PlaygroundSettings.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/navigation/resources/v1/types/PlaygroundSettings.d.ts
@@ -3,6 +3,8 @@
  */
 import * as FernRegistry from "../../../../../index";
 export interface PlaygroundSettings {
+    /** Whether the playground is disabled. Defaults to false. */
+    disabled: boolean | undefined;
     /**
      * A list of environment IDs that are allowed to be used in the playground.
      * If not provided, all environments are allowed. And if the provided list is empty, the playground should be disabled.


### PR DESCRIPTION
## Short description of the changes made
Add a `disabled` flag to the API Playgroud to start disabling the edge configuration. 

## What was the motivation & context behind this PR?
Deleting the `api-explorer-enabled` vercel storage config. 

## How has this PR been tested?
N/A
