### PR TITLE
fix(csharp): Use dotnet CLI for nuget package install (readme)

### DIFF
--- a/clis/generator-cli/src/readme/ReadmeGenerator.ts
+++ b/clis/generator-cli/src/readme/ReadmeGenerator.ts
@@ -492,7 +492,7 @@ export class ReadmeGenerator {
     nuget: FernGeneratorCli.NugetPublishInfo;
   }): void {
     writer.writeLine("```sh");
-    writer.writeLine(`nuget install ${nuget.packageName}`);
+    writer.writeLine(`dotnet add package ${nuget.packageName}`);
     writer.writeLine("```");
     writer.writeLine();
   }


### PR DESCRIPTION
Fixes FER-

## Short description of the changes made

.NET developers usually don't have the nuget CLI installed and either install with the `dotnet` CLI or their IDE.

## What was the motivation & context behind this PR?

## How has this PR been tested?

![Remove this, otherwise it will alert all that this template has not been filled out](https://media.giphy.com/media/YO7P8VC7nlQlO/giphy.gif)
