### PR TITLE
fix: Suggest endpoint to use bedrock, not query anthropic

### DIFF
--- a/packages/fern-docs/bundle/src/app/api/fern-docs/search/v2/suggest/route.ts
+++ b/packages/fern-docs/bundle/src/app/api/fern-docs/search/v2/suggest/route.ts
@@ -1,7 +1,7 @@
 import { track } from "@/server/analytics/posthog";
-import { algoliaAppId, anthropicApiKey } from "@/server/env-variables";
+import { algoliaAppId } from "@/server/env-variables";
 import { getDocsDomainEdge } from "@/server/xfernhost/edge";
-import { createAnthropic } from "@ai-sdk/anthropic";
+import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
 import { searchClient } from "@algolia/client-search";
 import { getEdgeFlags } from "@fern-docs/edge-config";
 import { SuggestionsSchema } from "@fern-docs/search-server";
@@ -27,8 +27,12 @@ const BodySchema = z.object({
 });
 
 export async function POST(req: NextRequest): Promise<Response> {
-  const anthropic = createAnthropic({ apiKey: anthropicApiKey() });
-  const languageModel = anthropic.languageModel("claude-3-5-haiku-latest");
+  const bedrock = createAmazonBedrock({
+    region: "us-east-1",
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  });
+  const languageModel = bedrock("us.anthropic.claude-3-5-haiku-20241022-v1:0");
 
   const start = Date.now();
   const domain = getDocsDomainEdge(req);


### PR DESCRIPTION
Fixes FER-

## Short description of the changes made
Suggest endpoint now uses bedrock

## What was the motivation & context behind this PR?
Should not be using Anthropic credits

## How has this PR been tested?
Tested locally