### PR TITLE
chore: rename play to try it

### DIFF
--- a/packages/fern-docs/bundle/src/components/playground/PlaygroundButton.tsx
+++ b/packages/fern-docs/bundle/src/components/playground/PlaygroundButton.tsx
@@ -47,7 +47,7 @@ export const PlaygroundButton: FC<{
           scroll={false}
         >
           <Play className="fill-current" />
-          Play
+          Try it
         </ButtonLink>
       </FernTooltip>
     </FernTooltipProvider>


### PR DESCRIPTION
Renames Play to Try it, even though @chdeskur still has to port over most of the API buttons. 