### PR TITLE
fix fdr org check in getDocsSitesForOrg

### DIFF
--- a/servers/fdr/src/controllers/dashboard/getDashboardController.ts
+++ b/servers/fdr/src/controllers/dashboard/getDashboardController.ts
@@ -2,16 +2,12 @@ import { DashboardService } from "../../api/generated/api/resources/dashboard/se
 import { FdrApplication } from "../../app";
 
 export function getDashboardController(app: FdrApplication): DashboardService {
-  async function checkIsFernUser(authorization: string | undefined) {
-    await app.services.auth.checkUserBelongsToOrg({
-      authHeader: authorization,
-      orgId: "fern",
-    });
-  }
-
   return new DashboardService({
     getDocsSitesForOrg: async (req, res) => {
-      await checkIsFernUser(req.headers.authorization);
+      await app.services.auth.checkUserBelongsToOrg({
+        authHeader: req.headers.authorization,
+        orgId: req.body.orgId,
+      });
       const docsSites = await app.dao
         .docsV2()
         .listDocsSitesForOrg(req.body.orgId);


### PR DESCRIPTION
bady copy/paste - `getDocsSitesForOrg` should check that the token is in the provided orgId (not in `"fern"`)