### PR TITLE
chore: no misused promises

### DIFF
--- a/clis/generator-cli/src/cli.ts
+++ b/clis/generator-cli/src/cli.ts
@@ -111,7 +111,7 @@ async function createWriteStream(
 async function createWriteStreamFromFile(
   filepath: AbsoluteFilePath
 ): Promise<fs.WriteStream> {
-  if (!doesPathExist(filepath)) {
+  if (await doesPathExist(filepath)) {
     await mkdir(path.dirname(filepath), { recursive: true });
   }
   return fs.createWriteStream(filepath);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -161,7 +161,6 @@ export default [
         "@typescript-eslint/no-empty-object-type": "off",
         "@typescript-eslint/no-extraneous-class": "off",
         "@typescript-eslint/no-inferrable-types": "off",
-        "@typescript-eslint/no-misused-promises": "off",
         "@typescript-eslint/no-redundant-type-constituents": "off",
         "@typescript-eslint/no-require-imports": "off",
         "@typescript-eslint/no-unsafe-argument": "off",

--- a/packages/commons/react-commons/src/useCopyToClipboard.ts
+++ b/packages/commons/react-commons/src/useCopyToClipboard.ts
@@ -6,7 +6,7 @@ import { useTimeout } from "./useTimeout";
 
 export declare namespace useCopyToClipboard {
   export interface Return {
-    copyToClipboard: (() => void) | undefined;
+    copyToClipboard: (() => Promise<void>) | undefined;
     wasJustCopied: boolean;
   }
 }

--- a/packages/commons/react-commons/src/useKeyboardCommand.ts
+++ b/packages/commons/react-commons/src/useKeyboardCommand.ts
@@ -41,10 +41,18 @@ export function useKeyboardCommand(args: useKeyboardCommand.Args): void {
       }
     }
 
-    document.addEventListener("keydown", handleSaveKeyPress, true);
+    document.addEventListener(
+      "keydown",
+      (e) => void handleSaveKeyPress(e),
+      true
+    );
 
     return () => {
-      document.removeEventListener("keydown", handleSaveKeyPress, true);
+      document.removeEventListener(
+        "keydown",
+        (e) => void handleSaveKeyPress(e),
+        true
+      );
     };
   }, [key, onCommand, platform, preventDefault]);
 }

--- a/packages/commons/react-commons/src/useKeyboardPress.ts
+++ b/packages/commons/react-commons/src/useKeyboardPress.ts
@@ -68,10 +68,18 @@ export function useKeyboardPress(args: useKeyboardPress.Args): void {
       }
     }
 
-    document.addEventListener("keydown", handleSaveKeyPress, capture);
+    document.addEventListener(
+      "keydown",
+      (e) => void handleSaveKeyPress(e),
+      capture
+    );
 
     return () => {
-      document.removeEventListener("keydown", handleSaveKeyPress, capture);
+      document.removeEventListener(
+        "keydown",
+        (e) => void handleSaveKeyPress(e),
+        capture
+      );
     };
   }, [capture, key, onPress, preventDefault]);
 }

--- a/packages/fern-dashboard/src/components/auth/OrgSwitcherSelect.tsx
+++ b/packages/fern-dashboard/src/components/auth/OrgSwitcherSelect.tsx
@@ -49,7 +49,7 @@ export const OrgSwitcherSelect = ({
   return (
     <Select
       value={localValue}
-      onValueChange={onClickOrg}
+      onValueChange={(value) => void onClickOrg(value as Auth0OrgID)}
       disabled={organizations.length === 0}
     >
       <SelectTrigger className="min-w-[180px]">

--- a/packages/fern-dashboard/src/components/layout/DocsSiteSelect.tsx
+++ b/packages/fern-dashboard/src/components/layout/DocsSiteSelect.tsx
@@ -42,7 +42,7 @@ export const DocsSiteSelect = ({
   return (
     <Select
       value={localValue}
-      onValueChange={onClickUrl}
+      onValueChange={(value) => void onClickUrl(value as DocsUrl)}
       disabled={docsSites.length === 0}
     >
       <SelectTrigger className="min-w-[180px]">

--- a/packages/fern-docs/bundle/src/components/Chip.tsx
+++ b/packages/fern-docs/bundle/src/components/Chip.tsx
@@ -31,7 +31,12 @@ export const Chip = ({ name, description = undefined }: ChipProps) => {
       open={wasJustCopied ? true : !description ? false : undefined}
       content={wasJustCopied ? "Copied!" : description}
     >
-      <Badge onClick={copyToClipboard} size={size}>
+      <Badge
+        onClick={() => {
+          void copyToClipboard?.();
+        }}
+        size={size}
+      >
         {name}
       </Badge>
     </FernTooltip>

--- a/packages/fern-docs/bundle/src/components/FernAnchor.tsx
+++ b/packages/fern-docs/bundle/src/components/FernAnchor.tsx
@@ -77,7 +77,9 @@ export function FernAnchor({
               shallow={true}
               scroll={false}
               replace={true}
-              onClick={copyToClipboard}
+              onClick={() => {
+                void copyToClipboard?.();
+              }}
               tabIndex={-1}
             >
               {!wasJustCopied && !forceMount && (

--- a/packages/fern-docs/bundle/src/components/PageActionsDropdown.tsx
+++ b/packages/fern-docs/bundle/src/components/PageActionsDropdown.tsx
@@ -58,7 +58,7 @@ export function PageActionsDropdown({ markdown }: { markdown: string }) {
       <FernButton
         variant="minimal"
         className="w-fit rounded-r-none px-2"
-        onClick={() => handleValueChange("copy-page")}
+        onClick={() => void handleValueChange("copy-page")}
       >
         {showCopied ? (
           <div className="flex items-center gap-2">
@@ -74,7 +74,7 @@ export function PageActionsDropdown({ markdown }: { markdown: string }) {
       </FernButton>
       <FernDropdown
         options={options}
-        onValueChange={handleValueChange}
+        onValueChange={(value) => void handleValueChange(value)}
         dropdownMenuElement={<a target="_blank" rel="noopener noreferrer" />}
       >
         <FernButton variant="minimal" className="rounded-l-none px-2">

--- a/packages/fern-docs/bundle/src/components/analytics/posthog.ts
+++ b/packages/fern-docs/bundle/src/components/analytics/posthog.ts
@@ -175,7 +175,13 @@ export function useInitializePosthog(
 ): void {
   const route = useApiRoute("/api/fern-docs/analytics/posthog");
   useEffect(() => {
-    safeCall(() => initializePosthog(route, customerConfig));
+    void (async () => {
+      try {
+        await initializePosthog(route, customerConfig);
+      } catch (e) {
+        console.error("Failed to initialize PostHog:", e);
+      }
+    })();
   }, [customerConfig, route]);
   const pathname = useCurrentPathname();
   useEffect(() => {

--- a/packages/fern-docs/bundle/src/components/api-reference/websockets/CardedSection.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/websockets/CardedSection.tsx
@@ -35,9 +35,9 @@ export function CardedSection({
         </FernAnchor>
         {headingElement}
       </div>
-      {React.Children.toArray(children).some((child) => child) && (
-        <div className="space-y-12 p-4">{children}</div>
-      )}
+      {React.Children.toArray(children).some((child) =>
+        React.isValidElement(child)
+      ) && <div className="space-y-12 p-4">{children}</div>}
     </section>
   );
 }

--- a/packages/fern-docs/bundle/src/components/playground/auth/PlaygroundOAuthForm.tsx
+++ b/packages/fern-docs/bundle/src/components/playground/auth/PlaygroundOAuthForm.tsx
@@ -173,7 +173,15 @@ export function FoundOAuthReferencedEndpointForm({
           <FernButton
             text={`${value.isLoggedIn ? "Refresh" : "Fetch"} Bearer Token`}
             intent="primary"
-            onClick={oAuthClientCredentialLogin}
+            onClick={() => {
+              void (async () => {
+                try {
+                  await oAuthClientCredentialLogin();
+                } catch (e) {
+                  console.error("Failed to login:", e);
+                }
+              })();
+            }}
             disabled={disabled}
           />
         )}

--- a/packages/fern-docs/bundle/src/components/playground/endpoint/PlaygroundEndpoint.tsx
+++ b/packages/fern-docs/bundle/src/components/playground/endpoint/PlaygroundEndpoint.tsx
@@ -216,7 +216,15 @@ export const PlaygroundEndpoint = ({
           <PlaygroundEndpointPath
             method={endpoint.method}
             formState={formState}
-            sendRequest={sendRequest}
+            sendRequest={() => {
+              void (async () => {
+                try {
+                  await sendRequest();
+                } catch (e) {
+                  console.error("Failed to send request:", e);
+                }
+              })();
+            }}
             environmentId={environmentId}
             baseUrl={baseUrl}
             // TODO: this is a temporary fix to show all environments in the playground, unless filtered in the settings
@@ -245,7 +253,15 @@ export const PlaygroundEndpoint = ({
             resetWithExample={resetWithExample}
             resetWithoutExample={resetWithoutExample}
             response={response}
-            sendRequest={sendRequest}
+            sendRequest={() => {
+              void (async () => {
+                try {
+                  await sendRequest();
+                } catch (e) {
+                  console.error("Failed to send request:", e);
+                }
+              })();
+            }}
           />
         </div>
       </div>

--- a/packages/fern-docs/bundle/src/components/playground/form/PlaygroundAudioControls.tsx
+++ b/packages/fern-docs/bundle/src/components/playground/form/PlaygroundAudioControls.tsx
@@ -84,7 +84,7 @@ export function PlaygroundAudioControls({
       <FernButtonGroup>
         <FernButton
           icon={isPlaying ? <Octagon /> : <Play />}
-          onClick={handlePlayPause}
+          onClick={() => void handlePlayPause()}
           size="small"
           variant="minimal"
           disabled={!audioUrl}

--- a/packages/fern-docs/bundle/src/components/playground/form/PlaygroundFileUploadForm.tsx
+++ b/packages/fern-docs/bundle/src/components/playground/form/PlaygroundFileUploadForm.tsx
@@ -178,7 +178,7 @@ export const PlaygroundFileUploadForm = memo<PlaygroundFileUploadFormProps>(
                 />
                 {canRecordAudio && (
                   <FernButton
-                    onClick={startRecording}
+                    onClick={() => void startRecording()}
                     icon={<Mic />}
                     rounded
                     variant="outlined"
@@ -217,7 +217,7 @@ export const PlaygroundFileUploadForm = memo<PlaygroundFileUploadFormProps>(
                     {canRecordAudio && (
                       <FernButton
                         icon={<Mic />}
-                        onClick={startRecording}
+                        onClick={() => void startRecording()}
                         size="small"
                         variant="minimal"
                       />

--- a/packages/fern-docs/bundle/src/components/playground/websocket/PlaygroundWebSocket.tsx
+++ b/packages/fern-docs/bundle/src/components/playground/websocket/PlaygroundWebSocket.tsx
@@ -203,13 +203,15 @@ export const PlaygroundWebSocket: FC<PlaygroundWebSocketProps> = ({
           <PlaygroundEndpointPath
             method={undefined}
             formState={formState}
-            sendRequest={() =>
-              connectedState === "closed"
-                ? startSession()
-                : connectedState === "opened"
-                  ? socket.current?.close()
-                  : null
-            }
+            sendRequest={() => {
+              void (async () => {
+                if (connectedState === "closed") {
+                  await startSession();
+                } else if (connectedState === "opened") {
+                  socket.current?.close();
+                }
+              })();
+            }}
             environmentId={environmentId}
             baseUrl={baseUrl}
             // TODO: this is a temporary fix to show all environments in the playground, unless filtered in the settings
@@ -246,8 +248,12 @@ export const PlaygroundWebSocket: FC<PlaygroundWebSocketProps> = ({
             context={context}
             formState={formState}
             setFormState={setFormState}
-            sendMessage={handleSendMessage}
-            startSesssion={startSession}
+            sendMessage={(message, data) => {
+              void handleSendMessage(message, data);
+            }}
+            startSesssion={() => {
+              void startSession();
+            }}
             clearMessages={clearMessages}
             connected={connectedState === "opened"}
             error={error}

--- a/packages/fern-docs/bundle/src/mdx/components/download/Download.tsx
+++ b/packages/fern-docs/bundle/src/mdx/components/download/Download.tsx
@@ -52,12 +52,32 @@ export function Download({
     return React.cloneElement(children, {
       href: src,
       download: filename || true,
-      onClick: handleClick,
+      onClick: (e) => {
+        void (async () => {
+          try {
+            await handleClick(e);
+          } catch (e) {
+            console.error("Failed to download:", e);
+          }
+        })();
+      },
     });
   }
 
   return (
-    <A href={src} download={filename || true} onClick={handleClick}>
+    <A
+      href={src}
+      download={filename || true}
+      onClick={(e) => {
+        void (async () => {
+          try {
+            await handleClick(e);
+          } catch (e) {
+            console.error("Failed to download:", e);
+          }
+        })();
+      }}
+    >
       {children}
     </A>
   );

--- a/packages/fern-docs/bundle/src/mdx/components/steps/Step.tsx
+++ b/packages/fern-docs/bundle/src/mdx/components/steps/Step.tsx
@@ -47,7 +47,7 @@ export function Step({
           shallow={true}
           scroll={false}
           replace={true}
-          onClick={copyToClipboard}
+          onClick={() => void copyToClipboard?.()}
           onPointerEnter={() => setHover(true)}
           onPointerLeave={() => setHover(false)}
           tabIndex={-1}

--- a/packages/fern-docs/bundle/tsconfig.eslint.json
+++ b/packages/fern-docs/bundle/tsconfig.eslint.json
@@ -1,3 +1,8 @@
 {
-  "extends": "./tsconfig.json"
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src/**/*", "next.config.ts", "next-env.d.ts"]
 }

--- a/packages/fern-docs/components/src/CopyToClipboardButton.tsx
+++ b/packages/fern-docs/components/src/CopyToClipboardButton.tsx
@@ -41,14 +41,14 @@ export const CopyToClipboardButton: React.FC<CopyToClipboardButton.Props> = ({
       >
         {children?.((e) => {
           onClick?.(e);
-          copyToClipboard?.();
+          void copyToClipboard?.();
         }) ?? (
           <Button
             className={cn("fern-copy-button group", className)}
             disabled={copyToClipboard == null}
             onClickCapture={(e) => {
               onClick?.(e);
-              copyToClipboard?.();
+              void copyToClipboard?.();
             }}
             data-testid={testId}
             variant={wasJustCopied ? "success" : "ghost"}

--- a/packages/fern-docs/components/src/syntax-highlighter/HastToJsx.tsx
+++ b/packages/fern-docs/components/src/syntax-highlighter/HastToJsx.tsx
@@ -96,7 +96,7 @@ function TemplateToken({
             !!data && "hover:bg-(color:--accent-a4) cursor-pointer"
           ),
           role: data ? "button" : undefined,
-          onClick: data ? copyToClipboard : undefined,
+          onClick: data ? () => void copyToClipboard?.() : undefined,
         },
         data ?? child.props.children
       )}

--- a/packages/fern-docs/icons-cdn/tsconfig.eslint.json
+++ b/packages/fern-docs/icons-cdn/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "rootDir": ".",
     "noEmit": true
   },
-  "include": ["src/**/*", "next.config.ts"]
+  "include": ["src/**/*", "next.config.ts", "next-env.d.ts"]
 }

--- a/servers/fdr/src/background.ts
+++ b/servers/fdr/src/background.ts
@@ -10,19 +10,23 @@ export function registerAlgoliaSearchRecordDeletionBackgroundTask(
   app: FdrApplication
 ) {
   // Runs every 10 minutes
-  cron.schedule("*/10 * * * *", async () => {
-    try {
-      const deletedIndexSegmentCount =
-        await app.services.algoliaIndexSegmentDeleter.deleteOldInactiveIndexSegments(
-          {
-            olderThanHours: 24,
-          }
+  cron.schedule("*/10 * * * *", () => {
+    (async () => {
+      try {
+        const deletedIndexSegmentCount =
+          await app.services.algoliaIndexSegmentDeleter.deleteOldInactiveIndexSegments(
+            {
+              olderThanHours: 24,
+            }
+          );
+        app.logger.debug(
+          `Successfully deleted ${deletedIndexSegmentCount} old index segments.`
         );
-      app.logger.debug(
-        `Successfully deleted ${deletedIndexSegmentCount} old index segments.`
-      );
-    } catch (e) {
-      app.logger.error("Error while deleting old index segments.", e);
-    }
+      } catch (e) {
+        app.logger.error("Error while deleting old index segments.", e);
+      }
+    })().catch((e: unknown) => {
+      app.logger.error("Unhandled error in background task:", e);
+    });
   });
 }


### PR DESCRIPTION
this PR introduces the eslint rule to ensure no promises are misused. 

the general approach was to void the promise for basic things like copying contents `onClick`, and to enforce the await for more complicated promises with side-effects. 