### PR TITLE
fix: [DO-NOT-MERGE] [AI chat] remove docs from system-prompt, rely on tool calls instead

### DIFF
--- a/packages/fern-docs/search-server/src/utils/system-prompt.ts
+++ b/packages/fern-docs/search-server/src/utils/system-prompt.ts
@@ -30,12 +30,6 @@ Use [^1] at the end of a sentence to link to a footnote. Then at the end, provid
 [^1]: https://{{domain}}/<path>
 
 {{promptTemplate}}
-
----
-
-Use the following documents to answer the user's question:
-
-{{documents}}
 `,
     { interpolate: /{{([^}]+)}}/g }
   )(data);


### PR DESCRIPTION
When injecting documents into system prompt, we are unable to get the URL metadata on the front-end. Relying on tool-calls (1) allows the LLM to make better query wording decisions and (2) allows us to get the beautified citation format in every message

Tested locally