### PR TITLE
Destructure process.env in auth0.ts

### DIFF
--- a/packages/fern-dashboard/src/lib/auth0.ts
+++ b/packages/fern-dashboard/src/lib/auth0.ts
@@ -2,10 +2,16 @@ import { redirect } from "next/navigation";
 
 import { Auth0Client } from "@auth0/nextjs-auth0/server";
 
-if (process.env.NEXT_PUBLIC_VENUS_AUDIENCE == null) {
+const { NEXT_PUBLIC_VENUS_AUDIENCE, NEXT_PUBLIC_APP_BASE_URL } = process.env;
+
+if (NEXT_PUBLIC_VENUS_AUDIENCE == null) {
   throw new Error(
     "NEXT_PUBLIC_VENUS_AUDIENCE is not defined in the environment"
   );
+}
+
+if (NEXT_PUBLIC_APP_BASE_URL == null) {
+  throw new Error("NEXT_PUBLIC_APP_BASE_URL is not defined in the environment");
 }
 
 export const auth0 = new Auth0Client({
@@ -16,8 +22,8 @@ export const auth0 = new Auth0Client({
     };
   },
   authorizationParameters: {
-    redirect_uri: `${process.env.NEXT_PUBLIC_APP_BASE_URL}/auth/callback`,
-    audience: process.env.NEXT_PUBLIC_VENUS_AUDIENCE,
+    redirect_uri: `${NEXT_PUBLIC_APP_BASE_URL}/auth/callback`,
+    audience: NEXT_PUBLIC_VENUS_AUDIENCE,
   },
 });
 


### PR DESCRIPTION
https://github.com/fern-api/fern-platform/pull/2460 and https://github.com/fern-api/fern-platform/pull/2461, didn't work, trying this so that the env vars are stored as constants instead of `process.env`
