### PR TITLE
chore: remove fern segment

### DIFF
--- a/packages/fern-docs/ui/src/analytics/CustomerAnalytics.tsx
+++ b/packages/fern-docs/ui/src/analytics/CustomerAnalytics.tsx
@@ -47,13 +47,15 @@ export const CustomerAnalytics = memo(
 
     return (
       <>
-        {/* renders either segment with our write key or segment with the customer's write key */}
-        <Script
-          id="segment-script"
-          dangerouslySetInnerHTML={{
-            __html: renderSegmentSnippet(domain, config.segment?.writeKey),
-          }}
-        />
+        {/* renders segment with the customer's write key */}
+        {config.segment?.writeKey != null && (
+          <Script
+            id="segment-script"
+            dangerouslySetInnerHTML={{
+              __html: renderSegmentSnippet(domain, config.segment?.writeKey),
+            }}
+          />
+        )}
         <Posthog customerConfig={config.posthog} />
         <IntercomScript config={config.intercom} />
         <FullstoryScript config={config.fullstory} />

--- a/packages/fern-docs/ui/src/analytics/segment.ts
+++ b/packages/fern-docs/ui/src/analytics/segment.ts
@@ -6,9 +6,8 @@ export function renderSegmentSnippet(
   domain: string,
   customSegmentWriteKey?: string
 ): string {
-  const apiKey = process.env.NEXT_PUBLIC_SEGMENT_API_KEY?.trim();
   const opts = {
-    apiKey: customSegmentWriteKey ? customSegmentWriteKey : apiKey,
+    apiKey: customSegmentWriteKey,
     page: true,
   };
   // Skip rendering the snippet for certain domains


### PR DESCRIPTION
This PR removes Fern's Segment from all docs sites. 

Docs site without customer Segment integration: 
![Screenshot 2025-03-03 at 6 03 29 PM](https://github.com/user-attachments/assets/e43f4a7c-bdbc-4dea-8d8d-ecac7c831dec)

Docs site with customer Segment integration: 
![Screenshot 2025-03-03 at 6 05 38 PM](https://github.com/user-attachments/assets/3bea60a1-a4c4-4155-84b6-bbe0ff8d7633)

