### PR TITLE
fix alias for a nodes in rehypeFernComponenets.ts

### DIFF
--- a/packages/fern-docs/ui/src/mdx/plugins/rehypeFernComponents.ts
+++ b/packages/fern-docs/ui/src/mdx/plugins/rehypeFernComponents.ts
@@ -35,6 +35,8 @@ export function rehypeFernComponents(): (tree: Hast.Root) => void {
         } else if (node.name === "table") {
           // DO NOT coerce <table> into <Table> (see: https://buildwithfern.slack.com/archives/C06QKJWD4VD/p1722602687550179)
           // node.name = "Table";
+        } else if (node.name === "a") {
+          node.name = "A";
         }
       }
     });


### PR DESCRIPTION
Fixes rehypeFernComponents.ts to properly convert "a" nodes to "A" when containing images.