### PR TITLE
fix(ui): ensure inline style tags dont throw hydration errors

### DIFF
--- a/packages/fern-docs/bundle/src/mdx/components/html/index.tsx
+++ b/packages/fern-docs/bundle/src/mdx/components/html/index.tsx
@@ -82,4 +82,10 @@ export function A({
   );
 }
 
+export function Style({ children }: React.ComponentProps<"style">) {
+  const cssContent = typeof children === "string" ? children : "";
+
+  return <style dangerouslySetInnerHTML={{ __html: cssContent }} />;
+}
+
 export { Image } from "./image";

--- a/packages/fern-docs/bundle/src/mdx/components/index.tsx
+++ b/packages/fern-docs/bundle/src/mdx/components/index.tsx
@@ -37,7 +37,7 @@ import { Column, ColumnGroup } from "./columns";
 import { Download } from "./download";
 import { Feature } from "./feature";
 import { Frame } from "./frame";
-import { A, HeadingRenderer, Image, Li, Ol, Strong, Ul } from "./html";
+import { A, HeadingRenderer, Image, Li, Ol, Strong, Style, Ul } from "./html";
 import { Table } from "./html-table";
 import { Icon } from "./icon/Icon";
 import { If } from "./if";
@@ -129,6 +129,7 @@ const HTML_COMPONENTS = {
   strong: Strong,
   table: Table,
   ul: Ul,
+  style: Style,
 };
 
 const ALIASED_HTML_COMPONENTS = {


### PR DESCRIPTION
Fixes FER-5296

## Short description of the changes made
- ensures we explicitly dictate how to render style tags when provided in markdown

## What was the motivation & context behind this PR?
- resolves hydration error

## How has this PR been tested?
- use `fern.docs.buildwithfern.com` homepage to observe no hydration error from inline style
