### PR TITLE
chore: Release @fern-api/docs-parser 0.0.65

### DIFF
--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fern-api/docs-parsers",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "repository": {
     "type": "git",
     "url": "https://github.com/fern-api/fern-platform.git",


### PR DESCRIPTION
Follow-up to https://github.com/fern-api/fern-platform/pull/2212 so that the types required in the Fern CLI are aligned.