### PR TITLE
chore(docs): restrict esbuild options in mdx bundler

### DIFF
--- a/packages/fern-docs/bundle/src/mdx/bundler/serialize.ts
+++ b/packages/fern-docs/bundle/src/mdx/bundler/serialize.ts
@@ -230,6 +230,17 @@ async function serializeMdxImpl(
 
       // Add write to memory instead of disk when possible
       o.write = false;
+
+      // Create a restricted define object that excludes process.env
+      const restrictedDefine = {
+        "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
+      };
+
+      o.define = restrictedDefine;
+
+      // Prevent direct process access
+      o.inject = o.inject?.filter((path) => !path.includes("process"));
+
       return o;
     },
   });


### PR DESCRIPTION
## Short description of the changes made
This PR removes `process.env` from mdx bundler. 

## What was the motivation & context behind this PR?
Security. 

## How has this PR been tested?
Previews
