### PR TITLE
feat: changelog formatting

### DIFF
--- a/packages/fern-docs/bundle/src/components/changelog/ChangelogContentLayout.tsx
+++ b/packages/fern-docs/bundle/src/components/changelog/ChangelogContentLayout.tsx
@@ -19,13 +19,15 @@ export function ChangelogContentLayout({
       {...props}
       className={cn("fern-changelog-content", props.className)}
     >
-      <aside>{stickyContent}</aside>
+      {/* hack: force the three-column layout */}
+      <aside />
       <div className="max-w-content-width mx-auto w-full">
         {stickyContent != null && (
           <div className="eyebrow">{stickyContent}</div>
         )}
         {children}
       </div>
+      <aside />
     </Component>
   );
 }

--- a/packages/fern-docs/bundle/src/components/changelog/ChangelogContentLayout.tsx
+++ b/packages/fern-docs/bundle/src/components/changelog/ChangelogContentLayout.tsx
@@ -6,14 +6,12 @@ interface ChangelogContentLayoutProps extends ComponentPropsWithoutRef<"div"> {
   as: "div" | "section" | "article";
   stickyContent?: ReactNode;
   children: ReactNode;
-  fullWidth?: boolean;
 }
 
 export function ChangelogContentLayout({
   as: Component,
   children,
   stickyContent,
-  fullWidth,
   ...props
 }: ChangelogContentLayoutProps): ReactElement<any> {
   return (
@@ -21,7 +19,7 @@ export function ChangelogContentLayout({
       {...props}
       className={cn("fern-changelog-content", props.className)}
     >
-      <aside className="floating-tag">{stickyContent}</aside>
+      <aside>{stickyContent}</aside>
       <div className="max-w-content-width mx-auto w-full">
         {stickyContent != null && (
           <div className="eyebrow">{stickyContent}</div>

--- a/packages/fern-docs/bundle/src/components/changelog/ChangelogContentLayout.tsx
+++ b/packages/fern-docs/bundle/src/components/changelog/ChangelogContentLayout.tsx
@@ -6,12 +6,14 @@ interface ChangelogContentLayoutProps extends ComponentPropsWithoutRef<"div"> {
   as: "div" | "section" | "article";
   stickyContent?: ReactNode;
   children: ReactNode;
+  fullWidth?: boolean;
 }
 
 export function ChangelogContentLayout({
   as: Component,
   children,
   stickyContent,
+  fullWidth,
   ...props
 }: ChangelogContentLayoutProps): ReactElement<any> {
   return (
@@ -19,15 +21,13 @@ export function ChangelogContentLayout({
       {...props}
       className={cn("fern-changelog-content", props.className)}
     >
-      {/* hack: force the three-column layout */}
-      <aside />
+      <aside className="floating-tag">{stickyContent}</aside>
       <div className="max-w-content-width mx-auto w-full">
         {stickyContent != null && (
           <div className="eyebrow">{stickyContent}</div>
         )}
         {children}
       </div>
-      <aside />
     </Component>
   );
 }

--- a/packages/fern-docs/bundle/src/components/changelog/ChangelogEntryPage.tsx
+++ b/packages/fern-docs/bundle/src/components/changelog/ChangelogEntryPage.tsx
@@ -33,18 +33,19 @@ export default function ChangelogEntryPage({
   children: React.ReactNode;
 }): ReactElement<any> {
   return (
-    <AsideAwareDiv className="fern-layout-aside-container mr-auto">
+    <AsideAwareDiv className="fern-layout-aside-container">
       <SetLayout value="page" />
       <HideAsides force />
       <article className="fern-layout-page">
         <HideBuiltWithFern>
-          <ChangelogContentLayout as="section" className="mb-8">
+          <ChangelogContentLayout as="section" className="mb-8" fullWidth>
             {overview}
           </ChangelogContentLayout>
           <Separator className="max-w-content-width mx-auto my-12" />
           <ChangelogContentLayout
             as="article"
             id={node.date}
+            fullWidth
             stickyContent={
               <Badge asChild>
                 <FernLink href={slugToHref(node.slug)} scroll={true}>

--- a/packages/fern-docs/bundle/src/components/changelog/ChangelogEntryPage.tsx
+++ b/packages/fern-docs/bundle/src/components/changelog/ChangelogEntryPage.tsx
@@ -33,7 +33,7 @@ export default function ChangelogEntryPage({
   children: React.ReactNode;
 }): ReactElement<any> {
   return (
-    <AsideAwareDiv className="fern-layout-aside-container">
+    <AsideAwareDiv className="fern-layout-changelog">
       <SetLayout value="page" />
       <HideAsides force />
       <article className="fern-layout-page">

--- a/packages/fern-docs/bundle/src/components/changelog/ChangelogEntryPage.tsx
+++ b/packages/fern-docs/bundle/src/components/changelog/ChangelogEntryPage.tsx
@@ -38,14 +38,13 @@ export default function ChangelogEntryPage({
       <HideAsides force />
       <article className="fern-layout-page">
         <HideBuiltWithFern>
-          <ChangelogContentLayout as="section" className="mb-8" fullWidth>
+          <ChangelogContentLayout as="section" className="mb-8">
             {overview}
           </ChangelogContentLayout>
           <Separator className="max-w-content-width mx-auto my-12" />
           <ChangelogContentLayout
             as="article"
             id={node.date}
-            fullWidth
             stickyContent={
               <Badge asChild>
                 <FernLink href={slugToHref(node.slug)} scroll={true}>

--- a/packages/fern-docs/bundle/src/components/changelog/ChangelogEntryPage.tsx
+++ b/packages/fern-docs/bundle/src/components/changelog/ChangelogEntryPage.tsx
@@ -13,6 +13,7 @@ import { DocsLoader } from "@/server/docs-loader";
 import { MdxSerializer } from "@/server/mdx-serializer";
 import { HideAsides, SetLayout } from "@/state/layout";
 
+import { AsideAwareDiv } from "../layouts/AsideAwareDiv";
 import { FooterLayout } from "../layouts/FooterLayout";
 import { ChangelogContentLayout } from "./ChangelogContentLayout";
 
@@ -32,36 +33,38 @@ export default function ChangelogEntryPage({
   children: React.ReactNode;
 }): ReactElement<any> {
   return (
-    <article className="fern-layout-page">
+    <AsideAwareDiv className="fern-layout-aside-container mr-auto">
       <SetLayout value="page" />
       <HideAsides force />
-      <HideBuiltWithFern>
-        <ChangelogContentLayout as="section" className="mb-8">
-          {overview}
-        </ChangelogContentLayout>
-        <Separator className="max-w-content-width mx-auto my-12" />
-        <ChangelogContentLayout
-          as="article"
-          id={node.date}
-          stickyContent={
-            <Badge asChild>
-              <FernLink href={slugToHref(node.slug)} scroll={true}>
-                {node.title}
-              </FernLink>
-            </Badge>
-          }
-        >
-          {children}
-        </ChangelogContentLayout>
-      </HideBuiltWithFern>
-      <FooterLayoutWithEditThisPageUrl
-        slug={node.slug}
-        pageId={node.pageId}
-        loader={loader}
-        serialize={serialize}
-        bottomNavigation={bottomNavigation}
-      />
-    </article>
+      <article className="fern-layout-page">
+        <HideBuiltWithFern>
+          <ChangelogContentLayout as="section" className="mb-8">
+            {overview}
+          </ChangelogContentLayout>
+          <Separator className="max-w-content-width mx-auto my-12" />
+          <ChangelogContentLayout
+            as="article"
+            id={node.date}
+            stickyContent={
+              <Badge asChild>
+                <FernLink href={slugToHref(node.slug)} scroll={true}>
+                  {node.title}
+                </FernLink>
+              </Badge>
+            }
+          >
+            {children}
+          </ChangelogContentLayout>
+        </HideBuiltWithFern>
+        <FooterLayoutWithEditThisPageUrl
+          slug={node.slug}
+          pageId={node.pageId}
+          loader={loader}
+          serialize={serialize}
+          bottomNavigation={bottomNavigation}
+        />
+      </article>
+    </AsideAwareDiv>
   );
 }
 

--- a/packages/fern-docs/bundle/src/components/changelog/ChangelogPageClient.tsx
+++ b/packages/fern-docs/bundle/src/components/changelog/ChangelogPageClient.tsx
@@ -156,7 +156,7 @@ export default function ChangelogPageClient({
             {visibleEntries.map((entry) => {
               return (
                 <Fragment key={entry.id}>
-                  <Separator className="max-w-content-width mx-auto my-12" />
+                  <Separator className="max-w-content-width mx-4 my-12" />
                   <ChangelogContentLayout
                     as="article"
                     id={entry.date}

--- a/packages/fern-docs/bundle/src/components/changelog/ChangelogPageClient.tsx
+++ b/packages/fern-docs/bundle/src/components/changelog/ChangelogPageClient.tsx
@@ -145,7 +145,7 @@ export default function ChangelogPageClient({
         tableOfContents={undefined}
         hideTableOfContents={true}
       />
-      <AsideAwareDiv className="fern-layout-guide">
+      <AsideAwareDiv className="fern-layout-aside-container fern-layout-guide">
         <article className="w-content-width max-w-full">
           <SetLayout value="guide" />
           <HideBuiltWithFern>

--- a/packages/fern-docs/bundle/src/components/changelog/ChangelogPageClient.tsx
+++ b/packages/fern-docs/bundle/src/components/changelog/ChangelogPageClient.tsx
@@ -156,10 +156,11 @@ export default function ChangelogPageClient({
             {visibleEntries.map((entry) => {
               return (
                 <Fragment key={entry.id}>
-                  <Separator className="max-w-content-width mx-4 my-12" />
+                  <Separator className="max-w-content-width mx-auto my-12" />
                   <ChangelogContentLayout
                     as="article"
                     id={entry.date}
+                    className="gap-0"
                     stickyContent={
                       <Badge asChild>
                         <FernLink href={slugToHref(entry.slug)} scroll={true}>

--- a/packages/fern-docs/bundle/src/components/changelog/ChangelogPageClient.tsx
+++ b/packages/fern-docs/bundle/src/components/changelog/ChangelogPageClient.tsx
@@ -146,8 +146,8 @@ export default function ChangelogPageClient({
         hideTableOfContents={true}
       />
       {/* TODO(cd): treat as a guide for now, update for large-screen changelog */}
-      <AsideAwareDiv className="fern-layout-aside-container fern-layout-guide">
-        <article className="w-content-width max-w-full">
+      <AsideAwareDiv className="fern-layout-changelog">
+        <article className="max-w-full">
           <SetLayout value="guide" />
           <HideBuiltWithFern>
             <ChangelogContentLayout as="section" className="mb-8">
@@ -161,7 +161,6 @@ export default function ChangelogPageClient({
                   <ChangelogContentLayout
                     as="article"
                     id={entry.date}
-                    className="gap-0"
                     stickyContent={
                       <Badge asChild>
                         <FernLink href={slugToHref(entry.slug)} scroll={true}>

--- a/packages/fern-docs/bundle/src/components/changelog/ChangelogPageClient.tsx
+++ b/packages/fern-docs/bundle/src/components/changelog/ChangelogPageClient.tsx
@@ -15,11 +15,13 @@ import { FernLink } from "@/components/FernLink";
 import { Separator } from "@/components/Separator";
 import { HideBuiltWithFern } from "@/components/built-with-fern";
 import { useCurrentAnchor } from "@/hooks/use-anchor";
-import { HideAsides, SetLayout } from "@/state/layout";
+import { SetLayout } from "@/state/layout";
 import { SCROLL_BODY_ATOM } from "@/state/viewport";
 
 import { BottomNavigationClient } from "../bottom-nav-client";
+import { AsideAwareDiv } from "../layouts/AsideAwareDiv";
 import { FooterLayout } from "../layouts/FooterLayout";
+import { TableOfContentsLayout } from "../layouts/TableOfContentsLayout";
 import { ChangelogContentLayout } from "./ChangelogContentLayout";
 
 function flattenChangelogEntries(
@@ -138,39 +140,48 @@ export default function ChangelogPageClient({
   }, [chunkedEntries.length, page]);
 
   return (
-    <article className="fern-layout-page">
-      <SetLayout value="page" />
-      <HideAsides force />
-      <HideBuiltWithFern>
-        <ChangelogContentLayout as="section" className="mb-8">
-          {overview}
-        </ChangelogContentLayout>
-
-        {visibleEntries.map((entry) => {
-          return (
-            <Fragment key={entry.id}>
-              <Separator className="max-w-content-width mx-auto my-12" />
-              <ChangelogContentLayout
-                as="article"
-                id={entry.date}
-                stickyContent={
-                  <Badge asChild>
-                    <FernLink href={slugToHref(entry.slug)} scroll={true}>
-                      {entry.title}
-                    </FernLink>
-                  </Badge>
-                }
-              >
-                {entries[entry.pageId]}
-              </ChangelogContentLayout>
-            </Fragment>
-          );
-        })}
-      </HideBuiltWithFern>
-      <FooterLayout
-        hideFeedback
-        bottomNavigation={<BottomNavigationClient prev={prev} next={next} />}
+    <>
+      <TableOfContentsLayout
+        tableOfContents={undefined}
+        hideTableOfContents={true}
       />
-    </article>
+      <AsideAwareDiv className="fern-layout-guide">
+        <article className="w-content-width max-w-full">
+          <SetLayout value="guide" />
+          <HideBuiltWithFern>
+            <ChangelogContentLayout as="section" className="mb-8">
+              {overview}
+            </ChangelogContentLayout>
+
+            {visibleEntries.map((entry) => {
+              return (
+                <Fragment key={entry.id}>
+                  <Separator className="max-w-content-width mx-auto my-12" />
+                  <ChangelogContentLayout
+                    as="article"
+                    id={entry.date}
+                    stickyContent={
+                      <Badge asChild>
+                        <FernLink href={slugToHref(entry.slug)} scroll={true}>
+                          {entry.title}
+                        </FernLink>
+                      </Badge>
+                    }
+                  >
+                    {entries[entry.pageId]}
+                  </ChangelogContentLayout>
+                </Fragment>
+              );
+            })}
+          </HideBuiltWithFern>
+          <FooterLayout
+            hideFeedback
+            bottomNavigation={
+              <BottomNavigationClient prev={prev} next={next} />
+            }
+          />
+        </article>
+      </AsideAwareDiv>
+    </>
   );
 }

--- a/packages/fern-docs/bundle/src/components/changelog/ChangelogPageClient.tsx
+++ b/packages/fern-docs/bundle/src/components/changelog/ChangelogPageClient.tsx
@@ -145,6 +145,7 @@ export default function ChangelogPageClient({
         tableOfContents={undefined}
         hideTableOfContents={true}
       />
+      {/* TODO(cd): treat as a guide for now, update for large-screen changelog */}
       <AsideAwareDiv className="fern-layout-aside-container fern-layout-guide">
         <article className="w-content-width max-w-full">
           <SetLayout value="guide" />

--- a/packages/fern-docs/bundle/src/components/layouts/index.scss
+++ b/packages/fern-docs/bundle/src/components/layouts/index.scss
@@ -6,11 +6,23 @@
 
   .fern-layout-aside-container {
     &[data-aside-state="hidden"] {
-      @apply lg:ml-0 xl:ml-auto;
+      @apply mx-auto min-w-0;
+
+      .eyebrow {
+        @apply flex lg:hidden;
+      }
+
+      .floating-tab {
+        @apply hidden lg:sticky lg:top-0;
+      }
     }
 
     &[data-aside-state="visible"] {
-      @apply pr-page-padding;
+      @apply pr-page-padding xl:ml-0 xl:mr-auto;
+
+      .floating-tab {
+        @apply hidden;
+      }
     }
   }
 
@@ -47,7 +59,7 @@
   }
 
   .fern-changelog-content {
-    @apply max-w-content-wide-width relative mx-auto grid w-full grid-cols-1 gap-4 lg:grid-cols-[1fr_minmax(0,var(--content-width))_1fr];
+    @apply max-w-content-wide-width relative mx-auto grid w-full grid-cols-1 gap-4;
 
     .eyebrow {
       @apply mb-4;

--- a/packages/fern-docs/bundle/src/components/layouts/index.scss
+++ b/packages/fern-docs/bundle/src/components/layouts/index.scss
@@ -4,9 +4,13 @@
     @apply w-(--sticky-aside-width) pr-(--aside-offset);
   }
 
-  .fern-layout-aside-container {
+  .fern-layout-changelog {
     &[data-aside-state="hidden"] {
-      @apply max-w-page-width-padded px-page-padding mx-auto min-w-0 flex-1;
+      @apply max-w-page-width-padded px-page-padding mx-auto min-w-0;
+
+      > aside {
+        @apply w-page-width;
+      }
 
       .fern-changelog-content {
         @apply max-w-content-wide-width relative mx-auto grid w-full grid-cols-1 gap-4 lg:grid-cols-[1fr_minmax(0,var(--content-width))_1fr];
@@ -22,6 +26,12 @@
     }
 
     &[data-aside-state="visible"] {
+      @apply px-page-padding mx-auto mb-12 min-w-0 shrink space-y-8;
+
+      > aside {
+        @apply w-content-width;
+      }
+
       .fern-changelog-content > aside {
         @apply hidden;
       }

--- a/packages/fern-docs/bundle/src/components/layouts/index.scss
+++ b/packages/fern-docs/bundle/src/components/layouts/index.scss
@@ -49,12 +49,8 @@
   .fern-changelog-content {
     @apply max-w-content-wide-width relative mx-auto grid w-full grid-cols-1 gap-4 lg:grid-cols-[1fr_minmax(0,var(--content-width))_1fr];
 
-    & > aside {
-      @apply sticky hidden h-fit lg:flex lg:justify-end;
-    }
-
     .eyebrow {
-      @apply mb-4 lg:hidden;
+      @apply mb-4;
     }
   }
 }

--- a/packages/fern-docs/bundle/src/components/layouts/index.scss
+++ b/packages/fern-docs/bundle/src/components/layouts/index.scss
@@ -6,21 +6,23 @@
 
   .fern-layout-aside-container {
     &[data-aside-state="hidden"] {
-      @apply mx-auto min-w-0;
+      @apply max-w-page-width-padded px-page-padding mx-auto min-w-0 flex-1;
+
+      .fern-changelog-content {
+        @apply max-w-content-wide-width relative mx-auto grid w-full grid-cols-1 gap-4 lg:grid-cols-[1fr_minmax(0,var(--content-width))_1fr];
+      }
 
       .eyebrow {
         @apply flex lg:hidden;
       }
 
-      .floating-tab {
-        @apply hidden lg:sticky lg:top-0;
+      .fern-changelog-content > aside {
+        @apply sticky hidden h-fit lg:flex lg:justify-end;
       }
     }
 
     &[data-aside-state="visible"] {
-      @apply pr-page-padding xl:ml-0 xl:mr-auto;
-
-      .floating-tab {
+      .fern-changelog-content > aside {
         @apply hidden;
       }
     }


### PR DESCRIPTION
this pr: 
- preserves the sidebar on the changelog overview page
- removes the sidebar if a user clicks into a specific changelog pahge
- removes the sidebar if a user clicks to a changelog tab

![Screenshot 2025-03-14 at 9 58 06 AM](https://github.com/user-attachments/assets/28a5601d-4251-4ff1-9f18-964fc763dd55)
![Screenshot 2025-03-14 at 9 58 12 AM](https://github.com/user-attachments/assets/d990d429-0a68-4c2c-b315-5917b78bcca7)
![Screenshot 2025-03-14 at 9 56 41 AM](https://github.com/user-attachments/assets/aa2b8142-c184-47cf-a958-892bbeb8133a)
