### PR TITLE
feat: create product selector

### DIFF
--- a/packages/fdr-sdk/src/navigation/utils/findNode.ts
+++ b/packages/fdr-sdk/src/navigation/utils/findNode.ts
@@ -8,6 +8,8 @@ import { isTabbedNode } from "../versions/latest/isTabbedNode";
 import { isUnversionedNode } from "../versions/latest/isUnversionedNode";
 import { isVersionNode } from "../versions/latest/isVersionNode";
 import { createBreadcrumb } from "./createBreadcrumb";
+import { isProductGroupNode } from "../versions/latest/isProductGroupNode";
+import { isProductNode } from "../versions/latest/isProductNode";
 
 export type Node = Node.Found | Node.Redirect | Node.NotFound;
 
@@ -18,6 +20,8 @@ export declare namespace Node {
     parents: readonly FernNavigation.NavigationNodeParent[];
     breadcrumb: readonly FernNavigation.BreadcrumbItem[];
     root: FernNavigation.RootNode;
+    products: readonly FernNavigation.ProductNode[];
+    currentProduct: FernNavigation.ProductNode | undefined;
     versions: readonly FernNavigation.VersionNode[];
     currentVersion: FernNavigation.VersionNode | undefined;
     /**
@@ -84,10 +88,16 @@ export function findNode(
   }
 
   const sidebar = found.parents.find(isSidebarRootNode);
+  const currentProductGroup = found.parents.find(isProductGroupNode);
+  console.log('currentProduct', currentProductGroup);
+  const productChildren = currentProductGroup?.children;
   const currentVersion = found.parents.find(isVersionNode);
   const unversionedNode = found.parents.find(isUnversionedNode);
   const versionChild = (currentVersion ?? unversionedNode)?.child;
-  const landingPage = (currentVersion ?? unversionedNode)?.landingPage;
+  const landingPage = (currentProductGroup ?? currentVersion ?? unversionedNode)?.landingPage;
+
+  const currentProduct = productChildren?.find(isProductNode);
+  console.log('currentProduct', currentProduct);
 
   const tabbedNode =
     found.parents.find(isTabbedNode) ??
@@ -100,7 +110,7 @@ export function findNode(
     found.parents.find(isApiReferenceNode) ??
     (found.node.type === "apiReference" ? found.node : undefined);
 
-  // if the node is visible (becaues it's a page), return it as "found"
+  // if the node is visible (because it's a page), return it as "found"
   if (FernNavigation.isPage(found.node)) {
     const parentsAndNode = [...found.parents, found.node];
     const tabbedNodeIndex = parentsAndNode.findIndex(
@@ -108,6 +118,18 @@ export function findNode(
     );
     const currentTabNode =
       tabbedNodeIndex !== -1 ? parentsAndNode[tabbedNodeIndex + 1] : undefined;
+      const products = collector.getProductNodes().map((node) => {
+        if (node.default) {
+          // if we're currently viewing the default version, we may be viewing the non-pruned version
+          if (node.id === currentProduct?.id) {
+            return currentProduct;
+          }
+          // otherwise, we should always use the pruned version node
+          return collector.defaultProductNode ?? node;
+        }
+        return node;
+      });
+
     const versions = collector.getVersionNodes().map((node) => {
       if (node.default) {
         // if we're currently viewing the default version, we may be viewing the non-pruned version
@@ -123,7 +145,7 @@ export function findNode(
       currentTabNode?.type === "tab" || currentTabNode?.type === "changelog"
         ? currentTabNode
         : undefined;
-    const slugPrefix = currentVersion?.slug ?? root.slug;
+    const slugPrefix = currentProduct?.slug ?? currentVersion?.slug ?? root.slug;
     const unversionedSlug = FernNavigation.Slug(
       found.node.slug.replace(new RegExp(`^${escapeRegExp(slugPrefix)}/`), "")
     );
@@ -133,8 +155,10 @@ export function findNode(
       breadcrumb: createBreadcrumb(found.parents),
       parents: found.parents,
       root,
-      versions, // this is used to render the version switcher
       tabs: tabbedNode?.children ?? [],
+      products,
+      currentProduct,
+      versions, // this is used to render the version switcher
       currentVersion,
       isCurrentVersionDefault: currentVersion?.default
         ? currentVersion === collector.defaultVersionNode

--- a/packages/fdr-sdk/src/navigation/utils/pruneProductNode.ts
+++ b/packages/fdr-sdk/src/navigation/utils/pruneProductNode.ts
@@ -1,0 +1,46 @@
+import { FernNavigation } from "../..";
+
+export function pruneProductNode<T extends FernNavigation.NavigationNode>(
+  node: T,
+  rootSlug: FernNavigation.Slug,
+  productSlug: FernNavigation.Slug
+): T;
+export function pruneProductNode<T extends FernNavigation.NavigationNode>(
+  node: T | undefined,
+  rootSlug: FernNavigation.Slug,
+  productSlug: FernNavigation.Slug
+): T | undefined;
+export function pruneProductNode<T extends FernNavigation.NavigationNode>(
+  node: T | undefined,
+  rootSlug: FernNavigation.Slug,
+  productSlug: FernNavigation.Slug
+): T | undefined {
+  if (node == null) {
+    return undefined;
+  }
+  FernNavigation.traverseDF(node, (node) => {
+    if (FernNavigation.hasMetadata(node)) {
+      const newSlug = FernNavigation.toDefaultSlug(
+        node.slug,
+        rootSlug,
+        productSlug
+      );
+      // children of this node was already pruned
+      if (node.slug === newSlug) {
+        return "skip";
+      }
+      node.canonicalSlug = node.canonicalSlug ?? node.slug;
+      node.slug = newSlug;
+    }
+
+    if (FernNavigation.hasRedirect(node)) {
+      node.pointsTo = FernNavigation.toDefaultSlug(
+        node.pointsTo,
+        rootSlug,
+        productSlug
+      );
+    }
+    return;
+  });
+  return node;
+}

--- a/packages/fdr-sdk/src/navigation/versions/latest/isProductGroupNode.ts
+++ b/packages/fdr-sdk/src/navigation/versions/latest/isProductGroupNode.ts
@@ -1,0 +1,5 @@
+import { NavigationNode, ProductGroupNode } from ".";
+
+export function isProductGroupNode(node: NavigationNode): node is ProductGroupNode {
+  return node.type === "productgroup";
+}

--- a/packages/fdr-sdk/src/navigation/versions/latest/isProductNode.ts
+++ b/packages/fdr-sdk/src/navigation/versions/latest/isProductNode.ts
@@ -1,0 +1,5 @@
+import { NavigationNode, ProductNode } from ".";
+
+export function isProductNode(node: NavigationNode): node is ProductNode {
+  return node.type === "product";
+}

--- a/packages/fern-docs/bundle/src/components/FernProductDropdown.tsx
+++ b/packages/fern-docs/bundle/src/components/FernProductDropdown.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren, ReactElement } from "react";
+
+import { FernProductDropdown as ProductDropdown } from "@fern-docs/components";
+
+import { FernLink } from "./FernLink";
+
+export function FernProductDropdown(
+  props: PropsWithChildren<ProductDropdown.Props>
+): ReactElement<any> {
+  // dropdownMenuElement is cloned in FernDropdown and href is passed to the cloned element
+  // TODO: make this more composeable
+  return (
+    <ProductDropdown
+      {...props}
+      dropdownMenuElement={<FernLink href={""} scroll={true} />}
+    />
+  );
+}

--- a/packages/fern-docs/bundle/src/components/header/HeaderContent.tsx
+++ b/packages/fern-docs/bundle/src/components/header/HeaderContent.tsx
@@ -14,6 +14,7 @@ import { MobileMenuButton } from "./MobileButtons";
 export function HeaderContent({
   logo,
   versionSelect,
+  productSelect,
   className,
   style,
   showSearchBar,
@@ -22,6 +23,7 @@ export function HeaderContent({
 }: {
   logo: React.ReactNode;
   versionSelect: React.ReactNode;
+  productSelect: React.ReactNode;
   className?: string;
   style?: CSSProperties;
   showSearchBar?: boolean;
@@ -39,7 +41,10 @@ export function HeaderContent({
     >
       <div className="fern-header-logo-container">
         <div className="flex items-center gap-2">
-          {logo}
+          <div className="flex items-start gap-2">
+            {logo}
+            {productSelect}
+          </div>
           {versionSelect}
         </div>
       </div>

--- a/packages/fern-docs/bundle/src/components/header/ProductDropdown.tsx
+++ b/packages/fern-docs/bundle/src/components/header/ProductDropdown.tsx
@@ -1,0 +1,33 @@
+import { FernNavigation } from "@fern-api/fdr-sdk";
+import { DocsLoader } from "@/server/docs-loader";
+import { FaIconServer } from "../fa-icon-server";
+import { ProductDropdownClient, ProductDropdownItem } from "./ProductDropdownClient";
+
+export declare namespace ProductDropdown {
+  export interface Props {}
+}
+
+export async function ProductDropdown({ loader }: { loader: DocsLoader }) {
+  const root = await loader.getRoot();
+  if (root.child.type !== "productgroup") {
+    return null;
+  }
+
+  const products = root.child.children;
+  const productOptions = products.map((product): ProductDropdownItem => {
+    const slug = product.slug ?? product.pointsTo;
+    return {
+      productId: product.productId,
+      title: product.title,
+      slug,
+      defaultSlug: product.default
+        ? FernNavigation.toDefaultSlug(slug, root.slug, product.slug)
+        : undefined,
+      icon: product.icon ? <FaIconServer icon={product.icon} /> : undefined,
+      authed: product.authed,
+      default: product.default,
+      hidden: product.hidden,
+    };
+  });
+  return <ProductDropdownClient products={productOptions} />;
+}

--- a/packages/fern-docs/bundle/src/components/header/ProductDropdown.tsx
+++ b/packages/fern-docs/bundle/src/components/header/ProductDropdown.tsx
@@ -1,7 +1,12 @@
 import { FernNavigation } from "@fern-api/fdr-sdk";
+
 import { DocsLoader } from "@/server/docs-loader";
+
 import { FaIconServer } from "../fa-icon-server";
-import { ProductDropdownClient, ProductDropdownItem } from "./ProductDropdownClient";
+import {
+  ProductDropdownClient,
+  ProductDropdownItem,
+} from "./ProductDropdownClient";
 
 export declare namespace ProductDropdown {
   export interface Props {}
@@ -27,6 +32,7 @@ export async function ProductDropdown({ loader }: { loader: DocsLoader }) {
       authed: product.authed,
       default: product.default,
       hidden: product.hidden,
+      subtitle: product.subtitle,
     };
   });
   return <ProductDropdownClient products={productOptions} />;

--- a/packages/fern-docs/bundle/src/components/header/ProductDropdownClient.tsx
+++ b/packages/fern-docs/bundle/src/components/header/ProductDropdownClient.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { ChevronDown, Lock } from "lucide-react";
+
+import { Availability, AvailabilityBadge } from "@fern-docs/components";
+import { FernProductDropdown } from "@fern-docs/components";
+import { slugToHref } from "@fern-docs/utils";
+
+import { useCurrentProductId, useCurrentProductSlug } from "@/state/navigation";
+
+// import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+
+export interface ProductDropdownItem {
+  productId: string;
+  title: string;
+  subtitle?: string;
+  slug: string;
+  defaultSlug?: string;
+  icon?: React.ReactNode;
+  authed?: boolean;
+  default: boolean;
+  availability?: Availability;
+  hidden?: boolean;
+}
+
+export function ProductDropdownClient({
+  products,
+}: {
+  products: ProductDropdownItem[];
+}) {
+  const currentProductId = useCurrentProductId();
+  const currentProductSlug = useCurrentProductSlug();
+  const currentProduct =
+    products.find((product) => product.productId === currentProductId) ??
+    products.find((product) => product.default);
+
+  console.log(
+    "currentProductSlug",
+    "pick",
+    pickProductSlug({
+      currentProductSlug,
+      slug: "learn/sdks",
+    })
+  );
+  return (
+    <FernProductDropdown
+      value={currentProductId}
+      options={products.map(
+        ({
+          icon,
+          productId,
+          title,
+          availability,
+          slug,
+          defaultSlug,
+          authed,
+          hidden,
+          subtitle,
+        }) => ({
+          type: "product",
+          id: productId,
+          title,
+          subtitle,
+          label: (
+            <div className="flex items-center gap-2">
+              {title}
+              {availability != null ? (
+                <AvailabilityBadge availability={availability} size="sm" />
+              ) : null}
+            </div>
+          ),
+          value: productId,
+          disabled: availability == null,
+          href: slugToHref(
+            pickProductSlug({
+              currentProductSlug,
+              defaultSlug,
+              slug,
+            })
+          ),
+          icon: authed ? (
+            <Lock className="text-(color:--grayscale-a9) size-4 self-center" />
+          ) : (
+            icon
+          ),
+          className: hidden ? "opacity-50" : undefined,
+        })
+      )}
+      contentProps={{
+        "data-testid": "product-dropdown-content",
+      }}
+      side="bottom"
+      align="start"
+    >
+      <button className="rounded-3/2 hover:bg-(color:--grayscale-a4) flex cursor-pointer items-center gap-1 self-baseline px-2 transition-[background-color]">
+        {currentProduct?.title}
+        <ChevronDown className="size-icon transition-transform data-[state=open]:rotate-180" />
+      </button>
+    </FernProductDropdown>
+  );
+
+  function pickProductSlug({
+    currentProductSlug,
+    defaultSlug,
+    slug,
+  }: {
+    currentProductSlug?: string;
+    defaultSlug?: string;
+    slug: string;
+  }): string {
+    if (!defaultSlug) {
+      return slug;
+    }
+
+    if (currentProductSlug != null && slug.startsWith(currentProductSlug)) {
+      return slug;
+    }
+
+    return defaultSlug;
+  }
+}

--- a/packages/fern-docs/bundle/src/components/header/ProductDropdownClient.tsx
+++ b/packages/fern-docs/bundle/src/components/header/ProductDropdownClient.tsx
@@ -2,8 +2,11 @@
 
 import { ChevronDown, Lock } from "lucide-react";
 
-import { Availability, AvailabilityBadge } from "@fern-docs/components";
-import { FernProductDropdown } from "@fern-docs/components";
+import {
+  Availability,
+  AvailabilityBadge,
+  FernProductDropdown,
+} from "@fern-docs/components";
 import { slugToHref } from "@fern-docs/utils";
 
 import { useCurrentProductId, useCurrentProductSlug } from "@/state/navigation";

--- a/packages/fern-docs/bundle/src/components/shared-layout.tsx
+++ b/packages/fern-docs/bundle/src/components/shared-layout.tsx
@@ -16,6 +16,7 @@ import { withLogo } from "@/server/withLogo";
 
 import { VersionDropdown } from "./header/VersionDropdown";
 import { LoginButton } from "./login-button";
+import { ProductDropdown } from "./header/ProductDropdown";
 
 export default async function SharedLayout({
   children,
@@ -83,6 +84,11 @@ export default async function SharedLayout({
               logo={withLogo(config, resolveFileSrc, basePath)}
               className="w-fit shrink-0"
             />
+          }
+          productSelect={
+            <React.Suspense fallback={null}>
+              <ProductDropdown loader={loader} />
+            </React.Suspense>
           }
           versionSelect={
             <React.Suspense fallback={null}>

--- a/packages/fern-docs/bundle/src/components/shared-page.tsx
+++ b/packages/fern-docs/bundle/src/components/shared-page.tsx
@@ -92,6 +92,7 @@ export default async function SharedPage({
   // find the node that is currently being viewed
   const found = FernNavigation.utils.findNode(root, slug);
 
+  console.log('found', found);
   const authState = await authStatePromise;
 
   // this is a special case for when the user is not authenticated, but the not-found status originates from an authed node
@@ -179,6 +180,8 @@ export default async function SharedPage({
         nodeId={found.node.id}
         sidebarRootNodeId={found.sidebar?.id}
         tabId={found.currentTab?.id}
+        productId={found.currentProduct?.productId}
+        productSlug={found.currentProduct?.slug}
         versionId={found.currentVersion?.versionId}
         versionSlug={found.currentVersion?.slug}
         versionIsDefault={found.isCurrentVersionDefault}

--- a/packages/fern-docs/bundle/src/server/docs-loader.ts
+++ b/packages/fern-docs/bundle/src/server/docs-loader.ts
@@ -62,6 +62,7 @@ import { postToEngineeringNotifs } from "./slack";
 import { FernColorTheme, FernLayoutConfig, FileData } from "./types";
 import { cleanBasePath } from "./utils/clean-base-path";
 import { pruneWithAuthState } from "./withRbac";
+import { MOCK_2 } from "./mock-data";
 
 const loadWithUrl = uncachedLoadWithUrl;
 
@@ -579,6 +580,10 @@ const getRoot = async (
   if (authConfig) {
     root = pruneWithAuthState(authState, authConfig, root);
   }
+  console.log("root", root);
+
+  root = MOCK_2;
+  console.log("root", root);
 
   FernNavigation.utils.mutableUpdatePointsTo(root);
 

--- a/packages/fern-docs/bundle/src/server/mock-data.ts
+++ b/packages/fern-docs/bundle/src/server/mock-data.ts
@@ -50,7 +50,7 @@ export const MOCK_2 = {
         default: "true",
         productId: "docs",
         title: "Docs",
-        icon: "fa-regular fa-file",
+        icon: "fa-regular fa-book",
         slug: "learn/docs",
         subtitle: "A beautiful, interactive documentation website",
         child: {
@@ -89,10 +89,10 @@ export const MOCK_2 = {
       {
         type: "product",
         default: "true",
-        productId: "docs",
+        productId: "management",
         title: "Management",
         icon: "fa-regular fa-cog",
-        slug: "learn/docs",
+        slug: "learn/management",
         subtitle: "A beautiful, interactive documentation website",
         child: {
           type: "tabbed",
@@ -130,7 +130,7 @@ export const MOCK_2 = {
       {
         type: "product",
         default: "true",
-        productId: "docs",
+        productId: "platform",
         title: "Platform",
         icon: "fa-regular fa-server",
         slug: "learn/docs",
@@ -171,7 +171,7 @@ export const MOCK_2 = {
       {
         type: "product",
         default: "true",
-        productId: "docs",
+        productId: "user-management",
         title: "User Management",
         icon: "fa-regular fa-user",
         slug: "learn/users",

--- a/packages/fern-docs/bundle/src/server/mock-data.ts
+++ b/packages/fern-docs/bundle/src/server/mock-data.ts
@@ -1,0 +1,227 @@
+export const MOCK_2 = {
+  type: "root",
+  child: {
+    type: "productgroup",
+    slug: "learn",
+    children: [
+      {
+        type: "product",
+        default: "true",
+        productId: "sdks",
+        title: "SDKs",
+        icon: "fa-regular fa-code",
+        slug: "learn/sdks",
+        subtitle: "Generate client libraries in multiple languages",
+        child: {
+          type: "tabbed",
+          id: "c8121862041af6daab2b3d47009b7ec97e2b1d360a4dfb4e33d8c2eb2b553f64",
+          children: [
+            {
+              type: "tab",
+              child: {
+                type: "sidebarRoot",
+                id: "e8648c40556ffcaad8e849fe85451c00a1332026d08e601664cb985fd87e0049",
+                children: [
+                  {
+                    type: "sidebarGroup",
+                    id: "6b5abc9475f204424d6e56d62eaf88a0a9dc2d084f6bbfe39afce43296058085",
+                    children: [
+                      {
+                        type: "page",
+                        id: "58c5b21c4f5f2a2fe334a40bee529ac42ab69a27ccd44f81b513c243818443d4",
+                        title: "Welcome",
+                        slug: "learn",
+                        pageId: "pages/welcome.mdx",
+                      },
+                    ],
+                  },
+                ],
+              },
+              title: "Home",
+              slug: "learn",
+              icon: "fa-regular fa-home",
+              id: "7aa2bdb0d372d12d6d29e3162b99c2c0dbaafbdb92abef003abeb0ae54aa9459",
+            },
+          ],
+        },
+      },
+      {
+        type: "product",
+        default: "true",
+        productId: "docs",
+        title: "Docs",
+        icon: "fa-regular fa-file",
+        slug: "learn/docs",
+        subtitle: "A beautiful, interactive documentation website",
+        child: {
+          type: "tabbed",
+          id: "c8121862041af6daab2b3d47009b7ec97e2b1d360a4dfb4e33d8c2eb2b553f64",
+          children: [
+            {
+              type: "tab",
+              child: {
+                type: "sidebarRoot",
+                id: "e8648c40556ffcaad8e849fe85451c00a1332026d08e601664cb985fd87e0049",
+                children: [
+                  {
+                    type: "sidebarGroup",
+                    id: "6b5abc9475f204424d6e56d62eaf88a0a9dc2d084f6bbfe39afce43296058085",
+                    children: [
+                      {
+                        type: "page",
+                        id: "58c5b21c4f5f2a2fe334a40bee529ac42ab69a27ccd44f81b513c243818443d4",
+                        title: "Welcome",
+                        slug: "learn",
+                        pageId: "pages/welcome.mdx",
+                      },
+                    ],
+                  },
+                ],
+              },
+              title: "Home",
+              slug: "learn",
+              icon: "fa-regular fa-home",
+              id: "7aa2bdb0d372d12d6d29e3162b99c2c0dbaafbdb92abef003abeb0ae54aa9459",
+            },
+          ],
+        },
+      },
+      {
+        type: "product",
+        default: "true",
+        productId: "docs",
+        title: "Management",
+        icon: "fa-regular fa-cog",
+        slug: "learn/docs",
+        subtitle: "A beautiful, interactive documentation website",
+        child: {
+          type: "tabbed",
+          id: "c8121862041af6daab2b3d47009b7ec97e2b1d360a4dfb4e33d8c2eb2b553f64",
+          children: [
+            {
+              type: "tab",
+              child: {
+                type: "sidebarRoot",
+                id: "e8648c40556ffcaad8e849fe85451c00a1332026d08e601664cb985fd87e0049",
+                children: [
+                  {
+                    type: "sidebarGroup",
+                    id: "6b5abc9475f204424d6e56d62eaf88a0a9dc2d084f6bbfe39afce43296058085",
+                    children: [
+                      {
+                        type: "page",
+                        id: "58c5b21c4f5f2a2fe334a40bee529ac42ab69a27ccd44f81b513c243818443d4",
+                        title: "Welcome",
+                        slug: "learn",
+                        pageId: "pages/welcome.mdx",
+                      },
+                    ],
+                  },
+                ],
+              },
+              title: "Home",
+              slug: "learn",
+              icon: "fa-regular fa-home",
+              id: "7aa2bdb0d372d12d6d29e3162b99c2c0dbaafbdb92abef003abeb0ae54aa9459",
+            },
+          ],
+        },
+      },
+      {
+        type: "product",
+        default: "true",
+        productId: "docs",
+        title: "Platform",
+        icon: "fa-regular fa-server",
+        slug: "learn/docs",
+        subtitle: "A beautiful, interactive documentation website",
+        child: {
+          type: "tabbed",
+          id: "c8121862041af6daab2b3d47009b7ec97e2b1d360a4dfb4e33d8c2eb2b553f64",
+          children: [
+            {
+              type: "tab",
+              child: {
+                type: "sidebarRoot",
+                id: "e8648c40556ffcaad8e849fe85451c00a1332026d08e601664cb985fd87e0049",
+                children: [
+                  {
+                    type: "sidebarGroup",
+                    id: "6b5abc9475f204424d6e56d62eaf88a0a9dc2d084f6bbfe39afce43296058085",
+                    children: [
+                      {
+                        type: "page",
+                        id: "58c5b21c4f5f2a2fe334a40bee529ac42ab69a27ccd44f81b513c243818443d4",
+                        title: "Welcome",
+                        slug: "learn",
+                        pageId: "pages/welcome.mdx",
+                      },
+                    ],
+                  },
+                ],
+              },
+              title: "Home",
+              slug: "learn",
+              icon: "fa-regular fa-home",
+              id: "7aa2bdb0d372d12d6d29e3162b99c2c0dbaafbdb92abef003abeb0ae54aa9459",
+            },
+          ],
+        },
+      },
+      {
+        type: "product",
+        default: "true",
+        productId: "docs",
+        title: "User Management",
+        icon: "fa-regular fa-user",
+        slug: "learn/users",
+        subtitle: "A beautiful, interactive documentation website",
+        child: {
+          type: "tabbed",
+          id: "c8121862041af6daab2b3d47009b7ec97e2b1d360a4dfb4e33d8c2eb2b553f64",
+          children: [
+            {
+              type: "tab",
+              child: {
+                type: "sidebarRoot",
+                id: "e8648c40556ffcaad8e849fe85451c00a1332026d08e601664cb985fd87e0049",
+                children: [
+                  {
+                    type: "sidebarGroup",
+                    id: "6b5abc9475f204424d6e56d62eaf88a0a9dc2d084f6bbfe39afce43296058085",
+                    children: [
+                      {
+                        type: "page",
+                        id: "58c5b21c4f5f2a2fe334a40bee529ac42ab69a27ccd44f81b513c243818443d4",
+                        title: "Welcome",
+                        slug: "learn",
+                        pageId: "pages/welcome.mdx",
+                      },
+                    ],
+                  },
+                ],
+              },
+              title: "Home",
+              slug: "learn",
+              icon: "fa-regular fa-home",
+              id: "7aa2bdb0d372d12d6d29e3162b99c2c0dbaafbdb92abef003abeb0ae54aa9459",
+            },
+          ],
+        },
+      },
+    ],
+    landingPage: {
+      type: "page",
+      id: "58c5b21c4f5f2a2fe334a40bee529ac42ab69a27ccd44f81b513c243818443d4",
+      title: "Welcome",
+      slug: "learn",
+      pageId: "pages/welcome.mdx",
+    },
+    id: "c2c16f227d081a4aebef6d1ac541e8dd264d911a6e7de72d7e8c3276a8bcea24",
+  },
+  version: "v2",
+  title: "Fern",
+  id: "d0b6b951d313294318002dfa2c33f529a0d58113d36dc35e0a83bb1e0f8638ec",
+  slug: "learn",
+  hidden: false,
+};

--- a/packages/fern-docs/bundle/src/state/navigation.tsx
+++ b/packages/fern-docs/bundle/src/state/navigation.tsx
@@ -78,9 +78,13 @@ const currentSidebarRootNodeIdAtom = atom<FernNavigation.NodeId | undefined>(
 );
 const currentNodeIdAtom = atom<FernNavigation.NodeId | undefined>(undefined);
 const currentTabIdAtom = atom<FernNavigation.NodeId | undefined>(undefined);
+const currentProductIdAtom = atom<FernNavigation.ProductId | undefined>(
+  undefined
+);
 const currentVersionIdAtom = atom<FernNavigation.VersionId | undefined>(
   undefined
 );
+const currentProductSlugAtom = atom<FernNavigation.Slug | undefined>(undefined);
 const currentVersionSlugAtom = atom<FernNavigation.Slug | undefined>(undefined);
 
 // if true, the current version is the default version
@@ -96,6 +100,14 @@ export function useCurrentNodeId() {
 
 export function useCurrentTabId() {
   return useAtomValue(currentTabIdAtom);
+}
+
+export function useCurrentProductId() {
+  return useAtomValue(currentProductIdAtom);
+}
+
+export function useCurrentProductSlug() {
+  return useAtomValue(currentProductSlugAtom);
 }
 
 export function useCurrentVersionId() {
@@ -114,6 +126,8 @@ export function SetCurrentNavigationNode({
   sidebarRootNodeId,
   nodeId,
   tabId,
+  productId,
+  productSlug,
   versionId,
   versionSlug,
   versionIsDefault,
@@ -121,6 +135,8 @@ export function SetCurrentNavigationNode({
   sidebarRootNodeId?: FernNavigation.NodeId;
   nodeId?: FernNavigation.NodeId;
   tabId?: FernNavigation.NodeId;
+  productId?: FernNavigation.ProductId;
+  productSlug?: FernNavigation.Slug;
   versionId?: FernNavigation.VersionId;
   versionSlug?: FernNavigation.Slug;
   versionIsDefault?: boolean;
@@ -130,12 +146,16 @@ export function SetCurrentNavigationNode({
   const setCurrentSidebarRootNodeId = useSetAtom(currentSidebarRootNodeIdAtom);
   const setCurrentNodeId = useSetAtom(currentNodeIdAtom);
   const setCurrentTabId = useSetAtom(currentTabIdAtom);
+  const setCurrentProductId = useSetAtom(currentProductIdAtom);
+  const setCurrentProductSlug = useSetAtom(currentProductSlugAtom);
   const setCurrentVersionId = useSetAtom(currentVersionIdAtom);
   const setCurrentVersionSlug = useSetAtom(currentVersionSlugAtom);
   const setCurrentVersionIsDefault = useSetAtom(currentVersionIsDefaultAtom);
   useIsomorphicLayoutEffect(() => {
     setCurrentSidebarRootNodeId(sidebarRootNodeId);
     setCurrentNodeId(nodeId);
+    setCurrentProductId(productId);
+    setCurrentProductSlug(productSlug);
     setCurrentTabId(tabId);
     setCurrentVersionId(versionId);
     setCurrentVersionSlug(versionSlug);
@@ -144,6 +164,8 @@ export function SetCurrentNavigationNode({
     nodeId,
     tabId,
     sidebarRootNodeId,
+    productId,
+    productSlug,
     versionId,
     versionSlug,
     versionIsDefault,

--- a/packages/fern-docs/components/src/FernDropdown.scss
+++ b/packages/fern-docs/components/src/FernDropdown.scss
@@ -18,5 +18,30 @@
         color: var(--accent-contrast) !important;
       }
     }
+    .fern-product-dropdown-item {
+      @apply rounded-3/2 flex cursor-pointer items-center gap-2 px-2 py-1;
+      @apply max-w-[min(300px,100%)];
+      @apply transition-all duration-200 ease-in-out;
+
+      .fern-product-dropdown-item-icon {
+        @apply rounded-3/2 border-(color:--grayscale-a9) border;
+        @apply m-1 flex h-[42px] w-[42px] shrink-0 items-center justify-center p-1;
+        svg {
+          @apply block h-[60%] w-[60%];
+        }
+      }
+
+      @apply data-[highlighted]:text-(color:--accent-contrast) data-[highlighted]:bg-(color:--accent) will-change-[background-color,color];
+
+      &[data-highlighted] .fern-api-property-meta {
+        border-color: var(--accent-contrast) !important;
+      }
+    }
+    .fern-product-dropdown-item:hover {
+      .fern-product-dropdown-item-icon {
+        @apply border-(color:--accent) text-(color:--accent);
+      }
+      @apply text-(color:--accent) bg-(color:--accent-2);
+    }
   }
 }

--- a/packages/fern-docs/components/src/FernDropdown.tsx
+++ b/packages/fern-docs/components/src/FernDropdown.tsx
@@ -19,11 +19,25 @@ import { Check, Info } from "lucide-react";
 
 import { useResizeObserver } from "@fern-ui/react-commons";
 
+import { FernProductDropdownItem } from "./FernProductDropdownItem";
 import { FernScrollArea } from "./FernScrollArea";
 import { FernTooltip, FernTooltipProvider } from "./FernTooltip";
 import { cn } from "./cn";
 
 export declare namespace FernDropdown {
+  export interface ProductOption {
+    type: "product";
+    id: string;
+    title: string;
+    subtitle?: string;
+    children?: ReactNode | ((active: boolean) => ReactNode);
+    value: string;
+    icon?: ReactNode;
+    className?: string;
+    labelClassName?: string;
+    href?: string;
+  }
+
   export interface ValueOption {
     type: "value";
     label?: ReactNode;
@@ -41,7 +55,7 @@ export declare namespace FernDropdown {
     type: "separator";
   }
 
-  export type Option = ValueOption | SeparatorOption;
+  export type Option = ProductOption | ValueOption | SeparatorOption;
 
   export interface Props {
     className?: string;
@@ -127,6 +141,8 @@ export const FernDropdown = forwardRef<
                     dropdownMenuElement={dropdownMenuElement}
                     container={container}
                   />
+                ) : option.type === "product" ? (
+                  <FernProductDropdownItem key={option.id} option={option} />
                 ) : (
                   <DropdownMenu.Separator
                     key={idx}

--- a/packages/fern-docs/components/src/FernProductDropdown.scss
+++ b/packages/fern-docs/components/src/FernProductDropdown.scss
@@ -1,0 +1,36 @@
+@layer components {
+  .fern-product-dropdown {
+    @apply relative z-50;
+    @apply animate-popover;
+    @apply min-w-(--radix-dropdown-menu-content-width) max-w-[50vw];
+    @apply bg-(color:--color-background) border-(color:--grayscale-a6) rounded-2 border will-change-[opacity,transform];
+    @apply shadow-xl;
+    @apply flex cursor-pointer flex-col gap-1 p-2;
+
+    .fern-product-dropdown-item {
+      @apply rounded-3/2 flex cursor-pointer items-center gap-2 px-3 py-1;
+      @apply max-w-[min(300px,100%)];
+      @apply transition-all duration-200 ease-in-out;
+
+      .fern-product-dropdown-item-icon {
+        @apply rounded-3/2 border-(color:--grayscale-a9) border;
+        @apply m-1 flex h-[42px] w-[42px] shrink-0 items-center justify-center p-1;
+        svg {
+          @apply block h-[60%] w-[60%];
+        }
+      }
+
+      @apply data-[highlighted]:text-(color:--accent-contrast) data-[highlighted]:bg-(color:--accent) will-change-[background-color,color];
+
+      &[data-highlighted] .fern-api-property-meta {
+        border-color: var(--accent-contrast) !important;
+      }
+    }
+    .fern-product-dropdown-item:hover {
+      .fern-product-dropdown-item-icon {
+        @apply border-(color:--accent) text-(color:--accent);
+      }
+      @apply text-(color:--accent) bg-(color:--accent-2);
+    }
+  }
+}

--- a/packages/fern-docs/components/src/FernProductDropdown.scss
+++ b/packages/fern-docs/components/src/FernProductDropdown.scss
@@ -2,13 +2,13 @@
   .fern-product-dropdown {
     @apply relative z-50;
     @apply animate-popover;
-    @apply min-w-(--radix-dropdown-menu-content-width) max-w-[50vw];
-    @apply bg-(color:--color-background) border-(color:--grayscale-a6) rounded-2 border will-change-[opacity,transform];
+    @apply min-w-(--radix-dropdown-menu-content-width) max-w-[min(50vw,300px)];
+    @apply bg-card-background border-(color:--grayscale-a6) rounded-2 border will-change-[opacity,transform];
     @apply shadow-xl;
     @apply flex cursor-pointer flex-col gap-1 p-2;
 
     .fern-product-dropdown-item {
-      @apply rounded-3/2 flex cursor-pointer items-center gap-2 px-3 py-1;
+      @apply rounded-3/2 flex cursor-pointer items-center gap-2 px-2 py-1;
       @apply max-w-[min(300px,100%)];
       @apply transition-all duration-200 ease-in-out;
 

--- a/packages/fern-docs/components/src/FernProductDropdown.tsx
+++ b/packages/fern-docs/components/src/FernProductDropdown.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import {
+  ComponentProps,
+  MouseEventHandler,
+  PropsWithChildren,
+  ReactElement,
+  ReactNode,
+  forwardRef,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
+
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+
+import { useResizeObserver } from "@fern-ui/react-commons";
+
+import { cn } from "./cn";
+
+export declare namespace FernProductDropdown {
+  export interface ProductOption {
+    type: "product";
+    id: string;
+    title: string;
+    subtitle?: string;
+    children?: ReactNode | ((active: boolean) => ReactNode);
+    value: string;
+    icon?: ReactNode;
+    // tooltip?: ReactNode;
+    className?: string;
+    labelClassName?: string;
+    href?: string;
+  }
+
+  export interface Props {
+    className?: string;
+    options: readonly ProductOption[];
+    onValueChange?: (value: string) => void;
+    value?: string;
+    onOpen?: () => void;
+    usePortal?: boolean;
+    side?: "top" | "right" | "bottom" | "left";
+    align?: "start" | "center" | "end";
+    defaultOpen?: boolean;
+    dropdownMenuElement?: ReactElement;
+    container?: HTMLElement; // portal container
+    onClick?: MouseEventHandler<HTMLDivElement> | undefined;
+    contentProps?: ComponentProps<typeof DropdownMenu.Content> & {
+      "data-testid"?: string;
+    };
+  }
+}
+
+export const FernProductDropdown = forwardRef<
+  HTMLButtonElement,
+  PropsWithChildren<FernProductDropdown.Props>
+>(
+  (
+    {
+      className,
+      options,
+      onValueChange,
+      value,
+      children,
+      onOpen,
+      usePortal = true,
+      side,
+      align,
+      defaultOpen = false,
+      dropdownMenuElement,
+      container,
+      onClick,
+      contentProps,
+    },
+    ref
+  ): ReactElement => {
+    const [isOpen, setOpen] = useState(defaultOpen);
+    const handleOpenChange = useCallback(
+      (toOpen: boolean) => {
+        setOpen(toOpen);
+        if (toOpen && onOpen != null) {
+          onOpen();
+        }
+      },
+      [onOpen]
+    );
+    const renderDropdownContent = () => (
+      <DropdownMenu.Content
+        sideOffset={4}
+        collisionPadding={4}
+        side={side}
+        align={align}
+        {...contentProps}
+        className={cn("fern-product-dropdown", contentProps?.className)}
+      >
+        {options.map((option, idx) => (
+          <ProductDropdownOption
+            key={option.id}
+            option={option}
+            value={value}
+            dropdownMenuElement={dropdownMenuElement}
+            container={container}
+          />
+        ))}
+      </DropdownMenu.Content>
+    );
+
+    return (
+      <DropdownMenu.Root
+        onOpenChange={handleOpenChange}
+        open={isOpen}
+        defaultOpen={defaultOpen}
+      >
+        <DropdownMenu.Trigger ref={ref} className={className}>
+          {children}
+        </DropdownMenu.Trigger>
+        {usePortal ? (
+          <DropdownMenu.Portal container={container}>
+            {renderDropdownContent()}
+          </DropdownMenu.Portal>
+        ) : (
+          renderDropdownContent()
+        )}
+      </DropdownMenu.Root>
+    );
+  }
+);
+
+FernProductDropdown.displayName = "ProductDropdown";
+
+function ProductDropdownOption({
+  option,
+  value,
+  dropdownMenuElement,
+  container,
+}: {
+  option: FernProductDropdown.ProductOption;
+  value: string | undefined;
+  dropdownMenuElement: ReactElement | undefined;
+  container?: HTMLElement;
+}) {
+  const helperTextRef = useRef<HTMLDivElement>(null);
+  const activeRef = useRef<HTMLButtonElement & HTMLAnchorElement>(null);
+  // useEffect(() => {
+  //   if (option.value === value) {
+  //     activeRef.current?.scrollIntoView({ block: "center" });
+  //   }
+  // }, [option.value, value]);
+
+  const [isEllipsisActive, setIsEllipsisActive] = useState(false);
+  useResizeObserver(helperTextRef, (entries) => {
+    for (const entry of entries) {
+      setIsEllipsisActive(entry.target.scrollWidth > entry.target.clientWidth);
+    }
+  });
+
+  console.log("option", option);
+
+  return (
+    <div className={cn("fern-product-dropdown-item", option.className)}>
+      <div className="fern-product-dropdown-item-icon">{option.icon}</div>
+
+      <div className="flex flex-col">
+        <p className="text-sm font-medium leading-tight">{option.title}</p>
+        <p className="text-(color:--grayscale-a9) text-sm leading-tight">
+          Lorem ipsum dolor sit amet, consectetur adipiscing
+        </p>
+        {option.subtitle ? (
+          <p className="text-(color:--grayscale-a9) text-sm">
+            {option.subtitle}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  // Note: we ignore href on the option if a custom dropdownMenuElement is not provided
+  // return (
+  //   <FernTooltip
+  //     content={
+  //       !isEllipsisActive ? (
+  //         option.tooltip
+  //       ) : (
+  //         <div className="space-y-2">
+  //           {option.helperText != null && <div>{option.helperText}</div>}
+  //           {option.tooltip != null && <div>{option.tooltip}</div>}
+  //         </div>
+  //       )
+  //     }
+  //     side="right"
+  //     sideOffset={8}
+  //     container={container}
+  //   >
+  //     <DropdownMenu.RadioItem
+  //       asChild={true}
+  //       value={option.value}
+  //       className="[&_svg]:size-icon data-[state=unchecked]:text-(color:--grayscale-a11 data-[highlighted]:data-[state=unchecked]:text-(color:--accent-contrast))"
+  //     >
+  //       {dropdownMenuElement != null ? (
+  //         cloneElement(
+  //           dropdownMenuElement,
+  //           {
+  //             ref: option.value === value ? activeRef : undefined,
+  //             href: option.href,
+  //             className: cn("fern-dropdown-item", option.className),
+  //           } as any,
+  //           renderButtonContent()
+  //         )
+  //       ) : (
+  //         <button
+  //           ref={option.value === value ? activeRef : undefined}
+  //           className={cn("fern-dropdown-item", option.className)}
+  //         >
+  //           {renderButtonContent()}
+  //         </button>
+  //       )}
+  //     </DropdownMenu.RadioItem>
+  //   </FernTooltip>
+  // );
+}

--- a/packages/fern-docs/components/src/FernProductDropdown.tsx
+++ b/packages/fern-docs/components/src/FernProductDropdown.tsx
@@ -5,37 +5,21 @@ import {
   MouseEventHandler,
   PropsWithChildren,
   ReactElement,
-  ReactNode,
   forwardRef,
   useCallback,
-  useRef,
   useState,
 } from "react";
 
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 
-import { useResizeObserver } from "@fern-ui/react-commons";
-
+import { FernDropdown } from "./FernDropdown";
+import { FernProductDropdownItem } from "./FernProductDropdownItem";
 import { cn } from "./cn";
 
 export declare namespace FernProductDropdown {
-  export interface ProductOption {
-    type: "product";
-    id: string;
-    title: string;
-    subtitle?: string;
-    children?: ReactNode | ((active: boolean) => ReactNode);
-    value: string;
-    icon?: ReactNode;
-    // tooltip?: ReactNode;
-    className?: string;
-    labelClassName?: string;
-    href?: string;
-  }
-
   export interface Props {
     className?: string;
-    options: readonly ProductOption[];
+    options: readonly FernDropdown.ProductOption[];
     onValueChange?: (value: string) => void;
     value?: string;
     onOpen?: () => void;
@@ -61,14 +45,13 @@ export const FernProductDropdown = forwardRef<
       className,
       options,
       onValueChange,
-      value,
+      // value,
       children,
       onOpen,
       usePortal = true,
       side,
       align,
       defaultOpen = false,
-      dropdownMenuElement,
       container,
       onClick,
       contentProps,
@@ -94,14 +77,15 @@ export const FernProductDropdown = forwardRef<
         {...contentProps}
         className={cn("fern-product-dropdown", contentProps?.className)}
       >
-        {options.map((option, idx) => (
-          <ProductDropdownOption
+        {options.map((option) => (
+          <DropdownMenu.Item
             key={option.id}
-            option={option}
-            value={value}
-            dropdownMenuElement={dropdownMenuElement}
-            container={container}
-          />
+            onClick={onClick}
+            onSelect={onValueChange && (() => onValueChange(option.value))}
+            className="hover:border-none"
+          >
+            <FernProductDropdownItem key={option.id} option={option} />
+          </DropdownMenu.Item>
         ))}
       </DropdownMenu.Content>
     );
@@ -128,94 +112,3 @@ export const FernProductDropdown = forwardRef<
 );
 
 FernProductDropdown.displayName = "ProductDropdown";
-
-function ProductDropdownOption({
-  option,
-  value,
-  dropdownMenuElement,
-  container,
-}: {
-  option: FernProductDropdown.ProductOption;
-  value: string | undefined;
-  dropdownMenuElement: ReactElement | undefined;
-  container?: HTMLElement;
-}) {
-  const helperTextRef = useRef<HTMLDivElement>(null);
-  const activeRef = useRef<HTMLButtonElement & HTMLAnchorElement>(null);
-  // useEffect(() => {
-  //   if (option.value === value) {
-  //     activeRef.current?.scrollIntoView({ block: "center" });
-  //   }
-  // }, [option.value, value]);
-
-  const [isEllipsisActive, setIsEllipsisActive] = useState(false);
-  useResizeObserver(helperTextRef, (entries) => {
-    for (const entry of entries) {
-      setIsEllipsisActive(entry.target.scrollWidth > entry.target.clientWidth);
-    }
-  });
-
-  console.log("option", option);
-
-  return (
-    <div className={cn("fern-product-dropdown-item", option.className)}>
-      <div className="fern-product-dropdown-item-icon">{option.icon}</div>
-
-      <div className="flex flex-col">
-        <p className="text-sm font-medium leading-tight">{option.title}</p>
-        <p className="text-(color:--grayscale-a9) text-sm leading-tight">
-          Lorem ipsum dolor sit amet, consectetur adipiscing
-        </p>
-        {option.subtitle ? (
-          <p className="text-(color:--grayscale-a9) text-sm">
-            {option.subtitle}
-          </p>
-        ) : null}
-      </div>
-    </div>
-  );
-
-  // Note: we ignore href on the option if a custom dropdownMenuElement is not provided
-  // return (
-  //   <FernTooltip
-  //     content={
-  //       !isEllipsisActive ? (
-  //         option.tooltip
-  //       ) : (
-  //         <div className="space-y-2">
-  //           {option.helperText != null && <div>{option.helperText}</div>}
-  //           {option.tooltip != null && <div>{option.tooltip}</div>}
-  //         </div>
-  //       )
-  //     }
-  //     side="right"
-  //     sideOffset={8}
-  //     container={container}
-  //   >
-  //     <DropdownMenu.RadioItem
-  //       asChild={true}
-  //       value={option.value}
-  //       className="[&_svg]:size-icon data-[state=unchecked]:text-(color:--grayscale-a11 data-[highlighted]:data-[state=unchecked]:text-(color:--accent-contrast))"
-  //     >
-  //       {dropdownMenuElement != null ? (
-  //         cloneElement(
-  //           dropdownMenuElement,
-  //           {
-  //             ref: option.value === value ? activeRef : undefined,
-  //             href: option.href,
-  //             className: cn("fern-dropdown-item", option.className),
-  //           } as any,
-  //           renderButtonContent()
-  //         )
-  //       ) : (
-  //         <button
-  //           ref={option.value === value ? activeRef : undefined}
-  //           className={cn("fern-dropdown-item", option.className)}
-  //         >
-  //           {renderButtonContent()}
-  //         </button>
-  //       )}
-  //     </DropdownMenu.RadioItem>
-  //   </FernTooltip>
-  // );
-}

--- a/packages/fern-docs/components/src/FernProductDropdownItem.tsx
+++ b/packages/fern-docs/components/src/FernProductDropdownItem.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { FernDropdown } from "./FernDropdown";
+import { cn } from "./cn";
+
+export function FernProductDropdownItem({
+  option,
+}: {
+  option: FernDropdown.ProductOption;
+}) {
+  return (
+    <div className={cn("fern-product-dropdown-item", option.className)}>
+      <div className="fern-product-dropdown-item-icon">{option.icon}</div>
+
+      <div className="flex flex-col">
+        <p className="text-sm font-medium leading-tight">{option.title}</p>
+        {option.subtitle ? (
+          <p className="text-(color:--grayscale-a9) text-sm leading-tight">
+            {option.subtitle}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/fern-docs/components/src/index.css
+++ b/packages/fern-docs/components/src/index.css
@@ -3,6 +3,7 @@
 @import "./FernCard.scss";
 @import "./FernCheckbox.scss";
 @import "./FernDropdown.scss";
+@import "./FernProductDropdown.scss";
 @import "./FernInput.scss";
 @import "./FernRadioGroup.scss";
 @import "./FernScrollArea.scss";

--- a/packages/fern-docs/components/src/index.ts
+++ b/packages/fern-docs/components/src/index.ts
@@ -27,6 +27,7 @@ export * from "./FernTabs";
 export * from "./FernTextarea";
 export * from "./FernToast";
 export * from "./FernTooltip";
+export * from "./FernProductDropdown";
 export * from "./kbd";
 export * from "./util/shared-component-types";
 export * from "./syntax-highlighter";


### PR DESCRIPTION
_DRAFT_
## Short description of the changes made
- creates the new UI for displaying a dropdown product selector
- wires up a faux product selector using dummy data (see `mock-data.ts`)

<img width="439" alt="image" src="https://github.com/user-attachments/assets/74b90c3f-47ab-45c5-81de-e4d4808c8dd1" />


## What was the motivation & context behind this PR?
- we want to allow users to be able to create and navigate between multiple products being offered

## How has this PR been tested?
- this PR is not ready to be merged yet -- there are still configuration updates required in order for the schema to accept products within `yml` files
