### PR TITLE
fix: Reroute from app.ferndocs to prod.ferndocs (app branch)

### DIFF
--- a/packages/fern-docs/bundle/src/components/search.tsx
+++ b/packages/fern-docs/bundle/src/components/search.tsx
@@ -85,8 +85,8 @@ export const SearchV2 = React.memo(function SearchV2({
   // Rerouting to ferndocs.com for production environments to ensure streaming works
   // Also see: next.config.mjs, where we set CORS headers
   if (process.env.NEXT_PUBLIC_VERCEL_ENV === "production") {
-    chatEndpoint = `https://app.ferndocs.com/api/fern-docs/search/v2/chat`;
-    suggestEndpoint = `https://app.ferndocs.com/api/fern-docs/search/v2/suggest`;
+    chatEndpoint = `https://prod.ferndocs.com/api/fern-docs/search/v2/chat`;
+    suggestEndpoint = `https://prod.ferndocs.com/api/fern-docs/search/v2/suggest`;
   }
 
   const router = useRouter();


### PR DESCRIPTION
Fixes FER-

## Short description of the changes made
Point from app router to app router for /chat/ route (this was a custom rerouting done for elevenlabs to get around their proxy messing up text-streaming)

## What was the motivation & context behind this PR?
Remove dependency of app-router on page-router

## How has this PR been tested?
Local