### PR TITLE
FER-6603 Patch Fix for default hostname for API Reference Docs

### DIFF
--- a/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointUrl.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointUrl.tsx
@@ -131,6 +131,8 @@ export const EndpointUrl = React.forwardRef<
     }
   }, [options, environmentId, baseUrl]);
 
+  baseUrl = baseUrl ?? "https://host.com";
+  
   return (
     <FernTooltipProvider>
       <FernTooltip


### PR DESCRIPTION
Fixes FER-6603

## Short description of the changes made
Override undefined or null base URL links to a default https://host.com

## What was the motivation & context behind this PR?
Method Security alerted to an issue in slack where, when no servers are defined, the baseURL is blank. This patches that issue on the frontend by catching where the baseURL is undefined or null, and setting it to a default https://host.com

## How has this PR been tested?
Locally, using a newly generated Fern Docs site called sasha_org_219830.
