### PR TITLE
`everyone` RBAC fix, based on Skyflow ticket.

### DIFF
--- a/packages/fern-docs/bundle/src/middleware.ts
+++ b/packages/fern-docs/bundle/src/middleware.ts
@@ -196,9 +196,6 @@ export const middleware: NextMiddleware = async (request) => {
         )
       );
     }
-    if (!authState.ok && authState.authorizationUrl) {
-      return NextResponse.redirect(authState.authorizationUrl);
-    }
 
     return rewrite(
       withDomain(

--- a/packages/fern-docs/bundle/src/server/auth/workos-handler.ts
+++ b/packages/fern-docs/bundle/src/server/auth/workos-handler.ts
@@ -1,5 +1,6 @@
 import urlJoin from "url-join";
 
+import { withDefaultProtocol } from "@fern-api/ui-core-utils";
 import { removeTrailingSlash } from "@fern-docs/utils";
 
 import { AuthState, getWorkosRbacRoles } from "./getAuthState";
@@ -78,7 +79,10 @@ export async function handleWorkosAuth({
   }
 
   const redirectUri = String(
-    new URL("/api/fern-docs/auth/sso/callback", preferPreview(host, domain))
+    new URL(
+      "/api/fern-docs/auth/sso/callback",
+      withDefaultProtocol(decodeURIComponent(preferPreview(host, domain)))
+    )
   );
   const authorizationUrlParams = getWorkosSSOAuthorizationUrl({
     redirectUri,


### PR DESCRIPTION
Fixes FER-4670

## Short description of the changes made

- Removed buggy lines in `middleware.ts` that is causing premature redirect to auth page 
- Added wrappers for `redirectUri` in `workos-handler.ts`

## What was the motivation & context behind this PR?

- Eliminate bug where `everyone` public pages are redirected to auth page
- Default behavior with this fix redirects user to the default public view, if specified
- Tagged to Skyflow issue

## How has this PR been tested?

Tested locally on:

- Skyflow 
  - observation: 
    - when unauthed: shows only `everyone` pages ✅
- Propexo 
  - observation: 
    - when unauthed: redirects to auth page ✅
    - when authed: shows authed docs ✅

