### PR TITLE
chore: limit notifications

### DIFF
--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/search/v2/reindex/algolia/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/search/v2/reindex/algolia/route.ts
@@ -109,7 +109,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     });
 
     postToEngineeringNotifs(
-      `:rotating_light: [ALGOLIA] Failed to reindex ${domain} with the following error: ${String(error)}`
+      `:rotating_light: [ALGOLIA] Failed to reindex ${domain} with the following error: ${String(error)}`,
+      "algolia-reindex"
     );
 
     return NextResponse.json("Internal server error", { status: 500 });

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/search/v2/reindex/turbopuffer/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/search/v2/reindex/turbopuffer/route.ts
@@ -117,7 +117,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     });
 
     postToEngineeringNotifs(
-      `:rotating_light: [TURBOPUFFER] Failed to reindex ${domain} with the following error: ${String(error)}`
+      `:rotating_light: [TURBOPUFFER] Failed to reindex ${domain} with the following error: ${String(error)}`,
+      "turbopuffer-reindex"
     );
 
     return NextResponse.json("Internal server error", { status: 500 });

--- a/packages/fern-docs/bundle/src/server/docs-loader.ts
+++ b/packages/fern-docs/bundle/src/server/docs-loader.ts
@@ -273,7 +273,8 @@ export const getMetadata = cache(
       return metadata;
     } catch (error) {
       postToEngineeringNotifs(
-        `:rotating_light: Failed to get metadata for ${domain} with the following error: ${String(error)}`
+        `:rotating_light: Failed to get metadata for ${domain} with the following error: ${String(error)}`,
+        "get-metadata"
       );
       throw error;
     }

--- a/packages/fern-docs/bundle/src/server/file-resolver.ts
+++ b/packages/fern-docs/bundle/src/server/file-resolver.ts
@@ -22,7 +22,8 @@ export function createFileResolver(
       // the file is not found, so we return the src as the image data
 
       postToEngineeringNotifs(
-        `:rotating_light: [createFileResolver] Could not find file ${fileId} for domain ${domain}.`
+        `:rotating_light: [createFileResolver] Could not find file ${fileId} for domain ${domain}.`,
+        "file-resolver"
       );
 
       return { src };

--- a/packages/fern-docs/bundle/src/server/mdx-serializer.ts
+++ b/packages/fern-docs/bundle/src/server/mdx-serializer.ts
@@ -94,6 +94,7 @@ export function createCachedMdxSerializer(
 
           postToEngineeringNotifs(
             `:rotating_light: [${domain}] \`Serialize MDX\` encountered an error: \`${String(error)}\` (url: \`https://${domain}/${slug ?? "UNKNOWN"}\`)`,
+            "serialize-mdx",
             {
               message: content,
               mrkdwn: true,

--- a/packages/fern-docs/bundle/src/server/rate-limiter.ts
+++ b/packages/fern-docs/bundle/src/server/rate-limiter.ts
@@ -1,0 +1,53 @@
+export class RateLimiter {
+  private count: number = 0;
+  private lastReset: number = Date.now();
+  private readonly maxRequests: number;
+  private readonly windowMs: number;
+
+  constructor(maxRequests: number, windowMs: number) {
+    this.maxRequests = maxRequests;
+    this.windowMs = windowMs;
+  }
+
+  canMakeRequest(): boolean {
+    const now = Date.now();
+    if (now - this.lastReset >= this.windowMs) {
+      this.count = 0;
+      this.lastReset = now;
+      return true;
+    }
+    return this.count < this.maxRequests;
+  }
+
+  increment(): void {
+    this.count++;
+  }
+}
+
+export class RateLimiterManager {
+  private static instance: RateLimiterManager;
+  private limiters: Map<string, RateLimiter> = new Map<string, RateLimiter>();
+
+  private constructor() {}
+
+  static getInstance(): RateLimiterManager {
+    if (!RateLimiterManager.instance) {
+      RateLimiterManager.instance = new RateLimiterManager();
+    }
+    return RateLimiterManager.instance;
+  }
+
+  getLimiter(
+    context: string,
+    maxRequests: number,
+    windowMs: number
+  ): RateLimiter {
+    const existingLimiter = this.limiters.get(context);
+    if (existingLimiter) {
+      return existingLimiter;
+    }
+    const newLimiter = new RateLimiter(maxRequests, windowMs);
+    this.limiters.set(context, newLimiter);
+    return newLimiter;
+  }
+}


### PR DESCRIPTION
this pr limits the rate at which we receive notifications about various failures from `fern-platform` in the `#engineering-notifs` channel. currently, the quantity of error messages we get is overwhelming. 

as a follow-up, we need to add more context and address the root cause of some of these failures.