### PR TITLE
fix: add fallback url when `servers` is not defined

### DIFF
--- a/packages/fern-docs/bundle/src/server/docs-loader.ts
+++ b/packages/fern-docs/bundle/src/server/docs-loader.ts
@@ -347,10 +347,10 @@ const createGetPrunedApiCached = (domain: string) =>
 
       for (const endpointK of Object.keys(pruned.endpoints)) {
         if (
-          pruned.endpoints[endpointK as EndpointId]?.environments?.length === 0
+          pruned.endpoints[EndpointId(endpointK)]?.environments?.length === 0
         ) {
           console.debug(endpointK, "has empty environments");
-          pruned.endpoints[endpointK as EndpointId]?.environments?.push({
+          pruned.endpoints[EndpointId(endpointK)]?.environments?.push({
             id: "Default" as EnvironmentId,
             baseUrl: "https://host.com",
           });

--- a/packages/fern-docs/bundle/src/server/docs-loader.ts
+++ b/packages/fern-docs/bundle/src/server/docs-loader.ts
@@ -349,7 +349,9 @@ const createGetPrunedApiCached = (domain: string) =>
         if (
           pruned.endpoints[EndpointId(endpointK)]?.environments?.length === 0
         ) {
-          console.debug(endpointK, "has empty environments");
+          console.debug(
+            `${endpointK} has empty environments, adding default URL.`
+          );
           pruned.endpoints[EndpointId(endpointK)]?.environments?.push({
             id: "Default" as EnvironmentId,
             baseUrl: "https://host.com",

--- a/packages/fern-docs/bundle/src/server/docs-loader.ts
+++ b/packages/fern-docs/bundle/src/server/docs-loader.ts
@@ -317,8 +317,6 @@ const createGetPrunedApiCached = (domain: string) =>
     ): Promise<ApiDefinition.ApiDefinition> => {
       const flagsPromise = cachedGetEdgeFlags(domain);
 
-      console.debug("@#$aab", nodes);
-
       // if there is only one node, and it's an endpoint, try to load from cache
       try {
         if (nodes.length === 1 && nodes[0]) {

--- a/packages/fern-docs/bundle/src/server/docs-loader.ts
+++ b/packages/fern-docs/bundle/src/server/docs-loader.ts
@@ -339,12 +339,6 @@ const createGetPrunedApiCached = (domain: string) =>
       const api = await getApi(domain, id);
       const pruned = prune(api, ...nodes);
 
-      // if there is only one node, and it's an endpoint, try to cache the result
-      if (nodes.length === 1 && nodes[0]) {
-        const key = `api:${id}:${createEndpointCacheKey(nodes[0])}`;
-        kvSet(domain, key, pruned);
-      }
-
       for (const endpointK of Object.keys(pruned.endpoints)) {
         if (
           pruned.endpoints[EndpointId(endpointK)]?.environments?.length === 0
@@ -357,6 +351,12 @@ const createGetPrunedApiCached = (domain: string) =>
             baseUrl: "https://host.com",
           });
         }
+      }
+
+      // if there is only one node, and it's an endpoint, try to cache the result
+      if (nodes.length === 1 && nodes[0]) {
+        const key = `api:${id}:${createEndpointCacheKey(nodes[0])}`;
+        kvSet(domain, key, pruned);
       }
 
       return backfillSnippets(pruned, await flagsPromise);

--- a/packages/fern-docs/bundle/src/server/docs-loader.ts
+++ b/packages/fern-docs/bundle/src/server/docs-loader.ts
@@ -338,9 +338,7 @@ const createGetPrunedApiCached = (domain: string) =>
         );
       }
 
-      console.debug("@#$aab2", domain, id);
       const api = await getApi(domain, id);
-      console.debug("@#$aab3", api);
       const pruned = prune(api, ...nodes);
 
       // if there is only one node, and it's an endpoint, try to cache the result
@@ -350,7 +348,6 @@ const createGetPrunedApiCached = (domain: string) =>
       }
 
       for (const endpointK of Object.keys(pruned.endpoints)) {
-        console.debug("@#$aab4", endpointK);
         if (
           pruned.endpoints[endpointK as EndpointId]?.environments?.length === 0
         ) {
@@ -362,8 +359,6 @@ const createGetPrunedApiCached = (domain: string) =>
         }
       }
 
-      console.debug("@#$aac", pruned);
-      console.debug("@#$aac-envs", pruned.endpoints);
       return backfillSnippets(pruned, await flagsPromise);
     },
     [domain, cacheSeed()],


### PR DESCRIPTION
Fixes FER-4654

## Short description of the changes made
- Added a check for pruned endpoints
- Added default entry `https://host.com` if `environments` is empty

## What was the motivation & context behind this PR?
- Fix breaking docs when `servers` not defined in `openapi.json`

## How has this PR been tested?
- tested locally
