### PR TITLE
Rename base env var to NEXT_PUBLIC_APP_BASE_URL

### DIFF
--- a/packages/fern-dashboard/next.config.ts
+++ b/packages/fern-dashboard/next.config.ts
@@ -4,7 +4,7 @@ import type { NextConfig } from "next";
 const APP_BASE_URL =
   process.env.VERCEL_ENV === "preview"
     ? `https://${process.env.VERCEL_BRANCH_URL}`
-    : process.env.APP_BASE_URL;
+    : process.env.NEXT_PUBLIC_APP_BASE_URL;
 
 const nextConfig: NextConfig = {
   transpilePackages: [


### PR DESCRIPTION
https://github.com/fern-api/fern-platform/pull/2460 didn't work, trying more renames 