### PR TITLE
fix: add a fallback for the root

### DIFF
--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@explorer/(..)explorer/@sidebar/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@explorer/(..)explorer/@sidebar/[slug]/page.tsx
@@ -31,7 +31,7 @@ export default async function EndpointSelectorPage({
   const versionNode = foundNode.versions.find(
     (version) => version.versionId === currentVersion
   );
-  const apiGroups = flattenApiSection(versionNode);
+  const apiGroups = flattenApiSection(versionNode ?? root);
 
   return (
     <PlaygroundEndpointSelectorContent

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/explorer/@sidebar/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/explorer/@sidebar/[slug]/page.tsx
@@ -31,7 +31,7 @@ export default async function EndpointSelectorPage({
   const versionNode = foundNode.versions.find(
     (version) => version.versionId === currentVersion
   );
-  const apiGroups = flattenApiSection(versionNode);
+  const apiGroups = flattenApiSection(versionNode ?? root);
 
   return (
     <PlaygroundEndpointSelectorContent

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@explorer/(..)explorer/@sidebar/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@explorer/(..)explorer/@sidebar/[slug]/page.tsx
@@ -26,7 +26,7 @@ export default async function EndpointSelectorPage({
   const versionNode = foundNode.versions.find(
     (version) => version.versionId === currentVersion
   );
-  const apiGroups = flattenApiSection(versionNode);
+  const apiGroups = flattenApiSection(versionNode ?? root);
 
   return (
     <PlaygroundEndpointSelectorContent


### PR DESCRIPTION
this pr adds a fallback for calculating the endpoints that should appear in the explorer sidebar. 

we first search for the endpoints assigned to the current version. if we can't filter to a version (e.g. the site is unversioned), we just use the root as context. 
