### PR TITLE
chore: disable examples for deployments on app router

### DIFF
--- a/packages/fern-docs/bundle/src/state/domain.ts
+++ b/packages/fern-docs/bundle/src/state/domain.ts
@@ -12,6 +12,6 @@ export function Domain({ value }: { value: string }) {
   return null;
 }
 
-export function useDomain() {
+export function useDomain(): string {
   return useAtomValue(domainAtom);
 }

--- a/packages/fern-docs/bundle/src/state/playground.ts
+++ b/packages/fern-docs/bundle/src/state/playground.ts
@@ -325,7 +325,7 @@ export function usePlaygroundEndpointFormState(
               : update;
           set(formStateAtom, newFormState);
         },
-        [formStateAtom, ctx, user?.playground?.initial_state]
+        [formStateAtom, ctx, user?.playground?.initial_state, domain]
       )
     ),
   ];

--- a/packages/fern-docs/bundle/src/state/playground.ts
+++ b/packages/fern-docs/bundle/src/state/playground.ts
@@ -39,8 +39,8 @@ import {
   getInitialWebSocketRequestFormState,
 } from "../components/playground/utils";
 import { pascalCaseHeaderKeys } from "../components/playground/utils/header-key-case";
-import { atomWithStorageValidation } from "./utils/atomWithStorageValidation";
 import { useDomain } from "./domain";
+import { atomWithStorageValidation } from "./utils/atomWithStorageValidation";
 
 export const PLAYGROUND_AUTH_STATE_ATOM =
   atomWithStorageValidation<PlaygroundAuthState>(
@@ -315,7 +315,8 @@ export function usePlaygroundEndpointFormState(
                     ? currentFormState
                     : getInitialEndpointRequestFormStateWithExample(
                         ctx,
-                        domain.includes("twelvelabs") || domain.includes("spscommerce")
+                        domain.includes("twelvelabs") ||
+                          domain.includes("spscommerce")
                           ? undefined
                           : ctx.endpoint.examples?.[0],
                         user?.playground?.initial_state

--- a/packages/fern-docs/bundle/src/state/playground.ts
+++ b/packages/fern-docs/bundle/src/state/playground.ts
@@ -40,6 +40,7 @@ import {
 } from "../components/playground/utils";
 import { pascalCaseHeaderKeys } from "../components/playground/utils/header-key-case";
 import { atomWithStorageValidation } from "./utils/atomWithStorageValidation";
+import { useDomain } from "./domain";
 
 export const PLAYGROUND_AUTH_STATE_ATOM =
   atomWithStorageValidation<PlaygroundAuthState>(
@@ -289,6 +290,7 @@ export function usePlaygroundEndpointFormState(
   const formStateAtom = playgroundFormStateFamily(ctx.node.id);
   const formState = useAtomValue(formStateAtom);
   const user = useAtomValue(fernUserAtom);
+  const domain = useDomain();
 
   return [
     formState?.type === "endpoint"
@@ -313,7 +315,9 @@ export function usePlaygroundEndpointFormState(
                     ? currentFormState
                     : getInitialEndpointRequestFormStateWithExample(
                         ctx,
-                        ctx.endpoint.examples?.[0],
+                        domain.includes("twelvelabs") || domain.includes("spscommerce")
+                          ? undefined
+                          : ctx.endpoint.examples?.[0],
                         user?.playground?.initial_state
                       )
                 )


### PR DESCRIPTION
## Short description of the changes made
Certain deployments dont want examples to be prepopulated in their docs. 

## What was the motivation & context behind this PR?
Even though the commits existed on the app router branch, these were removed. 

## How has this PR been tested?
Preview URLs. 
