### PR TITLE
Rename APP_BASE_URL to NEXT_PUBLIC_APP_BASE_URL

### DIFF
--- a/packages/fern-dashboard/next.config.ts
+++ b/packages/fern-dashboard/next.config.ts
@@ -25,7 +25,7 @@ const nextConfig: NextConfig = {
     ],
   },
   env: {
-    APP_BASE_URL:
+    NEXT_PUBLIC_APP_BASE_URL:
       process.env.VERCEL_ENV === "preview"
         ? `https://${process.env.VERCEL_BRANCH_URL}`
         : process.env.APP_BASE_URL,

--- a/packages/fern-dashboard/next.config.ts
+++ b/packages/fern-dashboard/next.config.ts
@@ -1,6 +1,11 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
 import type { NextConfig } from "next";
 
+const APP_BASE_URL =
+  process.env.VERCEL_ENV === "preview"
+    ? `https://${process.env.VERCEL_BRANCH_URL}`
+    : process.env.APP_BASE_URL;
+
 const nextConfig: NextConfig = {
   transpilePackages: [
     /**
@@ -25,10 +30,11 @@ const nextConfig: NextConfig = {
     ],
   },
   env: {
-    NEXT_PUBLIC_APP_BASE_URL:
-      process.env.VERCEL_ENV === "preview"
-        ? `https://${process.env.VERCEL_BRANCH_URL}`
-        : process.env.APP_BASE_URL,
+    // need this to be NEXT_PUBLIC_ so it's accessible in auth0.ts
+    NEXT_PUBLIC_APP_BASE_URL: APP_BASE_URL,
+
+    // Auth0 expects APP_BASE_URL to exist
+    APP_BASE_URL,
   },
   webpack: (webpackConfig) => {
     webpackConfig.externals.push("sharp");

--- a/packages/fern-dashboard/src/lib/auth0.ts
+++ b/packages/fern-dashboard/src/lib/auth0.ts
@@ -16,7 +16,7 @@ export const auth0 = new Auth0Client({
     };
   },
   authorizationParameters: {
-    redirect_uri: `${process.env.APP_BASE_URL}/auth/callback`,
+    redirect_uri: `${process.env.NEXT_PUBLIC_APP_BASE_URL}/auth/callback`,
     audience: process.env.NEXT_PUBLIC_VENUS_AUDIENCE,
   },
 });


### PR DESCRIPTION
`APP_BASE_URL` is not defined in `auth0.ts` (go to https://dashboard-dev.buildwithfern.com and log in to see the result)

<img width="1512" alt="Screenshot 2025-03-27 at 7 01 57 PM" src="https://github.com/user-attachments/assets/1fd664b4-47ff-424b-af86-99323582af4f" />

Hoping this fixes