### PR TITLE
fix: [AI chat] add backups to turbopuffer, default deleteExisting to true

### DIFF
--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/search/v2/chat/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/search/v2/chat/route.ts
@@ -223,7 +223,7 @@ async function runQueryTurbopuffer(
   return query == null || query.trimStart().length === 0
     ? []
     : await queryTurbopuffer(query, {
-        namespace: opts.namespace + "_this_will_break",
+        namespace: opts.namespace,
         apiKey: turbopufferApiKey(),
         topK: opts.topK ?? 5,
         vectorizer: async (text) => {

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/search/v2/chat/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/search/v2/chat/route.ts
@@ -177,7 +177,7 @@ export async function POST(req: NextRequest) {
         });
       },
     });
-    const response = result.toDataStreamResponse({
+    const response = result.toUIMessageStream({
       getErrorMessage: (error) => {
         if (error == null) {
           return "";
@@ -223,7 +223,7 @@ async function runQueryTurbopuffer(
   return query == null || query.trimStart().length === 0
     ? []
     : await queryTurbopuffer(query, {
-        namespace: opts.namespace,
+        namespace: opts.namespace + "_this_will_break",
         apiKey: turbopufferApiKey(),
         topK: opts.topK ?? 5,
         vectorizer: async (text) => {

--- a/packages/fern-docs/search-server/ask-fern/src/turbopuffer/query.ts
+++ b/packages/fern-docs/search-server/ask-fern/src/turbopuffer/query.ts
@@ -46,12 +46,23 @@ export async function queryTurbopuffer(
     documentIdsToIgnore = [],
   }: SemanticSearchOptions
 ): Promise<TurbopufferRecord[]> {
+  const tmp_namespace = namespace + "_" + "this_will_break";
   const tpuf = new Turbopuffer({
     apiKey,
     baseUrl: "https://gcp-us-east4.turbopuffer.com",
   });
-  const ns = tpuf.namespace(namespace);
-
+  let ns = tpuf.namespace(tmp_namespace);
+  try {
+    const numVectors = await ns.approxNumVectors();
+    if (numVectors === 0) {
+      throw new Error(
+        "No vectors found, using backup namespace: " + namespace + "_backup"
+      );
+    }
+  } catch (e) {
+    ns = tpuf.namespace(namespace + "_backup");
+    console.error(e);
+  }
   const vector = await vectorizer(query);
 
   const authFilter: FilterCondition = authed

--- a/packages/fern-docs/search-server/ask-fern/src/turbopuffer/query.ts
+++ b/packages/fern-docs/search-server/ask-fern/src/turbopuffer/query.ts
@@ -52,6 +52,9 @@ export async function queryTurbopuffer(
     baseUrl: "https://gcp-us-east4.turbopuffer.com",
   });
   let ns = tpuf.namespace(tmp_namespace);
+
+  // sanity check to make sure namespace exists and is not empty
+  // otherwise use backup namespace (turbopuffer throws 404 for empty namespaces)
   try {
     const numVectors = await ns.approxNumVectors();
     if (numVectors === 0) {

--- a/packages/fern-docs/search-server/ask-fern/src/turbopuffer/tasks/turbopuffer-indexer-task.ts
+++ b/packages/fern-docs/search-server/ask-fern/src/turbopuffer/tasks/turbopuffer-indexer-task.ts
@@ -34,6 +34,11 @@ interface TurbopufferIndexerTaskOptions {
    * Whether to delete the existing records before upserting.
    */
   deleteExisting?: boolean;
+
+  /**
+   * Whether to delete the existing backup records before upserting.
+   */
+  deleteBackup?: boolean;
 }
 
 export async function turbopufferUpsertTask({
@@ -43,14 +48,17 @@ export async function turbopufferUpsertTask({
   authed,
   vectorizer,
   splitText = (text) => Promise.resolve([text]),
-  deleteExisting = false,
+  deleteExisting = true,
+  deleteBackup = false,
 }: TurbopufferIndexerTaskOptions): Promise<number> {
+  const backupNamespace = namespace + "_backup";
+
   const tpuf = new Turbopuffer({
     apiKey,
     baseUrl: "https://gcp-us-east4.turbopuffer.com",
   });
   const ns = tpuf.namespace(namespace);
-
+  const backupNs = tpuf.namespace(backupNamespace);
   const { org_id, root, pages, apis, domain } = await loadDocsWithUrl(payload);
 
   const unvectorizedRecords = await createTurbopufferRecords({
@@ -72,7 +80,17 @@ export async function turbopufferUpsertTask({
     await ns.deleteAll();
   }
 
+  if (deleteBackup) {
+    await backupNs.deleteAll();
+  }
+
   await ns.upsert({
+    vectors: records,
+    distance_metric: "cosine_distance",
+    schema: FernTurbopufferAttributeSchema,
+  });
+
+  await backupNs.upsert({
     vectors: records,
     distance_metric: "cosine_distance",
     schema: FernTurbopufferAttributeSchema,

--- a/packages/fern-docs/search-ui/src/components/desktop/desktop-ask-ai.tsx
+++ b/packages/fern-docs/search-ui/src/components/desktop/desktop-ask-ai.tsx
@@ -486,7 +486,7 @@ const DesktopAskAIChat = ({
             }),
             [darkCodeEnabled]
           )}
-          isLoading={chat.status !== "ready"}
+          isLoading={chat.status !== "streaming"}
           userScrolled={userScrolled}
           domain={domain}
           renderActions={renderActions}
@@ -510,7 +510,10 @@ const DesktopAskAIChat = ({
         value={chat.input}
         onValueChange={chat.setInput}
         isLoading={chat.status !== "ready"}
-        stop={chat.stop}
+        stop={() => {
+          chat.stop();
+          chat.status = "ready";
+        }}
         onSend={askAI}
         onKeyDown={useEventCallback((e) => {
           if (e.key === "ArrowUp" || e.key === "ArrowDown") {

--- a/packages/fern-docs/search-ui/src/server/run-reindex-turbopuffer.ts
+++ b/packages/fern-docs/search-ui/src/server/run-reindex-turbopuffer.ts
@@ -24,9 +24,11 @@ const model = openai.embedding("text-embedding-3-large");
 export const runReindexTurbopuffer = async (
   domain: string
 ): Promise<number> => {
+  const namespace = `${domain}_${model.modelId}`;
+
   return turbopufferUpsertTask({
     apiKey: turbopufferApiKey(),
-    namespace: `${domain}_${model.modelId}`,
+    namespace: namespace,
     payload: {
       environment: fdrEnvironment(),
       fernToken: fernToken_admin(),
@@ -39,6 +41,7 @@ export const runReindexTurbopuffer = async (
       });
       return embeddings.embeddings;
     },
+    deleteExisting: true,
   });
 };
 


### PR DESCRIPTION
Previous behavior:
* Turbopuffer upserts into `namespace`, namespace is not deleted by default
* If id schema changes, we'll upsert new documents into the same index, creating duplicate documents
* this is bad, because for a topK of 5 documents, we might eventually get flooded by copies of the same document
* We don't want to drop namespace every time because although it's cleaner, makes us more vulnerable to outages if errors occur during indexing (with a dropped namespace)

New behavior:
* Turbopuffer drops and recreates `namespace`, but simply upserts into `namespace_backup`.
* Querying now falls back to `namespace_backup` if `namespace` does not exist or is empty