### PR TITLE
DO NOT MERGE feat: Add propertyAccess and use it for conditional rendering

### DIFF
--- a/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointContentLeft.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointContentLeft.tsx
@@ -9,8 +9,8 @@ import { MdxServerComponentProseSuspense } from "@/mdx/components/server-compone
 import { ObjectProperty } from "../type-definitions/ObjectProperty";
 import {
   TypeDefinitionAnchorPart,
+  TypeDefinitionRequest,
   TypeDefinitionResponse,
-  TypeDefinitionRequest
 } from "../type-definitions/TypeDefinitionContext";
 import { WithSeparator } from "../type-definitions/TypeDefinitionDetails";
 import { EndpointErrorGroup } from "./EndpointErrorGroup";

--- a/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointContentLeft.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointContentLeft.tsx
@@ -10,6 +10,7 @@ import { ObjectProperty } from "../type-definitions/ObjectProperty";
 import {
   TypeDefinitionAnchorPart,
   TypeDefinitionResponse,
+  TypeDefinitionRequest
 } from "../type-definitions/TypeDefinitionContext";
 import { WithSeparator } from "../type-definitions/TypeDefinitionDetails";
 import { EndpointErrorGroup } from "./EndpointErrorGroup";
@@ -62,6 +63,7 @@ export async function EndpointContentLeft({
           hidden: false,
           valueShape: stringShape,
           availability: undefined,
+          propertyAccess: undefined,
         };
       },
       bearerAuth: (bearerAuth) => {
@@ -73,6 +75,7 @@ export async function EndpointContentLeft({
           hidden: false,
           valueShape: stringShape,
           availability: undefined,
+          propertyAccess: undefined,
         };
       },
       header: (value) => {
@@ -85,6 +88,7 @@ export async function EndpointContentLeft({
           hidden: false,
           valueShape: stringShape,
           availability: undefined,
+          propertyAccess: undefined,
         };
       },
       oAuth: (value) => {
@@ -104,6 +108,7 @@ export async function EndpointContentLeft({
                 hidden: false,
                 valueShape: stringShape,
                 availability: undefined,
+                propertyAccess: undefined,
               }),
             }),
         });
@@ -188,27 +193,29 @@ export async function EndpointContentLeft({
           </TypeDefinitionAnchorPart>
         )}
         {endpoint.requests?.[0] != null && (
-          <EndpointSection
-            title="Request"
-            description={
-              <MdxServerComponentProseSuspense
-                size="sm"
-                className="text-(color:--grayscale-a11)"
-                mdx={endpoint.requests[0].description}
-                fallback={createEndpointRequestDescriptionFallback(
-                  endpoint.requests[0],
-                  types
-                )}
-              />
-            }
-          >
-            <TypeDefinitionAnchorPart part="body">
-              <EndpointRequestSection
-                request={endpoint.requests[0]}
-                types={types}
-              />
-            </TypeDefinitionAnchorPart>
-          </EndpointSection>
+          <TypeDefinitionRequest>
+            <EndpointSection
+              title="Request"
+              description={
+                <MdxServerComponentProseSuspense
+                  size="sm"
+                  className="text-(color:--grayscale-a11)"
+                  mdx={endpoint.requests[0].description}
+                  fallback={createEndpointRequestDescriptionFallback(
+                    endpoint.requests[0],
+                    types
+                  )}
+                />
+              }
+            >
+              <TypeDefinitionAnchorPart part="body">
+                <EndpointRequestSection
+                  request={endpoint.requests[0]}
+                  types={types}
+                />
+              </TypeDefinitionAnchorPart>
+            </EndpointSection>
+          </TypeDefinitionRequest>
         )}
       </TypeDefinitionAnchorPart>
       <TypeDefinitionResponse>

--- a/packages/fern-docs/bundle/src/components/api-reference/type-definitions/InternalTypeDefinition.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/type-definitions/InternalTypeDefinition.tsx
@@ -10,9 +10,8 @@ import { EnumValue } from "./EnumValue";
 import { FernCollapseWithButtonUncontrolled } from "./FernCollapseWithButtonUncontrolled";
 import { ObjectProperty } from "./ObjectProperty";
 import {
-  TypeDefinitionContextValue,
-  TypeDefinitionPathPart,
-  useTypeDefinitionContext,
+  IncludeObjectProperty,
+  TypeDefinitionPathPart
 } from "./TypeDefinitionContext";
 import { WithSeparator } from "./TypeDefinitionDetails";
 import { UndiscriminatedUnionVariant } from "./UndiscriminatedUnionVariant";
@@ -36,7 +35,6 @@ export const InternalTypeDefinition = memo(function InternalTypeDefinition({
     | ApiDefinition.TypeReference.Primitive;
   types: Record<ApiDefinition.TypeId, ApiDefinition.TypeDefinition>;
 }) {
-  const typeDefinitionContext = useTypeDefinitionContext();
 
   switch (shape.type) {
     case "enum": {
@@ -86,26 +84,32 @@ export const InternalTypeDefinition = memo(function InternalTypeDefinition({
         </FernCollapseWithButtonUncontrolled>
       );
     case "object": {
+      console.log("SHAPE");
+      console.log(JSON.stringify(shape, null, 2));
       const properties = ApiDefinition.unwrapObjectType(
         shape,
         types
       ).properties;
-      const filteredProperties = properties.filter((property) =>
-        shouldIncludeObjectProperty(property, typeDefinitionContext)
-      );
+      console.log("PROPERTIES");
+      console.log(JSON.stringify(properties, null, 2));
       return (
         <FernCollapseWithButtonUncontrolled
           showText={`Show ${properties.length} properties`}
           hideText={`Hide ${properties.length} properties`}
         >
           <WithSeparator>
-            {filteredProperties.map((property) => (
-              <TypeDefinitionPathPart
+            {properties.map((property) => (
+              <IncludeObjectProperty
                 key={property.key}
-                part={{ type: "objectProperty", propertyName: property.key }}
+                property={property}
               >
-                <ObjectProperty property={property} types={types} />
-              </TypeDefinitionPathPart>
+                <TypeDefinitionPathPart
+                  key={property.key}
+                  part={{ type: "objectProperty", propertyName: property.key }}
+                >
+                  <ObjectProperty property={property} types={types} />
+                </TypeDefinitionPathPart>
+              </IncludeObjectProperty>
             ))}
           </WithSeparator>
         </FernCollapseWithButtonUncontrolled>
@@ -117,20 +121,3 @@ export const InternalTypeDefinition = memo(function InternalTypeDefinition({
       throw new UnreachableCaseError(shape);
   }
 });
-
-export const shouldIncludeObjectProperty = (
-  property: ApiDefinition.ObjectProperty,
-  typeDefinitionContext: TypeDefinitionContextValue
-) => {
-  if (
-    typeDefinitionContext.isRequest &&
-    property.propertyAccess === "READ_ONLY"
-  )
-    return false;
-  if (
-    typeDefinitionContext.isResponse &&
-    property.propertyAccess === "WRITE_ONLY"
-  )
-    return false;
-  return true;
-};

--- a/packages/fern-docs/bundle/src/components/api-reference/type-definitions/InternalTypeDefinition.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/type-definitions/InternalTypeDefinition.tsx
@@ -9,7 +9,11 @@ import { EnumTypeDefinition } from "./EnumTypeDefinition";
 import { EnumValue } from "./EnumValue";
 import { FernCollapseWithButtonUncontrolled } from "./FernCollapseWithButtonUncontrolled";
 import { ObjectProperty } from "./ObjectProperty";
-import { TypeDefinitionContextValue, TypeDefinitionPathPart, useTypeDefinitionContext } from "./TypeDefinitionContext";
+import {
+  TypeDefinitionContextValue,
+  TypeDefinitionPathPart,
+  useTypeDefinitionContext,
+} from "./TypeDefinitionContext";
 import { WithSeparator } from "./TypeDefinitionDetails";
 import { UndiscriminatedUnionVariant } from "./UndiscriminatedUnionVariant";
 
@@ -86,7 +90,7 @@ export const InternalTypeDefinition = memo(function InternalTypeDefinition({
         shape,
         types
       ).properties;
-      const filteredProperties = properties.filter(property => 
+      const filteredProperties = properties.filter((property) =>
         shouldIncludeObjectProperty(property, typeDefinitionContext)
       );
       return (
@@ -114,8 +118,19 @@ export const InternalTypeDefinition = memo(function InternalTypeDefinition({
   }
 });
 
-export const shouldIncludeObjectProperty = (property: ApiDefinition.ObjectProperty, typeDefinitionContext: TypeDefinitionContextValue) => {
-  if (typeDefinitionContext.isRequest && property.propertyAccess === "READ_ONLY") return false;
-  if (typeDefinitionContext.isResponse && property.propertyAccess === "WRITE_ONLY") return false;
+export const shouldIncludeObjectProperty = (
+  property: ApiDefinition.ObjectProperty,
+  typeDefinitionContext: TypeDefinitionContextValue
+) => {
+  if (
+    typeDefinitionContext.isRequest &&
+    property.propertyAccess === "READ_ONLY"
+  )
+    return false;
+  if (
+    typeDefinitionContext.isResponse &&
+    property.propertyAccess === "WRITE_ONLY"
+  )
+    return false;
   return true;
-}
+};

--- a/packages/fern-docs/bundle/src/components/api-reference/type-definitions/InternalTypeDefinition.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/type-definitions/InternalTypeDefinition.tsx
@@ -9,7 +9,7 @@ import { EnumTypeDefinition } from "./EnumTypeDefinition";
 import { EnumValue } from "./EnumValue";
 import { FernCollapseWithButtonUncontrolled } from "./FernCollapseWithButtonUncontrolled";
 import { ObjectProperty } from "./ObjectProperty";
-import { TypeDefinitionPathPart } from "./TypeDefinitionContext";
+import { TypeDefinitionContextValue, TypeDefinitionPathPart, useTypeDefinitionContext } from "./TypeDefinitionContext";
 import { WithSeparator } from "./TypeDefinitionDetails";
 import { UndiscriminatedUnionVariant } from "./UndiscriminatedUnionVariant";
 
@@ -32,6 +32,8 @@ export const InternalTypeDefinition = memo(function InternalTypeDefinition({
     | ApiDefinition.TypeReference.Primitive;
   types: Record<ApiDefinition.TypeId, ApiDefinition.TypeDefinition>;
 }) {
+  const typeDefinitionContext = useTypeDefinitionContext();
+
   switch (shape.type) {
     case "enum": {
       return (
@@ -84,13 +86,16 @@ export const InternalTypeDefinition = memo(function InternalTypeDefinition({
         shape,
         types
       ).properties;
+      const filteredProperties = properties.filter(property => 
+        shouldIncludeObjectProperty(property, typeDefinitionContext)
+      );
       return (
         <FernCollapseWithButtonUncontrolled
           showText={`Show ${properties.length} properties`}
           hideText={`Hide ${properties.length} properties`}
         >
           <WithSeparator>
-            {properties.map((property) => (
+            {filteredProperties.map((property) => (
               <TypeDefinitionPathPart
                 key={property.key}
                 part={{ type: "objectProperty", propertyName: property.key }}
@@ -108,3 +113,9 @@ export const InternalTypeDefinition = memo(function InternalTypeDefinition({
       throw new UnreachableCaseError(shape);
   }
 });
+
+export const shouldIncludeObjectProperty = (property: ApiDefinition.ObjectProperty, typeDefinitionContext: TypeDefinitionContextValue) => {
+  if (typeDefinitionContext.isRequest && property.propertyAccess === "READ_ONLY") return false;
+  if (typeDefinitionContext.isResponse && property.propertyAccess === "WRITE_ONLY") return false;
+  return true;
+}

--- a/packages/fern-docs/bundle/src/components/api-reference/type-definitions/TypeDefinitionContext.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/type-definitions/TypeDefinitionContext.tsx
@@ -13,6 +13,7 @@ import { useCurrentPathname } from "@/hooks/use-current-pathname";
 
 import { JsonPropertyPath } from "../examples/JsonPropertyPath";
 import { JsonPropertyPathPart } from "../examples/JsonPropertyPath";
+import { ApiDefinition } from "@fern-api/fdr-sdk";
 
 export interface TypeDefinitionContextValue {
   types: Record<string, TypeDefinition>;
@@ -188,6 +189,23 @@ export function TypeDefinitionUncollapsible({
   );
 }
 
+export function IncludeObjectProperty({
+  property,
+  children,
+}: {
+  property: ApiDefinition.ObjectProperty;
+  children: React.ReactNode;
+}) {
+  const parent = useTypeDefinitionContext();
+  console.log("PARENT");
+  console.log(JSON.stringify(property, null, 2));
+  if (!shouldIncludeObjectProperty(property, parent)) {
+    return null;
+  }
+
+  return <>{children}</>;
+}
+
 export function useTypeDefinition(id: string) {
   const context = useTypeDefinitionContext();
   return context.types[id];
@@ -210,3 +228,20 @@ export function useIsActive(): boolean {
   const href = useHref();
   return currentHref === href;
 }
+
+export function shouldIncludeObjectProperty(
+  property: ApiDefinition.ObjectProperty,
+  typeDefinitionContext: TypeDefinitionContextValue
+) {
+  if (
+    typeDefinitionContext.isRequest &&
+    property.propertyAccess === "READ_ONLY"
+  )
+    return false;
+  if (
+    typeDefinitionContext.isResponse &&
+    property.propertyAccess === "WRITE_ONLY"
+  )
+    return false;
+  return true;
+};

--- a/packages/fern-docs/bundle/src/components/api-reference/type-definitions/TypeDefinitionContext.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/type-definitions/TypeDefinitionContext.tsx
@@ -14,11 +14,12 @@ import { useCurrentPathname } from "@/hooks/use-current-pathname";
 import { JsonPropertyPath } from "../examples/JsonPropertyPath";
 import { JsonPropertyPathPart } from "../examples/JsonPropertyPath";
 
-interface TypeDefinitionContextValue {
+export interface TypeDefinitionContextValue {
   types: Record<string, TypeDefinition>;
   isRootTypeDefinition: boolean;
   jsonPropertyPath: JsonPropertyPath;
   isResponse: boolean | undefined;
+  isRequest: boolean | undefined;
   slug: string;
   anchorIdParts: readonly string[];
   collapsible: boolean;
@@ -47,6 +48,7 @@ export function TypeDefinitionRoot({
     isRootTypeDefinition: true,
     jsonPropertyPath: [],
     isResponse: undefined,
+    isRequest: undefined,
     types,
     slug,
     anchorIdParts: [],
@@ -115,6 +117,24 @@ export function TypeDefinitionResponse({
   const contextValue = React.useRef(() => ({
     ...parent,
     isResponse: true,
+  }));
+
+  return (
+    <TypeDefinitionContext.Provider value={contextValue.current}>
+      {children}
+    </TypeDefinitionContext.Provider>
+  );
+}
+
+export function TypeDefinitionRequest({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const parent = useTypeDefinitionContext();
+  const contextValue = React.useRef(() => ({
+    ...parent,
+    isRequest: true,
   }));
 
   return (


### PR DESCRIPTION
## Short description of the changes made
- filter object properties in request/response bodies based on `READ_ONLY`/`WRITE_ONLY` property access
## What was the motivation & context behind this PR?
- Webflow OpenAPI spec requirements
## How has this PR been tested?
- not sure how to test...
