### PR TITLE
chore: backport support for 204 responses

### DIFF
--- a/packages/fern-docs/bundle/src/components/playground/endpoint/PlaygroundResponseCard.tsx
+++ b/packages/fern-docs/bundle/src/components/playground/endpoint/PlaygroundResponseCard.tsx
@@ -131,26 +131,57 @@ export function PlaygroundResponseCard({
               Loading...
             </div>
           ),
-        loaded: (response) =>
-          response.type !== "file" ||
-          response.contentType.startsWith("text") ||
-          response.contentType.startsWith("application/xml") ? (
-            <PlaygroundResponsePreview response={response} />
-          ) : response.contentType.startsWith("audio/") ||
+        loaded: (response) => {
+          // Handle JSON content type
+          try {
+            JSON.parse(JSON.stringify(response.response.body));
+            return <PlaygroundResponsePreview response={response} />;
+          } catch {
+            // If JSON parsing fails, continue to next handler
+          }
+
+          // Handle text-based content
+          if (
+            response.type !== "file" ||
+            response.contentType.startsWith("text") ||
+            response.contentType.startsWith("application/xml")
+          ) {
+            return <PlaygroundResponsePreview response={response} />;
+          }
+
+          // Handle audio content
+          if (
+            response.contentType.startsWith("audio/") ||
             (isBinaryOctetStreamAudioPlayer &&
-              response.contentType === "binary/octet-stream") ? (
-            <FernAudioPlayer
-              src={response.response.body}
-              className="flex h-full items-center justify-center p-4"
-            />
-          ) : response.contentType.includes("application/pdf") ? (
-            <iframe
-              src={response.response.body}
-              className="size-full"
-              title="PDF preview"
-              allowFullScreen
-            />
-          ) : (
+              response.contentType === "binary/octet-stream")
+          ) {
+            return (
+              <FernAudioPlayer
+                src={response.response.body}
+                className="flex h-full items-center justify-center p-4"
+              />
+            );
+          }
+
+          // Handle PDF content
+          if (response.contentType.includes("application/pdf")) {
+            return (
+              <iframe
+                src={response.response.body}
+                className="size-full"
+                title="PDF preview"
+                allowFullScreen
+              />
+            );
+          }
+
+          // Handle 204 status
+          if (response.response.status === 204) {
+            return <PlaygroundResponsePreview response={response} />;
+          }
+
+          // Default case - unsupported file type
+          return (
             <ErrorBoundaryFallback
               error={
                 new Error(
@@ -158,7 +189,8 @@ export function PlaygroundResponseCard({
                 )
               }
             />
-          ),
+          );
+        },
         failed: (e) => {
           console.error(e);
           return <ErrorBoundaryFallback error={new Error(String(e))} />;


### PR DESCRIPTION
## Short description of the changes made
This PR backports https://github.com/fern-api/fern-platform/pull/2251 to support 204 responses in the API playground. 

## What was the motivation & context behind this PR?
Customer asks. 

## How has this PR been tested?
Previews. 
