### PR TITLE
chore: remove slack notifs for file resolver

### DIFF
--- a/packages/fern-docs/bundle/src/components/shared-layout.tsx
+++ b/packages/fern-docs/bundle/src/components/shared-layout.tsx
@@ -30,7 +30,7 @@ export default async function SharedLayout({
   loader: DocsLoader;
 }) {
   const serialize = createCachedMdxSerializer(loader);
-  const [{ basePath, domain }, config, edgeFlags, files, colors, layout] =
+  const [{ basePath }, config, edgeFlags, files, colors, layout] =
     await Promise.all([
       loader.getMetadata(),
       loader.getConfig(),
@@ -41,7 +41,7 @@ export default async function SharedLayout({
     ]);
   const theme = edgeFlags.isCohereTheme ? "cohere" : "default";
   const announcementText = config.announcement?.text;
-  const resolveFileSrc = createFileResolver(files, domain);
+  const resolveFileSrc = createFileResolver(files);
 
   return (
     <ThemedDocs

--- a/packages/fern-docs/bundle/src/server/file-resolver.ts
+++ b/packages/fern-docs/bundle/src/server/file-resolver.ts
@@ -2,13 +2,9 @@ import "server-only";
 
 import { FernNavigation } from "@fern-api/fdr-sdk";
 
-import { postToEngineeringNotifs } from "./slack";
 import type { FileData } from "./types";
 
-export function createFileResolver(
-  files: Record<string, FileData>,
-  domain: string
-) {
+export function createFileResolver(files: Record<string, FileData>) {
   return (src: string | undefined) => {
     if (src == null) {
       return undefined;
@@ -20,12 +16,6 @@ export function createFileResolver(
     const file = files[fileId];
     if (file == null) {
       // the file is not found, so we return the src as the image data
-
-      postToEngineeringNotifs(
-        `:rotating_light: [createFileResolver] Could not find file ${fileId} for domain ${domain}.`,
-        "file-resolver"
-      );
-
       return { src };
     }
     return file;


### PR DESCRIPTION
this pr removes slack notifications for the file resolver failure. rate limiting does not seem to be working, and the logging appears to cause timeouts for docs. 

fast-follow: to push a potential fix for the file caching issue
