### PR TITLE
fix: AI Chat updates for footnotes, sizing, and thinking animation

### DIFF
--- a/packages/fern-docs/components/src/badges/badge.tsx
+++ b/packages/fern-docs/components/src/badges/badge.tsx
@@ -12,6 +12,7 @@ const badgeVariants = cva("fern-docs-badge", {
     color: {
       accent: "accent",
       gray: "grayscale",
+      grayWithAccent: "gray-hover-accent",
       tomato: "tomato",
       red: "red",
       ruby: "ruby",
@@ -40,6 +41,7 @@ const badgeVariants = cva("fern-docs-badge", {
     },
     variant: {
       subtle: "subtle",
+      subtleSolidHover: "subtle-solid-hover",
       solid: "solid",
       outlined: "outlined",
       "outlined-subtle": "outlined-subtle",

--- a/packages/fern-docs/components/src/badges/badge.tsx
+++ b/packages/fern-docs/components/src/badges/badge.tsx
@@ -12,7 +12,7 @@ const badgeVariants = cva("fern-docs-badge", {
     color: {
       accent: "accent",
       gray: "grayscale",
-      grayWithAccent: "gray-hover-accent",
+      grayHoverAccent: "gray-hover-accent",
       tomato: "tomato",
       red: "red",
       ruby: "ruby",

--- a/packages/fern-docs/components/src/badges/index.scss
+++ b/packages/fern-docs/components/src/badges/index.scss
@@ -13,7 +13,9 @@
 
     &.interactive:not(:disabled):hover,
     &[data-state="open"]:not(:disabled) {
-      transition: background-color 150ms ease-in-out;
+      transition:
+        background-color 150ms ease-in-out,
+        color 150ms ease-in-out;
     }
 
     &:disabled {

--- a/packages/fern-docs/components/src/badges/variants.scss
+++ b/packages/fern-docs/components/src/badges/variants.scss
@@ -487,7 +487,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--mauve-a9);
-        color: var(--grayscale-1);
+        color: var(--mauve-a1);
       }
     }
 
@@ -497,7 +497,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--slate-a9);
-        color: var(--grayscale-1);
+        color: var(--slate-a1);
       }
     }
 
@@ -507,7 +507,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--sage-a9);
-        color: var(--grayscale-1);
+        color: var(--sage-a1);
       }
     }
 
@@ -517,7 +517,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--olive-a9);
-        color: var(--grayscale-1);
+        color: var(--olive-a1);
       }
     }
 
@@ -527,7 +527,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--sand-a9);
-        color: var(--grayscale-1);
+        color: var(--sand-a1);
       }
     }
 
@@ -537,7 +537,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--tomato-a9);
-        color: var(--grayscale-1);
+        color: var(--tomato-a1);
       }
     }
 
@@ -547,7 +547,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--red-a9);
-        color: var(--grayscale-1);
+        color: var(--red-a1);
       }
     }
 
@@ -557,7 +557,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--ruby-a9);
-        color: var(--grayscale-1);
+        color: var(--ruby-a1);
       }
     }
 
@@ -567,7 +567,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--crimson-a9);
-        color: var(--grayscale-1);
+        color: var(--crimson-a1);
       }
     }
 
@@ -577,7 +577,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--pink-a9);
-        color: var(--grayscale-1);
+        color: var(--pink-a1);
       }
     }
 
@@ -587,7 +587,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--plum-a9);
-        color: var(--grayscale-1);
+        color: var(--plum-a1);
       }
     }
 
@@ -597,7 +597,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--purple-a9);
-        color: var(--grayscale-1);
+        color: var(--purple-a1);
       }
     }
 
@@ -607,7 +607,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--violet-a9);
-        color: var(--grayscale-1);
+        color: var(--violet-a1);
       }
     }
 
@@ -617,7 +617,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--iris-a9);
-        color: var(--grayscale-1);
+        color: var(--iris-a1);
       }
     }
 
@@ -627,7 +627,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--indigo-a9);
-        color: var(--grayscale-1);
+        color: var(--indigo-a1);
       }
     }
 
@@ -637,7 +637,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--blue-a9);
-        color: var(--grayscale-1);
+        color: var(--blue-a1);
       }
     }
 
@@ -647,7 +647,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--cyan-a9);
-        color: var(--grayscale-1);
+        color: var(--cyan-a1);
       }
     }
 
@@ -657,7 +657,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--teal-a9);
-        color: var(--grayscale-1);
+        color: var(--teal-a1);
       }
     }
 
@@ -667,7 +667,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--jade-a9);
-        color: var(--grayscale-1);
+        color: var(--jade-a1);
       }
     }
 
@@ -677,7 +677,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--green-a9);
-        color: var(--grayscale-1);
+        color: var(--green-a1);
       }
     }
 
@@ -687,7 +687,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--grass-a9);
-        color: var(--grayscale-1);
+        color: var(--grass-a1);
       }
     }
 
@@ -697,7 +697,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--bronze-a9);
-        color: var(--grayscale-1);
+        color: var(--bronze-a1);
       }
     }
 
@@ -707,7 +707,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--gold-a9);
-        color: var(--grayscale-1);
+        color: var(--gold-a1);
       }
     }
 
@@ -717,7 +717,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--brown-a9);
-        color: var(--grayscale-1);
+        color: var(--brown-a1);
       }
     }
 
@@ -727,7 +727,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--orange-a9);
-        color: var(--grayscale-1);
+        color: var(--orange-a1);
       }
     }
 
@@ -737,7 +737,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--amber-a9);
-        color: var(--grayscale-1);
+        color: var(--amber-a1);
       }
     }
 
@@ -747,7 +747,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--yellow-a9);
-        color: var(--grayscale-1);
+        color: var(--yellow-a1);
       }
     }
 
@@ -757,7 +757,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--lime-a9);
-        color: var(--grayscale-1);
+        color: var(--lime-a1);
       }
     }
 
@@ -767,7 +767,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--mint-a9);
-        color: var(--grayscale-1);
+        color: var(--mint-a1);
       }
     }
 
@@ -777,7 +777,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--sky-a9);
-        color: var(--grayscale-1);
+        color: var(--sky-a1);
       }
     }
   }

--- a/packages/fern-docs/components/src/badges/variants.scss
+++ b/packages/fern-docs/components/src/badges/variants.scss
@@ -737,7 +737,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--amber-a9);
-        color: var(--amber-a1);
+        color: var(--amber-a12);
       }
     }
 
@@ -747,7 +747,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--yellow-a9);
-        color: var(--yellow-a1);
+        color: var(--yellow-a12);
       }
     }
 
@@ -757,7 +757,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--lime-a9);
-        color: var(--lime-a1);
+        color: var(--lime-a12);
       }
     }
 
@@ -767,7 +767,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--mint-a9);
-        color: var(--mint-a1);
+        color: var(--mint-a12);
       }
     }
 
@@ -777,7 +777,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--sky-a9);
-        color: var(--sky-a1);
+        color: var(--sky-a12);
       }
     }
   }

--- a/packages/fern-docs/components/src/badges/variants.scss
+++ b/packages/fern-docs/components/src/badges/variants.scss
@@ -1,7 +1,8 @@
 @layer components {
   .fern-docs-badge.subtle,
   .fern-docs-badge.outlined,
-  .fern-docs-badge.outlined-subtle {
+  .fern-docs-badge.outlined-subtle,
+  .fern-docs-badge.subtle-solid-hover {
     color: var(--grayscale-a11);
 
     &.accent {
@@ -157,6 +158,15 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--gray-a4);
+      }
+    }
+
+    &.gray-hover-accent {
+      background-color: var(--gray-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--accent-a9);
       }
     }
 
@@ -431,6 +441,346 @@
     }
   }
 
+  .fern-docs-badge.subtle-solid-hover {
+    background-color: var(--grayscale-a3);
+
+    &.interactive:not(:disabled):hover,
+    &[data-state="open"]:not(:disabled) {
+      background-color: var(--grayscale-a9);
+      color: var(--grayscale-1);
+    }
+
+    &.accent {
+      background-color: var(--accent-a3, var(--grayscale-a3));
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--accent-a9, var(--grayscale-a9));
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.gray {
+      background-color: var(--gray-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--gray-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.gray-hover-accent {
+      background-color: var(--gray-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--accent-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.mauve {
+      background-color: var(--mauve-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--mauve-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.slate {
+      background-color: var(--slate-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--slate-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.sage {
+      background-color: var(--sage-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--sage-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.olive {
+      background-color: var(--olive-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--olive-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.sand {
+      background-color: var(--sand-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--sand-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.tomato {
+      background-color: var(--tomato-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--tomato-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.red {
+      background-color: var(--red-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--red-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.ruby {
+      background-color: var(--ruby-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--ruby-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.crimson {
+      background-color: var(--crimson-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--crimson-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.pink {
+      background-color: var(--pink-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--pink-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.plum {
+      background-color: var(--plum-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--plum-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.purple {
+      background-color: var(--purple-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--purple-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.violet {
+      background-color: var(--violet-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--violet-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.iris {
+      background-color: var(--iris-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--iris-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.indigo {
+      background-color: var(--indigo-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--indigo-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.blue {
+      background-color: var(--blue-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--blue-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.cyan {
+      background-color: var(--cyan-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--cyan-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.teal {
+      background-color: var(--teal-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--teal-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.jade {
+      background-color: var(--jade-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--jade-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.green {
+      background-color: var(--green-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--green-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.grass {
+      background-color: var(--grass-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--grass-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.bronze {
+      background-color: var(--bronze-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--bronze-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.gold {
+      background-color: var(--gold-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--gold-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.brown {
+      background-color: var(--brown-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--brown-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.orange {
+      background-color: var(--orange-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--orange-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.amber {
+      background-color: var(--amber-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--amber-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.yellow {
+      background-color: var(--yellow-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--yellow-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.lime {
+      background-color: var(--lime-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--lime-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.mint {
+      background-color: var(--mint-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--mint-a9);
+        color: var(--grayscale-1);
+      }
+    }
+
+    &.sky {
+      background-color: var(--sky-a3);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--sky-a9);
+        color: var(--grayscale-1);
+      }
+    }
+  }
+
   .fern-docs-badge.outlined-subtle {
     background-color: var(--grayscale-a1);
 
@@ -454,6 +804,15 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--gray-a2);
+      }
+    }
+
+    &.gray-hover-accent {
+      background-color: var(--gray-a1);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--accent-a9);
       }
     }
 
@@ -875,7 +1234,7 @@
     }
 
     &.accent {
-      color: var(--accent-1, var(--gray-1));
+      color: var(--accent-contrast, var(--gray-1));
       background-color: var(--accent-9, var(--gray-9));
 
       &.interactive:not(:disabled):hover,
@@ -891,6 +1250,16 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--gray-10);
+      }
+    }
+
+    &.gray-hover-accent {
+      background-color: var(--gray-9);
+      color: var(--gray-1);
+
+      &.interactive:not(:disabled):hover,
+      &[data-state="open"]:not(:disabled) {
+        background-color: var(--accent-10);
       }
     }
 

--- a/packages/fern-docs/components/src/badges/variants.scss
+++ b/packages/fern-docs/components/src/badges/variants.scss
@@ -457,7 +457,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--accent-a9, var(--grayscale-a9));
-        color: var(--grayscale-1);
+        color: var(--accent-contrast);
       }
     }
 

--- a/packages/fern-docs/components/src/badges/variants.scss
+++ b/packages/fern-docs/components/src/badges/variants.scss
@@ -447,7 +447,7 @@
 
     &.interactive:not(:disabled):hover,
     &[data-state="open"]:not(:disabled) {
-      background-color: var(--grayscale-a9);
+      background-color: var(--grayscale-a10);
       color: var(--accent-contrast);
     }
 
@@ -456,7 +456,7 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--accent-a9, var(--grayscale-a9));
+        background-color: var(--accent-a9, var(--grayscale-a10));
         color: var(--accent-contrast);
       }
     }
@@ -467,7 +467,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--gray-a9);
-        color: var(--accent-contrast);
+        color: var(--gray-a1);
       }
     }
 
@@ -476,7 +476,7 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--accent-a9);
+        background-color: var(--accent-a10);
         color: var(--accent-contrast);
       }
     }
@@ -486,8 +486,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--mauve-a9);
-        color: var(--accent-contrast);
+        background-color: var(--mauve-10);
+        color: var(--mauve-1);
       }
     }
 
@@ -496,8 +496,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--slate-a9);
-        color: var(--accent-contrast);
+        background-color: var(--slate-10);
+        color: var(--slate-1);
       }
     }
 
@@ -506,8 +506,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--sage-a9);
-        color: var(--accent-contrast);
+        background-color: var(--sage-10);
+        color: var(--sage-1);
       }
     }
 
@@ -516,8 +516,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--olive-a9);
-        color: var(--accent-contrast);
+        background-color: var(--olive-10);
+        color: var(--olive-1);
       }
     }
 
@@ -526,8 +526,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--sand-a9);
-        color: var(--accent-contrast);
+        background-color: var(--sand-10);
+        color: var(--sand-1);
       }
     }
 
@@ -536,8 +536,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--tomato-a9);
-        color: var(--accent-contrast);
+        background-color: var(--tomato-10);
+        color: var(--tomato-1);
       }
     }
 
@@ -546,8 +546,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--red-a9);
-        color: var(--accent-contrast);
+        background-color: var(--red-10);
+        color: var(--red-1);
       }
     }
 
@@ -556,8 +556,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--ruby-a9);
-        color: var(--accent-contrast);
+        background-color: var(--ruby-10);
+        color: var(--ruby-1);
       }
     }
 
@@ -566,8 +566,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--crimson-a9);
-        color: var(--accent-contrast);
+        background-color: var(--crimson-10);
+        color: var(--crimson-1);
       }
     }
 
@@ -576,8 +576,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--pink-a9);
-        color: var(--accent-contrast);
+        background-color: var(--pink-10);
+        color: var(--pink-1);
       }
     }
 
@@ -586,8 +586,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--plum-a9);
-        color: var(--accent-contrast);
+        background-color: var(--plum-10);
+        color: var(--plum-1);
       }
     }
 
@@ -596,8 +596,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--purple-a9);
-        color: var(--accent-contrast);
+        background-color: var(--purple-10);
+        color: var(--purple-1);
       }
     }
 
@@ -606,8 +606,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--violet-a9);
-        color: var(--accent-contrast);
+        background-color: var(--violet-10);
+        color: var(--violet-1);
       }
     }
 
@@ -616,8 +616,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--iris-a9);
-        color: var(--accent-contrast);
+        background-color: var(--iris-10);
+        color: var(--iris-1);
       }
     }
 
@@ -626,8 +626,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--indigo-a9);
-        color: var(--accent-contrast);
+        background-color: var(--indigo-10);
+        color: var(--indigo-1);
       }
     }
 
@@ -636,8 +636,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--blue-a9);
-        color: var(--accent-contrast);
+        background-color: var(--blue-10);
+        color: var(--blue-1);
       }
     }
 
@@ -646,8 +646,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--cyan-a9);
-        color: var(--accent-contrast);
+        background-color: var(--cyan-10);
+        color: var(--cyan-1);
       }
     }
 
@@ -656,8 +656,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--teal-a9);
-        color: var(--accent-contrast);
+        background-color: var(--teal-10);
+        color: var(--teal-1);
       }
     }
 
@@ -666,8 +666,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--jade-a9);
-        color: var(--accent-contrast);
+        background-color: var(--jade-10);
+        color: var(--jade-1);
       }
     }
 
@@ -676,8 +676,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--green-a9);
-        color: var(--accent-contrast);
+        background-color: var(--green-10);
+        color: var(--green-1);
       }
     }
 
@@ -686,8 +686,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--grass-a9);
-        color: var(--accent-contrast);
+        background-color: var(--grass-10);
+        color: var(--grass-1);
       }
     }
 
@@ -696,8 +696,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--bronze-a9);
-        color: var(--accent-contrast);
+        background-color: var(--bronze-10);
+        color: var(--bronze-1);
       }
     }
 
@@ -706,8 +706,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--gold-a9);
-        color: var(--accent-contrast);
+        background-color: var(--gold-9);
+        color: var(--gold-1);
       }
     }
 
@@ -716,8 +716,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--brown-a9);
-        color: var(--accent-contrast);
+        background-color: var(--brown-9);
+        color: var(--brown-1);
       }
     }
 
@@ -726,8 +726,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--orange-a11);
-        color: var(--accent-contrast);
+        background-color: var(--orange-10);
+        color: var(--orange-12);
       }
     }
 
@@ -736,8 +736,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--amber-a11);
-        color: var(--accent-contrast);
+        background-color: var(--amber-10);
+        color: var(--amber-12);
       }
     }
 
@@ -746,8 +746,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--yellow-a11);
-        color: var(--accent-contrast);
+        background-color: var(--yellow-10);
+        color: var(--yellow-12);
       }
     }
 
@@ -756,8 +756,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--lime-a11);
-        color: var(--accent-contrast);
+        background-color: var(--lime-10);
+        color: var(--lime-12);
       }
     }
 
@@ -766,8 +766,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--mint-a11);
-        color: var(--accent-contrast);
+        background-color: var(--mint-10);
+        color: var(--mint-12);
       }
     }
 
@@ -776,8 +776,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--sky-a11);
-        color: var(--accent-contrast);
+        background-color: var(--sky-10);
+        color: var(--sky-12);
       }
     }
   }

--- a/packages/fern-docs/components/src/badges/variants.scss
+++ b/packages/fern-docs/components/src/badges/variants.scss
@@ -167,6 +167,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--accent-a9);
+        color: var(--accent-contrast);
       }
     }
 
@@ -813,6 +814,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--accent-a9);
+        color: var(--accent-contrast);
       }
     }
 

--- a/packages/fern-docs/components/src/badges/variants.scss
+++ b/packages/fern-docs/components/src/badges/variants.scss
@@ -448,7 +448,7 @@
     &.interactive:not(:disabled):hover,
     &[data-state="open"]:not(:disabled) {
       background-color: var(--grayscale-a9);
-      color: var(--grayscale-1);
+      color: var(--accent-contrast);
     }
 
     &.accent {
@@ -467,7 +467,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--gray-a9);
-        color: var(--grayscale-1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -477,7 +477,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--accent-a9);
-        color: var(--grayscale-1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -487,7 +487,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--mauve-a9);
-        color: var(--mauve-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -497,7 +497,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--slate-a9);
-        color: var(--slate-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -507,7 +507,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--sage-a9);
-        color: var(--sage-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -517,7 +517,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--olive-a9);
-        color: var(--olive-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -527,7 +527,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--sand-a9);
-        color: var(--sand-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -537,7 +537,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--tomato-a9);
-        color: var(--tomato-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -547,7 +547,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--red-a9);
-        color: var(--red-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -557,7 +557,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--ruby-a9);
-        color: var(--ruby-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -567,7 +567,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--crimson-a9);
-        color: var(--crimson-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -577,7 +577,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--pink-a9);
-        color: var(--pink-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -587,7 +587,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--plum-a9);
-        color: var(--plum-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -597,7 +597,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--purple-a9);
-        color: var(--purple-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -607,7 +607,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--violet-a9);
-        color: var(--violet-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -617,7 +617,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--iris-a9);
-        color: var(--iris-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -627,7 +627,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--indigo-a9);
-        color: var(--indigo-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -637,7 +637,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--blue-a9);
-        color: var(--blue-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -647,7 +647,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--cyan-a9);
-        color: var(--cyan-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -657,7 +657,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--teal-a9);
-        color: var(--teal-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -667,7 +667,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--jade-a9);
-        color: var(--jade-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -677,7 +677,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--green-a9);
-        color: var(--green-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -687,7 +687,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--grass-a9);
-        color: var(--grass-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -697,7 +697,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--bronze-a9);
-        color: var(--bronze-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -707,7 +707,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--gold-a9);
-        color: var(--gold-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -717,7 +717,7 @@
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
         background-color: var(--brown-a9);
-        color: var(--brown-a1);
+        color: var(--accent-contrast);
       }
     }
 
@@ -726,8 +726,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--orange-a9);
-        color: var(--orange-a1);
+        background-color: var(--orange-a11);
+        color: var(--accent-contrast);
       }
     }
 
@@ -736,8 +736,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--amber-a9);
-        color: var(--amber-a12);
+        background-color: var(--amber-a11);
+        color: var(--accent-contrast);
       }
     }
 
@@ -746,8 +746,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--yellow-a9);
-        color: var(--yellow-a12);
+        background-color: var(--yellow-a11);
+        color: var(--accent-contrast);
       }
     }
 
@@ -756,8 +756,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--lime-a9);
-        color: var(--lime-a12);
+        background-color: var(--lime-a11);
+        color: var(--accent-contrast);
       }
     }
 
@@ -766,8 +766,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--mint-a9);
-        color: var(--mint-a12);
+        background-color: var(--mint-a11);
+        color: var(--accent-contrast);
       }
     }
 
@@ -776,8 +776,8 @@
 
       &.interactive:not(:disabled):hover,
       &[data-state="open"]:not(:disabled) {
-        background-color: var(--sky-a9);
-        color: var(--sky-a12);
+        background-color: var(--sky-a11);
+        color: var(--accent-contrast);
       }
     }
   }

--- a/packages/fern-docs/search-ui/src/components/chatbot/footnote.tsx
+++ b/packages/fern-docs/search-ui/src/components/chatbot/footnote.tsx
@@ -54,7 +54,7 @@ export function FootnoteSup({ node }: { node?: HastElement }) {
             disabled={!fn}
             size="lg"
             color="grayWithAccent"
-            variant="outlined"
+            variant="subtleSolidHover"
           >
             <a href={fn?.url} target="_blank" rel="noreferrer" className="ms-1">
               <span className="text-xs">{String(index + 1)}test</span>

--- a/packages/fern-docs/search-ui/src/components/chatbot/footnote.tsx
+++ b/packages/fern-docs/search-ui/src/components/chatbot/footnote.tsx
@@ -53,7 +53,7 @@ export function FootnoteSup({ node }: { node?: HastElement }) {
             className="not-prose"
             disabled={!fn}
             size="lg"
-            color="grayWithAccent"
+            color="grayHoverAccent"
             variant="subtleSolidHover"
           >
             <a href={fn?.url} target="_blank" rel="noreferrer" className="ms-1">

--- a/packages/fern-docs/search-ui/src/components/chatbot/footnote.tsx
+++ b/packages/fern-docs/search-ui/src/components/chatbot/footnote.tsx
@@ -53,7 +53,7 @@ export function FootnoteSup({ node }: { node?: HastElement }) {
             className="not-prose"
             disabled={!fn}
             size="lg"
-            color="grayHoverAccent"
+            color="orange"
             variant="subtleSolidHover"
           >
             <a href={fn?.url} target="_blank" rel="noreferrer" className="ms-1">

--- a/packages/fern-docs/search-ui/src/components/chatbot/footnote.tsx
+++ b/packages/fern-docs/search-ui/src/components/chatbot/footnote.tsx
@@ -48,17 +48,16 @@ export function FootnoteSup({ node }: { node?: HastElement }) {
       <Tooltip>
         <TooltipTrigger>
           <Badge
-            rounded
             interactive
             asChild
             className="not-prose"
             disabled={!fn}
-            size="sm"
+            size="lg"
+            color="grayWithAccent"
+            variant="subtleSolidHover"
           >
             <a href={fn?.url} target="_blank" rel="noreferrer" className="ms-1">
-              <span className="text-(color:--grayscale-a9) text-xs">
-                {String(index + 1)}
-              </span>
+              <span className="text-xs">{String(index + 1)}</span>
             </a>
           </Badge>
         </TooltipTrigger>
@@ -164,7 +163,7 @@ export function FootnotesSection({
       </VisuallyHidden>
       <div className="flex flex-wrap gap-1">
         {footnotes.map(({ ids, url, title, icon, type, api_type }, index) => (
-          <Badge key={ids[0] ?? index} asChild interactive rounded>
+          <Badge key={ids[0] ?? index} asChild interactive>
             <a href={url} target="_blank" rel="noreferrer">
               <PageIcon
                 icon={icon}

--- a/packages/fern-docs/search-ui/src/components/chatbot/footnote.tsx
+++ b/packages/fern-docs/search-ui/src/components/chatbot/footnote.tsx
@@ -54,10 +54,10 @@ export function FootnoteSup({ node }: { node?: HastElement }) {
             disabled={!fn}
             size="lg"
             color="grayWithAccent"
-            variant="subtleSolidHover"
+            variant="outlined"
           >
             <a href={fn?.url} target="_blank" rel="noreferrer" className="ms-1">
-              <span className="text-xs">{String(index + 1)}</span>
+              <span className="text-xs">{String(index + 1)}test</span>
             </a>
           </Badge>
         </TooltipTrigger>

--- a/packages/fern-docs/search-ui/src/components/desktop/desktop-ask-ai.tsx
+++ b/packages/fern-docs/search-ui/src/components/desktop/desktop-ask-ai.tsx
@@ -744,8 +744,8 @@ const AskAICommandItems = memo<{
                             message.toolInvocations.some(
                               (invocation) => invocation.state !== "result"
                             )) && (
-                            <p className="text-(color:--grayscale-a10)">
-                              Thinking...
+                            <p className="text-(color:--grayscale-a10) thinking-dots">
+                              Thinking
                             </p>
                           )}
                         {(!isLastMessage || !isLoading) &&
@@ -791,7 +791,9 @@ function FootnoteCommands({
           prefetch={prefetch}
           domain={domain}
         >
-          <Badge rounded>{String(idx + 1)}</Badge>
+          <Badge color="grayWithAccent" variant="subtleSolidHover">
+            {String(idx + 1)}
+          </Badge>
           <div>
             <div className="text-sm font-semibold">{footnote.title}</div>
             <div className="text-(color:--grayscale-a9) text-xs">
@@ -803,3 +805,27 @@ function FootnoteCommands({
     </>
   );
 }
+
+const AnimatedSparkles = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <path
+      className="sparkle-center"
+      d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"
+    />
+    <g className="sparkle-outer">
+      <path d="M20 3v4" />
+      <path d="M22 5h-4" />
+      <path d="M4 17v2" />
+      <path d="M5 18H3" />
+    </g>
+  </svg>
+);

--- a/packages/fern-docs/search-ui/src/components/desktop/desktop-filter-dropdown-menu.tsx
+++ b/packages/fern-docs/search-ui/src/components/desktop/desktop-filter-dropdown-menu.tsx
@@ -57,7 +57,7 @@ export function DesktopFilterDropdownMenu({
             className="fern-search-facet-filter-menu-button"
             interactive
           >
-            {facetDisplay} kapil-test
+            {facetDisplay}
           </Badge>
         )}
       </DropdownMenuTrigger>
@@ -92,7 +92,7 @@ export function DesktopFilterDropdownMenu({
                       titleCase: true,
                     })}
                     <Badge size="sm" rounded className="ml-auto">
-                      {option.count} kapil-test
+                      {option.count}
                     </Badge>
                   </DropdownMenuRadioItem>
                 ))}

--- a/packages/fern-docs/search-ui/src/components/desktop/desktop-filter-dropdown-menu.tsx
+++ b/packages/fern-docs/search-ui/src/components/desktop/desktop-filter-dropdown-menu.tsx
@@ -57,7 +57,7 @@ export function DesktopFilterDropdownMenu({
             className="fern-search-facet-filter-menu-button"
             interactive
           >
-            {facetDisplay}
+            {facetDisplay} kapil-test
           </Badge>
         )}
       </DropdownMenuTrigger>
@@ -92,7 +92,7 @@ export function DesktopFilterDropdownMenu({
                       titleCase: true,
                     })}
                     <Badge size="sm" rounded className="ml-auto">
-                      {option.count}
+                      {option.count} kapil-test
                     </Badge>
                   </DropdownMenuRadioItem>
                 ))}

--- a/packages/fern-docs/search-ui/src/components/desktop/desktop.scss
+++ b/packages/fern-docs/search-ui/src/components/desktop/desktop.scss
@@ -151,6 +151,11 @@
           background-color: var(--accent-a3);
           color: var(--accent-a12);
 
+          .fern-docs-badge {
+            background-color: var(--accent-a9);
+            color: var(--grayscale-1);
+          }
+
           .fern-search-hit-breadcrumb,
           .fern-search-hit-snippet,
           .fern-search-hit-endpoint-path {
@@ -163,19 +168,49 @@
   }
 
   @media (min-width: 40rem) {
+    #fern-search-dialog {
+      height: calc(100dvh - 20%);
+
+      &:has(> [data-mode="ask-ai"]) {
+        height: calc(100dvh - 10%);
+        top: 5%;
+      }
+    }
+
     #fern-search-desktop-command[data-cmdk-root] {
       border: 1px solid var(--color-border-default);
       border-radius: var(--radius-3);
 
-      &[data-mode="ask-ai"] [data-cmdk-list] {
-        height: 400px;
+      &[data-mode="ask-ai"] {
+        height: 100%;
+
+        & [data-cmdk-list] {
+          max-height: 100%;
+        }
       }
 
-      [data-cmdk-list] {
+      & [data-cmdk-list] {
         min-height: 0;
         height: min(400px, var(--cmdk-list-height));
         max-height: 400px;
       }
+    }
+  }
+
+  .thinking-dots:after {
+    content: ".";
+    animation: loading-dots 1.5s infinite;
+  }
+
+  @keyframes loading-dots {
+    0% {
+      content: ".";
+    }
+    33% {
+      content: "..";
+    }
+    66% {
+      content: "...";
     }
   }
 }

--- a/packages/fern-docs/search-ui/src/components/desktop/desktop.scss
+++ b/packages/fern-docs/search-ui/src/components/desktop/desktop.scss
@@ -213,4 +213,35 @@
       content: "...";
     }
   }
+
+  .thinking-state {
+    display: flex;
+    align-items: center;
+
+    &.solid {
+      color: var(--grayscale-1);
+      background-color: var(--grayscale-9);
+
+      @variant dark {
+        color: white;
+      }
+
+      &.accent,
+      &.gray,
+      &.mauve,
+      &.slate,
+      &.blue,
+      &.green {
+        color: white;
+      }
+
+      &.amber,
+      &.sky,
+      &.mint,
+      &.lime,
+      &.yellow {
+        color: black;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Short description of the changes made
- Updated hover state of the footnotes icons
- Made AI chat full screen when entered into
- Animated thinking... indicator

## What was the motivation & context behind this PR?
- Changes based on Feedback from Vic at Webflow https://fathom.video/share/3Dsjb4qVSBkQ_fqBsCfVXpzJfCEYx6fS
- Slack thread here: https://buildwithfern.slack.com/archives/C08FLD3M3PT/p1742333498488239?thread_ts=1742333488.539249&cid=C08FLD3M3PT

## How has this PR been tested?M
Manually

Video of changes:
https://github.com/user-attachments/assets/825e1ac4-0cd8-45cb-ae2d-af94b6b780b1


