### PR TITLE
fix: resolve regression in hidden node pruning

### DIFF
--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@sidebar/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@sidebar/[slug]/page.tsx
@@ -43,7 +43,11 @@ export default async function SidebarPage({
           <SidebarTabsList tabs={foundNode.tabs} />
         </SidebarTabsRootServer>
       )}
-      <SidebarRootNode root={foundNode.sidebar} loader={loader} />
+      <SidebarRootNode
+        root={foundNode.sidebar}
+        currentNodeId={foundNode.node.id}
+        loader={loader}
+      />
     </>
   );
 }

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@sidebar/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@sidebar/[slug]/page.tsx
@@ -38,7 +38,11 @@ export default async function SidebarPage({
           <SidebarTabsList tabs={foundNode.tabs} />
         </SidebarTabsRootServer>
       )}
-      <SidebarRootNode root={foundNode.sidebar} loader={loader} />
+      <SidebarRootNode
+        root={foundNode.sidebar}
+        currentNodeId={foundNode.node.id}
+        loader={loader}
+      />
     </>
   );
 }

--- a/packages/fern-docs/bundle/src/components/sidebar/nodes/SidebarRootNode.tsx
+++ b/packages/fern-docs/bundle/src/components/sidebar/nodes/SidebarRootNode.tsx
@@ -10,13 +10,15 @@ import { SidebarRootChild } from "./SidebarRootChild";
 
 export async function SidebarRootNode({
   root,
+  currentNodeId,
   loader,
 }: {
   root: FernNavigation.SidebarRootNode | undefined;
+  currentNodeId: FernNavigation.NodeId | undefined;
   loader: DocsLoader;
 }) {
   const node = withPrunedNavigation(root, {
-    visibleNodeIds: root != null ? [root.id] : undefined,
+    visibleNodeIds: currentNodeId != null ? [currentNodeId] : undefined,
     authed: (await loader.getAuthState()).authed,
     // when true, all unauthed pages are visible, but rendered with a LOCK button
     // so they're not actually "pruned" from the sidebar


### PR DESCRIPTION
`root.id` is not the right node to pass into the node pruner. `the <Sidebar>` component is re-rendered on each page, so we're able to pass in the `currentNode.id` to the node pruner without adverse effects.