### PR TITLE
fix: remote serializer

### DIFF
--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/preview/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/preview/route.ts
@@ -20,7 +20,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   // Only allow preview in dev and preview deployments, or if the hostname is canary.ferndocs.com
   if (
     VERCEL_ENV === "production" &&
-    req.nextUrl.hostname !== "canary.ferndocs.com"
+    req.nextUrl.hostname !== "canary.ferndocs.com" &&
+    !req.nextUrl.hostname.endsWith(".vercel.app")
   ) {
     console.debug("Production docs not hosted by canary.ferndocs.com detected");
     return notFound();

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/serialize/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/serialize/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from "next/server";
+
+import z from "zod";
+
+import { getFernToken } from "@/app/fern-token";
+import { createCachedDocsLoader } from "@/server/docs-loader";
+import { createCachedMdxSerializer } from "@/server/mdx-serializer";
+
+const bodySchema = z.object({
+  content: z.string(),
+  scope: z.record(z.string(), z.unknown()).optional(),
+  filename: z.string().optional(),
+  toc: z.boolean().optional(),
+  url: z.string().optional(),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ host: string; domain: string }> }
+) {
+  const { content, scope, filename, toc, url } = bodySchema.parse(
+    await request.json()
+  );
+
+  const { host, domain } = await params;
+  const loader = await createCachedDocsLoader(
+    host,
+    domain,
+    await getFernToken()
+  );
+
+  const serializer = createCachedMdxSerializer(loader, { scope });
+  const result = await serializer(content, { filename, toc, url });
+  return Response.json(result);
+}

--- a/packages/fern-docs/bundle/src/components/shared-layout.tsx
+++ b/packages/fern-docs/bundle/src/components/shared-layout.tsx
@@ -11,7 +11,7 @@ import { ThemedDocs } from "@/components/themes/ThemedDocs";
 import { MdxServerComponent } from "@/mdx/components/server-component";
 import { DocsLoader } from "@/server/docs-loader";
 import { createFileResolver } from "@/server/file-resolver";
-import { createCachedMdxSerializer } from "@/server/mdx-serializer";
+import { createRemoteMdxSerializer } from "@/server/mdx-serializer";
 import { withLogo } from "@/server/withLogo";
 
 import { VersionDropdown } from "./header/VersionDropdown";
@@ -28,7 +28,7 @@ export default async function SharedLayout({
   sidebar: React.ReactNode;
   loader: DocsLoader;
 }) {
-  const serialize = createCachedMdxSerializer(loader);
+  const serialize = createRemoteMdxSerializer(loader);
   const [{ basePath }, config, edgeFlags, files, colors, layout] =
     await Promise.all([
       loader.getMetadata(),

--- a/packages/fern-docs/bundle/src/components/shared-page.tsx
+++ b/packages/fern-docs/bundle/src/components/shared-page.tsx
@@ -27,7 +27,7 @@ import { createFindNode } from "@/server/find-node";
 import { withLaunchDarkly } from "@/server/ld-adapter";
 import {
   MdxSerializer,
-  createCachedMdxSerializer,
+  createRemoteMdxSerializer,
 } from "@/server/mdx-serializer";
 import { SetCurrentNavigationNode } from "@/state/navigation";
 
@@ -108,7 +108,7 @@ export default async function SharedPage({
     redirect(prepareRedirect(found.redirect));
   }
 
-  const serialize = createCachedMdxSerializer(loader, {
+  const serialize = createRemoteMdxSerializer(loader, {
     scope: {
       version: found?.currentVersion?.versionId,
       tab: found?.currentTab?.title,

--- a/packages/fern-docs/bundle/src/server/docs-loader.ts
+++ b/packages/fern-docs/bundle/src/server/docs-loader.ts
@@ -67,6 +67,7 @@ interface DocsMetadata {
 
 export interface DocsLoader {
   domain: string;
+  host: string;
   fern_token: string | undefined;
 
   getAuthConfig: () => Promise<AuthEdgeConfig | undefined>;
@@ -780,6 +781,7 @@ export const createCachedDocsLoader = async (
   });
 
   return {
+    host,
     domain,
     fern_token,
     getAuthConfig: () => authConfig,

--- a/packages/fern-docs/bundle/src/server/mdx-serializer.ts
+++ b/packages/fern-docs/bundle/src/server/mdx-serializer.ts
@@ -4,8 +4,13 @@ import { unstable_cache } from "next/cache";
 import { cache } from "react";
 
 import { Frontmatter } from "@fern-api/fdr-sdk/docs";
+import { withDefaultProtocol } from "@fern-api/ui-core-utils";
+import { HEADER_X_FERN_HOST } from "@fern-docs/utils";
 
-import { serializeMdx as internalSerializeMdx } from "@/mdx/bundler/serialize";
+import {
+  SerializeMdxResponse,
+  serializeMdx as internalSerializeMdx,
+} from "@/mdx/bundler/serialize";
 import { createCachedDocsLoader } from "@/server/docs-loader";
 
 import { cacheSeed } from "./cache-seed";
@@ -42,7 +47,7 @@ export type MdxSerializer = (
   | undefined
 >;
 
-export function createCachedMdxSerializer(
+export function createMdxSerializer(
   loader: Awaited<ReturnType<typeof createCachedDocsLoader>>,
   {
     scope,
@@ -51,7 +56,7 @@ export function createCachedMdxSerializer(
   } = {}
 ) {
   const domain = loader.domain;
-  const serializer = async (
+  return async (
     content: string | undefined,
     options: MdxSerializerOptions = {}
   ) => {
@@ -59,37 +64,38 @@ export function createCachedMdxSerializer(
       return;
     }
     // this lets us key on just
-    const cachedSerializer = unstable_cache(
-      async ({ filename, toc, scope, url }: MdxSerializerOptions) => {
-        const authState = await loader.getAuthState();
+    const uncachedSerializer = async ({
+      filename,
+      toc,
+      scope,
+      url,
+    }: MdxSerializerOptions) => {
+      const authState = await loader.getAuthState();
 
-        try {
-          return await internalSerializeMdx(content, {
-            filename,
-            loader,
-            toc,
-            scope: {
-              authed: authState.authed,
-              user: authState.authed ? authState.user : undefined,
-              ...scope,
-            },
-          });
-        } catch (error) {
-          console.error("Error serializing mdx", error);
+      try {
+        return await internalSerializeMdx(content, {
+          filename,
+          loader,
+          toc,
+          scope: {
+            authed: authState.authed,
+            user: authState.authed ? authState.user : undefined,
+            ...scope,
+          },
+        });
+      } catch (error) {
+        console.error("Error serializing mdx", error);
 
-          postToEngineeringNotifs(
-            `:rotating_light: [${domain}] \`Serialize MDX\` encountered an error: \`${String(error)}\` (url: \`${url ?? "unknown"}\ with the content ${content}`)`
-          );
+        postToEngineeringNotifs(
+          `:rotating_light: [${domain}] \`Serialize MDX\` encountered an error: \`${String(error)}\` (url: \`${url ?? "unknown"}\` with the content ${content})`
+        );
 
-          return undefined;
-        }
-      },
-      [domain, content, cacheSeed()],
-      { tags: [domain, "serializeMdx"] }
-    );
+        return undefined;
+      }
+    };
 
     // merge the scope from the page with the scope from the serializer
-    const result = await cachedSerializer({
+    const result = await uncachedSerializer({
       ...options,
       scope: { ...options.scope, ...scope },
     });
@@ -102,6 +108,61 @@ export function createCachedMdxSerializer(
 
     return result;
   };
+}
 
-  return cache(serializer);
+export async function remoteSerializeMdx(
+  opts: MdxSerializerOptions & {
+    loader: Awaited<ReturnType<typeof createCachedDocsLoader>>;
+    content: string;
+  }
+) {
+  const { loader, content, ...options } = opts;
+
+  const headers = new Headers();
+  headers.set("Content-Type", "application/json");
+  headers.set(HEADER_X_FERN_HOST, loader.domain);
+  if (loader.fern_token) {
+    headers.set("cookie", `fern_token=${loader.fern_token}`);
+  }
+
+  const response = await fetch(
+    `${withDefaultProtocol(decodeURIComponent(loader.host))}/api/fern-docs/serialize`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        content,
+        ...options,
+      }),
+      credentials: "include",
+    }
+  );
+
+  return response.json() as Promise<SerializeMdxResponse | undefined>;
+}
+
+export function createRemoteMdxSerializer(
+  loader: Awaited<ReturnType<typeof createCachedDocsLoader>>,
+  {
+    scope,
+  }: {
+    scope?: Record<string, unknown>;
+  } = {}
+) {
+  return cache(
+    async (content: string | undefined, options: MdxSerializerOptions = {}) => {
+      if (content == null || content.trimStart() === "") {
+        return;
+      }
+      const cachedSerializer = unstable_cache(
+        async ({ ...options }: MdxSerializerOptions) => {
+          return remoteSerializeMdx({ loader, content, ...options, scope });
+        },
+        [loader.domain, content, cacheSeed()],
+        { tags: [loader.domain, "serializeMdx"] }
+      );
+
+      return cachedSerializer({ ...options, scope });
+    }
+  );
 }

--- a/packages/fern-docs/bundle/src/server/slack.ts
+++ b/packages/fern-docs/bundle/src/server/slack.ts
@@ -1,12 +1,24 @@
 import { after } from "next/server";
 
 import { WebClient } from "@slack/web-api";
+import { kv } from "@vercel/kv";
 
 export function postToEngineeringNotifs(message: string) {
   return after(async () => {
     if (!process.env.SLACK_TOKEN) {
       return;
     }
+
+    // deduplicate messages by checking the last message
+    const lastMessage = await kv.get("slack-last-message");
+
+    if (lastMessage === message) {
+      return;
+    }
+
+    await kv.set("slack-last-message", message, {
+      ex: 60, // expires every 60 seconds
+    });
 
     const webClient = new WebClient(process.env.SLACK_TOKEN);
     await webClient.chat.postMessage({


### PR DESCRIPTION
introduces a new route `/api/fern-docs/serialize` that serializes markdown in its own serverless function