### PR TITLE
fix: 3 regressions related to sidebar

### DIFF
--- a/packages/fern-docs/bundle/src/components/layouts/PageLayout.tsx
+++ b/packages/fern-docs/bundle/src/components/layouts/PageLayout.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import { Prose } from "@/mdx/components/prose";
 import { HideAsides, SetLayout } from "@/state/layout";
 
+import { MobileMenuTrigger } from "../themes/default/dismissable-menu";
+
 interface PageLayoutProps {
   header?: React.ReactNode;
   children?: React.ReactNode;
@@ -12,6 +14,10 @@ interface PageLayoutProps {
 export function PageLayout({ header, children, footer }: PageLayoutProps) {
   return (
     <article className="fern-layout-page">
+      <div className="pointer-coarse:hidden top-(--header-height) fixed left-0 hidden p-3 md:block">
+        <MobileMenuTrigger />
+      </div>
+
       <SetLayout value="page" />
       <HideAsides force />
       {header}

--- a/packages/fern-docs/bundle/src/components/layouts/ReferenceLayout.tsx
+++ b/packages/fern-docs/bundle/src/components/layouts/ReferenceLayout.tsx
@@ -55,9 +55,13 @@ export const ReferenceLayout = React.forwardRef<
         ref={ref}
       >
         {header}
-        <div className="fern-layout-reference-content">
+        <div
+          className="fern-layout-reference-content"
+          data-kind={kind}
+          data-cols={aside ? "2" : "1"}
+        >
           {!isMobile && (
-            <aside className="fern-layout-reference-aside" data-kind={kind}>
+            <aside className="fern-layout-reference-aside">
               {kind === "api" ? (
                 aside
               ) : (
@@ -68,9 +72,7 @@ export const ReferenceLayout = React.forwardRef<
           <Prose className="mb-12 space-y-12">
             {children}
             {isMobile && (
-              <section className="fern-layout-reference-aside" data-kind={kind}>
-                {aside}
-              </section>
+              <section className="fern-layout-reference-aside">{aside}</section>
             )}
             {reference}
             {footer}

--- a/packages/fern-docs/bundle/src/components/layouts/index.scss
+++ b/packages/fern-docs/bundle/src/components/layouts/index.scss
@@ -53,12 +53,17 @@
       @apply sticky order-last h-fit;
     }
 
-    .fern-layout-reference-aside[data-kind="api"] {
+    .fern-layout-reference-content[data-kind="api"]
+      .fern-layout-reference-aside {
       @apply flex shrink-0;
     }
 
     .fern-layout-reference-content {
       @apply my-6 md:grid md:grid-cols-2 md:gap-8 lg:gap-12;
+    }
+
+    .fern-layout-reference-content[data-kind="guide"][data-cols="1"] {
+      @apply md:grid-cols-1;
     }
   }
 

--- a/packages/fern-docs/bundle/src/components/themes/cohere/CohereDocs.tsx
+++ b/packages/fern-docs/bundle/src/components/themes/cohere/CohereDocs.tsx
@@ -13,8 +13,8 @@ import { HeaderTabsRoot } from "@/components/header/HeaderTabsRoot";
 import { useCurrentPathname } from "@/hooks/use-current-pathname";
 import { SCROLL_BODY_ATOM } from "@/state/viewport";
 
+import { MainCtx } from "../default/dismissable-menu";
 import { FernHeader } from "../default/fern-header";
-import { MainCtx } from "../default/mobile-menu";
 import { SidebarNav } from "../default/side-nav";
 
 const CohereDocsStyle = () => {

--- a/packages/fern-docs/bundle/src/components/themes/cohere/CohereDocs.tsx
+++ b/packages/fern-docs/bundle/src/components/themes/cohere/CohereDocs.tsx
@@ -11,6 +11,7 @@ import { FernScrollArea } from "@fern-docs/components";
 import { FERN_COHERE_CONTENT_ID, FERN_FOOTER_ID } from "@/components/constants";
 import { HeaderTabsRoot } from "@/components/header/HeaderTabsRoot";
 import { useCurrentPathname } from "@/hooks/use-current-pathname";
+import { SetIsHeaderDisabled, SetIsSidebarFixed } from "@/state/layout";
 import { SCROLL_BODY_ATOM } from "@/state/viewport";
 
 import { MainCtx } from "../default/dismissable-menu";
@@ -90,6 +91,8 @@ export default function CohereDocs({
 
   return (
     <div className="fixed inset-0 flex flex-col">
+      <SetIsSidebarFixed value={false} />
+      <SetIsHeaderDisabled value={false} />
       <CohereDocsStyle />
       {announcement}
       {/* <HeaderContainer header={header} tabs={tabs} /> */}

--- a/packages/fern-docs/bundle/src/components/themes/cohere/index.scss
+++ b/packages/fern-docs/bundle/src/components/themes/cohere/index.scss
@@ -65,11 +65,13 @@
       @apply top-0 max-h-[calc(100dvh-var(--spacing-header-height)-2.25rem-2px)];
     }
 
-    .fern-layout-reference-aside[data-kind="api"] {
+    .fern-layout-reference-content[data-kind="api"]
+      .fern-layout-reference-aside {
       @apply max-h-[calc(100svh-var(--header-height)-8.25rem-2px)] md:top-6 md:max-h-[calc(100vh-var(--header-height)-5.25rem-2px)];
     }
 
-    .fern-layout-reference-aside[data-kind="guide"] {
+    .fern-layout-reference-content[data-kind="guide"]
+      .fern-layout-reference-aside {
       @apply top-6 pb-12;
     }
 

--- a/packages/fern-docs/bundle/src/components/themes/cohere/index.scss
+++ b/packages/fern-docs/bundle/src/components/themes/cohere/index.scss
@@ -44,12 +44,20 @@
       }
     }
 
-    #fern-sidebar[data-viewport="mobile"] {
+    #fern-sidebar[data-viewport="dismissable"] {
       @apply bg-sidebar-background rounded-2 border-border-default overflow-clip border;
-      @apply sm:w-sidebar-width border-border-concealed pointer-events-auto fixed bottom-3 right-3 top-[calc(var(--header-height)+1.5rem)] z-40 flex w-full max-w-[calc(100dvw-3rem)] flex-col border-l backdrop-blur-xl;
+      @apply sm:w-sidebar-width border-border-concealed pointer-events-auto fixed bottom-3 top-[calc(var(--header-height)+1.5rem)] z-40 flex w-full max-w-[calc(100dvw-3rem)] flex-col border-l backdrop-blur-xl;
 
       #fern-sidebar-scroll-area {
         @apply px-4 py-6 pb-12;
+      }
+
+      &[data-side="left"] {
+        @apply left-3;
+      }
+
+      &[data-side="right"] {
+        @apply right-3;
       }
     }
 

--- a/packages/fern-docs/bundle/src/components/themes/default/DefaultDocs.tsx
+++ b/packages/fern-docs/bundle/src/components/themes/default/DefaultDocs.tsx
@@ -7,7 +7,7 @@ import { cn } from "@fern-docs/components";
 
 import { FERN_FOOTER_ID } from "@/components/constants";
 import { HeaderTabsRoot } from "@/components/header/HeaderTabsRoot";
-import { SetIsSidebarFixed } from "@/state/layout";
+import { SetIsHeaderDisabled, SetIsSidebarFixed } from "@/state/layout";
 
 import { MainCtx } from "./dismissable-menu";
 import { FernHeader } from "./fern-header";
@@ -49,6 +49,7 @@ export default function DefaultDocs({
   return (
     <>
       <SetIsSidebarFixed value={isSidebarFixed} />
+      <SetIsHeaderDisabled value={isHeaderDisabled} />
       <div className="fern-background-image pointer-events-none fixed inset-0" />
       <FernHeader
         className={cn(

--- a/packages/fern-docs/bundle/src/components/themes/default/DefaultDocs.tsx
+++ b/packages/fern-docs/bundle/src/components/themes/default/DefaultDocs.tsx
@@ -9,8 +9,8 @@ import { FERN_FOOTER_ID } from "@/components/constants";
 import { HeaderTabsRoot } from "@/components/header/HeaderTabsRoot";
 import { SetIsSidebarFixed } from "@/state/layout";
 
+import { MainCtx } from "./dismissable-menu";
 import { FernHeader } from "./fern-header";
-import { MainCtx } from "./mobile-menu";
 import { SidebarNav } from "./side-nav";
 
 export default function DefaultDocs({

--- a/packages/fern-docs/bundle/src/components/themes/default/dismissable-menu.tsx
+++ b/packages/fern-docs/bundle/src/components/themes/default/dismissable-menu.tsx
@@ -24,6 +24,7 @@ import {
   FERN_SIDEBAR_OVERLAY_ID,
 } from "@/components/constants";
 import { useCurrentPathname } from "@/hooks/use-current-pathname";
+import { useIsHeaderDisabled } from "@/state/layout";
 import { useIsDismissableSidebarOpen } from "@/state/mobile";
 
 export const MainCtx = React.createContext<
@@ -292,8 +293,11 @@ export function DismissableMenu({
 }
 
 export function MobileMenuTrigger(props: React.ComponentProps<typeof Button>) {
+  const isHeaderDisabled = useIsHeaderDisabled();
   const [open, setOpen] = useIsDismissableSidebarOpen();
-  if (open) {
+
+  // if the header is disabled, the sidebar will always be fixed and visible (never dismissable) in desktop mode
+  if (open || isHeaderDisabled) {
     return null;
   }
   return (

--- a/packages/fern-docs/bundle/src/components/themes/default/index.scss
+++ b/packages/fern-docs/bundle/src/components/themes/default/index.scss
@@ -83,11 +83,13 @@
       @apply px-4 py-6 pb-12 lg:pl-5;
     }
 
-    .fern-layout-reference-aside[data-kind="api"] {
+    .fern-layout-reference-content[data-kind="api"]
+      .fern-layout-reference-aside {
       @apply max-h-[calc(100svh-var(--header-height)-6rem)] md:top-[calc(var(--header-height)+1.5rem)] md:max-h-[calc(100vh-var(--header-height)-3rem)];
     }
 
-    aside.fern-layout-reference-aside[data-kind="guide"] {
+    .fern-layout-reference-content[data-kind="guide"]
+      aside.fern-layout-reference-aside {
       @apply top-[calc(var(--header-height)+1.5rem)] pb-12;
     }
 

--- a/packages/fern-docs/bundle/src/components/themes/default/index.scss
+++ b/packages/fern-docs/bundle/src/components/themes/default/index.scss
@@ -59,8 +59,16 @@
       }
     }
 
-    #fern-sidebar[data-viewport="mobile"] {
-      @apply sm:w-sidebar-width border-border-concealed pointer-events-auto fixed inset-y-0 right-0 top-[calc(var(--header-height)+1px)] z-40 flex w-full max-w-[calc(100dvw-3rem)] flex-col border-l backdrop-blur-xl;
+    #fern-sidebar[data-viewport="dismissable"] {
+      @apply sm:w-sidebar-width border-border-concealed pointer-events-auto fixed inset-y-0 top-[calc(var(--header-height)+1px)] z-40 flex w-full max-w-[calc(100dvw-3rem)] flex-col border-l backdrop-blur-xl;
+
+      &[data-side="left"] {
+        @apply left-0;
+      }
+
+      &[data-side="right"] {
+        @apply right-0;
+      }
     }
 
     #fern-sidebar-spacer {

--- a/packages/fern-docs/bundle/src/components/themes/default/side-nav.tsx
+++ b/packages/fern-docs/bundle/src/components/themes/default/side-nav.tsx
@@ -7,9 +7,9 @@ import {
   FERN_SIDEBAR_ID,
   FERN_SIDEBAR_SPACER_ID,
 } from "@/components/constants";
-import { HideAsides, useIsSidebarFixed } from "@/state/layout";
+import { HideAsides, useIsSidebarFixed, useLayout } from "@/state/layout";
 
-import { MobileMenu } from "./mobile-menu";
+import { DismissableMenu } from "./dismissable-menu";
 
 export function SidebarNav({
   children,
@@ -25,12 +25,17 @@ export function SidebarNav({
   "data-theme"?: string;
 }) {
   const isDesktop = useIsDesktop();
+  const layout = useLayout();
 
-  if (!isDesktop) {
+  if (!isDesktop || layout === "page" || layout === "custom") {
     return (
-      <MobileMenu className={cn(className, mobileClassName)} {...props}>
+      <DismissableMenu
+        className={cn(className, mobileClassName)}
+        {...props}
+        side={isDesktop ? "left" : "right"}
+      >
         {children}
-      </MobileMenu>
+      </DismissableMenu>
     );
   }
 

--- a/packages/fern-docs/bundle/src/components/themes/default/side-nav.tsx
+++ b/packages/fern-docs/bundle/src/components/themes/default/side-nav.tsx
@@ -7,7 +7,12 @@ import {
   FERN_SIDEBAR_ID,
   FERN_SIDEBAR_SPACER_ID,
 } from "@/components/constants";
-import { HideAsides, useIsSidebarFixed, useLayout } from "@/state/layout";
+import {
+  HideAsides,
+  useIsHeaderDisabled,
+  useIsSidebarFixed,
+  useLayout,
+} from "@/state/layout";
 
 import { DismissableMenu } from "./dismissable-menu";
 
@@ -26,8 +31,14 @@ export function SidebarNav({
 }) {
   const isDesktop = useIsDesktop();
   const layout = useLayout();
+  const isHeaderDisabled = useIsHeaderDisabled();
 
-  if (!isDesktop || layout === "page" || layout === "custom") {
+  if (
+    !isDesktop ||
+    // side effect: if the header is disabled, the sidebar will always be fixed and visible (never dismissable) in desktop mode
+    // otherwise, the sidebar is unmounted only for the page and custom layouts
+    (!isHeaderDisabled && (layout === "page" || layout === "custom"))
+  ) {
     return (
       <DismissableMenu
         className={cn(className, mobileClassName)}

--- a/packages/fern-docs/bundle/src/state/layout.tsx
+++ b/packages/fern-docs/bundle/src/state/layout.tsx
@@ -7,6 +7,7 @@ import { FernDocs } from "@fern-api/fdr-sdk";
 import { useIsomorphicLayoutEffect } from "@fern-ui/react-commons";
 
 const isSidebarFixedAtom = atom<boolean>(false);
+const isHeaderDisabledAtom = atom<boolean>(false);
 
 export function SetIsSidebarFixed({ value }: { value: boolean }) {
   useHydrateAtoms([[isSidebarFixedAtom, value]], {
@@ -15,8 +16,19 @@ export function SetIsSidebarFixed({ value }: { value: boolean }) {
   return null;
 }
 
+export function SetIsHeaderDisabled({ value }: { value: boolean }) {
+  useHydrateAtoms([[isHeaderDisabledAtom, value]], {
+    dangerouslyForceHydrate: true,
+  });
+  return null;
+}
+
 export function useIsSidebarFixed() {
   return useAtomValue(isSidebarFixedAtom);
+}
+
+export function useIsHeaderDisabled() {
+  return useAtomValue(isHeaderDisabledAtom);
 }
 
 const isLandingPageAtom = atom<boolean>(false);


### PR DESCRIPTION
- re-enable dismissable sidebar in desktop view
- remove sidebar from DOM that's causing a gap on some docs pages using the page or custom layouts
- ~restore 1-col layout for reference layout (when the aside is null)~ https://github.com/fern-api/fern-platform/pull/2433

---

note: this pr fixes the behavior post-hydration, but theres still some layout shifting happening on load, and there are some performance bottlenecks present with the dismissable sidebar on the pages layout.