### PR TITLE
fix: get rid of stringified blob response

### DIFF
--- a/packages/fern-docs/bundle/src/components/playground/fetch-utils/executeProxyRest.ts
+++ b/packages/fern-docs/bundle/src/components/playground/fetch-utils/executeProxyRest.ts
@@ -16,7 +16,6 @@ export async function executeProxyRest(
     Object.keys(req.headers).join(",")
   );
 
-  // multipart/form-data will be handled by the fetch API with a boundary, and should not be forwarded
   if (req.body?.type === "form-data") {
     requestHeaders.delete("Content-Type");
   }
@@ -45,91 +44,91 @@ export async function executeProxyRest(
     }
   });
 
-  if (
-    res.headers.get("Content-Type")?.toLowerCase()?.includes("application/json")
-  ) {
-    const startTime = Date.now();
-    try {
-      const text = await res.text();
-      const endTime = Date.now();
+  const createBaseResponse = (body: unknown) => ({
+    headers: responseHeaders,
+    ok: res.ok,
+    redirected: res.redirected,
+    status: res.status,
+    statusText: res.statusText,
+    type: res.type,
+    url: res.url,
+    body,
+  });
 
-      const fallbackTime =
-        Number(res.headers.get("X-Fern-Proxy-Origin-Latency") ?? 0) +
-        endTime -
-        startTime;
-
-      try {
-        const json = JSON.parse(text);
-        return {
-          type: "json",
-          response: {
-            headers: responseHeaders,
-            ok: res.ok,
-            redirected: res.redirected,
-            status: res.status,
-            statusText: res.statusText,
-            type: res.type,
-            url: res.url,
-            body: json,
-          },
-          contentType: res.headers.get("Content-Type") ?? "application/json",
-          time: Number(
-            res.headers.get("X-Fern-Proxy-Response-Time") ?? fallbackTime
-          ),
-          size:
-            res.headers.get("Content-Length") ??
-            String(new TextEncoder().encode(text).length),
-        };
-      } catch {
-        return {
-          type: "string",
-          response: {
-            headers: responseHeaders,
-            ok: res.ok,
-            redirected: res.redirected,
-            status: res.status,
-            statusText: res.statusText,
-            type: res.type,
-            url: res.url,
-            body: text,
-          },
-          contentType: res.headers.get("Content-Type") ?? "text/plain",
-          time: Number(
-            res.headers.get("X-Fern-Proxy-Response-Time") ?? fallbackTime
-          ),
-          size:
-            res.headers.get("Content-Length") ??
-            String(new TextEncoder().encode(text).length),
-        };
-      }
-    } catch {
-      throw new Error("Failed to read response body");
-    }
-  }
+  const calculateTiming = (startTime: number, endTime: number) => {
+    const fallbackTime =
+      Number(res.headers.get("X-Fern-Proxy-Origin-Latency") ?? 0) +
+      endTime -
+      startTime;
+    return Number(
+      res.headers.get("X-Fern-Proxy-Response-Time") ?? fallbackTime
+    );
+  };
 
   const startTime = Date.now();
-  const blob = await res.blob();
-  const endTime = Date.now();
+  const contentType = res.headers.get("Content-Type") ?? "";
 
-  const fallbackTime =
-    Number(res.headers.get("X-Fern-Proxy-Origin-Latency") ?? 0) +
-    endTime -
-    startTime;
+  // Check if response is a blob/file first
+  if (
+    contentType.startsWith("application/octet-stream") ||
+    contentType.startsWith("image/") ||
+    contentType.startsWith("video/") ||
+    contentType.startsWith("audio/")
+  ) {
+    const blob = await res.blob();
+    const endTime = Date.now();
+    return {
+      type: "file",
+      response: {
+        ...createBaseResponse(URL.createObjectURL(blob)),
+        body: URL.createObjectURL(blob),
+      },
+      contentType,
+      time: calculateTiming(startTime, endTime),
+      size: res.headers.get("Content-Length") ?? String(blob.size),
+    };
+  }
 
-  return {
-    type: "file",
-    response: {
-      headers: responseHeaders,
-      ok: res.ok,
-      redirected: res.redirected,
-      status: res.status,
-      statusText: res.statusText,
-      type: res.type,
-      url: res.url,
-      body: URL.createObjectURL(blob),
-    },
-    contentType: res.headers.get("Content-Type") ?? "application/octet-stream",
-    time: Number(res.headers.get("X-Fern-Proxy-Response-Time") ?? fallbackTime),
-    size: res.headers.get("Content-Length") ?? String(blob.size),
-  };
+  // Try to parse as JSON and fallback to text
+  try {
+    const text = await res.text();
+    const endTime = Date.now();
+    const time = calculateTiming(startTime, endTime);
+    const size =
+      res.headers.get("Content-Length") ??
+      String(new TextEncoder().encode(text).length);
+
+    try {
+      const json = JSON.parse(text);
+      return {
+        type: "json",
+        response: createBaseResponse(json),
+        contentType: contentType || "application/json",
+        time,
+        size,
+      };
+    } catch {
+      return {
+        type: "string",
+        response: createBaseResponse(text),
+        contentType: contentType || "text/plain",
+        time,
+        size,
+      };
+    }
+  } catch {
+    // If text() fails, try as blob
+    const blob = await res.blob();
+    const endTime = Date.now();
+    return {
+      type: "file",
+      response: {
+        ...createBaseResponse(URL.createObjectURL(blob)),
+        body: URL.createObjectURL(blob),
+      },
+      contentType: contentType || "application/octet-stream",
+      time: calculateTiming(startTime, endTime),
+      size: res.headers.get("Content-Length") ?? String(blob.size),
+    };
+  }
 }


### PR DESCRIPTION
## Short description of the changes made
Occasionally we will see responses in the API playground be blob urls `blog:....` when they should be JSON. 
This updates the `executeProxyRest` logic to read content types for blobs, and then default to parsing as json (falling back to text). 

## What was the motivation & context behind this PR?
Customer complaints + prospect demos

## How has this PR been tested?
- Tested on Voice AI customers for media download
- Tested on other customers that reported seeing an unexpected blob
