### PR TITLE
chore: do not filter on ask-ai-enabled

### DIFF
--- a/packages/fern-docs/bundle/src/components/PageActionsDropdown.tsx
+++ b/packages/fern-docs/bundle/src/components/PageActionsDropdown.tsx
@@ -17,7 +17,6 @@ import {
 
 export function PageActionsDropdown({ markdown }: { markdown: string }) {
   const [showCopied, setShowCopied] = useState<boolean>(false);
-  const isAskAiEnabled = useIsAskAiEnabled();
   const { domain, slug } = useParams();
 
   const copyOption = CopyPageOption();
@@ -27,14 +26,10 @@ export function PageActionsDropdown({ markdown }: { markdown: string }) {
     copyOption,
     { type: "separator" } as FernDropdown.SeparatorOption,
     viewAsMarkdownOption,
-    ...(!isAskAiEnabled
-      ? [
-          { type: "separator" } as FernDropdown.SeparatorOption,
-          OpenWithLLM({ domain, slug, llm: "ChatGPT" }),
-          { type: "separator" } as FernDropdown.SeparatorOption,
-          OpenWithLLM({ domain, slug, llm: "Claude" }),
-        ]
-      : []),
+    { type: "separator" } as FernDropdown.SeparatorOption,
+    OpenWithLLM({ domain, slug, llm: "ChatGPT" }),
+    { type: "separator" } as FernDropdown.SeparatorOption,
+    OpenWithLLM({ domain, slug, llm: "Claude" }),
   ];
 
   const handleValueChange = async (value: string) => {


### PR DESCRIPTION
## Short description of the changes made
Ask AI enabled should not prevent users from using other AI models. 

## What was the motivation & context behind this PR?
Customers who have AI chat enabled like the dropdown. We will eventually add Fern's AI search here too. 

## How has this PR been tested?
N/A
