### PR TITLE
stash: toc ticks [proposal]

### DIFF
--- a/packages/fern-docs/bundle/src/components/layouts/TableOfContentsLayout.tsx
+++ b/packages/fern-docs/bundle/src/components/layouts/TableOfContentsLayout.tsx
@@ -23,7 +23,7 @@ export function TableOfContentsLayout({
     <aside id={FERN_TOC_ID}>
       <SetEmptyTableOfContents value={!showTableOfContents} />
       {showTableOfContents && (
-        <FernScrollArea className="px-4 pb-12 pt-8 lg:pr-5">
+        <FernScrollArea className="not-prose">
           <TableOfContents tableOfContents={tableOfContents} />
         </FernScrollArea>
       )}

--- a/packages/fern-docs/bundle/src/components/table-of-contents/TableOfContents.tsx
+++ b/packages/fern-docs/bundle/src/components/table-of-contents/TableOfContents.tsx
@@ -19,7 +19,11 @@ import type { TableOfContentsItem as TableOfContentsItemType } from "@fern-docs/
 import { useCurrentAnchor } from "@/hooks/use-anchor";
 
 import { WithFeatureFlags } from "../feature-flags/WithFeatureFlags";
-import { TableOfContentsItem } from "./TableOfContentsItem";
+import {
+  OnThisPageTitle,
+  TableOfContentsItem,
+  TocExpandedCtx,
+} from "./TableOfContentsItem";
 import { useTableOfContentsObserver } from "./useTableOfContentsObserver";
 
 export declare namespace TableOfContents {
@@ -127,27 +131,32 @@ export const TableOfContents: React.FC<TableOfContents.Props> = ({
     );
   };
 
+  const [hovering, setHovering] = useState(false);
+
   return (
-    <>
-      {tableOfContents.length > 0 && (
-        <div className="text-(color:--grayscale-a11) m-0 mb-3 text-sm font-medium">
-          On this page
-        </div>
-      )}
-      {tableOfContents.length > 0 && (
-        <ul
-          className={cn("toc-root not-prose", className)}
-          style={
-            {
-              ...style,
-              "--height": `${liHeight}px`,
-              "--top": `${offsetTop}px`,
-            } as CSSProperties
-          }
-        >
-          {flattenTableOfContents(tableOfContents)}
-        </ul>
-      )}
-    </>
+    <TocExpandedCtx.Provider value={hovering}>
+      <div
+        className={cn("fern-toc-root", className)}
+        data-state={hovering ? "expanded" : "collapsed"}
+        onMouseEnter={() => setHovering(true)}
+        onMouseLeave={() => setHovering(false)}
+      >
+        {tableOfContents.length > 0 && <OnThisPageTitle />}
+        {tableOfContents.length > 0 && (
+          <ul
+            className={"fern-toc-container"}
+            style={
+              {
+                ...style,
+                "--height": `${liHeight}px`,
+                "--top": `${offsetTop}px`,
+              } as CSSProperties
+            }
+          >
+            {flattenTableOfContents(tableOfContents)}
+          </ul>
+        )}
+      </div>
+    </TocExpandedCtx.Provider>
   );
 };

--- a/packages/fern-docs/bundle/src/components/table-of-contents/index.scss
+++ b/packages/fern-docs/bundle/src/components/table-of-contents/index.scss
@@ -1,25 +1,96 @@
 @layer components {
-  .toc-root {
-    @apply relative border-l-2 border-transparent pl-3;
-  }
+  .fern-toc-root {
+    @apply px-4 pb-12 pt-8 lg:pr-5;
 
-  .toc-root::before,
-  .toc-root::after {
-    @apply absolute -left-0.5 top-0 w-0.5 rounded-full;
+    .fern-toc-title {
+      @apply text-(color:--grayscale-a11) m-0 mb-3 text-sm font-medium;
+    }
 
-    content: "";
-  }
+    .fern-toc-title,
+    .fern-toc-text {
+      opacity: 1;
+      transition:
+        height 0.25s,
+        opacity 0.25s;
+      height: var(--expanded-link-height, 20px);
+    }
 
-  .toc-root::before {
-    @apply bg-(color:--grayscale-a5) h-full;
-  }
+    .fern-toc-line {
+      opacity: 0;
+      transition: opacity 0.25s;
+    }
 
-  .toc-root::after {
-    @apply bg-(color:--accent-a9);
+    .fern-toc-container {
+      @apply relative border-l-2 border-transparent pl-3;
 
-    height: var(--height, 20px);
-    transform: translateY(calc(var(--top, 0px)));
-    transition: 0.25s;
-    transition-property: transform, height;
+      &::before,
+      &::after {
+        @apply absolute -left-0.5 top-0 w-0.5 rounded-full content-[''];
+        opacity: 1;
+        transition: opacity 0.25s;
+      }
+
+      &::before {
+        @apply bg-(color:--grayscale-a5) h-full;
+      }
+
+      &::after {
+        @apply bg-(color:--accent-a9);
+
+        height: var(--height, 20px);
+        transform: translateY(calc(var(--top, 0px)));
+        transition: 0.25s;
+        transition-property: transform, height, opacity;
+      }
+
+      .fern-toc-item {
+        @apply relative mb-2;
+
+        &:last-child {
+          @apply mb-0;
+        }
+
+        &[data-state="active"] .fern-toc-text {
+          @apply text-(color:--accent-a11) font-semibold tracking-tight;
+        }
+
+        &[data-state="active"] .fern-toc-line {
+          background-color: var(--accent-track);
+        }
+      }
+
+      .fern-toc-text {
+        @apply block hyphens-auto break-words text-sm transition-colors hover:transition-none;
+        @apply text-(color:--grayscale-a11) hover:text-(color:--grayscale-a12);
+      }
+
+      .fern-toc-line {
+        position: absolute;
+        right: 0;
+        top: calc(50% - 1px);
+        opacity: 0;
+        height: 2px;
+        background-color: var(--grayscale-a5);
+        border-radius: 1px;
+      }
+    }
+
+    &[data-state="collapsed"] {
+      .fern-toc-container::before,
+      .fern-toc-container::after {
+        opacity: 0;
+      }
+
+      .fern-toc-line {
+        opacity: 1;
+        transition: opacity 0.25s;
+      }
+
+      .fern-toc-title,
+      .fern-toc-text {
+        height: 0;
+        opacity: 0;
+      }
+    }
   }
 }


### PR DESCRIPTION
Goal of this PR is to propose a new interaction mode for Table Of Contents:

<img width="180" alt="Screenshot 2025-03-22 at 1 21 18 PM" src="https://github.com/user-attachments/assets/eafbccd5-98f3-484a-a3e0-d2691b1968a8" />

<img width="234" alt="Screenshot 2025-03-22 at 1 21 42 PM" src="https://github.com/user-attachments/assets/1e6dcfdb-11f1-45f4-b689-74d849af4684" />

Not every page should have a fully enumerated table of content aside.
- if the page is a changelog (we can use the table of contents as a timeline overview breaking down year, month, and date)
- if the page is really long and the author wants to introduce a "focus mode" where the user can focus on reading the content
- if the page is a overview, reference page (containing an Aside) or a custom page where the content layout is too wide to fit a table of contents, but we still want to render a table of contents that's tucked away

