### PR TITLE
fix: use cache on routes

### DIFF
--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/llms.txt/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/llms.txt/route.ts
@@ -1,4 +1,5 @@
 import { unstable_cacheTag } from "next/cache";
+import { notFound } from "next/navigation";
 import { NextRequest, NextResponse } from "next/server";
 
 import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
@@ -36,19 +37,35 @@ export async function GET(
   req: NextRequest,
   props: { params: Promise<{ host: string; domain: string }> }
 ): Promise<NextResponse> {
-  "use cache";
-
   const { host, domain } = await props.params;
 
-  unstable_cacheTag(domain, "llms-txt");
-
   const path = slugToHref(req.nextUrl.searchParams.get("slug") ?? "");
+
+  return new NextResponse(await getLlmsTxt(host, domain, path), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "X-Robots-Tag": "noindex",
+      "Cache-Control": "s-maxage=60",
+    },
+  });
+}
+
+async function getLlmsTxt(
+  host: string,
+  domain: string,
+  path: string
+): Promise<string> {
+  "use cache";
+
+  unstable_cacheTag(domain, "getLlmsTxt");
+
   const loader = await createCachedDocsLoader(host, domain);
 
   const root = getSectionRoot(await loader.getRoot(), path);
 
   if (root == null) {
-    return NextResponse.json(null, { status: 404 });
+    notFound();
   }
 
   const pageInfos: {
@@ -187,35 +204,23 @@ export async function GET(
         `- ${endpoint.breadcrumb.join(" > ")} [${endpoint.title}](${endpoint.href})`
     );
 
-  return new NextResponse(
-    [
-      // if there's a landing page, use the llm-friendly markdown version instead of the ${root.title}
-      markdown?.content ?? `# ${root.title}`,
-      docs.length > 0
-        ? `## Docs\n\n${docs
-            .filter((doc) => doc.status === "fulfilled")
-            .map((doc) => doc.value)
-            .map(
-              (doc) =>
-                `- [${doc.title}](${doc.href})${doc.description != null ? `: ${doc.description}` : ""}`
-            )
-            .join("\n")}`
-        : undefined,
-      endpoints.length > 0
-        ? `## API Docs\n\n${endpoints.join("\n")}`
-        : undefined,
-    ]
-      .filter(isNonNullish)
-      .join("\n\n"),
-    {
-      status: 200,
-      headers: {
-        "Content-Type": "text/plain; charset=utf-8",
-        "X-Robots-Tag": "noindex",
-        "Cache-Control": "s-maxage=60",
-      },
-    }
-  );
+  return [
+    // if there's a landing page, use the llm-friendly markdown version instead of the ${root.title}
+    markdown?.content ?? `# ${root.title}`,
+    docs.length > 0
+      ? `## Docs\n\n${docs
+          .filter((doc) => doc.status === "fulfilled")
+          .map((doc) => doc.value)
+          .map(
+            (doc) =>
+              `- [${doc.title}](${doc.href})${doc.description != null ? `: ${doc.description}` : ""}`
+          )
+          .join("\n")}`
+      : undefined,
+    endpoints.length > 0 ? `## API Docs\n\n${endpoints.join("\n")}` : undefined,
+  ]
+    .filter(isNonNullish)
+    .join("\n\n");
 }
 
 function getLandingPage(


### PR DESCRIPTION
https://github.com/fern-api/fern-platform/pull/2386/files triggers the following 500-level error:

```
Cannot access nextUrl on the server. You cannot dot into a temporary client reference from a server component. You can only pass the value through to the client.
```

This is because `.nextUrl`, `.searchParams`, and `cookies()` cannot be contained within a `"use cache"` function. This PR breaks it up.