### PR TITLE
chore: fix lint again

### DIFF
--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@versionSelect/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@versionSelect/[slug]/page.tsx
@@ -22,9 +22,9 @@ export default async function VersionSelectPage({
   const rootPromise = loader.getRoot();
 
   // preload:
-  loader.getLayout();
-  loader.getAuthState();
-  loader.getEdgeFlags();
+  await loader.getLayout();
+  await loader.getAuthState();
+  await loader.getEdgeFlags();
 
   const foundNode = FernNavigation.utils.findNode(
     await rootPromise,

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@versionSelect/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@versionSelect/[slug]/page.tsx
@@ -22,9 +22,9 @@ export default async function VersionSelectPage({
   const rootPromise = loader.getRoot();
 
   // preload:
-  loader.getLayout();
-  loader.getAuthState();
-  loader.getEdgeFlags();
+  await loader.getLayout();
+  await loader.getAuthState();
+  await loader.getEdgeFlags();
 
   const foundNode = FernNavigation.utils.findNode(
     await rootPromise,


### PR DESCRIPTION
Handles a semantic merge conflict to make linting green again. 