### PR TITLE
fix: self hosted dockerfile

### DIFF
--- a/servers/self-hosted/Dockerfile.self_hosted
+++ b/servers/self-hosted/Dockerfile.self_hosted
@@ -50,7 +50,7 @@ RUN apk add --no-cache libc6-compat && \
 WORKDIR /app
 RUN npm install -g turbo@2.0.1
 COPY . .
-RUN turbo prune @fern-platform/fdr @fern-docs/bundle @fern-docs/edge-config @fern-docs/auth --docker
+RUN turbo prune @fern-platform/fdr @fern-docs/bundle --docker
 
 # Add lockfile and package.json's
 FROM base AS installer

--- a/servers/self-hosted/src/__test__/setupSelfHostedDocs.ts
+++ b/servers/self-hosted/src/__test__/setupSelfHostedDocs.ts
@@ -33,9 +33,6 @@ export async function setup() {
   await removeContainer(SELF_HOSTED_CONTAINER_NAME);
   await removeImage(SELF_HOSTED_IMAGE_TAG_NAME);
 
-  const monorepoRoot = path.join(__dirname, "../../../");
-  await execa("pnpm", ["compile"], { stdio: "inherit", cwd: monorepoRoot });
-  await execa("pnpm", ["docs:self-hosted-bundle:build"], { stdio: "inherit", cwd: monorepoRoot });
   await execa(
     "pnpm",
     ["docker:build", SELF_HOSTED_IMAGE_NAME, SELF_HOSTED_TAG],

--- a/servers/self-hosted/src/__test__/setupSelfHostedDocs.ts
+++ b/servers/self-hosted/src/__test__/setupSelfHostedDocs.ts
@@ -33,6 +33,8 @@ export async function setup() {
   await removeContainer(SELF_HOSTED_CONTAINER_NAME);
   await removeImage(SELF_HOSTED_IMAGE_TAG_NAME);
 
+  await execa("pnpm", ["compile"], { stdio: "inherit" });
+  await execa("pnpm", ["docs:self-hosted-bundle:build"], { stdio: "inherit" });
   await execa(
     "pnpm",
     ["docker:build", SELF_HOSTED_IMAGE_NAME, SELF_HOSTED_TAG],

--- a/servers/self-hosted/src/__test__/setupSelfHostedDocs.ts
+++ b/servers/self-hosted/src/__test__/setupSelfHostedDocs.ts
@@ -33,8 +33,10 @@ export async function setup() {
   await removeContainer(SELF_HOSTED_CONTAINER_NAME);
   await removeImage(SELF_HOSTED_IMAGE_TAG_NAME);
 
-  await execa("pnpm", ["compile"], { stdio: "inherit" });
-  await execa("pnpm", ["docs:self-hosted-bundle:build"], { stdio: "inherit" });
+  const monorepoRoot = path.join(__dirname, "../../../"); // adjust if your root is elsewhere
+
+  await execa("pnpm", ["compile"], { stdio: "inherit", cwd: monorepoRoot });
+  await execa("pnpm", ["docs:self-hosted-bundle:build"], { stdio: "inherit", cwd: monorepoRoot });
   await execa(
     "pnpm",
     ["docker:build", SELF_HOSTED_IMAGE_NAME, SELF_HOSTED_TAG],

--- a/servers/self-hosted/src/__test__/setupSelfHostedDocs.ts
+++ b/servers/self-hosted/src/__test__/setupSelfHostedDocs.ts
@@ -33,8 +33,7 @@ export async function setup() {
   await removeContainer(SELF_HOSTED_CONTAINER_NAME);
   await removeImage(SELF_HOSTED_IMAGE_TAG_NAME);
 
-  const monorepoRoot = path.join(__dirname, "../../../"); // adjust if your root is elsewhere
-
+  const monorepoRoot = path.join(__dirname, "../../../");
   await execa("pnpm", ["compile"], { stdio: "inherit", cwd: monorepoRoot });
   await execa("pnpm", ["docs:self-hosted-bundle:build"], { stdio: "inherit", cwd: monorepoRoot });
   await execa(


### PR DESCRIPTION
## Short description of the changes made

This is failing again because the package.json files for `@fern-docs/edge-config @fern-docs/auth` were removed from the codebase. 

## What was the motivation & context behind this PR?

The self hosted tests are failing again. i suspect actually since the self-hostest tests are not required to pass to merge to app that maybe we just broke this and merged anyways. 

## How has this PR been tested?
Ran the test suite and it passes.