### PR TITLE
backport: move webflow callback off edge runtime

### DIFF
--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/oauth/webflow/callback/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/oauth/webflow/callback/route.ts
@@ -15,8 +15,6 @@ import { redirectWithLoginError } from "@/server/redirectWithLoginError";
 import { safeUrl } from "@/server/safeUrl";
 import { getDocsDomainEdge } from "@/server/xfernhost/edge";
 
-export const runtime = "edge";
-
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const domain = getDocsDomainEdge(req);
   const host = req.nextUrl.host;
@@ -59,7 +57,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     return redirectWithLoginError(
       req,
       redirectLocation,
-      "unknown_error",
+      "config_error",
       "Couldn't login, please try again"
     );
   }


### PR DESCRIPTION
this pr mirrors a change made yesterday on the pages router. required to move webflow to app router. 

does two things: 
- updates logs for clearer debugging
- moves the function off the edge runtime (-> node.js runtime)
