### PR TITLE
chore: backport fix if `x-fern-host` is a comma delimited array

### DIFF
--- a/packages/fern-docs/bundle/src/server/xfernhost/util.test.ts
+++ b/packages/fern-docs/bundle/src/server/xfernhost/util.test.ts
@@ -1,0 +1,13 @@
+import { cleanHost } from "./util";
+
+describe("cleanHost", () => {
+  it("handles comma-separated domains by taking the first one", () => {
+    expect(cleanHost("example.com,another.com")).toBe("example.com");
+    expect(cleanHost("first.domain.com, second.domain.com")).toBe(
+      "first.domain.com"
+    );
+    expect(cleanHost("api.test.com,www.test.com,test.com")).toBe(
+      "api.test.com"
+    );
+  });
+});

--- a/packages/fern-docs/bundle/src/server/xfernhost/util.ts
+++ b/packages/fern-docs/bundle/src/server/xfernhost/util.ts
@@ -3,6 +3,11 @@ export function cleanHost(host: string | null | undefined): string | undefined {
     return undefined;
   }
 
+  // handle case where host might contain multiple domains separated by commas
+  if (host.includes(",")) {
+    host = host.split(",")[0];
+  }
+
   host = host.trim();
 
   // host should not be localhost

--- a/packages/fern-docs/bundle/src/server/xfernhost/util.ts
+++ b/packages/fern-docs/bundle/src/server/xfernhost/util.ts
@@ -8,6 +8,10 @@ export function cleanHost(host: string | null | undefined): string | undefined {
     host = host.split(",")[0];
   }
 
+  if (typeof host !== "string") {
+    return undefined;
+  }
+
   host = host.trim();
 
   // host should not be localhost


### PR DESCRIPTION
## Short description of the changes made
If for some reason, a comma-delimited list is forwarded to x-fern-host, we handle parsing this. This may happen due to proxies being added in x-forwarded-hosts. 

## What was the motivation & context behind this PR?
This broke search indexing for a customer b/c we failed to parse `x-fern-host` correctly. 

## How has this PR been tested?
unit tests 
