### PR TITLE
chore: background blur

### DIFF
--- a/packages/fern-docs/bundle/src/state/search.tsx
+++ b/packages/fern-docs/bundle/src/state/search.tsx
@@ -47,9 +47,7 @@ searchInitializedAtom.onMount = (setInitialized) => {
 };
 
 export const SearchV2Trigger = React.memo(function SearchV2Trigger(
-  props: React.ComponentProps<typeof DesktopSearchButton> & {
-    isSearchInSidebar?: boolean;
-  }
+  props: React.ComponentProps<typeof DesktopSearchButton>
 ) {
   const isInitialized = useAtomValue(searchInitializedAtom);
   const toggleSearchDialog = useToggleSearchDialog();

--- a/packages/fern-docs/components/src/FernDropdown.scss
+++ b/packages/fern-docs/components/src/FernDropdown.scss
@@ -3,7 +3,7 @@
     @apply relative z-50;
     @apply animate-popover;
     @apply min-w-(--radix-dropdown-menu-trigger-width);
-    @apply bg-background-translucent border-border-default rounded-2 flex max-h-[300px] flex-col border backdrop-blur will-change-[opacity,transform];
+    @apply bg-background border-border-default rounded-2 flex max-h-[300px] flex-col border backdrop-blur will-change-[opacity,transform];
     @apply shadow-xl;
 
     .fern-dropdown-item {

--- a/packages/fern-docs/components/src/FernTooltip.tsx
+++ b/packages/fern-docs/components/src/FernTooltip.tsx
@@ -42,7 +42,7 @@ export const FernTooltip: FC<FernTooltipProps> = ({
           collisionPadding={6}
           {...props}
           className={cn(
-            "bg-background-translucent border-border-default animate-popover rounded-2 shadow-card-grayscale z-50 max-w-xs border p-2 text-sm leading-normal backdrop-blur will-change-[transform,opacity]",
+            "bg-background border-border-default animate-popover rounded-2 shadow-card-grayscale z-50 max-w-xs border p-2 text-sm leading-normal backdrop-blur will-change-[transform,opacity]",
             props.className
           )}
         >

--- a/packages/fern-docs/search-ui/src/components/desktop/desktop-search-button.tsx
+++ b/packages/fern-docs/search-ui/src/components/desktop/desktop-search-button.tsx
@@ -28,20 +28,33 @@ export const DesktopSearchButton = forwardRef<
   ComponentPropsWithoutRef<"button"> &
     VariantProps<typeof buttonVariants> & {
       placeholder?: string;
+      isSearchInSidebar?: boolean;
     }
->(({ children, variant, placeholder = "Search", className, ...rest }, ref) => {
-  return (
-    <button
-      {...rest}
-      className={buttonVariants({ variant, className })}
-      ref={ref}
-    >
-      <SearchIcon />
-      {placeholder}
-      <CommandKbd className="pointer-coarse:hidden ml-auto" />
-    </button>
-  );
-});
+>(
+  (
+    {
+      children,
+      variant,
+      placeholder = "Search",
+      className,
+      isSearchInSidebar,
+      ...rest
+    },
+    ref
+  ) => {
+    return (
+      <button
+        {...rest}
+        className={buttonVariants({ variant, className })}
+        ref={ref}
+      >
+        <SearchIcon />
+        {placeholder}
+        <CommandKbd className="pointer-coarse:hidden ml-auto" />
+      </button>
+    );
+  }
+);
 
 DesktopSearchButton.displayName = "DesktopSearchButton";
 


### PR DESCRIPTION
this pr adjusts the background of tooltips and dropdowns to ensure readability (especially within the API explorer)

this pr also slightly adjusts the prop construction of the searchbar button to resolve a warning

before: 
![Screenshot 2025-03-31 at 9 47 10 PM](https://github.com/user-attachments/assets/543c20e0-4392-4ef4-8d32-761219728f8d)

after:
![Screenshot 2025-03-31 at 10 05 03 PM](https://github.com/user-attachments/assets/0926d02e-3aac-44d7-90b2-772395f141c4)

