### PR TITLE
chore: conditionally disable v1 indexing.

### DIFF
--- a/servers/fdr/src/controllers/docs/v2/getDocsWriteV2Service.ts
+++ b/servers/fdr/src/controllers/docs/v2/getDocsWriteV2Service.ts
@@ -266,13 +266,24 @@ export function getDocsWriteV2Service(app: FdrApplication): DocsV2WriteService {
           }
         );
 
-        const indexSegments = await uploadToAlgoliaForRegistration(
-          app,
-          docsRegistrationInfo,
-          dbDocsDefinition,
-          apiDefinitionsById,
-          apiDefinitionsLatestById
-        );
+        let indexSegments: IndexSegment[] = [];
+        // HACK: we don't want to index monite docs in algolia. To be removed after search v2 migration.
+        if (!docsRegistrationInfo.fernUrl.getFullUrl().includes("monite")) {
+          try {
+            indexSegments = await uploadToAlgoliaForRegistration(
+              app,
+              docsRegistrationInfo,
+              dbDocsDefinition,
+              apiDefinitionsById,
+              apiDefinitionsLatestById
+            );
+          } catch (e) {
+            app.logger.error(
+              `Error while trying to upload to Algolia for ${docsRegistrationInfo.fernUrl.getFullUrl()}`,
+              e
+            );
+          }
+        }
 
         await app.docsDefinitionCache.storeDocsForUrl({
           docsRegistrationInfo,


### PR DESCRIPTION
## Short description of the changes made

Adds conditional check to perform v1 indexing.

## What was the motivation & context behind this PR?

Indexing is currently recursive and may break on certain references.

## How has this PR been tested?

Backport fix to `app` branch.