### PR TITLE
Append .md to URL for LLM dropdown

### DIFF
--- a/packages/fern-docs/bundle/src/components/PageActionsDropdownOptions.tsx
+++ b/packages/fern-docs/bundle/src/components/PageActionsDropdownOptions.tsx
@@ -78,7 +78,7 @@ export const OpenWithLLM = ({
   const decodedDomain = resolveParam(domain);
   const decodedSlug = resolveParam(slug);
 
-  const prompt = `Read ${decodedDomain}${decodedSlug} so I can ask questions about it.`;
+  const prompt = `Read ${decodedDomain}${decodedSlug}.md so I can ask questions about it.`;
 
   return {
     type: "value",


### PR DESCRIPTION
## Short description of the changes made
- append .md to URL for LLM dropdown

## What was the motivation & context behind this PR?
- LLM has easy access to page content on the publicly-accessible .md pages

## How has this PR been tested?
- previews
