### PR TITLE
fix: move page router to use prod.ferndocs

### DIFF
--- a/packages/fern-docs/ui/src/search/SearchV2.tsx
+++ b/packages/fern-docs/ui/src/search/SearchV2.tsx
@@ -93,8 +93,8 @@ export function SearchV2(): ReactElement | false {
   // Rerouting to ferndocs.com for production environments to ensure streaming works
   // Also see: next.config.mjs, where we set CORS headers
   if (process.env.NEXT_PUBLIC_VERCEL_ENV === "production") {
-    chatEndpoint = `https://legacy.ferndocs.com/api/fern-docs/search/v2/chat`;
-    suggestEndpoint = `https://legacy.ferndocs.com/api/fern-docs/search/v2/suggest`;
+    chatEndpoint = `https://prod.ferndocs.com/api/fern-docs/search/v2/chat`;
+    suggestEndpoint = `https://prod.ferndocs.com/api/fern-docs/search/v2/suggest`;
   }
 
   const router = useRouter();


### PR DESCRIPTION
Fixes FER-

## Short description of the changes made
Reroute pages router /chat/ endpoint to use app router /chat/ endpoint

## What was the motivation & context behind this PR?
Will make it simpler (not requiring pushing to app and main branch for all AI chat)

## How has this PR been tested?
