### PR TITLE
feat: add displayName to top-level undiscriminated union objects in DB conversion

### DIFF
--- a/fern/apis/fdr/definition/api/v1/register/type.yml
+++ b/fern/apis/fdr/definition/api/v1/register/type.yml
@@ -170,6 +170,7 @@ types:
     properties:
       typeName: optional<string>
       type: TypeReference
+      displayName: optional<string>
 
   DiscriminatedUnionType:
     properties:

--- a/packages/fdr-sdk/src/client/generated/api/resources/api/resources/v1/resources/register/resources/type/types/UndiscriminatedUnionVariant.ts
+++ b/packages/fdr-sdk/src/client/generated/api/resources/api/resources/v1/resources/register/resources/type/types/UndiscriminatedUnionVariant.ts
@@ -9,4 +9,5 @@ export interface UndiscriminatedUnionVariant
         FernRegistry.api.v1.WithAvailability {
     typeName: string | undefined;
     type: FernRegistry.api.v1.register.TypeReference;
+    displayName: string | undefined;
 }

--- a/packages/fdr-sdk/src/converters/db/convertAPIDefinitionToDb.ts
+++ b/packages/fdr-sdk/src/converters/db/convertAPIDefinitionToDb.ts
@@ -58,6 +58,25 @@ export function convertAPIDefinitionToDb(
     },
     types: Object.fromEntries(
       Object.entries(writeShape.types).map(([typeId, typeDefinition]) => {
+        if (typeDefinition.shape.type === "undiscriminatedUnion") {
+          typeDefinition.shape.variants = typeDefinition.shape.variants.map(
+            (variant) => {
+              let displayName: string | undefined;
+              if (variant.typeName != null) {
+                const type =
+                  writeShape.types[variant.typeName as APIV1Write.TypeId];
+                if (type != null) {
+                  displayName = type.displayName;
+                }
+              }
+              return {
+                ...variant,
+                displayName,
+              };
+            }
+          );
+        }
+
         return [
           typeId,
           transformTypeDefinition({ writeShape: typeDefinition }),
@@ -726,7 +745,9 @@ function transformDiscriminatedVariant({
 function transformUnDiscriminatedVariant({
   writeShape,
 }: {
-  writeShape: APIV1Write.UndiscriminatedUnionVariant;
+  writeShape: APIV1Write.UndiscriminatedUnionVariant & {
+    displayName?: string;
+  };
 }): FdrAPI.api.v1.read.UndiscriminatedUnionVariant {
   // const htmlDescription = getHtmlDescription(writeShape.description);
   return {
@@ -735,7 +756,10 @@ function transformUnDiscriminatedVariant({
     // htmlDescription,
     type: writeShape.type,
     displayName:
-      writeShape.typeName != null ? titleCase(writeShape.typeName) : undefined,
+      writeShape.displayName ??
+      (writeShape.typeName != null
+        ? titleCase(writeShape.typeName)
+        : undefined),
     // descriptionContainsMarkdown: true,
   };
 }

--- a/servers/fdr/src/api/generated/api/resources/api/resources/v1/resources/register/resources/type/types/UndiscriminatedUnionVariant.d.ts
+++ b/servers/fdr/src/api/generated/api/resources/api/resources/v1/resources/register/resources/type/types/UndiscriminatedUnionVariant.d.ts
@@ -5,4 +5,5 @@ import * as FernRegistry from "../../../../../../../../../index";
 export interface UndiscriminatedUnionVariant extends FernRegistry.api.v1.WithDescription, FernRegistry.api.v1.WithAvailability {
     typeName: string | undefined;
     type: FernRegistry.api.v1.register.TypeReference;
+    displayName: string | undefined;
 }


### PR DESCRIPTION
## Short description of the changes made
- plumb through displayName for undiscriminatedUnions variants

## What was the motivation & context behind this PR?
- for undiscriminated unions, the display name for each of the variants is set while processing the top-level object instead of the individual variant definitions

i.e.
```        
"OrganismAnimal": {
            "name": "OrganismAnimal",
            "shape": {
                "type": "undiscriminatedUnion",
                "variants": [
                    {
                        "typeName": "OrganismAnimal0",
                        "type": {
                            "type": "id",
                            "value": "OrganismAnimal0"
                        }
                    },
                    {
                        "typeName": "OrganismAnimal1",
                        "type": {
                            "type": "id",
                            "value": "OrganismAnimal1"
                        }
                    }
                ]
            }
        },
```

has no knowledge of the `displayName`s of `OrganismAnimal0` and `OrganismAnimal1` because they are stored in the respective objects

## How has this PR been tested?
- unit tests