### PR TITLE
fix: `coalesceServers` should only add new servers.

### DIFF
--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fern-api/docs-parsers",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern-platform.git",

--- a/packages/parsers/src/openapi/utils/3.1/coalesceServers.ts
+++ b/packages/parsers/src/openapi/utils/3.1/coalesceServers.ts
@@ -8,9 +8,12 @@ export function coalesceServers(
   context: BaseOpenApiV3_1ConverterNodeContext,
   accessPath: string[]
 ): ServerObjectConverterNode[] {
-  return [
-    ...(existingServers ?? []),
-    ...(serversToAdd ?? []).map(
+  const existing = existingServers ?? [];
+  const existingUrls = new Set(existing.map((server) => server.url));
+
+  const newServers = (serversToAdd ?? [])
+    .filter((server) => !existingUrls.has(server.url))
+    .map(
       (server, index) =>
         new ServerObjectConverterNode({
           input: server,
@@ -18,6 +21,7 @@ export function coalesceServers(
           accessPath,
           pathId: ["servers", `${index}`],
         })
-    ),
-  ];
+    );
+
+  return [...existing, ...newServers];
 }

--- a/packages/parsers/src/openapi/utils/__test__/3.1/coalesceServers.test.ts
+++ b/packages/parsers/src/openapi/utils/__test__/3.1/coalesceServers.test.ts
@@ -56,4 +56,26 @@ describe("coalesceServers", () => {
     expect(result[0]).toBe(existingServer);
     expect(result[1]).toBeInstanceOf(ServerObjectConverterNode);
   });
+
+  it("should not add new servers containing an existing url", () => {
+    const existingServer = new ServerObjectConverterNode({
+      input: { url: "https://existing.com" },
+      context: mockContext,
+      accessPath: [],
+      pathId: "servers[0]",
+    });
+    const newServers: OpenAPIV3_1.ServerObject[] = [
+      { url: "https://existing.com" },
+      { url: "https://new.com" }
+    ];
+    const result = coalesceServers(
+      [existingServer],
+      newServers,
+      mockContext,
+      []
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(existingServer);
+    expect(result[1].url).toBe("https://new.com");
+  });
 });

--- a/packages/parsers/src/openapi/utils/__test__/3.1/coalesceServers.test.ts
+++ b/packages/parsers/src/openapi/utils/__test__/3.1/coalesceServers.test.ts
@@ -66,7 +66,7 @@ describe("coalesceServers", () => {
     });
     const newServers: OpenAPIV3_1.ServerObject[] = [
       { url: "https://existing.com" },
-      { url: "https://new.com" }
+      { url: "https://new.com" },
     ];
     const result = coalesceServers(
       [existingServer],


### PR DESCRIPTION
This PR ensure that we do not duplicate servers when coalescing.