### PR TITLE
fix: reindex sets up cache for llms-full txt

### DIFF
--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/llms-full.txt/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/llms-full.txt/route.ts
@@ -13,6 +13,8 @@ import { createCachedDocsLoader } from "@/server/docs-loader";
 import { getMarkdownForPath } from "@/server/getMarkdownForPath";
 import { getSectionRoot } from "@/server/getSectionRoot";
 
+export const maxDuration = 300; // 5 minutes timeout
+
 export async function GET(
   req: NextRequest,
   props: { params: Promise<{ host: string; domain: string }> }

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/revalidate/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/revalidate/route.ts
@@ -37,6 +37,8 @@ import {
 } from "@/server/queue-reindex";
 import { pruneWithAuthState } from "@/server/withRbac";
 
+export const maxDuration = 300; // 5 minutes timeout
+
 export async function GET(
   req: NextRequest,
   props: { params: Promise<{ host: string; domain: string }> }


### PR DESCRIPTION
## Short description of the changes made
Caches `llms-full.txt` as part of reindex. 

## What was the motivation & context behind this PR?
Currently `llms-full.txt` will often time out and the idea here is to make sure that it is cached as soon as possible. 

## How has this PR been tested?
Preview URLs
