### PR TITLE
feat: clear anchor on accordion close

### DIFF
--- a/packages/fern-docs/ui/src/atoms/location.ts
+++ b/packages/fern-docs/ui/src/atoms/location.ts
@@ -28,7 +28,7 @@ export const ANCHOR_ATOM = atom(
   (get) => get(LOCATION_ATOM).hash?.slice(1),
   (get, set, anchor: string | undefined) => {
     const location = get(LOCATION_ATOM);
-    const hash = anchor != null ? `#${anchor}` : undefined;
+    const hash = anchor != null ? `#${anchor}` : "";
     if (location.hash === hash) {
       return;
     }

--- a/packages/fern-docs/ui/src/mdx/components/accordion/AccordionGroup.tsx
+++ b/packages/fern-docs/ui/src/mdx/components/accordion/AccordionGroup.tsx
@@ -66,6 +66,12 @@ export const AccordionGroup = forwardRef<HTMLDivElement, AccordionGroupProps>(
           if (added[0] != null) {
             setAnchor(added[0]);
           }
+
+          const removed = prev.filter((tab) => !nextActiveTabs.includes(tab));
+          if (removed[0] != null) {
+            setAnchor(undefined);
+          }
+
           return nextActiveTabs;
         });
       },


### PR DESCRIPTION
This PR updates the behavior of accordions, removing the anchor link when an accordion is closed. As a user, if I close an accordion, I do not expect the page location to still show me as navigating within that accordion. 

https://github.com/user-attachments/assets/e2bace78-7636-45f1-9773-df31e262d18c

