### PR TITLE
fix: fix self hosted FDR docs files

### DIFF
--- a/servers/fdr/src/services/s3/S3Service.ts
+++ b/servers/fdr/src/services/s3/S3Service.ts
@@ -100,10 +100,16 @@ export class S3ServiceImpl implements S3Service {
     private readonly config: FdrConfig,
     private readonly app: FdrApplication
   ) {
+    // MinIO does not support path style requests, so we need to force the forcePathStyle to true if we are in local / self-hosted mode
+    const shouldForcePathStyle = config.localModeOverride ? true : false;
+
     this.publicDocsCDNUrl = config.cdnPublicDocsUrl;
     this.publicDocsS3 = new S3Client({
       ...(config.publicDocsS3.urlOverride != null
-        ? { endpoint: config.publicDocsS3.urlOverride }
+        ? { 
+            endpoint: config.publicDocsS3.urlOverride,
+            forcePathStyle: shouldForcePathStyle
+          }
         : {}),
       region: config.publicDocsS3.bucketRegion,
       credentials: {
@@ -113,7 +119,10 @@ export class S3ServiceImpl implements S3Service {
     });
     this.privateDocsS3 = new S3Client({
       ...(config.privateDocsS3.urlOverride != null
-        ? { endpoint: config.privateDocsS3.urlOverride }
+        ? { 
+            endpoint: config.privateDocsS3.urlOverride,
+            forcePathStyle: shouldForcePathStyle
+          }
         : {}),
       region: config.privateDocsS3.bucketRegion,
       credentials: {
@@ -123,7 +132,10 @@ export class S3ServiceImpl implements S3Service {
     });
     this.dbDocsDefinitionS3 = new S3Client({
       ...(config.dbDocsDefinitionS3.urlOverride != null
-        ? { endpoint: config.dbDocsDefinitionS3.urlOverride }
+        ? { 
+            endpoint: config.dbDocsDefinitionS3.urlOverride,
+            forcePathStyle: shouldForcePathStyle
+          }
         : {}),
       region: config.dbDocsDefinitionS3.bucketRegion,
       credentials: {
@@ -133,7 +145,10 @@ export class S3ServiceImpl implements S3Service {
     });
     this.privateApiDefinitionSourceS3 = new S3Client({
       ...(config.privateApiDefinitionSourceS3.urlOverride != null
-        ? { endpoint: config.privateApiDefinitionSourceS3.urlOverride }
+        ? { 
+            endpoint: config.privateApiDefinitionSourceS3.urlOverride,
+            forcePathStyle: shouldForcePathStyle
+          }
         : {}),
       region: config.privateApiDefinitionSourceS3.bucketRegion,
       credentials: {
@@ -190,9 +205,10 @@ export class S3ServiceImpl implements S3Service {
         Bucket: this.config.privateDocsS3.bucketName,
         Key: key,
       });
+
       const signedUrl = await getSignedUrl(this.privateDocsS3, command, {
-        expiresIn: 604800,
-      });
+          expiresIn: 604800,
+        });
       this.presignedDownloadUrlCache.set(key, signedUrl);
       return FdrAPI.Url(signedUrl);
     }
@@ -266,6 +282,11 @@ export class S3ServiceImpl implements S3Service {
     filepath: DocsV1Write.FilePath;
     isPrivate: boolean;
   }): Promise<{ url: string; key: string }> {
+    const urlOverride = isPrivate ? this.config.privateDocsS3.urlOverride : this.config.publicDocsS3.urlOverride;
+    if (!urlOverride) {
+      throw new Error("urlOverride is not set");
+    }
+
     const key = this.constructS3DocsKey({ domain, time, filepath });
     const bucketName = isPrivate
       ? this.config.privateDocsS3.bucketName
@@ -278,12 +299,13 @@ export class S3ServiceImpl implements S3Service {
       input.ContentType = "image/svg+xml";
     }
     const command = new PutObjectCommand(input);
+    const url = await getSignedUrl(
+      isPrivate ? this.privateDocsS3 : this.publicDocsS3,
+      command,
+      { expiresIn: 3600 }
+    )
     return {
-      url: await getSignedUrl(
-        isPrivate ? this.privateDocsS3 : this.publicDocsS3,
-        command,
-        { expiresIn: 3600 }
-      ),
+      url: url,
       key,
     };
   }

--- a/servers/fdr/src/services/s3/S3Service.ts
+++ b/servers/fdr/src/services/s3/S3Service.ts
@@ -100,7 +100,8 @@ export class S3ServiceImpl implements S3Service {
     private readonly config: FdrConfig,
     private readonly app: FdrApplication
   ) {
-    // MinIO does not support path style requests, so we need to force the forcePathStyle to true if we are in local / self-hosted mode
+    // When FDR is running in local mode, use path-style URLs instead of virtual-hosted style because MinIO
+    // runs at http://localhost:9000, and virtual-hosted URLs look like https://my-bucket.localhost:9000/my-key
     const shouldForcePathStyle = config.localModeOverride ? true : false;
 
     this.publicDocsCDNUrl = config.cdnPublicDocsUrl;

--- a/servers/fdr/src/services/s3/S3Service.ts
+++ b/servers/fdr/src/services/s3/S3Service.ts
@@ -282,11 +282,6 @@ export class S3ServiceImpl implements S3Service {
     filepath: DocsV1Write.FilePath;
     isPrivate: boolean;
   }): Promise<{ url: string; key: string }> {
-    const urlOverride = isPrivate ? this.config.privateDocsS3.urlOverride : this.config.publicDocsS3.urlOverride;
-    if (!urlOverride) {
-      throw new Error("urlOverride is not set");
-    }
-
     const key = this.constructS3DocsKey({ domain, time, filepath });
     const bucketName = isPrivate
       ? this.config.privateDocsS3.bucketName
@@ -299,13 +294,12 @@ export class S3ServiceImpl implements S3Service {
       input.ContentType = "image/svg+xml";
     }
     const command = new PutObjectCommand(input);
-    const url = await getSignedUrl(
-      isPrivate ? this.privateDocsS3 : this.publicDocsS3,
-      command,
-      { expiresIn: 3600 }
-    )
     return {
-      url: url,
+      url: await getSignedUrl(
+        isPrivate ? this.privateDocsS3 : this.publicDocsS3,
+        command,
+        { expiresIn: 3600 }
+      ),
       key,
     };
   }

--- a/servers/fdr/src/services/s3/S3Service.ts
+++ b/servers/fdr/src/services/s3/S3Service.ts
@@ -106,9 +106,9 @@ export class S3ServiceImpl implements S3Service {
     this.publicDocsCDNUrl = config.cdnPublicDocsUrl;
     this.publicDocsS3 = new S3Client({
       ...(config.publicDocsS3.urlOverride != null
-        ? { 
+        ? {
             endpoint: config.publicDocsS3.urlOverride,
-            forcePathStyle: shouldForcePathStyle
+            forcePathStyle: shouldForcePathStyle,
           }
         : {}),
       region: config.publicDocsS3.bucketRegion,
@@ -119,9 +119,9 @@ export class S3ServiceImpl implements S3Service {
     });
     this.privateDocsS3 = new S3Client({
       ...(config.privateDocsS3.urlOverride != null
-        ? { 
+        ? {
             endpoint: config.privateDocsS3.urlOverride,
-            forcePathStyle: shouldForcePathStyle
+            forcePathStyle: shouldForcePathStyle,
           }
         : {}),
       region: config.privateDocsS3.bucketRegion,
@@ -132,9 +132,9 @@ export class S3ServiceImpl implements S3Service {
     });
     this.dbDocsDefinitionS3 = new S3Client({
       ...(config.dbDocsDefinitionS3.urlOverride != null
-        ? { 
+        ? {
             endpoint: config.dbDocsDefinitionS3.urlOverride,
-            forcePathStyle: shouldForcePathStyle
+            forcePathStyle: shouldForcePathStyle,
           }
         : {}),
       region: config.dbDocsDefinitionS3.bucketRegion,
@@ -145,9 +145,9 @@ export class S3ServiceImpl implements S3Service {
     });
     this.privateApiDefinitionSourceS3 = new S3Client({
       ...(config.privateApiDefinitionSourceS3.urlOverride != null
-        ? { 
+        ? {
             endpoint: config.privateApiDefinitionSourceS3.urlOverride,
-            forcePathStyle: shouldForcePathStyle
+            forcePathStyle: shouldForcePathStyle,
           }
         : {}),
       region: config.privateApiDefinitionSourceS3.bucketRegion,
@@ -207,8 +207,8 @@ export class S3ServiceImpl implements S3Service {
       });
 
       const signedUrl = await getSignedUrl(this.privateDocsS3, command, {
-          expiresIn: 604800,
-        });
+        expiresIn: 604800,
+      });
       this.presignedDownloadUrlCache.set(key, signedUrl);
       return FdrAPI.Url(signedUrl);
     }


### PR DESCRIPTION
## Short description of the changes made

In the case where FDR is running locally, we need to insert files into local MinIO storage instead of S3. Today we are inserting these files into MinIO correctly but storing the wrong URL to retrieve these files again. We should use "http://localhost:9000" for the root of the URL but instead we were defaulting to using virtual-hosted-style URLs which look like this `http://bucket-name.localhost:9000/`; MinIO isn't configured to handle that subdomain so we couldn't retrieve files using this URL. Instead the solution is to just force path style URLs when we run FDR locally.

## What was the motivation & context behind this PR?

Any sort of assets on self-hosted docs like the logo are broken because today they get inserted into MinIO in the fdr.json file in virtual-hosted style (`http://example-org.docs.buildwithfern.com.localhost:9000`) for the root of the URL when they should be formatted in path style (`http://localhost:9000`) so that we hit MinIO, which is running at localhost:9000, when we try to retrieve these files.

<img width="1087" alt="Screenshot 2025-06-10 at 3 44 52 PM" src="https://github.com/user-attachments/assets/fff186aa-0753-4f81-80e4-8c2a9652f66a" />

## How has this PR been tested?

i rebuilt the container and checked to see that the fdr.json file uses the correct path for its files now:

<img width="452" alt="Screenshot 2025-06-10 at 4 12 58 PM" src="https://github.com/user-attachments/assets/0bd6b9a4-e8a2-411e-b07e-619ed6516958" />

I then visited the URL of one of those files to make sure that you can actually pull it from MINIO:

<img width="1076" alt="Screenshot 2025-06-10 at 4 13 06 PM" src="https://github.com/user-attachments/assets/7c597769-cdf9-4c40-9be2-b5cb332b9f6a" />

also added a new image to my local fern folder and confirmed it loaded correctly in the docs 👌 