### PR TITLE
fix(csharp): Read snippets from SdkDao

### DIFF
--- a/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
+++ b/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
@@ -807,6 +807,20 @@ export class ApiDefinitionV1ToLatest {
       });
     }
 
+    if (
+      !userProvidedLanguages.has(SupportedLanguage.Csharp) &&
+      codeExamples.csharpSdk != null
+    ) {
+      push(SupportedLanguage.Csharp, {
+        name: undefined,
+        language: SupportedLanguage.Csharp,
+        install: codeExamples.csharpSdk.install,
+        code: codeExamples.csharpSdk.client,
+        generated: true,
+        description: undefined,
+      });
+    }
+
     return toRet;
   }
 }

--- a/servers/fdr/src/db/sdk/SdkDao.ts
+++ b/servers/fdr/src/db/sdk/SdkDao.ts
@@ -160,6 +160,16 @@ export class SdkDaoImpl implements SdkDao {
         result.rubySdk = { ...snippetConfig.rubySdk, sdkId };
       }
     }
+    if (snippetConfig.csharpSdk != null) {
+      const sdkId = await this.getSdkIdForPackage({
+        sdkPackage: snippetConfig.csharpSdk.package,
+        language: Language.CSHARP,
+        version: snippetConfig.csharpSdk.version,
+      });
+      if (sdkId != null) {
+        result.csharpSdk = { ...snippetConfig.csharpSdk, sdkId };
+      }
+    }
 
     return result;
   }
@@ -183,6 +193,9 @@ export class SdkDaoImpl implements SdkDao {
           break;
         case Language.RUBY:
           id = SdkIdFactory.fromRuby({ gem: sdkPackage, version });
+          break;
+        case Language.CSHARP:
+          id = SdkIdFactory.fromCSharp({ package: sdkPackage, version });
           break;
         default:
           break;


### PR DESCRIPTION
This updates the `SdkDao` so that we surface the C# snippets written to the database (for consumption in the front-end).