### PR TITLE
chore: disable asset prefix

### DIFF
--- a/packages/fern-docs/bundle/next.config.ts
+++ b/packages/fern-docs/bundle/next.config.ts
@@ -119,7 +119,7 @@ const nextConfig: NextConfig = {
    *
    * Note that local development should not set the CDN_URI to ensure that the assets are served from the local server.
    */
-  assetPrefix: cdnUri != null ? cdnUri.href : undefined,
+  // assetPrefix: cdnUri != null ? cdnUri.href : undefined,
   compiler: {
     // Note: i think this removes console logs in server-side code?
     // removeConsole:


### PR DESCRIPTION
## Short description of the changes made
Disable asset prefix to prevent hitting `prod.ferndocs.com`

## What was the motivation & context behind this PR?
Not hitting external domains from app router

## How has this PR been tested?
Preview links
