### PR TITLE
Upgrade fdr ts-generator to 0.49.7

### DIFF
--- a/fern/apis/fdr/generators.yml
+++ b/fern/apis/fdr/generators.yml
@@ -14,7 +14,7 @@ groups:
           noOptionalProperties: true
           useBrandedStringAliases: true
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.42.7
+        version: 0.49.7
         output:
           location: local-file-system
           path: ../../../packages/fdr-sdk/src/client/generated

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "fern",
-  "version": "0.57.0"
+  "version": "0.57.16"
 }


### PR DESCRIPTION
Fixes failing `fern-generate` check