### PR TITLE
fix: Use NEXT_PUBLIC_CDN_URI in place of hardcoded ferndocs URI

### DIFF
--- a/packages/fern-docs/bundle/src/components/search.tsx
+++ b/packages/fern-docs/bundle/src/components/search.tsx
@@ -85,8 +85,8 @@ export const SearchV2 = React.memo(function SearchV2({
   // Rerouting to ferndocs.com for production environments to ensure streaming works
   // Also see: next.config.mjs, where we set CORS headers
   if (process.env.NEXT_PUBLIC_VERCEL_ENV === "production") {
-    chatEndpoint = `https://prod.ferndocs.com/api/fern-docs/search/v2/chat`;
-    suggestEndpoint = `https://prod.ferndocs.com/api/fern-docs/search/v2/suggest`;
+    chatEndpoint = `${process.env.NEXT_PUBLIC_CDN_URI}/api/fern-docs/search/v2/chat`;
+    suggestEndpoint = `${process.env.NEXT_PUBLIC_CDN_URI}/api/fern-docs/search/v2/suggest`;
   }
 
   const router = useRouter();


### PR DESCRIPTION
Fixes FER-

## Short description of the changes made
Using environment variables for suggest/chat endpoints

## What was the motivation & context behind this PR?
Avoiding hardcoded ferndocs URI

## How has this PR been tested?