### PR TITLE
feat: introduce `github` commands to the generator CLI

### DIFF
--- a/packages/generator-cli/src/cli.ts
+++ b/packages/generator-cli/src/cli.ts
@@ -96,6 +96,83 @@ void yargs(hideBin(process.argv))
       process.exit(0);
     }
   )
+  .command(
+    "github",
+    "GitHub operations",
+    (yargs) => {
+      return yargs
+        .command(
+          "push",
+          "Push changes to GitHub",
+          (subYargs) => {
+            return subYargs.option("config", {
+              string: true,
+              required: true,
+              description: "Path to configuration file",
+            });
+          },
+          async (argv) => {
+            if (argv.config == null) {
+              process.stderr.write(
+                "missing required arguments; please specify the --config flag\n"
+              );
+              process.exit(1);
+            }
+            const wd = cwd();
+            // Implementation for github push command
+            process.stderr.write(`Pushing to GitHub with config: ${resolve(wd, argv.config)}\n`);
+            process.exit(0);
+          }
+        )
+        .command(
+          "pr",
+          "Create a pull request on GitHub",
+          (subYargs) => {
+            return subYargs.option("config", {
+              string: true,
+              required: true,
+              description: "Path to configuration file",
+            });
+          },
+          async (argv) => {
+            if (argv.config == null) {
+              process.stderr.write(
+                "missing required arguments; please specify the --config flag\n"
+              );
+              process.exit(1);
+            }
+            const wd = cwd();
+            // Implementation for github pr command
+            process.stderr.write(`Creating PR on GitHub with config: ${resolve(wd, argv.config)}\n`);
+            process.exit(0);
+          }
+        )
+        .command(
+          "release",
+          "Create a release on GitHub",
+          (subYargs) => {
+            return subYargs.option("config", {
+              string: true,
+              required: true,
+              description: "Path to configuration file",
+            });
+          },
+          async (argv) => {
+            if (argv.config == null) {
+              process.stderr.write(
+                "missing required arguments; please specify the --config flag\n"
+              );
+              process.exit(1);
+            }
+            const wd = cwd();
+            // Implementation for github release command
+            process.stderr.write(`Creating release on GitHub with config: ${resolve(wd, argv.config)}\n`);
+            process.exit(0);
+          }
+        )
+        .demandCommand();
+    }
+  )
   .demandCommand()
   .showHelpOnFail(true)
   .parse();


### PR DESCRIPTION
## Short description of the changes made
The following commands are being added: 
- `generator-cil github push --config <>`
- `generator-cil github pr --config <>`
- `generator-cil github release --config <>`

This will allow for self-hosted SDK generators. 

## What was the motivation & context behind this PR?
Self hosting github pushing in the SDK generators instead of going through fiddle. 

## How has this PR been tested?
N/A