### PR TITLE
fix: don't hard fail when Algolia Registration fails.

### DIFF
--- a/servers/fdr/src/controllers/docs/v2/getDocsWriteV2Service.ts
+++ b/servers/fdr/src/controllers/docs/v2/getDocsWriteV2Service.ts
@@ -263,13 +263,22 @@ export function getDocsWriteV2Service(app: FdrApplication): DocsV2WriteService {
           }
         );
 
-        const indexSegments = await uploadToAlgoliaForRegistration(
-          app,
-          docsRegistrationInfo,
-          dbDocsDefinition,
-          apiDefinitionsById,
-          apiDefinitionsLatestById
-        );
+        let indexSegments: IndexSegment[] = [];
+        try {
+          indexSegments = await uploadToAlgoliaForRegistration(
+            app,
+            docsRegistrationInfo,
+            dbDocsDefinition,
+            apiDefinitionsById,
+            apiDefinitionsLatestById
+          );
+        } catch (e) {
+          app.logger.error(
+            `Error while trying to upload to Algolia for ${docsRegistrationInfo.fernUrl.getFullUrl()}`,
+            e
+          );
+          indexSegments = [];
+        }
 
         await app.docsDefinitionCache.storeDocsForUrl({
           docsRegistrationInfo,


### PR DESCRIPTION
## Short description of the changes made

This wraps the `uploadToAlgoliaForRegistration` method in a `try-catch` that prevents docs hard failure when indexing fails.

## What was the motivation & context behind this PR?

Unblock Monite docs generation.

## How has this PR been tested?

Will be testing!