### PR TITLE
chore: set fallbacks for disable-header

### DIFF
--- a/packages/fern-docs/bundle/src/server/docs-loader.ts
+++ b/packages/fern-docs/bundle/src/server/docs-loader.ts
@@ -801,10 +801,12 @@ const getLayout = cache(async (domain: string) => {
         calcDefaultPageWidth(sidebarWidth, contentWidth));
   const headerHeight =
     toPx(config.layout?.headerHeight) ?? DEFAULT_HEADER_HEIGHT;
-  const tabsPlacement =
-    config.layout?.tabsPlacement ?? defaultTabsPlacement(domain);
-  const searchbarPlacement =
-    config.layout?.searchbarPlacement ?? defaultSearchbarPlacement(domain);
+  const tabsPlacement = config.layout?.disableHeader
+    ? "SIDEBAR"
+    : (config.layout?.tabsPlacement ?? defaultTabsPlacement(domain));
+  const searchbarPlacement = config.layout?.disableHeader
+    ? "SIDEBAR"
+    : (config.layout?.searchbarPlacement ?? defaultSearchbarPlacement(domain));
   return {
     logoHeight,
     sidebarWidth,


### PR DESCRIPTION
This PR resolves a conflict if both are true:
- `disable-header: true`
- `tabs-placement: header`