### PR TITLE
fix: aside component for guides

### DIFF
--- a/packages/fern-docs/bundle/package.json
+++ b/packages/fern-docs/bundle/package.json
@@ -68,6 +68,7 @@
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-portal": "^1.1.4",
+    "@radix-ui/react-primitive": "^2.0.2",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",

--- a/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointContentCodeSnippets.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointContentCodeSnippets.tsx
@@ -133,6 +133,7 @@ const UnmemoizedEndpointContentCodeSnippets: React.FC<
   return (
     <div
       className={cn(
+        "not-prose",
         // note: .fern-endpoint-code-snippets class is used to detect clicks outside of the code snippets
         // this is used to clear the selected error when the user clicks outside of the error
         "fern-endpoint-code-snippets w-full",

--- a/packages/fern-docs/bundle/src/components/api-reference/webhooks/WebhookExample.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/webhooks/WebhookExample.tsx
@@ -31,7 +31,7 @@ export const WebhookExample: React.FC<WebhookExample.Props> = ({
   );
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+    <div className="not-prose flex min-h-0 min-w-0 flex-1 flex-col">
       <div className="flex min-h-0 min-w-0 flex-1 shrink flex-col">
         {example.payload != null && (
           <CodeSnippetExample

--- a/packages/fern-docs/bundle/src/components/api-reference/websockets/WebSocket.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/websockets/WebSocket.tsx
@@ -106,7 +106,7 @@ export async function WebSocketContent({
         </PageHeader>
       }
       aside={
-        <div className="grid grid-rows-[repeat(auto-fit,minmax(0,min-content))] gap-6">
+        <div className="not-prose grid grid-rows-[repeat(auto-fit,minmax(0,min-content))] gap-6">
           <TitledExample
             title="Handshake"
             tryIt={

--- a/packages/fern-docs/bundle/src/components/layouts/FooterLayout.tsx
+++ b/packages/fern-docs/bundle/src/components/layouts/FooterLayout.tsx
@@ -20,7 +20,7 @@ export function FooterLayout({
   className?: string;
 }) {
   return (
-    <footer className={cn("fern-layout-footer", className)}>
+    <footer className={cn("fern-layout-footer not-prose", className)}>
       <div className="fern-layout-footer-toolbar">
         <div>{!hideFeedback && <Feedback pathname={pathname} />}</div>
         <EditThisPageButton editThisPageUrl={editThisPageUrl} />

--- a/packages/fern-docs/bundle/src/components/layouts/LayoutEvaluatorContent.tsx
+++ b/packages/fern-docs/bundle/src/components/layouts/LayoutEvaluatorContent.tsx
@@ -102,7 +102,12 @@ export async function LayoutEvaluatorContent({
       );
     case "reference":
       return (
-        <ReferenceLayout header={pageHeader} aside={aside} footer={footer}>
+        <ReferenceLayout
+          header={pageHeader}
+          aside={aside}
+          footer={footer}
+          kind="guide"
+        >
           {children}
         </ReferenceLayout>
       );

--- a/packages/fern-docs/bundle/src/components/layouts/ReferenceLayout.tsx
+++ b/packages/fern-docs/bundle/src/components/layouts/ReferenceLayout.tsx
@@ -32,7 +32,11 @@ export const ReferenceLayout = React.forwardRef<
     <AsideAwareDiv className="fern-layout-reference">
       <SetLayout value="reference" />
       <slot.In>
-        <aside className="fern-layout-reference-aside">{aside}</aside>
+        <aside className="fern-layout-reference-aside">
+          <Prose className="w-full">
+            {aside}
+          </Prose>
+        </aside>
       </slot.In>
       <article
         {...props}

--- a/packages/fern-docs/bundle/src/components/layouts/ReferenceLayout.tsx
+++ b/packages/fern-docs/bundle/src/components/layouts/ReferenceLayout.tsx
@@ -3,7 +3,7 @@
 import React, { ComponentPropsWithoutRef } from "react";
 
 import { cn } from "@fern-docs/components";
-import { tunnel, useIsMobile, useLazyRef } from "@fern-ui/react-commons";
+import { useIsMobile } from "@fern-ui/react-commons";
 
 import { Prose } from "@/mdx/components/prose";
 import { SetLayout } from "@/state/layout";
@@ -17,27 +17,34 @@ interface ReferenceLayoutProps {
   reference?: React.ReactNode;
   footer?: React.ReactNode;
   enableFullWidth?: boolean;
+  /**
+   * If true, scrolling will be disabled on the reference sidebar
+   * so that the code examples are constrained and must implement
+   * scrolling within themselves.
+   */
+  kind?: "api" | "guide";
 }
 
 export const ReferenceLayout = React.forwardRef<
   HTMLDivElement,
   ComponentPropsWithoutRef<"article"> & ReferenceLayoutProps
 >(function ReferenceLayout(
-  { header, aside, children, footer, reference, enableFullWidth, ...props },
+  {
+    header,
+    aside,
+    children,
+    footer,
+    reference,
+    enableFullWidth,
+    kind = "api",
+    ...props
+  },
   ref
 ) {
-  const slot = useLazyRef(() => tunnel()).current;
   const isMobile = useIsMobile();
   return (
     <AsideAwareDiv className="fern-layout-reference">
       <SetLayout value="reference" />
-      <slot.In>
-        <aside className="fern-layout-reference-aside">
-          <Prose className="w-full">
-            {aside}
-          </Prose>
-        </aside>
-      </slot.In>
       <article
         {...props}
         className={cn(
@@ -49,17 +56,25 @@ export const ReferenceLayout = React.forwardRef<
       >
         {header}
         <div className="fern-layout-reference-content">
-          {!isMobile && <slot.Out />}
-          <div className="mb-12 space-y-12">
-            {children && (
-              <Prose className="prose-h1:mt-[1.5em] first:prose-h1:mt-0 max-w-full">
-                {children}
-              </Prose>
+          {!isMobile && (
+            <aside className="fern-layout-reference-aside" data-kind={kind}>
+              {kind === "api" ? (
+                aside
+              ) : (
+                <Prose className="relative">{aside}</Prose>
+              )}
+            </aside>
+          )}
+          <Prose className="mb-12 space-y-12">
+            {children}
+            {isMobile && (
+              <section className="fern-layout-reference-aside" data-kind={kind}>
+                {aside}
+              </section>
             )}
-            {isMobile && <slot.Out />}
             {reference}
             {footer}
-          </div>
+          </Prose>
         </div>
       </article>
     </AsideAwareDiv>

--- a/packages/fern-docs/bundle/src/components/layouts/index.scss
+++ b/packages/fern-docs/bundle/src/components/layouts/index.scss
@@ -25,8 +25,12 @@
   .fern-layout-reference {
     @apply pl-page-padding mx-auto min-w-0 shrink pr-[calc(var(--page-padding)+var(--aside-offset))];
 
+    aside.fern-layout-reference-aside {
+      @apply sticky order-last h-fit;
+    }
+
     .fern-layout-reference-aside {
-      @apply order-last flex shrink-0 md:sticky md:h-fit;
+      @apply flex shrink-0;
     }
 
     .fern-layout-reference-content {

--- a/packages/fern-docs/bundle/src/components/layouts/index.scss
+++ b/packages/fern-docs/bundle/src/components/layouts/index.scss
@@ -29,7 +29,7 @@
       @apply sticky order-last h-fit;
     }
 
-    .fern-layout-reference-aside {
+    .fern-layout-reference-aside[data-kind="api"] {
       @apply flex shrink-0;
     }
 

--- a/packages/fern-docs/bundle/src/components/themes/cohere/index.scss
+++ b/packages/fern-docs/bundle/src/components/themes/cohere/index.scss
@@ -61,6 +61,10 @@
       @apply max-h-[calc(100svh-var(--header-height)-8.25rem-2px)] md:top-6 md:max-h-[calc(100vh-var(--header-height)-5.25rem-2px)];
     }
 
+    .fern-layout-reference-aside[data-kind="guide"] {
+      @apply top-6 pb-12;
+    }
+
     .fern-changelog-content > aside {
       @apply top-4;
     }

--- a/packages/fern-docs/bundle/src/components/themes/cohere/index.scss
+++ b/packages/fern-docs/bundle/src/components/themes/cohere/index.scss
@@ -57,7 +57,7 @@
       @apply top-0 max-h-[calc(100dvh-var(--spacing-header-height)-2.25rem-2px)];
     }
 
-    .fern-layout-reference-aside {
+    .fern-layout-reference-aside[data-kind="api"] {
       @apply max-h-[calc(100svh-var(--header-height)-8.25rem-2px)] md:top-6 md:max-h-[calc(100vh-var(--header-height)-5.25rem-2px)];
     }
 

--- a/packages/fern-docs/bundle/src/components/themes/default/index.scss
+++ b/packages/fern-docs/bundle/src/components/themes/default/index.scss
@@ -75,8 +75,16 @@
       @apply px-4 py-6 pb-12 lg:pl-5;
     }
 
-    .fern-layout-reference-aside {
+    .fern-layout-reference-aside[data-kind="api"] {
       @apply max-h-[calc(100svh-var(--header-height)-6rem)] md:top-[calc(var(--header-height)+1.5rem)] md:max-h-[calc(100vh-var(--header-height)-3rem)];
+    }
+
+    aside.fern-layout-reference-aside[data-kind="guide"] {
+      @apply top-[calc(var(--header-height)+1.5rem)] pb-12;
+
+      & > * {
+        @apply min-w-0 shrink;
+      }
     }
 
     .fern-changelog-content > aside {

--- a/packages/fern-docs/bundle/src/components/themes/default/index.scss
+++ b/packages/fern-docs/bundle/src/components/themes/default/index.scss
@@ -81,10 +81,6 @@
 
     aside.fern-layout-reference-aside[data-kind="guide"] {
       @apply top-[calc(var(--header-height)+1.5rem)] pb-12;
-
-      & > * {
-        @apply min-w-0 shrink;
-      }
     }
 
     .fern-changelog-content > aside {

--- a/packages/fern-docs/bundle/src/mdx/bundler/component.tsx
+++ b/packages/fern-docs/bundle/src/mdx/bundler/component.tsx
@@ -7,8 +7,6 @@ import _jsx_runtime from "react/jsx-runtime";
 import { MDXProvider, useMDXComponents } from "@mdx-js/react";
 import { getMDXExport } from "mdx-bundler/client";
 
-import { FernScrollArea } from "@fern-docs/components";
-
 import { ErrorBoundary } from "@/components/error-boundary";
 
 import { createMdxComponents } from "../components";
@@ -50,9 +48,7 @@ export const MdxAside = React.memo<{
     return (
       <ErrorBoundary>
         <MDXProvider components={createMdxComponents(jsxElements)}>
-          <FernScrollArea rootClassName="pb-12">
-            <Aside />
-          </FernScrollArea>
+          <Aside />
         </MDXProvider>
       </ErrorBoundary>
     );

--- a/packages/fern-docs/bundle/src/mdx/components/prose.tsx
+++ b/packages/fern-docs/bundle/src/mdx/components/prose.tsx
@@ -1,22 +1,26 @@
+import React from "react";
+
+import { Primitive } from "@radix-ui/react-primitive";
+
 import { cn } from "@fern-docs/components";
 
-export function Prose({
-  children,
-  className,
-  size = "base",
-  pre,
-}: {
-  children: React.ReactNode;
-  className?: string;
-  size?: "xs" | "sm" | "base" | "lg";
-  pre?: boolean;
-}) {
+export const Prose = React.forwardRef<
+  HTMLDivElement,
+  {
+    children: React.ReactNode;
+    className?: string;
+    size?: "xs" | "sm" | "base" | "lg";
+    pre?: boolean;
+    asChild?: boolean;
+  }
+>(({ children, className, size = "base", pre, asChild }, ref) => {
   if (!children) {
     return null;
   }
 
   return (
-    <div
+    <Primitive.div
+      ref={ref}
       className={cn(
         "fern-prose prose max-w-none hyphens-auto break-words",
         {
@@ -27,8 +31,11 @@ export function Prose({
         },
         className
       )}
+      asChild={asChild}
     >
       {children}
-    </div>
+    </Primitive.div>
   );
-}
+});
+
+Prose.displayName = "Prose";

--- a/packages/fern-docs/bundle/src/mdx/components/steps/index.scss
+++ b/packages/fern-docs/bundle/src/mdx/components/steps/index.scss
@@ -1,6 +1,6 @@
 @layer components {
   .fern-steps {
-    @apply border-border-default mb-12 ml-2 mt-4 border-l pl-7;
+    @apply border-border-default mb-12 ml-3 mt-4 border-l pl-7;
   }
 
   .fern-step > .fern-anchor {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -718,6 +718,9 @@ importers:
       '@radix-ui/react-portal':
         specifier: ^1.1.4
         version: 1.1.4(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive':
+        specifier: ^2.0.2
+        version: 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-select':
         specifier: ^2.1.6
         version: 2.1.6(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -834,7 +837,7 @@ importers:
         version: 1.1.6(jotai@2.12.1(@types/react@19.0.10)(react@19.0.0))
       jsonpath-plus:
         specifier: 10.0.7
-        version: 10.3.0
+        version: 10.0.7
       launchdarkly-react-client-sdk:
         specifier: ^3.6.0
         version: 3.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -11272,11 +11275,6 @@ packages:
 
   jsonpath-plus@10.0.7:
     resolution: {integrity: sha512-GDA8d8fu9+s4QzAzo5LMGiLL/9YjecAX+ytlnqdeXYpU55qME57StDgaHt9R2pA7Dr8U31nwzxNJMJiHkrkRgw==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
-  jsonpath-plus@10.3.0:
-    resolution: {integrity: sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -27235,12 +27233,6 @@ snapshots:
       graceful-fs: 4.2.11
 
   jsonpath-plus@10.0.7:
-    dependencies:
-      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
-      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
-      jsep: 1.4.0
-
-  jsonpath-plus@10.3.0:
     dependencies:
       '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
       '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "moduleResolution": "Bundler",
-    "strict": true,
-    "jsx": "react"
+    "strict": true
   },
   "ts-node": {
     "compilerOptions": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "target": "ESNext",
     "moduleResolution": "Bundler",
-    "strict": true
+    "strict": true,
+    "jsx": "react"
   },
   "ts-node": {
     "compilerOptions": {


### PR DESCRIPTION
Fixes FER-

## Short description of the changes made
- Added prose around steps
- Added styling so numbers in steps renders properly

## What was the motivation & context behind this PR?
- Issue with https://docs.frankieone.com/v2.0.0/docs/quickstart-guide/use-case-1-hosted-onesdk in canary

## How has this PR been tested?
Manually
