### PR TITLE
fix: Reroute from app.ferndocs to legacy.ferndocs (main branch)

### DIFF
--- a/packages/fern-docs/ui/src/search/SearchV2.tsx
+++ b/packages/fern-docs/ui/src/search/SearchV2.tsx
@@ -93,8 +93,8 @@ export function SearchV2(): ReactElement | false {
   // Rerouting to ferndocs.com for production environments to ensure streaming works
   // Also see: next.config.mjs, where we set CORS headers
   if (process.env.NEXT_PUBLIC_VERCEL_ENV === "production") {
-    chatEndpoint = `https://app.ferndocs.com/api/fern-docs/search/v2/chat`;
-    suggestEndpoint = `https://app.ferndocs.com/api/fern-docs/search/v2/suggest`;
+    chatEndpoint = `https://legacy.ferndocs.com/api/fern-docs/search/v2/chat`;
+    suggestEndpoint = `https://legacy.ferndocs.com/api/fern-docs/search/v2/suggest`;
   }
 
   const router = useRouter();


### PR DESCRIPTION
Fixes FER-

## Short description of the changes made
Point from pages router to pages router for legacy AI chat deployments (mirror of: https://github.com/fern-api/fern-platform/pull/2451, see description)

## What was the motivation & context behind this PR?
Need to move from app. -> legacy.

## How has this PR been tested?
Local