### PR TITLE
backport: code sync override

### DIFF
--- a/packages/fern-docs/bundle/src/mdx/components/code/CodeGroup.tsx
+++ b/packages/fern-docs/bundle/src/mdx/components/code/CodeGroup.tsx
@@ -39,9 +39,8 @@ export function CodeGroup({
   useEffect(() => {
     if (selectedLanguage) {
       const matchingTab = itemsRef.current.find((item) => {
-        const normalizedLanguage = cleanLanguage(
-          item.props.language ?? "plaintext"
-        );
+        const matchLanguage = item.props.for || item.props.language;
+        const normalizedLanguage = cleanLanguage(matchLanguage ?? "plaintext");
         return normalizedLanguage === selectedLanguage;
       });
 
@@ -49,10 +48,12 @@ export function CodeGroup({
         const newIndex = itemsRef.current.indexOf(matchingTab);
         setSelectedTabIndex((prevIndex) => {
           const prevTab = itemsRef.current[prevIndex];
-          if (
-            prevTab?.props.language &&
-            cleanLanguage(prevTab.props.language) === selectedLanguage
-          ) {
+          const prevMatchLanguage =
+            prevTab?.props.for || prevTab?.props.language;
+          const normalizedPrevLanguage = cleanLanguage(
+            prevMatchLanguage ?? "plaintext"
+          );
+          if (normalizedPrevLanguage === selectedLanguage) {
             return prevIndex;
           }
           return newIndex;
@@ -70,8 +71,9 @@ export function CodeGroup({
     setSelectedTabIndex(newIndex);
 
     const tab = itemsRef.current[newIndex];
-    const normalizedLanguage = tab?.props.language
-      ? cleanLanguage(tab.props.language)
+    const matchLanguage = tab?.props.for || tab?.props.language;
+    const normalizedLanguage = matchLanguage
+      ? cleanLanguage(matchLanguage)
       : undefined;
 
     if (normalizedLanguage && normalizedLanguage !== selectedLanguage) {

--- a/packages/fern-docs/bundle/src/mdx/components/snippets/EndpointRequestSnippet.tsx
+++ b/packages/fern-docs/bundle/src/mdx/components/snippets/EndpointRequestSnippet.tsx
@@ -37,9 +37,6 @@ export function EndpointRequestSnippet({
     return null;
   }
 
-  console.log("endpoint example: ", example);
-  console.log("endpoint examples: ", endpointDefinition.examples);
-
   return (
     <EndpointRequestSnippetInternal
       endpoint={endpointDefinition}

--- a/packages/fern-docs/bundle/src/mdx/components/snippets/EndpointRequestSnippet.tsx
+++ b/packages/fern-docs/bundle/src/mdx/components/snippets/EndpointRequestSnippet.tsx
@@ -37,6 +37,9 @@ export function EndpointRequestSnippet({
     return null;
   }
 
+  console.log("endpoint example: ", example);
+  console.log("endpoint examples: ", endpointDefinition.examples);
+
   return (
     <EndpointRequestSnippetInternal
       endpoint={endpointDefinition}

--- a/packages/fern-docs/bundle/src/mdx/plugins/rehype-code-block.test.ts
+++ b/packages/fern-docs/bundle/src/mdx/plugins/rehype-code-block.test.ts
@@ -83,4 +83,8 @@ describe("migrateMeta", () => {
       `"wordWrap title="myFile.txt" "`
     );
   });
+
+  it("should respect the for meta", () => {
+    expect(migrateMeta(`for="npm"`)).toMatchInlineSnapshot(`"for="npm""`);
+  });
 });

--- a/packages/fern-docs/bundle/src/mdx/plugins/rehype-code-block.test.ts
+++ b/packages/fern-docs/bundle/src/mdx/plugins/rehype-code-block.test.ts
@@ -68,23 +68,27 @@ describe("migrateMeta", () => {
 
   it("should remove wordWrap if it is next to the title", () => {
     expect(migrateMeta("Python wordWrap maxLines=100")).toMatchInlineSnapshot(
-      `"title="Python"  wordWrap maxLines={100}"`
+      `"title="Python" wordWrap maxLines={100}"`
     );
   });
 
   it("should remove wordWrap if that is the only word", () => {
-    expect(migrateMeta("wordWrap")).toMatchInlineSnapshot(
-      `"title="" wordWrap"`
-    );
+    expect(migrateMeta("wordWrap")).toMatchInlineSnapshot(`"wordWrap"`);
   });
 
   it("should remove wordWrap if it is next to just a title", () => {
     expect(migrateMeta("wordWrap myFile.txt")).toMatchInlineSnapshot(
-      `"wordWrap title="myFile.txt" "`
+      `"wordWrap title="myFile.txt""`
     );
   });
 
-  it("should respect the for meta", () => {
+  it("should respect the for meta property", () => {
+    expect(migrateMeta(`"a title" for="npm"`)).toMatchInlineSnapshot(
+      `"title="a title" for="npm""`
+    );
+  });
+
+  it("should respect the for meta property even if no title is present", () => {
     expect(migrateMeta(`for="npm"`)).toMatchInlineSnapshot(`"for="npm""`);
   });
 });

--- a/packages/fern-docs/bundle/src/mdx/plugins/rehype-code-block.ts
+++ b/packages/fern-docs/bundle/src/mdx/plugins/rehype-code-block.ts
@@ -182,14 +182,10 @@ export function migrateMeta(metastring: string): string {
   }
 
   function createMetaWithTitleAttribute(text: string): string {
-    console.log("meta: ", text);
     const strippedMeta = text
       .replaceAll(/(wordWrap)/g, "")
       .replaceAll(/(for="(.*?)")/g, "")
       .trim();
-    console.log("stripMeta: ", strippedMeta);
-    console.log(strippedMeta.length);
-    console.log(text.length);
     if (strippedMeta.length === 0) {
       return text;
     }

--- a/packages/fern-docs/bundle/src/mdx/plugins/rehype-code-block.ts
+++ b/packages/fern-docs/bundle/src/mdx/plugins/rehype-code-block.ts
@@ -204,14 +204,12 @@ export function migrateMeta(metastring: string): string {
     !metastring.includes("{...") &&
     !/\{[^}]*[a-zA-Z][^}]*\}/.test(metastring)
   ) {
-    console.log("migrate abc");
     return createMetaWithTitleAttribute(metastring);
   }
 
   metastring = metastring.replaceAll(
     /^([^{]*?)(?=[a-zA-Z]+=)/g,
     (_original, text) => {
-      console.log("migrate =");
       if (text.trim() === "") {
         return "";
       }

--- a/packages/fern-docs/bundle/src/mdx/plugins/rehype-code-block.ts
+++ b/packages/fern-docs/bundle/src/mdx/plugins/rehype-code-block.ts
@@ -182,10 +182,21 @@ export function migrateMeta(metastring: string): string {
   }
 
   function createMetaWithTitleAttribute(text: string): string {
-    const textWithoutWordWrap = text.replaceAll(/(wordWrap)/g, "").trim();
+    console.log("meta: ", text);
+    const strippedMeta = text
+      .replaceAll(/(wordWrap)/g, "")
+      .replaceAll(/(for="(.*?)")/g, "")
+      .trim();
+    console.log("stripMeta: ", strippedMeta);
+    console.log(strippedMeta.length);
+    console.log(text.length);
+    if (strippedMeta.length === 0) {
+      return text;
+    }
+
     return text.replace(
-      textWithoutWordWrap,
-      `title="${textWithoutWordWrap.replace(/"/g, '\\"')}"${text.includes("wordWrap") ? " " : ""}`
+      strippedMeta,
+      `title="${strippedMeta.replace(/"/g, '\\"')}"`
     );
   }
 
@@ -197,12 +208,14 @@ export function migrateMeta(metastring: string): string {
     !metastring.includes("{...") &&
     !/\{[^}]*[a-zA-Z][^}]*\}/.test(metastring)
   ) {
+    console.log("migrate abc");
     return createMetaWithTitleAttribute(metastring);
   }
 
   metastring = metastring.replaceAll(
     /^([^{]*?)(?=[a-zA-Z]+=)/g,
     (_original, text) => {
+      console.log("migrate =");
       if (text.trim() === "") {
         return "";
       }
@@ -216,6 +229,7 @@ export function migrateMeta(metastring: string): string {
     // ignore special words, anything in curly braces
     const parseForTitle = metastring
       .replaceAll(/(wordWrap)/g, "")
+      .replaceAll(/(for="(.*?)")/g, "")
       .replaceAll(/([^=]+)={(.*?)}/g, "")
       .replaceAll(/{(.*?)}/g, "");
     if (parseForTitle !== "") {


### PR DESCRIPTION
this pr backports a feature that allows the language sync between codeblocks to be overridden by any custom string


https://github.com/user-attachments/assets/d474a4ee-91bf-4747-a0f8-30cd3490ba70

