### PR TITLE
chore: add auditing for getMetadata requests; track down vercel errors

### DIFF
--- a/packages/commons/docs-loader/src/editable-docs-loader.ts
+++ b/packages/commons/docs-loader/src/editable-docs-loader.ts
@@ -113,14 +113,22 @@ export const createEditableDocsLoader = cache(
   async (
     host: string,
     encodedDocsUrl: string,
+    source: string, // tracking down getMetadata() usage
     fern_token?: string,
     gitLoader?: GitLoader,
     forceRevalidate?: boolean
   ) => {
+    console.log(
+      "[created-editable-docs-loader] host:",
+      host,
+      "encodedDocsUrl:",
+      encodedDocsUrl
+    );
     // TODO: derive the domain from the workspace
     const docsLoader = await createCachedDocsLoader(
       host,
       decodeURIComponent(encodedDocsUrl),
+      `[source:${source}] createEditableDocsLoader`,
       fern_token,
       {
         returnRawMarkdown: true,

--- a/packages/commons/docs-loader/src/readonly-docs-loader.ts
+++ b/packages/commons/docs-loader/src/readonly-docs-loader.ts
@@ -227,7 +227,10 @@ export const getMetadataFromResponse = async (
   };
 };
 
-export const getMetadata = (cacheConfig: Required<CacheConfig>) =>
+export const getMetadata = (
+  source: string,
+  cacheConfig: Required<CacheConfig>
+) =>
   cache(async (domain: string): Promise<DocsMetadata> => {
     "use cache";
     unstable_cacheTag(domain, "getMetadata");
@@ -242,12 +245,12 @@ export const getMetadata = (cacheConfig: Required<CacheConfig>) =>
         )
       );
       if (cached.success) {
-        console.log("[getMetadata] cache hit:", cached.data);
+        console.log(`[getMetadata:${source}] cache hit:`, cached.data);
         return cached.data;
       }
     } catch (error) {
       console.warn(
-        `Failed to get metadata for ${domain} from kv, fallback to uncached`,
+        `[getMetadata:${source}] Failed to get metadata for ${domain} from kv, fallback to uncached`,
         error
       );
     }
@@ -1058,7 +1061,8 @@ export const createCachedDocsLoader = async (
   const authConfig = options?.skipAuth
     ? Promise.resolve(undefined)
     : getAuthConfig(domain);
-  const metadata = getMetadata(config)(withoutStaging(domain));
+  const source = "createCachedDocsLoader-host:" + host + "-domain:" + domain;
+  const metadata = getMetadata(source, config)(withoutStaging(domain));
 
   const getAuthState = options?.skipAuth
     ? async (_pathname?: string) => ({

--- a/packages/commons/docs-loader/src/readonly-docs-loader.ts
+++ b/packages/commons/docs-loader/src/readonly-docs-loader.ts
@@ -227,11 +227,8 @@ export const getMetadataFromResponse = async (
   };
 };
 
-export const getMetadata = (
-  source: string,
-  cacheConfig: Required<CacheConfig>
-) =>
-  cache(async (domain: string): Promise<DocsMetadata> => {
+export const getMetadata = (cacheConfig: Required<CacheConfig>) =>
+  cache(async (domain: string, source: string): Promise<DocsMetadata> => {
     "use cache";
     unstable_cacheTag(domain, "getMetadata");
     assertDocsDomain(domain);
@@ -1061,8 +1058,10 @@ export const createCachedDocsLoader = async (
   const authConfig = options?.skipAuth
     ? Promise.resolve(undefined)
     : getAuthConfig(domain);
-  const source = "createCachedDocsLoader-host:" + host + "-domain:" + domain;
-  const metadata = getMetadata(source, config)(withoutStaging(domain));
+  const metadata = getMetadata(config)(
+    withoutStaging(domain),
+    "createCachedDocsLoader"
+  );
 
   const getAuthState = options?.skipAuth
     ? async (_pathname?: string) => ({

--- a/packages/commons/docs-loader/src/readonly-docs-loader.ts
+++ b/packages/commons/docs-loader/src/readonly-docs-loader.ts
@@ -1043,6 +1043,7 @@ export type DocsLoaderOptions = {
 export const createCachedDocsLoader = async (
   host: string,
   domain: string,
+  source: string, // tracking down getMetadata() usage
   fern_token?: string,
   options?: DocsLoaderOptions
 ): Promise<DocsLoader & { clearKvCache: () => Promise<void> }> => {
@@ -1060,7 +1061,7 @@ export const createCachedDocsLoader = async (
     : getAuthConfig(domain);
   const metadata = getMetadata(config)(
     withoutStaging(domain),
-    "createCachedDocsLoader"
+    `[source:${source}] createCachedDocsLoader`
   );
 
   const getAuthState = options?.skipAuth

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@headertabs/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@headertabs/page.tsx
@@ -19,6 +19,7 @@ export default async function HeaderTabsPage({
   const loader = await createEditableDocsLoader(
     host,
     docsUrl,
+    "visual-editor-header-tabs-page",
     session?.accessToken
   );
   const layout = await loader.getLayout();

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@logo/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@logo/page.tsx
@@ -21,6 +21,7 @@ export default async function LogoPage({
   const loader = await createEditableDocsLoader(
     host,
     docsUrl,
+    "visual-editor-logo-page",
     session?.accessToken
   );
 

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@productSelect/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@productSelect/page.tsx
@@ -21,6 +21,7 @@ export default async function ProductSelectPage({
   const loader = await createEditableDocsLoader(
     host,
     docsUrl,
+    "visual-editor-product-select-page",
     session?.accessToken
   );
 

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@sidebar/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@sidebar/page.tsx
@@ -27,6 +27,7 @@ export default async function SidebarPage({
   const loader = await createEditableDocsLoader(
     host,
     docsUrl,
+    "visual-editor-sidebar-page",
     session?.accessToken
   );
   const [config, root] = await Promise.all([

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@versionSelect/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@versionSelect/page.tsx
@@ -24,6 +24,7 @@ export default async function VersionSelectPage({
   const loader = await createEditableDocsLoader(
     host,
     docsUrl,
+    "visual-editor-version-select-page",
     session?.accessToken
   );
 

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/layout.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/layout.tsx
@@ -63,6 +63,7 @@ export default async function VisualEditorPreviewLayout({
   const loader = await createEditableDocsLoader(
     host,
     docsUrl,
+    "visual-editor-layout",
     session.accessToken,
     new GitHubLoader(githubUrl)
   );

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/page.tsx
@@ -46,6 +46,7 @@ export default async function Page({
   const loader = await createEditableDocsLoader(
     host,
     docsUrl,
+    "visual-editor-page",
     session.accessToken,
     new GitHubLoader(githubUrl)
   );

--- a/packages/fern-dashboard/src/app/api/preload-editor-data/handler.ts
+++ b/packages/fern-dashboard/src/app/api/preload-editor-data/handler.ts
@@ -19,9 +19,10 @@ export default async function preloadEditorData(request: {
     const loader = await createEditableDocsLoader(
       request.host, // Use the host from the request parameter instead of trying to get it from headers
       request.docsUrl,
+      "preload-editor-data",
       session.accessToken,
       undefined, // No GitHubLoader for preload since we don't have orgName context
-      true // force revalidate when preloading
+      true // force revalidate when preloading,
     );
 
     // Preload root and config in parallel

--- a/packages/fern-dashboard/src/app/api/preload-editor-data/handler.ts
+++ b/packages/fern-dashboard/src/app/api/preload-editor-data/handler.ts
@@ -22,7 +22,7 @@ export default async function preloadEditorData(request: {
       "preload-editor-data",
       session.accessToken,
       undefined, // No GitHubLoader for preload since we don't have orgName context
-      true // force revalidate when preloading,
+      true // force revalidate when preloading
     );
 
     // Preload root and config in parallel

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/changelog/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/changelog/route.ts
@@ -142,7 +142,12 @@ async function createFeed(
   path: string,
   fernToken: string | undefined
 ): Promise<Feed> {
-  const loader = await createCachedDocsLoader(host, domain, fernToken);
+  const loader = await createCachedDocsLoader(
+    host,
+    domain,
+    "create-changelog-feed",
+    fernToken
+  );
   const root = await loader.getRoot();
 
   if (!root) {
@@ -286,7 +291,12 @@ async function checkRedirect(
     return undefined;
   }
 
-  const loader = await createCachedDocsLoader(host, domain, fernToken);
+  const loader = await createCachedDocsLoader(
+    host,
+    domain,
+    "changelog-redirects",
+    fernToken
+  );
   const redirects = (await loader.getConfig()).redirects;
   const { basePath } = await loader.getMetadata();
 

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/llms-full.txt/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/llms-full.txt/route.ts
@@ -55,7 +55,12 @@ async function getLlmsFullTxt(
 
   unstable_cacheTag(domain, "getLlmsFullTxt");
 
-  const loader = await createCachedDocsLoader(host, domain, fernToken);
+  const loader = await createCachedDocsLoader(
+    host,
+    domain,
+    "get-llms-full-txt",
+    fernToken
+  );
 
   const root = getSectionRoot(await loader.getRoot(), path);
 

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/llms.txt/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/llms.txt/route.ts
@@ -87,7 +87,12 @@ async function getLlmsTxt(
 
   unstable_cacheTag(domain, "getLlmsTxt");
 
-  const loader = await createCachedDocsLoader(host, domain, fernToken);
+  const loader = await createCachedDocsLoader(
+    host,
+    domain,
+    "get-llms-txt",
+    fernToken
+  );
 
   const root = getSectionRoot(await loader.getRoot(), path);
 

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/markdown/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/markdown/route.ts
@@ -34,7 +34,12 @@ export async function GET(
   const slug = path.replace(MARKDOWN_PATTERN, "");
   const cleanSlug = removeLeadingSlash(slug);
 
-  const loader = await createCachedDocsLoader(host, domain, fernToken);
+  const loader = await createCachedDocsLoader(
+    host,
+    domain,
+    "markdown-route",
+    fernToken
+  );
   const node = getPageNodeForPath(await loader.getRoot(), cleanSlug);
 
   if (node == null) {

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/search/v2/chat/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/search/v2/chat/route.ts
@@ -50,7 +50,7 @@ export async function POST(req: NextRequest) {
   const roles = authState.authed ? (authState.user.roles ?? []) : [];
   const explodedRoles = createDelimitedRolesetCombinations({ roleset: roles });
 
-  const loader = await createCachedDocsLoader(host, domain);
+  const loader = await createCachedDocsLoader(host, domain, "ai-chat");
   const metadata = await loader.getMetadata();
   if (metadata == null) {
     return NextResponse.json("Not found", { status: 404 });

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/search/v2/reindex/algolia/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/search/v2/reindex/algolia/route.ts
@@ -34,7 +34,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const domain = getDocsDomainEdge(req);
 
   try {
-    const loader = await createCachedDocsLoader(host, domain);
+    const loader = await createCachedDocsLoader(
+      host,
+      domain,
+      "algolia-reindex"
+    );
     const metadata = await loader.getMetadata();
     if (metadata == null) {
       return NextResponse.json("Not found", { status: 404 });

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/search/v2/reindex/turbopuffer/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/search/v2/reindex/turbopuffer/route.ts
@@ -48,7 +48,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const namespace = getTurbopufferNamespace(domain, fernDocsIndexName);
 
   try {
-    const loader = await createCachedDocsLoader(host, domain);
+    const loader = await createCachedDocsLoader(
+      host,
+      domain,
+      "turbopuffer-reindex"
+    );
     const metadata = await loader.getMetadata();
     if (metadata == null) {
       return NextResponse.json("Not found", { status: 404 });

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@explorer/@sidebar/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@explorer/@sidebar/[slug]/page.tsx
@@ -19,6 +19,7 @@ export default async function EndpointSelectorPage({
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "dynamic-endpoint-selector-page",
     await getFernToken()
   );
   const root = await loader.getRoot();

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@explorer/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@explorer/[slug]/page.tsx
@@ -33,6 +33,7 @@ export default async function ExplorerPage({
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "explorer-page",
     await getFernToken()
   );
   const root = await loader.getRoot();

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@explorer/layout.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@explorer/layout.tsx
@@ -20,6 +20,7 @@ export default async function ExplorerLayout({
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "dynamic-explorer-layout",
     await getFernToken()
   );
   const edgeFlags = await loader.getEdgeFlags();

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@headertabs/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@headertabs/[slug]/page.tsx
@@ -17,6 +17,7 @@ export default async function HeaderTabsPage({
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "header-tabs-page",
     await getFernToken()
   );
   const layout = await loader.getLayout();

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@logo/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@logo/[slug]/page.tsx
@@ -19,6 +19,7 @@ export default async function LogoPage({
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "logo-page",
     await getFernToken()
   );
 

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@sidebar/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/@sidebar/[slug]/page.tsx
@@ -27,6 +27,7 @@ export default async function SidebarPage({
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "sidebar-page",
     await getFernToken()
   );
   const config = await loader.getConfig();

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/layout.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/dynamic/layout.tsx
@@ -26,7 +26,12 @@ export default async function Layout({
 }) {
   const { host, domain } = await params;
   const fernToken = await getFernToken();
-  const loader = await createCachedDocsLoader(host, domain, fernToken);
+  const loader = await createCachedDocsLoader(
+    host,
+    domain,
+    "dynamic-layout",
+    fernToken
+  );
 
   return (
     <SharedLayout

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/explorer/@sidebar/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/explorer/@sidebar/[slug]/page.tsx
@@ -19,6 +19,7 @@ export default async function EndpointSelectorPage({
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "endpoint-selector-page",
     await getFernToken()
   );
   const root = await loader.getRoot();

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/explorer/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/explorer/[slug]/page.tsx
@@ -23,6 +23,7 @@ export default async function Page(props: {
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "page",
     await getFernToken()
   );
 
@@ -61,6 +62,7 @@ export async function generateMetadata({
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "generate-metadata",
     await getFernToken()
   );
   const root = await loader.getRoot();

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/explorer/layout.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/explorer/layout.tsx
@@ -23,6 +23,7 @@ export default async function Layout({
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "explorer-layout",
     await getFernToken()
   );
   const edgeFlags = await loader.getEdgeFlags();

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/layout.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/layout.tsx
@@ -54,7 +54,7 @@ export default async function Layout({
 }) {
   const { host, domain } = await params;
   const isLocalEnvironment = isLocal();
-  const loader = await createCachedDocsLoader(host, domain);
+  const loader = await createCachedDocsLoader(host, domain, "layout");
   const [
     { basePath },
     config,

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@explorer/@sidebar/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@explorer/@sidebar/[slug]/page.tsx
@@ -15,7 +15,11 @@ export default async function EndpointSelectorPage({
 }) {
   const { host, domain, slug } = await params;
 
-  const loader = await createCachedDocsLoader(host, domain);
+  const loader = await createCachedDocsLoader(
+    host,
+    domain,
+    "endpoint-selector-page"
+  );
   const root = await loader.getRoot();
 
   const foundNode = FernNavigation.utils.findNode(root, slugjoin(slug));

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@explorer/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@explorer/[slug]/page.tsx
@@ -29,7 +29,7 @@ export default async function ExplorerPage({
 
   const slug = FernNavigation.slugjoin(slugProp);
 
-  const loader = await createCachedDocsLoader(host, domain);
+  const loader = await createCachedDocsLoader(host, domain, "explorer-page");
   const root = await loader.getRoot();
 
   const found = FernNavigation.utils.findNode(root, slug);

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@explorer/layout.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@explorer/layout.tsx
@@ -16,7 +16,7 @@ export default async function ExplorerLayout({
 }) {
   const { host, domain } = await params;
 
-  const loader = await createCachedDocsLoader(host, domain);
+  const loader = await createCachedDocsLoader(host, domain, "explorer-layout");
   const edgeFlags = await loader.getEdgeFlags();
 
   return (

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@headertabs/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@headertabs/[slug]/page.tsx
@@ -12,7 +12,7 @@ export default async function HeaderTabsPage({
   params: Promise<{ host: string; domain: string; slug: string }>;
 }) {
   const { host, domain, slug } = await params;
-  const loader = await createCachedDocsLoader(host, domain);
+  const loader = await createCachedDocsLoader(host, domain, "header-tabs-page");
   const layout = await loader.getLayout();
 
   if (layout.tabsPlacement !== "HEADER") {

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@logo/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@logo/[slug]/page.tsx
@@ -19,6 +19,7 @@ export default async function LogoPage({
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "logo-page",
     await getFernToken()
   );
 

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@productSelect/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@productSelect/[slug]/page.tsx
@@ -17,6 +17,7 @@ export default async function ProductSelectPage({
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "product-select-page",
     await getFernToken()
   );
 

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@sidebar/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@sidebar/[slug]/page.tsx
@@ -19,7 +19,7 @@ export default async function SidebarPage({
   params: Promise<{ host: string; domain: string; slug: string }>;
 }) {
   const { host, domain, slug } = await params;
-  const loader = await createCachedDocsLoader(host, domain);
+  const loader = await createCachedDocsLoader(host, domain, "sidebar-page");
   const config = await loader.getConfig();
   const isSidebarFixed = getIsSidebarFixed(config);
 

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@versionSelect/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/static/@versionSelect/[slug]/page.tsx
@@ -17,6 +17,7 @@ export default async function VersionSelectPage({
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "version-select-page",
     await getFernToken()
   );
 

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/static/[slug]/page.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/static/[slug]/page.tsx
@@ -20,7 +20,7 @@ export default async function StaticPage({
   if (slug === "index.html") {
     return <RootPage />;
   }
-  const loader = await createCachedDocsLoader(host, domain);
+  const loader = await createCachedDocsLoader(host, domain, "static-page");
   return <SharedPage loader={loader} slug={slugjoin(slug)} />;
 }
 
@@ -30,6 +30,10 @@ export async function generateMetadata({
   params: Promise<{ host: string; domain: string; slug: string }>;
 }): Promise<Metadata> {
   const { host, domain, slug } = await params;
-  const loader = await createCachedDocsLoader(host, domain);
+  const loader = await createCachedDocsLoader(
+    host,
+    domain,
+    "generate-metadata"
+  );
   return generateMetadataFromPage({ loader, slug: slugjoin(slug) });
 }

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/static/layout.tsx
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/static/layout.tsx
@@ -24,7 +24,7 @@ export default async function Layout({
   explorer: React.ReactNode;
 }) {
   const { host, domain } = await params;
-  const loader = await createCachedDocsLoader(host, domain);
+  const loader = await createCachedDocsLoader(host, domain, "layout");
   return (
     <SharedLayout
       loader={loader}

--- a/packages/fern-docs/bundle/src/app/sitemap.ts
+++ b/packages/fern-docs/bundle/src/app/sitemap.ts
@@ -26,6 +26,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "sitemap",
     await getFernToken()
   );
   const root = await loader.getRoot();

--- a/packages/fern-docs/bundle/src/app/utils.tsx
+++ b/packages/fern-docs/bundle/src/app/utils.tsx
@@ -16,7 +16,9 @@ export async function generateHtml({
   let faviconUrl: string | undefined;
 
   const loader =
-    host && domain ? await createCachedDocsLoader(host, domain) : undefined;
+    host && domain
+      ? await createCachedDocsLoader(host, domain, "generate-html")
+      : undefined;
 
   if (loader) {
     const [config, files] = await Promise.all([

--- a/packages/fern-docs/bundle/src/components/fern-user.tsx
+++ b/packages/fern-docs/bundle/src/components/fern-user.tsx
@@ -15,6 +15,7 @@ export async function FernUser({
   const loader = await createCachedDocsLoader(
     host,
     domain,
+    "fern-user",
     await getFernToken()
   );
   const authState = await loader.getAuthState();

--- a/packages/fern-docs/bundle/src/components/seo.ts
+++ b/packages/fern-docs/bundle/src/components/seo.ts
@@ -143,7 +143,11 @@ export async function generateMetadataFromConfig(props: {
 }): Promise<Metadata> {
   const { host, domain } = await props.params;
 
-  const loader = await createCachedDocsLoader(host, domain);
+  const loader = await createCachedDocsLoader(
+    host,
+    domain,
+    "generate-metadata-from-config"
+  );
   const [files, config, seoDisabled] = await Promise.all([
     loader.getFiles(),
     loader.getConfig(),


### PR DESCRIPTION
Goal of PR is to track down getMetadata calls, which seem to be sometimes all over the place (going to multiple different hosts at once?) - hoping to root cause a larger issue