### PR TITLE
fix: shorten turbopuffer record ids 

### DIFF
--- a/packages/fern-docs/search-server/src/turbopuffer/records/create-base-record.ts
+++ b/packages/fern-docs/search-server/src/turbopuffer/records/create-base-record.ts
@@ -72,7 +72,7 @@ export function createBaseRecord({
   );
 
   return {
-    id: `${org_id}:${domain}:${node.id}`,
+    id: node.id,
     attributes: {
       type,
       org_id,


### PR DESCRIPTION
Copy of https://github.com/fern-api/fern-platform/pull/2158
