### PR TITLE
fix: disable playground examples in certain conditions

### DIFF
--- a/packages/fern-docs/bundle/src/state/playground.ts
+++ b/packages/fern-docs/bundle/src/state/playground.ts
@@ -327,7 +327,13 @@ export function usePlaygroundEndpointFormState(
               : update;
           set(formStateAtom, newFormState);
         },
-        [formStateAtom, ctx, user?.playground?.initial_state, domain, firstExample]
+        [
+          formStateAtom,
+          ctx,
+          user?.playground?.initial_state,
+          domain,
+          firstExample,
+        ]
       )
     ),
   ];

--- a/packages/fern-docs/bundle/src/state/playground.ts
+++ b/packages/fern-docs/bundle/src/state/playground.ts
@@ -292,9 +292,10 @@ export function usePlaygroundEndpointFormState(
   const user = useAtomValue(fernUserAtom);
   const domain = useDomain();
 
-  const firstExample = domain.includes("twelvelabs") || domain.includes("spscommerce")
-    ? undefined
-    : ctx.endpoint.examples?.[0];
+  const firstExample =
+    domain.includes("twelvelabs") || domain.includes("spscommerce")
+      ? undefined
+      : ctx.endpoint.examples?.[0];
 
   return [
     formState?.type === "endpoint"
@@ -326,7 +327,7 @@ export function usePlaygroundEndpointFormState(
               : update;
           set(formStateAtom, newFormState);
         },
-        [formStateAtom, ctx, user?.playground?.initial_state, domain]
+        [formStateAtom, ctx, user?.playground?.initial_state, domain, firstExample]
       )
     ),
   ];

--- a/packages/fern-docs/bundle/src/state/playground.ts
+++ b/packages/fern-docs/bundle/src/state/playground.ts
@@ -327,12 +327,7 @@ export function usePlaygroundEndpointFormState(
               : update;
           set(formStateAtom, newFormState);
         },
-        [
-          formStateAtom,
-          ctx,
-          user?.playground?.initial_state,
-          firstExample,
-        ]
+        [formStateAtom, ctx, user?.playground?.initial_state, firstExample]
       )
     ),
   ];

--- a/packages/fern-docs/bundle/src/state/playground.ts
+++ b/packages/fern-docs/bundle/src/state/playground.ts
@@ -292,12 +292,16 @@ export function usePlaygroundEndpointFormState(
   const user = useAtomValue(fernUserAtom);
   const domain = useDomain();
 
+  const firstExample = domain.includes("twelvelabs") || domain.includes("spscommerce")
+    ? undefined
+    : ctx.endpoint.examples?.[0];
+
   return [
     formState?.type === "endpoint"
       ? formState
       : getInitialEndpointRequestFormStateWithExample(
           ctx,
-          ctx.endpoint.examples?.[0],
+          firstExample,
           user?.playground?.initial_state
         ),
     useAtomCallback(
@@ -315,10 +319,7 @@ export function usePlaygroundEndpointFormState(
                     ? currentFormState
                     : getInitialEndpointRequestFormStateWithExample(
                         ctx,
-                        domain.includes("twelvelabs") ||
-                          domain.includes("spscommerce")
-                          ? undefined
-                          : ctx.endpoint.examples?.[0],
+                        firstExample,
                         user?.playground?.initial_state
                       )
                 )

--- a/packages/fern-docs/bundle/src/state/playground.ts
+++ b/packages/fern-docs/bundle/src/state/playground.ts
@@ -331,7 +331,6 @@ export function usePlaygroundEndpointFormState(
           formStateAtom,
           ctx,
           user?.playground?.initial_state,
-          domain,
           firstExample,
         ]
       )


### PR DESCRIPTION
## Short description of the changes made
Allow certain customers to migrate to app router. 

## What was the motivation & context behind this PR?
Unblock app router. 

## How has this PR been tested?
Preview URls. 
