### PR TITLE
fix: add `shrink-0` to `HelpCircle` icon.

### DIFF
--- a/packages/fern-docs/ui/src/playground/WithLabel.tsx
+++ b/packages/fern-docs/ui/src/playground/WithLabel.tsx
@@ -110,7 +110,7 @@ export const WithLabelInternal: FC<
               content={<Markdown mdx={description} size="xs" />}
               delayDuration={0}
             >
-              <HelpCircle className="t-muted size-4 self-center" />
+              <HelpCircle className="t-muted size-4 shrink-0 self-center" />
             </FernTooltip>
           )}
 

--- a/packages/fern-docs/ui/src/playground/auth/PlaygroundOAuthForm.tsx
+++ b/packages/fern-docs/ui/src/playground/auth/PlaygroundOAuthForm.tsx
@@ -120,7 +120,7 @@ function FoundOAuthReferencedEndpointForm({
                     <span className="inline-flex font-mono text-sm">
                       Generated OAuth Token
                       <FernTooltip content="This bearer token was generated from an OAuth API call, and as a result cannot be edited">
-                        <HelpCircle className="t-muted ml-2 size-4 self-center" />
+                        <HelpCircle className="t-muted ml-2 size-4 shrink-0 self-center" />
                       </FernTooltip>
                     </span>
                   </label>


### PR DESCRIPTION
## Short description of the changes made

This PR resolves a visual bug where the `HelpCircle` icon (associated with parameter inputs in the Playground) were shrinking out of view.

## What was the motivation & context behind this PR?

Icon were previously disappearing when shrunk beyond a certain point. See thread [here](https://buildwithfern.slack.com/archives/C05E0S0A9SN/p1740411688660169)

## How has this PR been tested?

Verified against Deepgram docs Playground:

<img width="410" alt="Screenshot 2025-02-24 at 11 02 02 AM" src="https://github.com/user-attachments/assets/a12b33f9-d51a-40e2-be5d-ce7238a621cc" />

<img width="392" alt="Screenshot 2025-02-24 at 11 02 22 AM" src="https://github.com/user-attachments/assets/ea4d0eb2-e893-441f-811e-d791cf33742b" />