### PR TITLE
Fix/codeblock 20 maxlines

### DIFF
--- a/packages/fern-docs/bundle/src/mdx/components/code/CodeBlock.tsx
+++ b/packages/fern-docs/bundle/src/mdx/components/code/CodeBlock.tsx
@@ -93,7 +93,7 @@ export function toSyntaxHighlighterProps(
     highlightLines: typeof highlight === "number" ? [highlight] : highlight,
     highlightStyle: props.focus != null ? "focus" : "highlight",
     code: props.code ?? "",
-    maxLines: props.maxLines,
+    maxLines: props.maxLines ?? 20,
     wordWrap: props.wordWrap,
   };
 }


### PR DESCRIPTION
Fixes FER-

## Short description of the changes made
- Added a default maxlines of 20 for codeblock

## What was the motivation & context behind this PR?
- Support for elevenlabs

## How has this PR been tested?
- Manually with customers

