### PR TITLE
build: add verbatimModuleSyntax and isolatedDeclarations to fern-dashboard

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -244,6 +244,7 @@ export default [
         "packages/commons/**/*",
         "packages/fdr-sdk/**/*",
         "packages/fern-docs/search-ui/**/*",
+        "packages/fern-dashboard/**/*",
       ],
       rules: {
         "@typescript-eslint/consistent-type-exports": "error",

--- a/packages/fern-dashboard/src/app/[orgName]/(homepage)/@header/default.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(homepage)/@header/default.tsx
@@ -4,7 +4,7 @@ import { PopoverArrow } from "@radix-ui/react-popover";
 import { Book, RotateCcw } from "lucide-react";
 
 import { getCurrentSession } from "@/app/services/auth0/getCurrentSession";
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { LogoutButton } from "@/components/auth/LogoutButton";
 import { OrgSwitcher } from "@/components/auth/OrgSwitcher";
 import { HeaderLinkButton } from "@/components/layout/HeaderLinkButton";
@@ -18,13 +18,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 export default async function HeaderLayout({
   params,
 }: Readonly<{
   params: Promise<{ docsUrl?: DocsUrl; orgName: Auth0OrgName }>;
-}>) {
+}>): Promise<JSX.Element | null> {
   const { orgName, docsUrl } = await params;
   const session = await getCurrentSession();
   if (session == null) {

--- a/packages/fern-dashboard/src/app/[orgName]/(homepage)/docs/[docsUrl]/@header/default.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(homepage)/docs/[docsUrl]/@header/default.tsx
@@ -4,11 +4,11 @@ import { PageHeader } from "@/components/layout/PageHeader";
 import { StatusBadge } from "@/components/ui/StatusBadge";
 import { Button } from "@/components/ui/button";
 import { parseDocsUrlParam } from "@/utils/parseDocsUrlParam";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 export default async function DocsHeader({
   params,
-}: Readonly<{ params: Promise<{ docsUrl: DocsUrl }> }>) {
+}: Readonly<{ params: Promise<{ docsUrl: DocsUrl }> }>): Promise<JSX.Element> {
   const { docsUrl: encodedDocsUrl } = await params;
   const docsUrl = parseDocsUrlParam({ docsUrl: encodedDocsUrl });
   return (

--- a/packages/fern-dashboard/src/app/[orgName]/(homepage)/docs/[docsUrl]/layout.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(homepage)/docs/[docsUrl]/layout.tsx
@@ -3,11 +3,11 @@ import "server-only";
 import { notFound, redirect } from "next/navigation";
 
 import { getCurrentSession } from "@/app/services/auth0/getCurrentSession";
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import getDocsSitesForOrg from "@/app/services/dal/fdr/getDocsSitesForOrg";
 import { getDocsSiteUrl } from "@/utils/getDocsSiteUrl";
 import { parseDocsUrlParam } from "@/utils/parseDocsUrlParam";
-import { EncodedDocsUrl } from "@/utils/types";
+import type { EncodedDocsUrl } from "@/utils/types";
 
 export default async function DocsLayout({
   navbar,
@@ -19,7 +19,7 @@ export default async function DocsLayout({
   children: React.JSX.Element;
   header: React.JSX.Element;
   params: Promise<{ orgName: Auth0OrgName; docsUrl: EncodedDocsUrl }>;
-}>) {
+}>): Promise<React.JSX.Element> {
   const session = await getCurrentSession();
   if (session == null) {
     redirect("/");

--- a/packages/fern-dashboard/src/app/[orgName]/(homepage)/docs/[docsUrl]/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(homepage)/docs/[docsUrl]/page.tsx
@@ -3,27 +3,25 @@ import "server-only";
 import { notFound } from "next/navigation";
 
 import getGithubSourceMetadataHandler from "@/app/api/get-github-source-metadata/handler";
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import getDocsSitesForOrg from "@/app/services/dal/fdr/getDocsSitesForOrg";
 import getDocsGithubUrl from "@/app/services/dal/github/getDocsGithubUrl";
 import { validateGithubRepoAccess } from "@/app/services/dal/github/validators";
 import { getAuthenticatedSessionOrRedirect } from "@/app/services/dal/organization";
 import { DocsSiteOverviewCard } from "@/components/docs-page/DocsSiteOverviewCard";
 import { FernCliVersionDisplay } from "@/components/docs-page/FernCliVersionDisplay";
-import {
-  GithubAuthState,
-  GithubSource,
-} from "@/components/docs-page/GithubSource";
+import type { GithubAuthState } from "@/components/docs-page/GithubSource";
+import { GithubSource } from "@/components/docs-page/GithubSource";
 import { VisualEditorSection } from "@/components/docs-page/visual-editor-section/VisualEditorSection";
 import { getDocsSiteUrl } from "@/utils/getDocsSiteUrl";
 import { parseDocsUrlParam } from "@/utils/parseDocsUrlParam";
-import { EncodedDocsUrl } from "@/utils/types";
+import type { EncodedDocsUrl } from "@/utils/types";
 
 export const dynamic = "force-dynamic";
 
 export default async function Page(props: {
   params: Promise<{ orgName: Auth0OrgName; docsUrl: EncodedDocsUrl }>;
-}) {
+}): Promise<React.JSX.Element> {
   const { orgName, docsUrl: encodedDocsUrl } = await props.params;
 
   const session = await getAuthenticatedSessionOrRedirect(orgName);

--- a/packages/fern-dashboard/src/app/[orgName]/(homepage)/docs/[docsUrl]/settings/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(homepage)/docs/[docsUrl]/settings/page.tsx
@@ -5,13 +5,13 @@ import { Auth0OrgName } from "@/app/services/auth0/types";
 import { getAuthenticatedSessionOrRedirect } from "@/app/services/dal/organization";
 import { Settings } from "@/components/settings/Settings";
 import { parseDocsUrlParam } from "@/utils/parseDocsUrlParam";
-import { EncodedDocsUrl } from "@/utils/types";
+import type { EncodedDocsUrl } from "@/utils/types";
 
 export default async function Page({
   params,
 }: {
   params: Promise<{ orgName: Auth0OrgName; docsUrl: EncodedDocsUrl }>;
-}) {
+}): Promise<JSX.Element> {
   const { orgName, docsUrl: encodedDocsUrl } = await params;
   const docsUrl = parseDocsUrlParam({ docsUrl: encodedDocsUrl });
 

--- a/packages/fern-dashboard/src/app/[orgName]/(homepage)/docs/layout.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(homepage)/docs/layout.tsx
@@ -1,6 +1,6 @@
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { getAuthenticatedSessionOrRedirect } from "@/app/services/dal/organization";
-import { EncodedDocsUrl } from "@/utils/types";
+import type { EncodedDocsUrl } from "@/utils/types";
 
 export default async function DocsLayout({
   children,
@@ -8,7 +8,7 @@ export default async function DocsLayout({
 }: {
   children: React.ReactNode;
   params: Promise<{ docsUrl: EncodedDocsUrl; orgName: Auth0OrgName }>;
-}) {
+}): Promise<JSX.Element> {
   const { orgName } = await params;
 
   await getAuthenticatedSessionOrRedirect(orgName);

--- a/packages/fern-dashboard/src/app/[orgName]/(homepage)/layout.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(homepage)/layout.tsx
@@ -4,7 +4,7 @@ import { AppLayout } from "@/components/layout/AppLayout";
 import { SidepanelProvider } from "@/components/layout/SidepanelContext";
 import { ServerSidePylonSetup } from "@/components/pylon/ServerSidePylonSetup";
 
-import { Auth0OrgName } from "../../services/auth0/types";
+import type { Auth0OrgName } from "../../services/auth0/types";
 import { OrgNameProvider } from "../context/OrgNameContext";
 
 export default async function AuthedLayout({
@@ -19,7 +19,7 @@ export default async function AuthedLayout({
   sidepanel: React.ReactNode;
   navbar: React.ReactNode;
   header: React.ReactNode;
-}>) {
+}>): Promise<React.JSX.Element> {
   const { orgName } = await params;
 
   return (

--- a/packages/fern-dashboard/src/app/[orgName]/(homepage)/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(homepage)/page.tsx
@@ -1,13 +1,13 @@
 import { redirect } from "next/navigation";
 
 import { getCurrentSession } from "../../services/auth0/getCurrentSession";
-import { Auth0OrgName } from "../../services/auth0/types";
+import type { Auth0OrgName } from "../../services/auth0/types";
 
 export default async function Page({
   params,
 }: {
   params: Promise<{ orgName: Auth0OrgName }>;
-}) {
+}): Promise<JSX.Element> {
   const session = await getCurrentSession();
   if (session == null) {
     redirect("/");

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@devPanel/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@devPanel/page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useRef } from "react";
 
-import CodeEditor, { Monaco } from "@monaco-editor/react";
+import type { Monaco } from "@monaco-editor/react";
+import CodeEditor from "@monaco-editor/react";
 import { Code2 } from "lucide-react";
 
 import { mdxToHtml } from "@fern-docs/mdx";
@@ -16,7 +17,7 @@ import { useDevMode } from "@/providers/DevModeProvider";
 import { usePages } from "@/providers/PagesStoreContext";
 import { cn } from "@/utils/utils";
 
-export default function DevPanel() {
+export default function DevPanel(): JSX.Element {
   const { panelOpen } = useDevMode();
   const { currentFilename } = useCurrentPage();
   const { allMdxFiles, updatePage, emitSaveEvent } = usePages();

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@headertabs/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@headertabs/page.tsx
@@ -6,13 +6,13 @@ import { HeaderTabsList } from "@fern-docs/components/HeaderTabsList";
 
 import { getCurrentSession } from "@/app/services/auth0/getCurrentSession";
 import { getHostFromHeaders } from "@/utils/getHostFromHeaders";
-import { EncodedDocsUrl } from "@/utils/types";
+import type { EncodedDocsUrl } from "@/utils/types";
 
 export default async function HeaderTabsPage({
   params,
 }: {
   params: Promise<{ docsUrl: EncodedDocsUrl; slug: string; branch: string }>;
-}) {
+}): Promise<JSX.Element | null> {
   const { docsUrl, slug, branch } = await params;
   const session = await getCurrentSession();
   const host = await getHostFromHeaders();

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@logo/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@logo/page.tsx
@@ -8,13 +8,13 @@ import { getFrontmatter } from "@fern-docs/mdx";
 
 import { getCurrentSession } from "@/app/services/auth0/getCurrentSession";
 import { getHostFromHeaders } from "@/utils/getHostFromHeaders";
-import { EncodedDocsUrl } from "@/utils/types";
+import type { EncodedDocsUrl } from "@/utils/types";
 
 export default async function LogoPage({
   params,
 }: {
   params: Promise<{ docsUrl: EncodedDocsUrl; slug: string; branch: string }>;
-}) {
+}): Promise<JSX.Element> {
   const session = await getCurrentSession();
   const { docsUrl, slug, branch } = await params;
   const host = await getHostFromHeaders();

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@productSelect/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@productSelect/page.tsx
@@ -8,13 +8,13 @@ import { ProductDropdown } from "@fern-docs/components/header/ProductDropdown";
 
 import { getCurrentSession } from "@/app/services/auth0/getCurrentSession";
 import { getHostFromHeaders } from "@/utils/getHostFromHeaders";
-import { EncodedDocsUrl } from "@/utils/types";
+import type { EncodedDocsUrl } from "@/utils/types";
 
 export default async function ProductSelectPage({
   params,
 }: {
   params: Promise<{ docsUrl: EncodedDocsUrl; slug: string; branch: string }>;
-}) {
+}): Promise<JSX.Element | null> {
   const session = await getCurrentSession();
   const { docsUrl, slug, branch } = await params;
   const host = await getHostFromHeaders();

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@sidebar/CreateClientPage.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@sidebar/CreateClientPage.tsx
@@ -6,15 +6,16 @@ import React, { useCallback, useMemo, useState } from "react";
 import { useRouter } from "@bprogress/next/app";
 
 import type * as FernNavigation from "@fern-api/fdr-sdk/navigation";
+import type { NavigationContext } from "@fern-docs/components";
 import {
-  NavigationContext,
   UNNAMED_SECTION_DISPLAY_NAMES,
   createMdxFrontmatter,
 } from "@fern-docs/components";
-import { SectionWithHierarchy, getAllSections } from "@fern-docs/components";
+import type { SectionWithHierarchy } from "@fern-docs/components";
+import { getAllSections } from "@fern-docs/components";
 import { mdxToHtml } from "@fern-docs/mdx";
 
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -34,7 +35,7 @@ import { useGitPrInfo } from "@/providers/GitPRContext";
 import { usePages } from "@/providers/PagesStoreContext";
 import { constructEditorSlug } from "@/utils/editor-routing";
 import { pageTitleToSlug } from "@/utils/pageTitleToSlug";
-import { EncodedDocsUrl } from "@/utils/types";
+import type { EncodedDocsUrl } from "@/utils/types";
 
 interface CreateClientPageProps {
   children: React.ReactNode;
@@ -48,7 +49,7 @@ export function CreateClientPage({
   root,
   disabled = false,
   navigationContext,
-}: CreateClientPageProps) {
+}: CreateClientPageProps): JSX.Element {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [pageTitle, setPageTitle] = useState("");
   const [pageSlug, setPageSlug] = useState("");

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@sidebar/CreatePageButton.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@sidebar/CreatePageButton.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
-import { NavigationContext, getAllSections } from "@fern-docs/components";
+import type * as FernNavigation from "@fern-api/fdr-sdk/navigation";
+import type { NavigationContext } from "@fern-docs/components";
+import { getAllSections } from "@fern-docs/components";
 
 import { DashboardTooltip } from "@/components/editor/DashboardTooltip";
 import { Icon } from "@/components/icon/Icon";
@@ -19,7 +20,7 @@ interface CreatePageButtonProps {
 export function CreatePageButton({
   root,
   navigationContext,
-}: CreatePageButtonProps) {
+}: CreatePageButtonProps): JSX.Element | boolean {
   const { prStatus } = useGitPrInfo();
   const isEditingDisabled = useEditingDisabled();
 

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@sidebar/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@sidebar/page.tsx
@@ -16,7 +16,7 @@ import { HiddenSidebar } from "@fern-docs/components/theming/HiddenSidebar";
 
 import { getCurrentSession } from "@/app/services/auth0/getCurrentSession";
 import { getHostFromHeaders } from "@/utils/getHostFromHeaders";
-import { EncodedDocsUrl } from "@/utils/types";
+import type { EncodedDocsUrl } from "@/utils/types";
 
 import { CreatePageButton } from "./CreatePageButton";
 
@@ -26,7 +26,7 @@ export default async function SidebarPage({
 }: {
   params: Promise<{ docsUrl: EncodedDocsUrl; slug: string[]; branch: string }>;
   searchParams: Promise<Record<string, string>>;
-}) {
+}): Promise<JSX.Element> {
   const { docsUrl, slug: slugArray, branch } = await params;
   const resolvedSearchParams = await searchParams;
   const clientNodeId = resolvedSearchParams["client-node-id"];

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@sidebar/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@sidebar/page.tsx
@@ -26,7 +26,7 @@ export default async function SidebarPage({
 }: {
   params: Promise<{ docsUrl: EncodedDocsUrl; slug: string[]; branch: string }>;
   searchParams: Promise<Record<string, string>>;
-}): Promise<JSX.Element> {
+}): Promise<JSX.Element | null> {
   const { docsUrl, slug: slugArray, branch } = await params;
   const resolvedSearchParams = await searchParams;
   const clientNodeId = resolvedSearchParams["client-node-id"];

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@versionSelect/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/@versionSelect/page.tsx
@@ -11,13 +11,13 @@ import { VersionDropdown } from "@fern-docs/components/header/VersionDropdown";
 
 import { getCurrentSession } from "@/app/services/auth0/getCurrentSession";
 import { getHostFromHeaders } from "@/utils/getHostFromHeaders";
-import { EncodedDocsUrl } from "@/utils/types";
+import type { EncodedDocsUrl } from "@/utils/types";
 
 export default async function VersionSelectPage({
   params,
 }: {
   params: Promise<{ docsUrl: EncodedDocsUrl; slug: string; branch: string }>;
-}) {
+}): Promise<JSX.Element | null> {
   const session = await getCurrentSession();
   const { docsUrl, slug, branch } = await params;
   const host = await getHostFromHeaders();

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/PageContents.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/PageContents.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect } from "react";
 
-import { NodeId } from "@fern-api/fdr-sdk/navigation";
-import { MdxToHtmlResponse } from "@fern-docs/mdx";
+import type { NodeId } from "@fern-api/fdr-sdk/navigation";
+import type { MdxToHtmlResponse } from "@fern-docs/mdx";
 
 import { useCurrentPage } from "@/providers/CurrentPageContext";
 import { usePages } from "@/providers/PagesStoreContext";
@@ -28,7 +28,7 @@ export default function PageContents({
   initialFrontmatter,
   initialOriginalFrontmatter,
   clientNodeId,
-}: PageContents.Props) {
+}: PageContents.Props): JSX.Element {
   const { title, subtitle } = initialFrontmatter ?? {};
 
   const { setCurrentFilename } = useCurrentPage();

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/PageEditor.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/PageEditor.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 
-import { Editor, EditorEvents } from "@tiptap/react";
+import type { Editor, EditorEvents } from "@tiptap/react";
 
 import { getChangedNodesFromHtml } from "@fern-docs/mdx";
 
@@ -22,7 +22,7 @@ export default function PageEditor({
   className,
   filename,
   initialHtml,
-}: PageEditor.Props) {
+}: PageEditor.Props): JSX.Element {
   const editorRef = useRef<Editor | null>(null);
   const skipNormalUpdateBecauseUpdateIsFromDevPanel = useRef(false);
   const latestTiptapHtml = useRef<string>(initialHtml || "");

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/PageNode.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/PageNode.tsx
@@ -2,10 +2,10 @@
 
 import { useMemo } from "react";
 
-import { NodeId } from "@fern-api/fdr-sdk/navigation";
-import { SerializableFoundNode } from "@fern-docs/components";
+import type { NodeId } from "@fern-api/fdr-sdk/navigation";
+import type { SerializableFoundNode } from "@fern-docs/components";
 import { SetCurrentNavigationNode } from "@fern-docs/components/state/navigation";
-import { MdxToHtmlResponse } from "@fern-docs/mdx";
+import type { MdxToHtmlResponse } from "@fern-docs/mdx";
 
 import { UnsupportedContent } from "@/components/editor/UnsupportedContent";
 import { CSSProvider } from "@/components/editor/extension-custom-element/CSSContext";
@@ -29,7 +29,7 @@ export default function PageNode({
   serializableFoundNode,
   clientNodeId,
   ...props
-}: PageNode.Props) {
+}: PageNode.Props): JSX.Element {
   const { buildPageDataFromSources } = usePages();
 
   const {

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/layout.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/layout.tsx
@@ -14,7 +14,7 @@ import AbstractDefaultDocs from "@fern-docs/components/theming/AbstractDefaultDo
 import { GlobalStyles } from "@fern-docs/components/theming/global-styles";
 import { DesktopSearchButton } from "@fern-docs/search-ui/components/desktop/desktop-search-button";
 
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { assertAuthAndFetchGithubUrl } from "@/app/services/dal/github/assertAuthAndFetchGithubUrl";
 import { GitHubLoader } from "@/app/services/github/github-loader";
 import { PreviewHeader } from "@/components/docs-preview/PreviewHeader";
@@ -23,7 +23,7 @@ import { EditorRoutingProvider } from "@/providers/EditorRoutingContext";
 import { FileResolverProvider } from "@/providers/FileResolverContext";
 import { getHostFromHeaders } from "@/utils/getHostFromHeaders";
 import { parseDocsUrlParam } from "@/utils/parseDocsUrlParam";
-import { EncodedDocsUrl } from "@/utils/types";
+import type { EncodedDocsUrl } from "@/utils/types";
 
 import "./index.css";
 
@@ -49,7 +49,7 @@ export default async function VisualEditorPreviewLayout({
   sidebar: React.ReactNode;
   logo: React.ReactNode;
   devPanel: React.ReactNode;
-}>) {
+}>): Promise<React.JSX.Element> {
   const { orgName, docsUrl, branch } = await params;
 
   const { githubUrl, session } = await assertAuthAndFetchGithubUrl({

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/page.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/[...slug]/page.tsx
@@ -4,17 +4,18 @@ import { notFound, redirect } from "next/navigation";
 
 import { createEditableDocsLoader } from "@fern-api/docs-loader";
 import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
-import { NodeId, getPageId, slugjoin } from "@fern-api/fdr-sdk/navigation";
+import type { NodeId } from "@fern-api/fdr-sdk/navigation";
+import { getPageId, slugjoin } from "@fern-api/fdr-sdk/navigation";
 import { AbstractLayoutEvaluatorContent } from "@fern-docs/components/layouts/AbstractLayoutEvaluatorContent";
 import { mdxToHtml } from "@fern-docs/mdx";
 
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { assertAuthAndFetchGithubUrl } from "@/app/services/dal/github/assertAuthAndFetchGithubUrl";
 import { GitHubLoader } from "@/app/services/github/github-loader";
 import { ROOT_SLUG_ALIAS, constructEditorSlug } from "@/utils/editor-routing";
 import { getHostFromHeaders } from "@/utils/getHostFromHeaders";
 import { parseDocsUrlParam } from "@/utils/parseDocsUrlParam";
-import { EncodedDocsUrl } from "@/utils/types";
+import type { EncodedDocsUrl } from "@/utils/types";
 
 import PageNode from "./PageNode";
 
@@ -29,7 +30,7 @@ export default async function Page({
     slug: string[];
   }>;
   searchParams: Promise<Record<string, string>>;
-}) {
+}): Promise<React.JSX.Element> {
   const { orgName, docsUrl, branch, slug: slugArray } = await params;
 
   const { githubUrl, session } = await assertAuthAndFetchGithubUrl({

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/layout.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/[branch]/layout.tsx
@@ -39,7 +39,7 @@ export default async function EditorLayout({
     branch: string;
   }>;
   children: React.JSX.Element;
-}>) {
+}>): Promise<React.JSX.Element> {
   const { orgName, docsUrl: encodedDocsUrl, branch } = await params;
   const docsUrl = parseDocsUrlParam({ docsUrl: encodedDocsUrl });
 

--- a/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/error.tsx
+++ b/packages/fern-dashboard/src/app/[orgName]/(visual-editor)/editor/[docsUrl]/error.tsx
@@ -6,7 +6,7 @@ import { useParams } from "next/navigation";
 import GradientExclamation from "@fern-docs/components/GradientExclamation";
 
 import { Button } from "@/components/ui/button";
-import { ERROR_DIGEST_KEYS } from "@/utils/errors";
+import type { ERROR_DIGEST_KEYS } from "@/utils/errors";
 import { ERROR_DIGEST_MESSAGES } from "@/utils/errors";
 
 export default function Error({
@@ -15,7 +15,7 @@ export default function Error({
 }: {
   error: Error & { digest?: string };
   reset: () => void;
-}) {
+}): JSX.Element {
   const { orgName } = useParams();
 
   return (

--- a/packages/fern-dashboard/src/app/accept-invite/[token]/page.tsx
+++ b/packages/fern-dashboard/src/app/accept-invite/[token]/page.tsx
@@ -5,10 +5,8 @@ import { Suspense } from "react";
 
 import { Loader2 } from "lucide-react";
 
-import {
-  RedeemInviteTokenErrors,
-  redeemInviteToken,
-} from "@/app/actions/redeemInviteToken";
+import type { RedeemInviteTokenErrors } from "@/app/actions/redeemInviteToken";
+import { redeemInviteToken } from "@/app/actions/redeemInviteToken";
 import {
   GithubLoginButton,
   GoogleLoginButton,
@@ -25,7 +23,7 @@ export default async function AcceptInvitePage({
   params,
 }: {
   params: Promise<{ token: string }>;
-}) {
+}): Promise<JSX.Element> {
   const { token } = await params;
   return (
     <div className="relative flex h-[100dvh] w-screen items-center justify-center overflow-hidden">

--- a/packages/fern-dashboard/src/app/actions/createPersonalProject.ts
+++ b/packages/fern-dashboard/src/app/actions/createPersonalProject.ts
@@ -1,12 +1,14 @@
 "use server";
 
-import { User } from "@auth0/nextjs-auth0/types";
+import type { User } from "@auth0/nextjs-auth0/types";
 
-import { FernVenusApi, FernVenusApiClient } from "@fern-api/venus-api-sdk";
-import { APIResponse } from "@fern-api/venus-api-sdk/core";
+import type { FernVenusApiClient } from "@fern-api/venus-api-sdk";
+import { FernVenusApi } from "@fern-api/venus-api-sdk";
+import type { APIResponse } from "@fern-api/venus-api-sdk/core";
 
 import { getCurrentSessionOrThrow } from "../services/auth0/getCurrentSession";
-import { Auth0OrgName, Auth0UserID } from "../services/auth0/types";
+import type { Auth0UserID } from "../services/auth0/types";
+import { Auth0OrgName } from "../services/auth0/types";
 import { getVenusClient } from "../services/venus/getVenusClient";
 
 export async function createPersonalProject(): Promise<{

--- a/packages/fern-dashboard/src/app/actions/upgradeFernVersion.ts
+++ b/packages/fern-dashboard/src/app/actions/upgradeFernVersion.ts
@@ -1,12 +1,12 @@
 "use server";
 
 import { getCurrentSession } from "@/app/services/auth0/getCurrentSession";
-import { GithubCommitableFile } from "@/app/services/github/types";
-import { DocsUrl } from "@/utils/types";
+import type { GithubCommitableFile } from "@/app/services/github/types";
+import type { DocsUrl } from "@/utils/types";
 
 import postGitCommit from "../api/post-git-commit/handler";
 import postCreatePr from "../api/post-git-create-pr/handler";
-import { Auth0OrgName } from "../services/auth0/types";
+import type { Auth0OrgName } from "../services/auth0/types";
 import createBranchIfNotExists from "../services/dal/github/createBranchIfNotExists";
 import { withGithubAuth } from "../services/dal/github/middleware";
 import { getUpgradePrBranchName } from "../services/dal/github/request-utils";

--- a/packages/fern-dashboard/src/app/api/generate-pr-description/route.ts
+++ b/packages/fern-dashboard/src/app/api/generate-pr-description/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
@@ -6,7 +7,7 @@ import { orgNameValidator } from "@/app/api/utils/validators";
 import { withGithubAuthNextRoute } from "@/app/services/dal/github/middleware";
 import { GithubIdentificationScheme } from "@/app/services/dal/github/types";
 import { withZodValidation } from "@/app/services/dal/zod/middleware";
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import handler from "./handler";
 

--- a/packages/fern-dashboard/src/app/api/get-docs-url-owner/route.ts
+++ b/packages/fern-dashboard/src/app/api/get-docs-url-owner/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
 import * as auth0Management from "@/app/services/auth0/management";
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import { maybeGetCurrentSession } from "../utils/maybeGetCurrentSession";
 import { parseNextRequestBody } from "../utils/parseNextRequestBody";
@@ -14,11 +15,15 @@ export declare namespace getDocsUrlOwner {
   export type Response = ResolvedReturnType<typeof handler>;
 }
 
-const GetDocsUrlOwnerRequest = z.object({
+type GetDocsUrlOwnerRequest = {
+  url: string;
+};
+
+const GetDocsUrlOwnerRequest: z.ZodType<GetDocsUrlOwnerRequest> = z.object({
   url: z.string(),
 });
 
-export async function POST(req: NextRequest) {
+export async function POST(req: NextRequest): Promise<NextResponse> {
   const maybeSessionData = await maybeGetCurrentSession(req);
   if (maybeSessionData.errorResponse != null) {
     return maybeSessionData.errorResponse;

--- a/packages/fern-dashboard/src/app/api/get-github-source-metadata/handler.ts
+++ b/packages/fern-dashboard/src/app/api/get-github-source-metadata/handler.ts
@@ -5,7 +5,7 @@ import {
   getFernBotOctokitForRepo,
 } from "@/app/services/auth0/fernBotOctokit";
 import { getOwnerAndRepoFromGithubUrl } from "@/app/services/github/github";
-import { GithubSourceRepo } from "@/app/services/github/types";
+import type { GithubSourceRepo } from "@/app/services/github/types";
 
 const EMPTY_RESPONSE: GithubSourceRepo = {
   githubUrl: undefined,

--- a/packages/fern-dashboard/src/app/api/get-github-source-metadata/route.ts
+++ b/packages/fern-dashboard/src/app/api/get-github-source-metadata/route.ts
@@ -1,12 +1,17 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
 import { orgNameValidator } from "@/app/api/utils/validators";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { withGithubAuthNextRoute } from "@/app/services/dal/github/middleware";
-import { GithubIdentificationScheme } from "@/app/services/dal/github/types";
+import {
+  GithubIdentificationScheme,
+  type GithubIdentificationSchemeType,
+} from "@/app/services/dal/github/types";
 import { withZodValidation } from "@/app/services/dal/zod/middleware";
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import handler from "./handler";
 
@@ -15,38 +20,53 @@ export declare namespace getGithubSourceMetadata {
   export type Response = ResolvedReturnType<typeof handler>;
 }
 
-const GetGithubSourceMetadataRequest = GithubIdentificationScheme.and(
+type GetGithubSourceMetadataRequest = GithubIdentificationSchemeType & {
+  orgName: Auth0OrgName;
+  skipCache?: boolean;
+};
+
+type GetGithubSourceMetadataRequestInput = GithubIdentificationSchemeType & {
+  orgName: string;
+  skipCache?: boolean;
+};
+
+const GetGithubSourceMetadataRequest: z.ZodType<
+  GetGithubSourceMetadataRequest,
+  z.ZodTypeDef,
+  GetGithubSourceMetadataRequestInput
+> = GithubIdentificationScheme.and(
   z.object({
     orgName: orgNameValidator,
     skipCache: z.boolean().optional(),
   })
 );
 
-export const POST = withZodValidation(
-  GetGithubSourceMetadataRequest,
-  async (
-    req: NextRequest,
-    validatedBody: z.infer<typeof GetGithubSourceMetadataRequest>
-  ) => {
-    const { orgName, skipCache, ...repoData } = validatedBody;
+export const POST: (req: NextRequest) => Promise<NextResponse> =
+  withZodValidation(
+    GetGithubSourceMetadataRequest,
+    async (
+      req: NextRequest,
+      validatedBody: z.infer<typeof GetGithubSourceMetadataRequest>
+    ) => {
+      const { orgName, skipCache, ...repoData } = validatedBody;
 
-    return withGithubAuthNextRoute(
-      req,
-      orgName,
-      repoData,
-      async ({ githubUrl }) => {
-        const { maybeGetCurrentSession } = await import(
-          "@/app/api/utils/maybeGetCurrentSession"
-        );
-        const sessionResult = await maybeGetCurrentSession(req);
-        if (sessionResult.errorResponse != null) {
-          return sessionResult.errorResponse;
+      return withGithubAuthNextRoute(
+        req,
+        orgName,
+        repoData,
+        async ({ githubUrl }) => {
+          const { maybeGetCurrentSession } = await import(
+            "@/app/api/utils/maybeGetCurrentSession"
+          );
+          const sessionResult = await maybeGetCurrentSession(req);
+          if (sessionResult.errorResponse != null) {
+            return sessionResult.errorResponse;
+          }
+          const { userId } = sessionResult.data;
+
+          const response = await handler({ userId, githubUrl, skipCache });
+          return NextResponse.json(response);
         }
-        const { userId } = sessionResult.data;
-
-        const response = await handler({ userId, githubUrl, skipCache });
-        return NextResponse.json(response);
-      }
-    );
-  }
-);
+      );
+    }
+  );

--- a/packages/fern-dashboard/src/app/api/get-my-organizations/route.ts
+++ b/packages/fern-dashboard/src/app/api/get-my-organizations/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import { maybeGetCurrentSession } from "../utils/maybeGetCurrentSession";
 import handler from "./handler";

--- a/packages/fern-dashboard/src/app/api/get-org-invitations/route.ts
+++ b/packages/fern-dashboard/src/app/api/get-org-invitations/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
 import { ensureUserBelongsToOrg } from "@/app/services/auth0/management";
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import { maybeGetCurrentSession } from "../utils/maybeGetCurrentSession";
 import { parseNextRequestBody } from "../utils/parseNextRequestBody";

--- a/packages/fern-dashboard/src/app/api/get-org-members/route.ts
+++ b/packages/fern-dashboard/src/app/api/get-org-members/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
 import { ensureUserBelongsToOrg } from "@/app/services/auth0/management";
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import { maybeGetCurrentSession } from "../utils/maybeGetCurrentSession";
 import { parseNextRequestBody } from "../utils/parseNextRequestBody";

--- a/packages/fern-dashboard/src/app/api/get-pr-for-branch/route.ts
+++ b/packages/fern-dashboard/src/app/api/get-pr-for-branch/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
@@ -6,7 +7,7 @@ import { orgNameValidator } from "@/app/api/utils/validators";
 import { withGithubAuthNextRoute } from "@/app/services/dal/github/middleware";
 import { GithubIdentificationScheme } from "@/app/services/dal/github/types";
 import { withZodValidation } from "@/app/services/dal/zod/middleware";
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import handler from "./handler";
 

--- a/packages/fern-dashboard/src/app/api/get-validate-github-branch/route.ts
+++ b/packages/fern-dashboard/src/app/api/get-validate-github-branch/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
@@ -6,7 +7,7 @@ import { orgNameValidator } from "@/app/api/utils/validators";
 import { withGithubAuthNextRoute } from "@/app/services/dal/github/middleware";
 import { GithubIdentificationScheme } from "@/app/services/dal/github/types";
 import { withZodValidation } from "@/app/services/dal/zod/middleware";
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import handler from "./handler";
 

--- a/packages/fern-dashboard/src/app/api/homepage-images/auth.ts
+++ b/packages/fern-dashboard/src/app/api/homepage-images/auth.ts
@@ -2,10 +2,10 @@ import { NextResponse } from "next/server";
 
 import { FernVenusApi } from "@fern-api/venus-api-sdk";
 
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { getVenusClient } from "@/app/services/venus/getVenusClient";
 
-import { MaybeErrorResponse } from "../utils/MaybeErrorResponse";
+import type { MaybeErrorResponse } from "../utils/MaybeErrorResponse";
 import { getDocsUrlOwner } from "../utils/getDocsUrlMetadata";
 
 export async function ensureUserOwnsUrl({

--- a/packages/fern-dashboard/src/app/api/homepage-images/generate/handler.ts
+++ b/packages/fern-dashboard/src/app/api/homepage-images/generate/handler.ts
@@ -1,13 +1,14 @@
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import chromium from "@sparticuz/chromium";
-import puppeteer, { Browser, Page } from "puppeteer-core";
+import type { Browser, Page } from "puppeteer-core";
+import puppeteer from "puppeteer-core";
 import sharp from "sharp";
 import { setTimeout } from "timers/promises";
 
 import { getS3Client } from "@/app/services/s3";
 import { isProduction } from "@/utils/environment";
 
-import { MaybeErrorResponse } from "../../utils/MaybeErrorResponse";
+import type { MaybeErrorResponse } from "../../utils/MaybeErrorResponse";
 import {
   HOMEPAGE_SCREENSHOT_HEIGHT,
   HOMEPAGE_SCREENSHOT_WIDTH,
@@ -15,7 +16,7 @@ import {
   getHomepageImagesS3BucketName,
 } from "../constants";
 import { getS3KeyForHomepageScreenshot } from "../getS3KeyForHomepageScreenshot";
-import { Theme } from "../types";
+import type { Theme } from "../types";
 
 export default async function generateHomepageImages({
   url,

--- a/packages/fern-dashboard/src/app/api/homepage-images/get/handler.ts
+++ b/packages/fern-dashboard/src/app/api/homepage-images/get/handler.ts
@@ -3,7 +3,7 @@ import { doesObjectExist, getPresignedUrlForS3Object } from "@/app/services/s3";
 import { getHomepageImagesS3BucketName } from "../constants";
 import generateHomepageImages from "../generate/handler";
 import { getS3KeyForHomepageScreenshot } from "../getS3KeyForHomepageScreenshot";
-import { Theme } from "../types";
+import type { Theme } from "../types";
 
 export default async function getHomepageImageUrl({
   urls,
@@ -11,7 +11,7 @@ export default async function getHomepageImageUrl({
 }: {
   urls: string[];
   theme: Theme;
-}) {
+}): Promise<{ imageUrl: string }> {
   for (const url of urls) {
     console.debug(`Getting homepage image for ${url}`);
     const bucketName = getHomepageImagesS3BucketName();

--- a/packages/fern-dashboard/src/app/api/homepage-images/get/route.ts
+++ b/packages/fern-dashboard/src/app/api/homepage-images/get/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import { maybeGetCurrentSession } from "../../utils/maybeGetCurrentSession";
 import { parseNextRequestBody } from "../../utils/parseNextRequestBody";

--- a/packages/fern-dashboard/src/app/api/homepage-images/getS3KeyForHomepageScreenshot.ts
+++ b/packages/fern-dashboard/src/app/api/homepage-images/getS3KeyForHomepageScreenshot.ts
@@ -1,5 +1,5 @@
 import { IMAGE_FILETYPE } from "./constants";
-import { Theme } from "./types";
+import type { Theme } from "./types";
 
 // NOTE: DO NOT CHANGE THIS LOGIC as this is the only source of truth for the
 // homepage screenshot s3 key (i.e. keys are not stored in a db anywhere).

--- a/packages/fern-dashboard/src/app/api/post-docs-github-source/route.ts
+++ b/packages/fern-dashboard/src/app/api/post-docs-github-source/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import { maybeGetCurrentSession } from "../utils/maybeGetCurrentSession";
 import { parseNextRequestBody } from "../utils/parseNextRequestBody";
@@ -13,12 +14,18 @@ export declare namespace postDocsGithubSource {
   export type Response = ResolvedReturnType<typeof handler>;
 }
 
-const PostDocsGithubSourceRequest = z.object({
-  url: z.string(),
-  githubUrl: z.string(),
-});
+type PostDocsGithubSourceRequest = {
+  url: string;
+  githubUrl: string;
+};
 
-export async function POST(req: NextRequest) {
+const PostDocsGithubSourceRequest: z.ZodType<PostDocsGithubSourceRequest> =
+  z.object({
+    url: z.string(),
+    githubUrl: z.string(),
+  });
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
   const maybeSessionData = await maybeGetCurrentSession(req);
   if (maybeSessionData.errorResponse != null) {
     return maybeSessionData.errorResponse;

--- a/packages/fern-dashboard/src/app/api/post-git-commit/handler.ts
+++ b/packages/fern-dashboard/src/app/api/post-git-commit/handler.ts
@@ -1,6 +1,6 @@
 import { getFernBotOctokitForRepo } from "@/app/services/auth0/fernBotOctokit";
 import { getCurrentSession } from "@/app/services/auth0/getCurrentSession";
-import { GithubCommitableFile } from "@/app/services/github/types";
+import type { GithubCommitableFile } from "@/app/services/github/types";
 
 export default async function postGitCommit(request: {
   owner: string;

--- a/packages/fern-dashboard/src/app/api/post-git-commit/route.ts
+++ b/packages/fern-dashboard/src/app/api/post-git-commit/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
@@ -6,7 +7,7 @@ import { orgNameValidator } from "@/app/api/utils/validators";
 import { withGithubAuthNextRoute } from "@/app/services/dal/github/middleware";
 import { GithubIdentificationScheme } from "@/app/services/dal/github/types";
 import { withZodValidation } from "@/app/services/dal/zod/middleware";
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import handler from "./handler";
 

--- a/packages/fern-dashboard/src/app/api/post-git-create-pr/route.ts
+++ b/packages/fern-dashboard/src/app/api/post-git-create-pr/route.ts
@@ -1,12 +1,17 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
 import { orgNameValidator } from "@/app/api/utils/validators";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { withGithubAuthNextRoute } from "@/app/services/dal/github/middleware";
-import { GithubIdentificationScheme } from "@/app/services/dal/github/types";
+import {
+  GithubIdentificationScheme,
+  type GithubIdentificationSchemeType,
+} from "@/app/services/dal/github/types";
 import { withZodValidation } from "@/app/services/dal/zod/middleware";
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import handler from "./handler";
 
@@ -15,7 +20,29 @@ export declare namespace postCreatePr {
   export type Response = ResolvedReturnType<typeof handler>;
 }
 
-export const PostCreatePrRequest = GithubIdentificationScheme.and(
+type PostCreatePrRequest = GithubIdentificationSchemeType & {
+  orgName: Auth0OrgName;
+  head: string;
+  base: string;
+  title: string;
+  body?: string;
+  draft?: boolean;
+};
+
+type PostCreatePrRequestInput = GithubIdentificationSchemeType & {
+  orgName: string;
+  head: string;
+  base: string;
+  title: string;
+  body?: string;
+  draft?: boolean;
+};
+
+export const PostCreatePrRequest: z.ZodType<
+  PostCreatePrRequest,
+  z.ZodTypeDef,
+  PostCreatePrRequestInput
+> = GithubIdentificationScheme.and(
   z.object({
     orgName: orgNameValidator,
     head: z.string(),
@@ -26,31 +53,32 @@ export const PostCreatePrRequest = GithubIdentificationScheme.and(
   })
 );
 
-export const POST = withZodValidation(
-  PostCreatePrRequest,
-  async (
-    req: NextRequest,
-    validatedBody: z.infer<typeof PostCreatePrRequest>
-  ) => {
-    const { orgName, head, base, title, body, draft, ...repoData } =
-      validatedBody;
+export const POST: (req: NextRequest) => Promise<NextResponse> =
+  withZodValidation(
+    PostCreatePrRequest,
+    async (
+      req: NextRequest,
+      validatedBody: z.infer<typeof PostCreatePrRequest>
+    ) => {
+      const { orgName, head, base, title, body, draft, ...repoData } =
+        validatedBody;
 
-    return withGithubAuthNextRoute(
-      req,
-      orgName,
-      repoData,
-      async ({ owner, repo }) => {
-        const result = await handler({
-          owner,
-          repo,
-          head,
-          base,
-          title,
-          body,
-          draft,
-        });
-        return NextResponse.json(result);
-      }
-    );
-  }
-);
+      return withGithubAuthNextRoute(
+        req,
+        orgName,
+        repoData,
+        async ({ owner, repo }) => {
+          const result = await handler({
+            owner,
+            repo,
+            head,
+            base,
+            title,
+            body,
+            draft,
+          });
+          return NextResponse.json(result);
+        }
+      );
+    }
+  );

--- a/packages/fern-dashboard/src/app/api/preload-editor-data/route.ts
+++ b/packages/fern-dashboard/src/app/api/preload-editor-data/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import { maybeGetCurrentSession } from "../utils/maybeGetCurrentSession";
 import { parseNextRequestBody } from "../utils/parseNextRequestBody";
@@ -13,11 +14,15 @@ export declare namespace preloadEditorData {
   export type Response = ResolvedReturnType<typeof handler>;
 }
 
-const PostPreloadEditorData = z.object({
+type PostPreloadEditorData = {
+  docsUrl: string;
+};
+
+const PostPreloadEditorData: z.ZodType<PostPreloadEditorData> = z.object({
   docsUrl: z.string(),
 });
 
-export async function POST(req: NextRequest) {
+export async function POST(req: NextRequest): Promise<NextResponse> {
   const maybeSessionData = await maybeGetCurrentSession(req);
   if (maybeSessionData.errorResponse != null) {
     return maybeSessionData.errorResponse;

--- a/packages/fern-dashboard/src/app/api/signed-image-url/generate/handler.ts
+++ b/packages/fern-dashboard/src/app/api/signed-image-url/generate/handler.ts
@@ -7,7 +7,7 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 import { getS3Client } from "@/app/services/s3";
 
-import { MaybeErrorResponse } from "../../utils/MaybeErrorResponse";
+import type { MaybeErrorResponse } from "../../utils/MaybeErrorResponse";
 import { getSignedImageUrlBucketName } from "../bucket";
 
 export default async function generateSignedUploadUrlHandler({

--- a/packages/fern-dashboard/src/app/api/update-pr-status/handler.ts
+++ b/packages/fern-dashboard/src/app/api/update-pr-status/handler.ts
@@ -1,5 +1,5 @@
 import { getFernBotOctokitForRepo } from "@/app/services/auth0/fernBotOctokit";
-import { GithubPrStatus } from "@/app/services/github/types";
+import type { GithubPrStatus } from "@/app/services/github/types";
 
 import getPrForBranch from "../get-pr-for-branch/handler";
 

--- a/packages/fern-dashboard/src/app/api/update-pr-status/route.ts
+++ b/packages/fern-dashboard/src/app/api/update-pr-status/route.ts
@@ -1,12 +1,17 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
 import { orgNameValidator } from "@/app/api/utils/validators";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { withGithubAuthNextRoute } from "@/app/services/dal/github/middleware";
-import { GithubIdentificationScheme } from "@/app/services/dal/github/types";
+import {
+  GithubIdentificationScheme,
+  type GithubIdentificationSchemeType,
+} from "@/app/services/dal/github/types";
 import { withZodValidation } from "@/app/services/dal/zod/middleware";
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import handler from "./handler";
 
@@ -15,7 +20,25 @@ export declare namespace updatePrStatus {
   export type Response = ResolvedReturnType<typeof handler>;
 }
 
-export const UpdatePrStatusRequest = GithubIdentificationScheme.and(
+type UpdatePrStatusRequest = GithubIdentificationSchemeType & {
+  orgName: Auth0OrgName;
+  branch: string;
+  status: "open" | "draft";
+  baseBranch?: string;
+};
+
+type UpdatePrStatusRequestInput = GithubIdentificationSchemeType & {
+  orgName: string;
+  branch: string;
+  status: "open" | "draft";
+  baseBranch?: string;
+};
+
+export const UpdatePrStatusRequest: z.ZodType<
+  UpdatePrStatusRequest,
+  z.ZodTypeDef,
+  UpdatePrStatusRequestInput
+> = GithubIdentificationScheme.and(
   z.object({
     orgName: orgNameValidator,
     branch: z.string(),
@@ -24,28 +47,30 @@ export const UpdatePrStatusRequest = GithubIdentificationScheme.and(
   })
 );
 
-export const POST = withZodValidation(
-  UpdatePrStatusRequest,
-  async (
-    req: NextRequest,
-    validatedBody: z.infer<typeof UpdatePrStatusRequest>
-  ) => {
-    const { orgName, branch, status, baseBranch, ...repoData } = validatedBody;
+export const POST: (req: NextRequest) => Promise<NextResponse> =
+  withZodValidation(
+    UpdatePrStatusRequest,
+    async (
+      req: NextRequest,
+      validatedBody: z.infer<typeof UpdatePrStatusRequest>
+    ) => {
+      const { orgName, branch, status, baseBranch, ...repoData } =
+        validatedBody;
 
-    return withGithubAuthNextRoute(
-      req,
-      orgName,
-      repoData,
-      async ({ owner, repo }) => {
-        const result = await handler({
-          owner,
-          repo,
-          branch,
-          status,
-          baseBranch,
-        });
-        return NextResponse.json(result);
-      }
-    );
-  }
-);
+      return withGithubAuthNextRoute(
+        req,
+        orgName,
+        repoData,
+        async ({ owner, repo }) => {
+          const result = await handler({
+            owner,
+            repo,
+            branch,
+            status,
+            baseBranch,
+          });
+          return NextResponse.json(result);
+        }
+      );
+    }
+  );

--- a/packages/fern-dashboard/src/app/api/update-pr-title/route.ts
+++ b/packages/fern-dashboard/src/app/api/update-pr-title/route.ts
@@ -1,12 +1,17 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { z } from "zod";
 
 import { orgNameValidator } from "@/app/api/utils/validators";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { withGithubAuthNextRoute } from "@/app/services/dal/github/middleware";
-import { GithubIdentificationScheme } from "@/app/services/dal/github/types";
+import {
+  GithubIdentificationScheme,
+  type GithubIdentificationSchemeType,
+} from "@/app/services/dal/github/types";
 import { withZodValidation } from "@/app/services/dal/zod/middleware";
-import { ResolvedReturnType } from "@/utils/types";
+import type { ResolvedReturnType } from "@/utils/types";
 
 import handler from "./handler";
 
@@ -15,7 +20,25 @@ export declare namespace updatePrTitle {
   export type Response = ResolvedReturnType<typeof handler>;
 }
 
-export const UpdatePrTitleRequest = GithubIdentificationScheme.and(
+type UpdatePrTitleRequest = GithubIdentificationSchemeType & {
+  orgName: Auth0OrgName;
+  branch: string;
+  title: string;
+  baseBranch?: string;
+};
+
+type UpdatePrTitleRequestInput = GithubIdentificationSchemeType & {
+  orgName: string;
+  branch: string;
+  title: string;
+  baseBranch?: string;
+};
+
+export const UpdatePrTitleRequest: z.ZodType<
+  UpdatePrTitleRequest,
+  z.ZodTypeDef,
+  UpdatePrTitleRequestInput
+> = GithubIdentificationScheme.and(
   z.object({
     orgName: orgNameValidator,
     branch: z.string(),
@@ -24,28 +47,29 @@ export const UpdatePrTitleRequest = GithubIdentificationScheme.and(
   })
 );
 
-export const POST = withZodValidation(
-  UpdatePrTitleRequest,
-  async (
-    req: NextRequest,
-    validatedBody: z.infer<typeof UpdatePrTitleRequest>
-  ) => {
-    const { orgName, branch, title, baseBranch, ...repoData } = validatedBody;
+export const POST: (req: NextRequest) => Promise<NextResponse> =
+  withZodValidation(
+    UpdatePrTitleRequest,
+    async (
+      req: NextRequest,
+      validatedBody: z.infer<typeof UpdatePrTitleRequest>
+    ) => {
+      const { orgName, branch, title, baseBranch, ...repoData } = validatedBody;
 
-    return withGithubAuthNextRoute(
-      req,
-      orgName,
-      repoData,
-      async ({ owner, repo }) => {
-        const result = await handler({
-          owner,
-          repo,
-          branch,
-          title,
-          baseBranch,
-        });
-        return NextResponse.json(result);
-      }
-    );
-  }
-);
+      return withGithubAuthNextRoute(
+        req,
+        orgName,
+        repoData,
+        async ({ owner, repo }) => {
+          const result = await handler({
+            owner,
+            repo,
+            branch,
+            title,
+            baseBranch,
+          });
+          return NextResponse.json(result);
+        }
+      );
+    }
+  );

--- a/packages/fern-dashboard/src/app/api/utils/maybeGetCurrentSession.ts
+++ b/packages/fern-dashboard/src/app/api/utils/maybeGetCurrentSession.ts
@@ -1,12 +1,13 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import {
   decodeAccessToken,
   getCurrentSessionOrThrow,
 } from "@/app/services/auth0/getCurrentSession";
-import { Auth0UserID } from "@/app/services/auth0/types";
+import type { Auth0UserID } from "@/app/services/auth0/types";
 
-import { MaybeErrorResponse } from "./MaybeErrorResponse";
+import type { MaybeErrorResponse } from "./MaybeErrorResponse";
 import { parseAuthHeader } from "./parseAuthHeader";
 
 export interface ApiSessionData {

--- a/packages/fern-dashboard/src/app/api/utils/parseNextRequestBody.ts
+++ b/packages/fern-dashboard/src/app/api/utils/parseNextRequestBody.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
-import { ZodType, z } from "zod";
+import type { ZodType, z } from "zod";
 
-import { MaybeErrorResponse } from "./MaybeErrorResponse";
+import type { MaybeErrorResponse } from "./MaybeErrorResponse";
 
 export async function parseNextRequestBody<T extends ZodType>(
   req: NextRequest,

--- a/packages/fern-dashboard/src/app/api/utils/validators.ts
+++ b/packages/fern-dashboard/src/app/api/utils/validators.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
 
-import { Auth0OrgName, Auth0UserID } from "@/app/services/auth0/types";
+import type { Auth0OrgName, Auth0UserID } from "@/app/services/auth0/types";
 
-export const userIdValidator = z
+export const userIdValidator: z.ZodType<Auth0UserID, z.ZodTypeDef, string> = z
   .string()
   .refine((orgName: string): orgName is Auth0UserID => true);
 
-export const orgNameValidator = z
+export const orgNameValidator: z.ZodType<Auth0OrgName, z.ZodTypeDef, string> = z
   .string()
   .refine((orgName: string): orgName is Auth0OrgName => true);

--- a/packages/fern-dashboard/src/app/error.tsx
+++ b/packages/fern-dashboard/src/app/error.tsx
@@ -9,7 +9,7 @@ export default function Error({
   error: _error,
 }: {
   error: Error & { digest?: string };
-}) {
+}): JSX.Element {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-2">
       <div className="flex h-24 w-24 items-center justify-center">

--- a/packages/fern-dashboard/src/app/layout.tsx
+++ b/packages/fern-dashboard/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.JSX.Element;
-}>) {
+}>): Promise<React.JSX.Element> {
   const session = await getCurrentSession();
 
   await applyOrgMappings();

--- a/packages/fern-dashboard/src/app/page.tsx
+++ b/packages/fern-dashboard/src/app/page.tsx
@@ -8,13 +8,10 @@ import {
   type Auth0SessionData,
   getCurrentSession,
 } from "./services/auth0/getCurrentSession";
-import {
-  getFirstOrganizationForUser,
-  getMyOrganizations,
-} from "./services/auth0/management";
+import { getFirstOrganizationForUser } from "./services/auth0/management";
 import { Auth0OrgName } from "./services/auth0/types";
 
-export default async function Page() {
+export default async function Page(): Promise<JSX.Element> {
   const session = await getCurrentSession();
 
   if (session == null) {

--- a/packages/fern-dashboard/src/app/services/auth0/getCurrentSession.ts
+++ b/packages/fern-dashboard/src/app/services/auth0/getCurrentSession.ts
@@ -2,7 +2,8 @@ import jwt from "jsonwebtoken";
 
 import { getAuth0Client } from "@/app/services/auth0/auth0";
 
-import { Auth0User, Auth0UserID } from "./types";
+import type { Auth0User } from "./types";
+import { Auth0UserID } from "./types";
 
 export interface Auth0SessionData {
   user: Auth0User;

--- a/packages/fern-dashboard/src/app/services/auth0/management.ts
+++ b/packages/fern-dashboard/src/app/services/auth0/management.ts
@@ -2,27 +2,20 @@
 import { unstable_cacheTag } from "next/cache";
 
 import {
-  ApiResponse,
-  GetInvitations200ResponseOneOfInner,
-  GetMembers200ResponseOneOfInner,
+  type ApiResponse,
+  type GetInvitations200ResponseOneOfInner,
+  type GetMembers200ResponseOneOfInner,
   ManagementClient,
 } from "auth0";
 import { v4 as uuidv4 } from "uuid";
 
 import { AsyncRedisCache } from "../redis/AsyncRedisCache";
-import {
-  InviteToken,
-  RedisCacheKey,
-  RedisCacheKeyType,
-} from "../redis/cacheKey";
-import {
-  Auth0OrgID,
-  Auth0OrgName,
-  Auth0Organization,
-  Auth0UserID,
-} from "./types";
+import type { InviteToken } from "../redis/cacheKey";
+import { RedisCacheKey, RedisCacheKeyType } from "../redis/cacheKey";
+import type { Auth0Organization } from "./types";
+import { Auth0OrgID, Auth0OrgName, Auth0UserID } from "./types";
 
-export const FERN_ORG_NAME = Auth0OrgName("fern");
+export const FERN_ORG_NAME: Auth0OrgName = Auth0OrgName("fern");
 
 /****************************
  * getAuth0ManagementClient *
@@ -30,7 +23,7 @@ export const FERN_ORG_NAME = Auth0OrgName("fern");
 
 let AUTH0_MANAGEMENT_CLIENT: ManagementClient | undefined;
 
-export function getAuth0ManagementClient() {
+export function getAuth0ManagementClient(): ManagementClient {
   if (AUTH0_MANAGEMENT_CLIENT == null) {
     const { AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET } = process.env;
 
@@ -92,7 +85,7 @@ export async function invalidateCachesAfterAddingOrRemovingOrgMember({
   orgName,
 }: {
   orgName: Auth0OrgName;
-}) {
+}): Promise<void> {
   await ORGANIZATION_MEMBERS_CACHE.invalidate(
     RedisCacheKey.organizationMembers(orgName)
   );
@@ -100,7 +93,7 @@ export async function invalidateCachesAfterAddingOrRemovingOrgMember({
 
 export async function invalidateCachesAfterInvitingUserToOrg(
   orgName: Auth0OrgName
-) {
+): Promise<void> {
   await ORGANIZATION_INVITATIONS_CACHE.invalidate(
     RedisCacheKey.organizationInvitations(orgName)
   );
@@ -108,13 +101,13 @@ export async function invalidateCachesAfterInvitingUserToOrg(
 
 export async function invalidateCachesAfterRescindingInvitation(
   orgName: Auth0OrgName
-) {
+): Promise<void> {
   await ORGANIZATION_INVITATIONS_CACHE.invalidate(
     RedisCacheKey.organizationInvitations(orgName)
   );
 }
 
-export async function invalidateInviteToken(token: string) {
+export async function invalidateInviteToken(token: string): Promise<void> {
   await INVITE_TOKEN_CACHE.invalidate(RedisCacheKey.inviteToken(token));
 }
 
@@ -122,14 +115,16 @@ export async function invalidateInviteToken(token: string) {
  * helpers *
  ***********/
 
-export async function getInviteToken(token: string) {
+export async function getInviteToken(
+  token: string
+): Promise<InviteToken | undefined> {
   return await INVITE_TOKEN_CACHE.getDirectly(RedisCacheKey.inviteToken(token));
 }
 
 export async function createInviteToken(
   orgName: Auth0OrgName,
   inviterId: string
-) {
+): Promise<{ token: string; expiresAt: string }> {
   const token = uuidv4();
   const now = new Date();
   const expiresAt = new Date(now.getTime() + 24 * 60 * 60 * 1000); // 24 hours
@@ -144,7 +139,9 @@ export async function createInviteToken(
   return { token, expiresAt: expiresAt.toISOString() };
 }
 
-export async function getOrganization(orgName: Auth0OrgName) {
+export async function getOrganization(
+  orgName: Auth0OrgName
+): Promise<Auth0Organization> {
   return await ORGANIZATIONS_CACHE.get(
     RedisCacheKey.organization(orgName),
     async () => {
@@ -158,7 +155,9 @@ export async function getOrganization(orgName: Auth0OrgName) {
   );
 }
 
-export async function getOrgIdFromName(orgName: Auth0OrgName) {
+export async function getOrgIdFromName(
+  orgName: Auth0OrgName
+): Promise<Auth0OrgID> {
   return await ORGANIZATION_NAME_TO_ID_CACHE.get(
     RedisCacheKey.organizationNameToId(orgName),
     async () => {
@@ -228,7 +227,7 @@ export async function getFirstOrganizationForUser(
 export async function getOrgMembers(
   orgName: Auth0OrgName,
   { includeFernEmployees }: { includeFernEmployees: boolean }
-) {
+): Promise<GetMembers200ResponseOneOfInner[]> {
   let members = await ORGANIZATION_MEMBERS_CACHE.get(
     RedisCacheKey.organizationMembers(orgName),
     async () => {
@@ -245,7 +244,9 @@ export async function getOrgMembers(
   return members;
 }
 
-async function getAllOrgMembers(orgId: Auth0OrgID) {
+async function getAllOrgMembers(
+  orgId: Auth0OrgID
+): Promise<GetMembers200ResponseOneOfInner[]> {
   const members: GetMembers200ResponseOneOfInner[] = [];
 
   const auth0 = getAuth0ManagementClient();
@@ -293,7 +294,9 @@ export async function isFernEmployee(userId: Auth0UserID): Promise<boolean> {
   return isFernEmployeeFunc(userId);
 }
 
-export async function getOrgInvitations(orgName: Auth0OrgName) {
+export async function getOrgInvitations(
+  orgName: Auth0OrgName
+): Promise<GetInvitations200ResponseOneOfInner[]> {
   return await ORGANIZATION_INVITATIONS_CACHE.get(
     RedisCacheKey.organizationInvitations(orgName),
     async () => {
@@ -337,7 +340,7 @@ export const ensureUserBelongsToOrgCacheTag = (
 export async function ensureUserBelongsToOrg(
   userId: Auth0UserID,
   orgName: Auth0OrgName
-) {
+): Promise<void> {
   "use cache";
   unstable_cacheTag(ensureUserBelongsToOrgCacheTag(userId, orgName));
   if (!(await doesUserBelongToOrg(userId, orgName))) {
@@ -345,7 +348,7 @@ export async function ensureUserBelongsToOrg(
   }
 }
 
-export async function doesOrgExist(orgName: Auth0OrgName) {
+export async function doesOrgExist(orgName: Auth0OrgName): Promise<boolean> {
   try {
     const org = await getOrganization(orgName);
     return org != null;
@@ -357,7 +360,7 @@ export async function doesOrgExist(orgName: Auth0OrgName) {
 export async function doesUserBelongToOrg(
   userId: Auth0UserID,
   orgName: Auth0OrgName
-) {
+): Promise<boolean> {
   // a fern employee is considered to be in every org, but we need to check if the org exists
   if (await isFernEmployee(userId)) {
     const orgExists = await doesOrgExist(orgName);
@@ -370,7 +373,10 @@ export async function doesUserBelongToOrg(
   return orgs.some((o) => o.name === orgName);
 }
 
-export async function addUserToOrg(userId: Auth0UserID, orgName: Auth0OrgName) {
+export async function addUserToOrg(
+  userId: Auth0UserID,
+  orgName: Auth0OrgName
+): Promise<void> {
   const auth0 = getAuth0ManagementClient();
   await auth0.organizations.addMembers(
     { id: await getOrgIdFromName(orgName) },
@@ -384,8 +390,9 @@ export async function getUserGithubToken(
 ): Promise<string | undefined> {
   const auth0 = getAuth0ManagementClient();
   const user = (await auth0.users.get({ id: userId })).data;
-  return user.identities.find((identity) => identity.provider === "github")
-    ?.access_token;
+  return user.identities.find(
+    (identity: { provider: string }) => identity.provider === "github"
+  )?.access_token;
 }
 export async function getUserGoogleOauth2EmailInfo(
   userId: Auth0UserID
@@ -395,7 +402,8 @@ export async function getUserGoogleOauth2EmailInfo(
 
   // Find the google-oauth2 connection
   const googleIdentity = user.identities?.find(
-    (identity) => identity.connection === "google-oauth2"
+    (identity: { connection: string }) =>
+      identity.connection === "google-oauth2"
   );
 
   // Only return email info if the user has a google-oauth2 connection

--- a/packages/fern-dashboard/src/app/services/auth0/types.ts
+++ b/packages/fern-dashboard/src/app/services/auth0/types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-invalid-void-type */
-import { GetOrganizations200ResponseOneOfInner } from "auth0";
+import type { GetOrganizations200ResponseOneOfInner } from "auth0";
 
 const createBrandedStringCreator = <T>(value: string) => value as T;
 

--- a/packages/fern-dashboard/src/app/services/dal/github/assertAuthAndFetchGithubUrl.ts
+++ b/packages/fern-dashboard/src/app/services/dal/github/assertAuthAndFetchGithubUrl.ts
@@ -1,15 +1,21 @@
 import { redirect } from "next/navigation";
 import { cache } from "react";
 
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
-import { getCurrentSession } from "../../auth0/getCurrentSession";
-import { Auth0OrgName } from "../../auth0/types";
+import {
+  type Auth0SessionData,
+  getCurrentSession,
+} from "../../auth0/getCurrentSession";
+import type { Auth0OrgName } from "../../auth0/types";
 import { assertUserHasOrganizationAccess } from "../organization";
 import getDocsGithubUrl from "./getDocsGithubUrl";
 import { assertGithubAccessByUrl } from "./validators";
 
-export const assertAuthAndFetchGithubUrl = cache(
+export const assertAuthAndFetchGithubUrl: (params: {
+  orgName: Auth0OrgName;
+  docsUrl: DocsUrl;
+}) => Promise<{ githubUrl: string; session: Auth0SessionData }> = cache(
   async ({ orgName, docsUrl }: { orgName: Auth0OrgName; docsUrl: DocsUrl }) => {
     // Validate session
     const session = await getCurrentSession();

--- a/packages/fern-dashboard/src/app/services/dal/github/checkOrgWritePermissionToRepo.ts
+++ b/packages/fern-dashboard/src/app/services/dal/github/checkOrgWritePermissionToRepo.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { FernConfigJsonErrors } from "@fern-api/docs-loader";
+import type { FernConfigJsonErrors } from "@fern-api/docs-loader";
 
 import { getFernBotOctokitForRepo } from "@/app/services/auth0/fernBotOctokit";
 import { getOwnerAndRepoFromGithubUrl } from "@/app/services/github/github";

--- a/packages/fern-dashboard/src/app/services/dal/github/createBranchIfNotExists.ts
+++ b/packages/fern-dashboard/src/app/services/dal/github/createBranchIfNotExists.ts
@@ -2,9 +2,9 @@
 
 import { getFernBotOctokitForRepo } from "@/app/services/auth0/fernBotOctokit";
 import { getCurrentSession } from "@/app/services/auth0/getCurrentSession";
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { validateGithubRepoAccess } from "@/app/services/dal/github/validators";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 import { assertUserHasOrganizationAccess } from "../organization";
 

--- a/packages/fern-dashboard/src/app/services/dal/github/getFernVersionFromRepo.ts
+++ b/packages/fern-dashboard/src/app/services/dal/github/getFernVersionFromRepo.ts
@@ -1,9 +1,9 @@
 import "server-only";
 
-import { FernConfigJsonErrors } from "@fern-api/docs-loader";
+import type { FernConfigJsonErrors } from "@fern-api/docs-loader";
 
 import { getOwnerAndRepoFromGithubUrl } from "@/app/services/github/github";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 import { GitHubLoader } from "../../github/github-loader";
 

--- a/packages/fern-dashboard/src/app/services/dal/github/getFernVersionUpdateInfo.ts
+++ b/packages/fern-dashboard/src/app/services/dal/github/getFernVersionUpdateInfo.ts
@@ -5,13 +5,11 @@ import {
   compareVersions,
   getLatestFernCliVersion,
 } from "@/utils/fernCliVersion";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 import { checkUpgradePrStatus } from "./checkUpgradePrStatus";
-import {
-  GetFernVersionFromRepoError,
-  getFernVersionFromRepo,
-} from "./getFernVersionFromRepo";
+import type { GetFernVersionFromRepoError } from "./getFernVersionFromRepo";
+import { getFernVersionFromRepo } from "./getFernVersionFromRepo";
 
 export type GetFernVersionUpdateInfoResult = {
   current: string;

--- a/packages/fern-dashboard/src/app/services/dal/github/middleware.ts
+++ b/packages/fern-dashboard/src/app/services/dal/github/middleware.ts
@@ -1,18 +1,17 @@
 import "server-only";
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 import { maybeGetCurrentSession } from "@/app/api/utils/maybeGetCurrentSession";
-import { Auth0OrgName, Auth0UserID } from "@/app/services/auth0/types";
+import type { Auth0OrgName, Auth0UserID } from "@/app/services/auth0/types";
 import { getValidationErrorMessage } from "@/utils/errors";
 
 import { getOwnerAndRepoFromGithubUrl } from "../../github/github";
 import { assertUserHasOrganizationAccess } from "../organization";
 import type { GithubIdentificationSchemeType, RepoIdentifier } from "./types";
-import {
-  GithubRepoValidationError,
-  validateGithubRepoAccess,
-} from "./validators";
+import type { GithubRepoValidationError } from "./validators";
+import { validateGithubRepoAccess } from "./validators";
 
 export interface ParsedRepoData {
   owner: string;

--- a/packages/fern-dashboard/src/app/services/dal/github/types.ts
+++ b/packages/fern-dashboard/src/app/services/dal/github/types.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest, NextResponse } from "next/server";
 
 import { z } from "zod";
 
-import { Auth0UserID } from "../../auth0/types";
+import type { Auth0UserID } from "../../auth0/types";
 
 export type RepoIdentifier =
   | {
@@ -25,21 +25,29 @@ export interface GithubAccessValidationOptions {
   githubUrl?: string;
 }
 
-export const GithubIdentificationScheme = z.union([
-  z.object({
-    site: z.string(),
-    owner: z.string(),
-    repo: z.string(),
-  }),
-  z.object({
-    site: z.string(),
-    githubUrl: z.string(),
-  }),
-]);
+export type GithubIdentificationSchemeType =
+  | {
+      site: string;
+      owner: string;
+      repo: string;
+    }
+  | {
+      site: string;
+      githubUrl: string;
+    };
 
-export type GithubIdentificationSchemeType = z.infer<
-  typeof GithubIdentificationScheme
->;
+export const GithubIdentificationScheme: z.ZodType<GithubIdentificationSchemeType> =
+  z.union([
+    z.object({
+      site: z.string(),
+      owner: z.string(),
+      repo: z.string(),
+    }),
+    z.object({
+      site: z.string(),
+      githubUrl: z.string(),
+    }),
+  ]);
 
 // Wrapper-specific types
 export interface RepoData {

--- a/packages/fern-dashboard/src/app/services/dal/github/validators.ts
+++ b/packages/fern-dashboard/src/app/services/dal/github/validators.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { FernConfigJsonErrors } from "@fern-api/docs-loader";
+import type { FernConfigJsonErrors } from "@fern-api/docs-loader";
 
 import {
   getValidationErrorMessage,
@@ -8,7 +8,7 @@ import {
 } from "@/utils/errors";
 
 import { checkOrgWritePermissionToRepo } from "./checkOrgWritePermissionToRepo";
-import { RepoIdentifier } from "./types";
+import type { RepoIdentifier } from "./types";
 
 export type GithubRepoValidationError =
   | { type: "REPO_NOT_CONNECTED" }

--- a/packages/fern-dashboard/src/app/services/edge-config/checkOrgHasFlag.ts
+++ b/packages/fern-dashboard/src/app/services/edge-config/checkOrgHasFlag.ts
@@ -1,4 +1,4 @@
-import { OrgEdgeFlags } from "@fern-api/docs-utils";
+import type { OrgEdgeFlags } from "@fern-api/docs-utils";
 import { getEdgeFlagsForOrg } from "@fern-docs/edge-config";
 
 export async function checkOrgHasFlag(

--- a/packages/fern-dashboard/src/app/services/github/github-loader.ts
+++ b/packages/fern-dashboard/src/app/services/github/github-loader.ts
@@ -1,10 +1,10 @@
 import "server-only";
 
-import { Octokit } from "@octokit/core";
+import type { Octokit } from "@octokit/core";
 import yaml from "js-yaml";
 import z from "zod";
 
-import {
+import type {
   FernProject,
   GetDocsYmlResult,
   GetFernConfigJsonResult,

--- a/packages/fern-dashboard/src/app/services/redis/AsyncRedisCache.ts
+++ b/packages/fern-dashboard/src/app/services/redis/AsyncRedisCache.ts
@@ -1,4 +1,8 @@
-import { RedisCacheKey, RedisCacheKeyType, inferCachedData } from "./cacheKey";
+import type {
+  RedisCacheKey,
+  RedisCacheKeyType,
+  inferCachedData,
+} from "./cacheKey";
 import { redisDel, redisGet, redisSet } from "./redis";
 
 export class AsyncRedisCache<T extends RedisCacheKeyType> {
@@ -57,7 +61,7 @@ export class AsyncRedisCache<T extends RedisCacheKeyType> {
     return await redisGet(key);
   }
 
-  public async invalidate(key: RedisCacheKey<T>) {
+  public async invalidate(key: RedisCacheKey<T>): Promise<void> {
     await redisDel(key);
   }
 }

--- a/packages/fern-dashboard/src/app/services/redis/cacheKey.ts
+++ b/packages/fern-dashboard/src/app/services/redis/cacheKey.ts
@@ -1,9 +1,13 @@
-import {
+import type {
   GetInvitations200ResponseOneOfInner,
   GetMembers200ResponseOneOfInner,
 } from "auth0";
 
-import { Auth0OrgID, Auth0OrgName, Auth0Organization } from "../auth0/types";
+import type {
+  Auth0OrgID,
+  Auth0OrgName,
+  Auth0Organization,
+} from "../auth0/types";
 
 export interface InviteToken {
   orgName: Auth0OrgName;

--- a/packages/fern-dashboard/src/app/services/redis/redis.ts
+++ b/packages/fern-dashboard/src/app/services/redis/redis.ts
@@ -1,10 +1,14 @@
 import { Redis } from "@upstash/redis";
 
-import { RedisCacheKey, RedisCacheKeyType, inferCachedData } from "./cacheKey";
+import type {
+  RedisCacheKey,
+  RedisCacheKeyType,
+  inferCachedData,
+} from "./cacheKey";
 
 let redis: Redis | undefined;
 
-export function getRedisClient() {
+export function getRedisClient(): Redis {
   if (redis == null) {
     redis = new Redis({
       url: process.env.KV_REST_API_URL,
@@ -18,7 +22,7 @@ export async function redisSet<T extends RedisCacheKeyType>(
   key: RedisCacheKey<T>,
   value: inferCachedData<T>,
   { ttlInSeconds }: { ttlInSeconds: number }
-) {
+): Promise<void> {
   await getRedisClient().set<inferCachedData<T>>(key, value, {
     ex: ttlInSeconds,
   });
@@ -33,6 +37,6 @@ export async function redisGet<T extends RedisCacheKeyType>(
 
 export async function redisDel<T extends RedisCacheKeyType>(
   key: RedisCacheKey<T>
-) {
+): Promise<void> {
   await getRedisClient().del(key);
 }

--- a/packages/fern-dashboard/src/components/analytics/AnalyticsHistogram.tsx
+++ b/packages/fern-dashboard/src/components/analytics/AnalyticsHistogram.tsx
@@ -1,13 +1,13 @@
-"use client";
-
-import { FernAI } from "@fern-api/fai-sdk";
+import type { FernAI } from "@fern-api/fai-sdk";
 
 import { cn } from "@/utils/utils";
 
 import { AnalyticsHistogramChart } from "./AnalyticsHistogramChart";
 import { AnalyticsHistogramTabBar } from "./AnalyticsHistogramTabBar";
-import { BORDER_STYLES, RenderType } from "./AnalyticsPageClient";
-import { TimeRangeOption, TimeRangeSelect } from "./TimeRangeSelect";
+import type { RenderType } from "./AnalyticsPageClient";
+import { BORDER_STYLES } from "./AnalyticsPageClient";
+import type { TimeRangeOption } from "./TimeRangeSelect";
+import { TimeRangeSelect } from "./TimeRangeSelect";
 import { TimeRange } from "./utils/get-request-params";
 import { parseLabel } from "./utils/parse-label";
 
@@ -29,7 +29,7 @@ export function AnalyticsHistogram({
   histogramTimeRange: TimeRange;
   setHistogramTimeRange: (range: TimeRange) => void;
   histogramData: FernAI.GetHistogramAnalyticsResponse;
-}) {
+}): JSX.Element {
   const chartData = histogramData.bars.map((bar) => ({
     displayLabel: parseLabel(bar.label),
     count: renderType === "QUERIES" ? bar.queryCount : bar.conversationCount,

--- a/packages/fern-dashboard/src/components/analytics/AnalyticsHistogramChart.tsx
+++ b/packages/fern-dashboard/src/components/analytics/AnalyticsHistogramChart.tsx
@@ -4,7 +4,7 @@ import { Bar, BarChart, CartesianGrid, Tooltip, XAxis } from "recharts";
 
 import { ChartContainer, ChartTooltipContent } from "@/components/ui/chart";
 
-import { RenderType } from "./AnalyticsPageClient";
+import type { RenderType } from "./AnalyticsPageClient";
 
 interface AnalyticsHistogramProps {
   chartData: {
@@ -24,7 +24,7 @@ const CHART_CONFIG = {
 export function AnalyticsHistogramChart({
   chartData,
   renderType,
-}: AnalyticsHistogramProps) {
+}: AnalyticsHistogramProps): JSX.Element {
   return (
     <div
       style={{

--- a/packages/fern-dashboard/src/components/analytics/AnalyticsHistogramTabBar.tsx
+++ b/packages/fern-dashboard/src/components/analytics/AnalyticsHistogramTabBar.tsx
@@ -1,10 +1,8 @@
-"use client";
-
 import ChatBubbleLeftEllipsisIcon from "@heroicons/react/24/outline/ChatBubbleLeftEllipsisIcon";
 import SparklesIcon from "@heroicons/react/24/outline/SparklesIcon";
 
 import { AnalyticsHistogramTabItem } from "./AnalyticsHistogramTabItem";
-import { RenderType } from "./AnalyticsPageClient";
+import type { RenderType } from "./AnalyticsPageClient";
 
 export function AnalyticsHistogramTabBar({
   renderType,
@@ -12,7 +10,7 @@ export function AnalyticsHistogramTabBar({
 }: {
   renderType: RenderType;
   onChangeRenderType: (type: RenderType) => void;
-}) {
+}): JSX.Element {
   return (
     <div className="flex min-w-0">
       <AnalyticsHistogramTabItem

--- a/packages/fern-dashboard/src/components/analytics/ConversationColumnDef.tsx
+++ b/packages/fern-dashboard/src/components/analytics/ConversationColumnDef.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { ColumnDef } from "@tanstack/react-table";
+import type { ColumnDef } from "@tanstack/react-table";
 
-import { FernAI } from "@fern-api/fai-sdk";
+import type { FernAI } from "@fern-api/fai-sdk";
 
 export const columns: ColumnDef<FernAI.Query>[] = [
   {

--- a/packages/fern-dashboard/src/components/analytics/QueriesDataTable.tsx
+++ b/packages/fern-dashboard/src/components/analytics/QueriesDataTable.tsx
@@ -1,9 +1,7 @@
 "use client";
 
+import type { Cell, ColumnDef, Row } from "@tanstack/react-table";
 import {
-  Cell,
-  ColumnDef,
-  Row,
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
@@ -11,13 +9,13 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 
-import { FernAI } from "@fern-api/fai-sdk";
+import type { FernAI } from "@fern-api/fai-sdk";
 
 import { getConversation } from "@/app/actions/getConversation";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 
 import { QueriesDataTableHeader } from "./QueriesDataTableHeader";
-import { TimeRange } from "./utils/get-request-params";
+import type { TimeRange } from "./utils/get-request-params";
 
 interface QueriesDataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -41,7 +39,7 @@ export function QueriesDataTable<TData, TValue>({
   setQueryTimeRange,
   onExport,
   isExporting,
-}: QueriesDataTableProps<TData, TValue>) {
+}: QueriesDataTableProps<TData, TValue>): JSX.Element {
   const table = useReactTable({
     data,
     columns,

--- a/packages/fern-dashboard/src/components/analytics/QueriesDataTableHeader.tsx
+++ b/packages/fern-dashboard/src/components/analytics/QueriesDataTableHeader.tsx
@@ -1,11 +1,12 @@
 import ChatBubbleLeftEllipsisIcon from "@heroicons/react/24/outline/ChatBubbleLeftEllipsisIcon";
 import MagnifyingGlassIcon from "@heroicons/react/24/outline/MagnifyingGlassIcon";
-import { Table } from "@tanstack/react-table";
+import type { Table } from "@tanstack/react-table";
 
 import { Input } from "@/components/ui/input";
 
 import { ExportButton } from "./ExportButton";
-import { TimeRangeOption, TimeRangeSelect } from "./TimeRangeSelect";
+import type { TimeRangeOption } from "./TimeRangeSelect";
+import { TimeRangeSelect } from "./TimeRangeSelect";
 import { TimeRange } from "./utils/get-request-params";
 
 const QUERIES_TIME_RANGE_OPTIONS: TimeRangeOption[] = [
@@ -29,7 +30,7 @@ export function QueriesDataTableHeader<TData>({
   setQueryTimeRange,
   onExport,
   isExporting,
-}: QueriesDataTableHeaderProps<TData>) {
+}: QueriesDataTableHeaderProps<TData>): JSX.Element {
   return (
     <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
       <div className="flex items-center gap-2">

--- a/packages/fern-dashboard/src/components/auth/OrgSwitcherClient.tsx
+++ b/packages/fern-dashboard/src/components/auth/OrgSwitcherClient.tsx
@@ -6,7 +6,10 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "@bprogress/next/app";
 import { ChevronDown } from "lucide-react";
 
-import { Auth0OrgName, Auth0Organization } from "@/app/services/auth0/types";
+import type {
+  Auth0OrgName,
+  Auth0Organization,
+} from "@/app/services/auth0/types";
 import { SearchableDropdown } from "@/components/ui/SearchableDropdown";
 import { Button } from "@/components/ui/button";
 import { getOrgDisplayName } from "@/utils/getOrgDisplayName";
@@ -21,7 +24,7 @@ export const OrgSwitcherClient = ({
 }: {
   organizations: Auth0Organization[];
   currentOrgName: Auth0OrgName;
-}) => {
+}): JSX.Element => {
   const orgName = useOrgNameFromPathname();
   const [localOrgName, setLocalOrgName] = useState(currentOrgName);
   const [searchTerm, setSearchTerm] = useState("");

--- a/packages/fern-dashboard/src/components/auth/org-logo/OrgLogo.tsx
+++ b/packages/fern-dashboard/src/components/auth/org-logo/OrgLogo.tsx
@@ -1,4 +1,4 @@
-import { Auth0Organization } from "@/app/services/auth0/types";
+import type { Auth0Organization } from "@/app/services/auth0/types";
 
 import { OrgLogoContent } from "./OrgLogoContent";
 
@@ -8,7 +8,7 @@ export declare namespace OrgLogo {
   }
 }
 
-export function OrgLogo({ organization }: OrgLogo.Props) {
+export function OrgLogo({ organization }: OrgLogo.Props): JSX.Element {
   return (
     <div className="flex size-6">
       <OrgLogoContent organization={organization} />

--- a/packages/fern-dashboard/src/components/auth/org-logo/OrgLogoContent.tsx
+++ b/packages/fern-dashboard/src/components/auth/org-logo/OrgLogoContent.tsx
@@ -1,4 +1,4 @@
-import { Auth0Organization } from "@/app/services/auth0/types";
+import type { Auth0Organization } from "@/app/services/auth0/types";
 
 import { OrgPlaceholderLogo } from "./OrgPlaceholderLogo";
 import { SvgOrgLogo } from "./SvgOrgLogo";
@@ -9,7 +9,9 @@ export declare namespace OrgLogoContent {
   }
 }
 
-export function OrgLogoContent({ organization }: OrgLogoContent.Props) {
+export function OrgLogoContent({
+  organization,
+}: OrgLogoContent.Props): JSX.Element {
   if (organization.branding?.logo_url == null) {
     return <OrgPlaceholderLogo org={organization} />;
   }

--- a/packages/fern-dashboard/src/components/auth/org-logo/OrgPlaceholderLogo.tsx
+++ b/packages/fern-dashboard/src/components/auth/org-logo/OrgPlaceholderLogo.tsx
@@ -1,4 +1,4 @@
-import { Auth0Organization } from "@/app/services/auth0/types";
+import type { Auth0Organization } from "@/app/services/auth0/types";
 
 export declare namespace OrgPlaceholderLogo {
   export interface Props {
@@ -6,7 +6,9 @@ export declare namespace OrgPlaceholderLogo {
   }
 }
 
-export function OrgPlaceholderLogo({ org }: OrgPlaceholderLogo.Props) {
+export function OrgPlaceholderLogo({
+  org,
+}: OrgPlaceholderLogo.Props): JSX.Element {
   return (
     <div className="text-primary border-border flex flex-1 items-center justify-center rounded border bg-green-200 p-1 text-xl uppercase">
       {org.display_name[0]}

--- a/packages/fern-dashboard/src/components/docs-page/BranchList.tsx
+++ b/packages/fern-dashboard/src/components/docs-page/BranchList.tsx
@@ -7,12 +7,12 @@ import { useRouter } from "@bprogress/next/app";
 import { createNavigationLocalStorage } from "@fern-docs/components";
 
 import { useOrgName } from "@/app/[orgName]/context/OrgNameContext";
-import { Auth0SessionData } from "@/app/services/auth0/getCurrentSession";
-import { GithubSourceRepo } from "@/app/services/github/types";
+import type { Auth0SessionData } from "@/app/services/auth0/getCurrentSession";
+import type { GithubSourceRepo } from "@/app/services/github/types";
 import { Button } from "@/components/ui/button";
 import Card from "@/components/ui/card";
 import { ROOT_SLUG_ALIAS, constructEditorSlug } from "@/utils/editor-routing";
-import { DocsUrl, EncodedDocsUrl } from "@/utils/types";
+import type { DocsUrl, EncodedDocsUrl } from "@/utils/types";
 
 import { BranchListItem } from "./BranchListItem";
 import { GoToEditorButton } from "./GoToEditorButton";
@@ -30,7 +30,7 @@ export function BranchList({
   session: Auth0SessionData;
   sourceRepo?: GithubSourceRepo;
   branches: string[];
-}) {
+}): JSX.Element {
   const orgName = useOrgName();
   const router = useRouter();
 

--- a/packages/fern-dashboard/src/components/docs-page/BranchPRInfo.tsx
+++ b/packages/fern-dashboard/src/components/docs-page/BranchPRInfo.tsx
@@ -2,10 +2,10 @@
 
 import { GitPullRequest, GitPullRequestDraft } from "lucide-react";
 
-import { GithubSourceRepo } from "@/app/services/github/types";
+import type { GithubSourceRepo } from "@/app/services/github/types";
 import { StatusBadge } from "@/components/ui/StatusBadge";
 import { GitPRProvider, useGitPrInfo } from "@/providers/GitPRContext";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 import { ClickablePrNumber } from "../editor/ClickablePrNumber";
 import { PRTitleEditor } from "../editor/PRTitleEditor";
@@ -29,7 +29,7 @@ export function BranchPRInfo({
   branch,
   sourceRepo,
   docsUrl,
-}: BranchPRInfoProps) {
+}: BranchPRInfoProps): JSX.Element | null {
   if (!sourceRepo?.owner || !sourceRepo?.repo) {
     return null;
   }

--- a/packages/fern-dashboard/src/components/docs-page/DocsZeroState.tsx
+++ b/packages/fern-dashboard/src/components/docs-page/DocsZeroState.tsx
@@ -1,4 +1,4 @@
-import { User } from "@auth0/nextjs-auth0/types";
+import type { User } from "@auth0/nextjs-auth0/types";
 import { PlusIcon } from "lucide-react";
 
 import { Button } from "../ui/button";
@@ -10,7 +10,9 @@ export declare namespace DocsZeroState {
   }
 }
 
-export async function DocsZeroState({ user }: DocsZeroState.Props) {
+export async function DocsZeroState({
+  user,
+}: DocsZeroState.Props): Promise<JSX.Element> {
   let welcomeString = "Welcome";
   const firstName = getFirstName(user);
   if (firstName != null) {

--- a/packages/fern-dashboard/src/components/docs-page/DocsZeroStateImage.tsx
+++ b/packages/fern-dashboard/src/components/docs-page/DocsZeroStateImage.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import Image, { StaticImageData } from "next/image";
+import type { StaticImageData } from "next/image";
+import Image from "next/image";
 
 import { useIsFirstClientSideRender } from "@/utils/useIsFirstClientSideRender";
 

--- a/packages/fern-dashboard/src/components/docs-page/FernCliVersionDisplay.tsx
+++ b/packages/fern-dashboard/src/components/docs-page/FernCliVersionDisplay.tsx
@@ -1,6 +1,6 @@
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { getFernVersionUpdateInfo } from "@/app/services/dal/github/getFernVersionUpdateInfo";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 import { FernIcon } from "../theme/FernIcon";
 import { UpgradeFernButton } from "./UpgradeFernButton";
@@ -15,7 +15,7 @@ export async function FernCliVersionDisplay({
   docsUrl: DocsUrl;
   baseBranch?: string;
   orgName: Auth0OrgName;
-}) {
+}): Promise<JSX.Element | null> {
   const fernVersionInfoResult = await getFernVersionUpdateInfo({
     githubUrl,
     docsUrl,

--- a/packages/fern-dashboard/src/components/docs-page/GithubSource.tsx
+++ b/packages/fern-dashboard/src/components/docs-page/GithubSource.tsx
@@ -4,10 +4,10 @@ import { useState } from "react";
 
 import { Cog, Loader2 } from "lucide-react";
 
-import { GithubRepoValidationResult } from "@/app/services/dal/github/validators";
+import type { GithubRepoValidationResult } from "@/app/services/dal/github/validators";
 import { getRepoDisplayNameFromUrl } from "@/app/services/github/github";
-import { GithubSourceRepo } from "@/app/services/github/types";
-import { DocsUrl } from "@/utils/types";
+import type { GithubSourceRepo } from "@/app/services/github/types";
+import type { DocsUrl } from "@/utils/types";
 
 import { GithubLogo } from "../auth/GithubLogo";
 import { Button } from "../ui/button";
@@ -28,7 +28,7 @@ export function GithubSource({
   docsUrl: DocsUrl;
   githubUrl?: string;
   isLoading?: boolean;
-}) {
+}): JSX.Element {
   const [isSaving, setIsSaving] = useState(false);
   const [isDomainHovered, setIsDomainHovered] = useState(false);
 

--- a/packages/fern-dashboard/src/components/docs-page/GoToEditorButton.tsx
+++ b/packages/fern-dashboard/src/components/docs-page/GoToEditorButton.tsx
@@ -12,9 +12,9 @@ import {
 import { generateBranchName } from "@fern-docs/components/navigation/local-storage";
 
 import { useOrgName } from "@/app/[orgName]/context/OrgNameContext";
-import { Auth0SessionData } from "@/app/services/auth0/getCurrentSession";
+import type { Auth0SessionData } from "@/app/services/auth0/getCurrentSession";
 import { ROOT_SLUG_ALIAS, constructEditorSlug } from "@/utils/editor-routing";
-import { DocsUrl, EncodedDocsUrl } from "@/utils/types";
+import type { DocsUrl, EncodedDocsUrl } from "@/utils/types";
 
 import { Button } from "../ui/button";
 
@@ -29,7 +29,7 @@ export function GoToEditorButton({
   disabled?: boolean;
   disabledReason?: string;
   isValidatingSource?: boolean;
-}) {
+}): JSX.Element {
   const orgName = useOrgName();
   const [isLoading, setIsLoading] = useState(false);
 

--- a/packages/fern-dashboard/src/components/docs-page/SetGithubSource.tsx
+++ b/packages/fern-dashboard/src/components/docs-page/SetGithubSource.tsx
@@ -7,7 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { DashboardApiClient } from "@/app/services/dashboard-api/client";
 import { validateUrlIsGithubUrl } from "@/app/services/github/github";
 import { ReactQueryKey } from "@/state/queryKeys";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 import {
   ErrorEditSourceToast,
@@ -26,7 +26,7 @@ export function SetGithubSourcePopover({
   docsUrl: DocsUrl;
   children: React.ReactNode;
   setIsSaving: (isSaving: boolean) => void;
-}) {
+}): JSX.Element {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [inputUrl, setInputUrl] = useState("");
 

--- a/packages/fern-dashboard/src/components/docs-page/UpgradeFernButton.tsx
+++ b/packages/fern-dashboard/src/components/docs-page/UpgradeFernButton.tsx
@@ -6,8 +6,8 @@ import SparklesIcon from "@heroicons/react/24/outline/SparklesIcon";
 import { ExternalLink, Loader2 } from "lucide-react";
 
 import { upgradeFernVersionAction } from "@/app/actions/upgradeFernVersion";
-import { Auth0OrgName } from "@/app/services/auth0/types";
-import { DocsUrl } from "@/utils/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
+import type { DocsUrl } from "@/utils/types";
 import { cn } from "@/utils/utils";
 
 import { ErrorUpgradeFernCliVersionToast } from "../editor/EditorToasts";
@@ -41,7 +41,7 @@ export function UpgradeFernButton({
   existingPr,
   variant = "outline",
   abbreviateText = false,
-}: UpgradeFernButtonProps) {
+}: UpgradeFernButtonProps): JSX.Element {
   const [isLoading, setIsLoading] = useState(false);
   const [loadingStep, setLoadingStep] = useState<string>("");
   const [currentPr, setCurrentPr] = useState(existingPr);

--- a/packages/fern-dashboard/src/components/docs-page/visual-editor-section/CriticalUpdateWarning.tsx
+++ b/packages/fern-dashboard/src/components/docs-page/visual-editor-section/CriticalUpdateWarning.tsx
@@ -1,6 +1,6 @@
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { getFernVersionUpdateInfo } from "@/app/services/dal/github/getFernVersionUpdateInfo";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 import { UpgradeFernButton } from "../UpgradeFernButton";
 import { WarningNote } from "../WarningNote";
@@ -15,7 +15,7 @@ export async function CriticalUpdateWarning({
   docsUrl: DocsUrl;
   githubUrl: string;
   baseBranch: string;
-}) {
+}): Promise<JSX.Element | null> {
   const fernVersionInfoResult = await getFernVersionUpdateInfo({
     githubUrl,
     docsUrl,

--- a/packages/fern-dashboard/src/components/docs-page/visual-editor-section/VisualEditorSection.tsx
+++ b/packages/fern-dashboard/src/components/docs-page/visual-editor-section/VisualEditorSection.tsx
@@ -1,10 +1,10 @@
 import "server-only";
 
-import { Auth0SessionData } from "@/app/services/auth0/getCurrentSession";
-import { Auth0OrgName } from "@/app/services/auth0/types";
-import { DocsUrl } from "@/utils/types";
+import type { Auth0SessionData } from "@/app/services/auth0/getCurrentSession";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
+import type { DocsUrl } from "@/utils/types";
 
-import { GithubAuthState } from "../GithubSource";
+import type { GithubAuthState } from "../GithubSource";
 import { CriticalUpdateWarning } from "./CriticalUpdateWarning";
 import { VisualEditorEmptyCard } from "./VisualEditorEmptyCard";
 import { VisualEditorSectionClient } from "./VisualEditorSectionClient";
@@ -22,7 +22,7 @@ export async function VisualEditorSection({
   githubAuthState: GithubAuthState;
   githubUrl?: string;
   orgName: Auth0OrgName;
-}) {
+}): Promise<JSX.Element> {
   if (!githubAuthState.validationResult.ok) {
     return (
       <VisualEditorEmptyCard>

--- a/packages/fern-dashboard/src/components/docs-page/visual-editor-section/VisualEditorSectionClient.tsx
+++ b/packages/fern-dashboard/src/components/docs-page/visual-editor-section/VisualEditorSectionClient.tsx
@@ -4,13 +4,13 @@ import { useEffect, useState } from "react";
 
 import { createNavigationLocalStorage } from "@fern-docs/components";
 
-import { Auth0SessionData } from "@/app/services/auth0/getCurrentSession";
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0SessionData } from "@/app/services/auth0/getCurrentSession";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { getRelevantUserBranchesForSite } from "@/app/services/dal/mongodb/getRelevantUserBranchesForSite";
-import { GithubSourceRepo } from "@/app/services/github/types";
+import type { GithubSourceRepo } from "@/app/services/github/types";
 import Card from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 import { BranchList } from "../BranchList";
 import { GoToEditorButton } from "../GoToEditorButton";
@@ -29,7 +29,7 @@ export function VisualEditorSectionClient({
   docsUrl: DocsUrl;
   sourceRepo?: GithubSourceRepo;
   orgName: Auth0OrgName;
-}) {
+}): JSX.Element {
   const [relevantBranches, setRelevantBranches] = useState<string[]>([]);
   const [loadingBranches, setLoadingBranches] = useState(true);
 

--- a/packages/fern-dashboard/src/components/docs-page/visual-editor-section/VisualEditorValidationErrorHandler.tsx
+++ b/packages/fern-dashboard/src/components/docs-page/visual-editor-section/VisualEditorValidationErrorHandler.tsx
@@ -1,5 +1,5 @@
-import { Auth0OrgName } from "@/app/services/auth0/types";
-import { GithubRepoValidationError } from "@/app/services/dal/github/validators";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
+import type { GithubRepoValidationError } from "@/app/services/dal/github/validators";
 import { getRepoDisplayNameFromUrl } from "@/app/services/github/github";
 import { getValidationErrorMessage } from "@/utils/errors";
 
@@ -18,7 +18,7 @@ export function VisualEditorValidationErrorHandler({
   orgName,
   site,
   githubUrl,
-}: ValidationErrorHandlerProps) {
+}: ValidationErrorHandlerProps): JSX.Element {
   switch (error.type) {
     case "FERN_BOT_NOT_INSTALLED":
       return (

--- a/packages/fern-dashboard/src/components/editor/BubbleMenu.tsx
+++ b/packages/fern-dashboard/src/components/editor/BubbleMenu.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler } from "react";
+import type { MouseEventHandler } from "react";
 
 import { useCurrentEditor } from "@tiptap/react";
 import { BubbleMenu as EditorBubbleMenu } from "@tiptap/react/menus";
@@ -16,7 +16,7 @@ type BubbleMenuAction =
   | "toggleBulletList"
   | "toggleOrderedList";
 
-export default function BubbleMenu() {
+export default function BubbleMenu(): JSX.Element {
   const { editor } = useCurrentEditor();
 
   function menuItemClickHandler(action: BubbleMenuAction) {

--- a/packages/fern-dashboard/src/components/editor/HeaderToolbar.tsx
+++ b/packages/fern-dashboard/src/components/editor/HeaderToolbar.tsx
@@ -6,12 +6,12 @@ import { useEffect } from "react";
 import { ArrowLeftIcon } from "lucide-react";
 
 import { useOrgName } from "@/app/[orgName]/context/OrgNameContext";
-import { Auth0SessionData } from "@/app/services/auth0/getCurrentSession";
+import type { Auth0SessionData } from "@/app/services/auth0/getCurrentSession";
 import { useEditingDisabled } from "@/hooks/useEditingDisabled";
 import { useBranch } from "@/providers/BranchContext";
 import { useGitHubRepo } from "@/providers/GitHubRepoContext";
 import { useGitPrInfo } from "@/providers/GitPRContext";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 import { ProfileImage } from "../layout/ProfileImage";
 import { Button } from "../ui/button";
@@ -28,7 +28,7 @@ export function HeaderToolbar({
 }: {
   session: Auth0SessionData;
   docsUrl: DocsUrl;
-}) {
+}): JSX.Element {
   const { name, picture } = session.user;
   const { gitPrUrl, setPrUrl } = useGitPrInfo();
   const { branch } = useBranch();

--- a/packages/fern-dashboard/src/components/editor/PRStatusDropdown.tsx
+++ b/packages/fern-dashboard/src/components/editor/PRStatusDropdown.tsx
@@ -6,7 +6,7 @@ import { ChevronDownIcon } from "lucide-react";
 
 import { useOrgName } from "@/app/[orgName]/context/OrgNameContext";
 import { DashboardApiClient } from "@/app/services/dashboard-api/client";
-import { GithubPrStatus } from "@/app/services/github/types";
+import type { GithubPrStatus } from "@/app/services/github/types";
 import { useGitPrInfo } from "@/providers/GitPRContext";
 
 import { StatusBadge } from "../ui/StatusBadge";
@@ -27,7 +27,7 @@ export function PRStatusDropdown({
   branch,
   gitPrUrl,
   baseBranch,
-}: PRStatusDropdownProps) {
+}: PRStatusDropdownProps): JSX.Element {
   const { prStatus, setPrStatus, loading, site } = useGitPrInfo();
   const orgName = useOrgName();
   const [isUpdating, setIsUpdating] = useState(false);

--- a/packages/fern-dashboard/src/components/editor/TiptapEditor.tsx
+++ b/packages/fern-dashboard/src/components/editor/TiptapEditor.tsx
@@ -4,10 +4,9 @@ import { useEffect } from "react";
 
 import CodeBlock from "@tiptap/extension-code-block";
 import Placeholder from "@tiptap/extension-placeholder";
+import type { EditorProviderProps, Extension } from "@tiptap/react";
 import {
   EditorProvider,
-  EditorProviderProps,
-  Extension,
   ReactNodeViewRenderer,
   useCurrentEditor,
 } from "@tiptap/react";
@@ -23,7 +22,7 @@ import BubbleMenu from "./BubbleMenu";
 import FloatingMenu from "./FloatingMenu";
 import NodeHoverHandle from "./NodeHoverHandle";
 import { createCodeBlockComponent } from "./extension-code-block/CodeBlockComponent";
-import { LowlightInstance } from "./extension-code-block/types";
+import type { LowlightInstance } from "./extension-code-block/types";
 import CustomElement from "./extension-custom-element";
 import { FVEAttributesExtension } from "./extension-fve-attributes";
 import { LowlightPlugin } from "./tiptap-node/lowlight/lowlight-plugin";
@@ -100,7 +99,7 @@ export default function TiptapEditor({
   onCreate,
   onUpdate,
   disableDragging,
-}: TiptapEditor.Props) {
+}: TiptapEditor.Props): JSX.Element {
   const isEditingDisabled = useEditingDisabled();
 
   return (

--- a/packages/fern-dashboard/src/components/editor/editor-component/EditorComponentContext.tsx
+++ b/packages/fern-dashboard/src/components/editor/editor-component/EditorComponentContext.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import React, { ReactNode, createContext, useContext } from "react";
+import type { ReactNode } from "react";
+import React, { createContext, useContext } from "react";
 
-import { KeyedAttributes } from "../editor-mdx-renderer/types";
+import type { KeyedAttributes } from "../editor-mdx-renderer/types";
 
 interface EditorComponentContextValue {
   keyedAttributes: KeyedAttributes;
@@ -63,7 +64,7 @@ export const useEditorComponent = (): EditorComponentContextValue => {
   return useContext(EditorComponentContext);
 };
 
-export const InterceptedChildren = () => {
+export const InterceptedChildren = (): React.ReactElement => {
   const { providedChildren } = useContext(EditorComponentContext);
   return providedChildren;
 };

--- a/packages/fern-dashboard/src/components/editor/editor-component/EditorComponentPopover.tsx
+++ b/packages/fern-dashboard/src/components/editor/editor-component/EditorComponentPopover.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import React, {
-  ReactNode,
-  RefObject,
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-} from "react";
+import type { ReactNode, RefObject } from "react";
+import React, { createContext, useContext, useEffect, useState } from "react";
 
 import * as Popover from "@radix-ui/react-popover";
 import { EllipsisVertical, Trash2, TriangleAlert } from "lucide-react";
@@ -24,13 +18,11 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/utils/utils";
 
-import { AttributeValue } from "../editor-mdx-renderer/types";
+import type { AttributeValue } from "../editor-mdx-renderer/types";
 import { useEditorComponent } from "./EditorComponentContext";
+import type { AttributeConfig, AttributeValues, Control } from "./controls";
 import {
-  AttributeConfig,
-  AttributeValues,
   CheckboxControl,
-  Control,
   IntegerInputControl,
   SelectControl,
   TextInputControl,
@@ -53,7 +45,9 @@ interface EditorComponentPopoverContextValue<
 const EditorComponentPopoverContext =
   createContext<EditorComponentPopoverContextValue<any> | null>(null);
 
-export function useEditorComponentPopover<T extends AttributeConfig>() {
+export function useEditorComponentPopover<
+  T extends AttributeConfig,
+>(): EditorComponentPopoverContextValue<T> {
   const context = useContext(
     EditorComponentPopoverContext
   ) as EditorComponentPopoverContextValue<T> | null;
@@ -76,7 +70,7 @@ export function EditorComponentPopoverProvider<T extends AttributeConfig>({
   children: ReactNode;
   targetRef?: RefObject<HTMLElement | null>;
   hoverSlopThreshold?: number;
-}) {
+}): JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
   const [isWithinThreshold, setIsWithinThreshold] = useState(false);
 
@@ -442,7 +436,7 @@ export function EditorComponentPopoverButton<T extends AttributeConfig>({
 }: {
   className?: string;
   disableDelete?: boolean;
-}) {
+}): JSX.Element {
   const {
     attributes,
     values,

--- a/packages/fern-dashboard/src/components/editor/editor-component/controls.ts
+++ b/packages/fern-dashboard/src/components/editor/editor-component/controls.ts
@@ -1,4 +1,4 @@
-import { AttributeValue } from "../editor-mdx-renderer/types";
+import type { AttributeValue } from "../editor-mdx-renderer/types";
 
 // Base Control class
 export abstract class Control {

--- a/packages/fern-dashboard/src/components/editor/editor-mdx-renderer/FernEditorMDXRenderer.tsx
+++ b/packages/fern-dashboard/src/components/editor/editor-mdx-renderer/FernEditorMDXRenderer.tsx
@@ -3,15 +3,12 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useMDXComponents } from "@mdx-js/react";
 import { getMDXComponent } from "mdx-bundler/client";
 
-import {
+import type {
   MdastNodes,
   MdxJsxAttribute,
   MdxJsxExpressionAttribute,
-  astToMDX,
-  htmlToMdx,
-  mdxToAST,
-  mdxToHtml,
 } from "@fern-docs/mdx";
+import { astToMDX, htmlToMdx, mdxToAST, mdxToHtml } from "@fern-docs/mdx";
 
 import TiptapEditor from "@/components/editor/TiptapEditor";
 import { EditorComponentProvider } from "@/components/editor/editor-component/EditorComponentContext";
@@ -21,7 +18,11 @@ import { useDebounce } from "@/hooks/useDebounce";
 
 import { UnsupportedContent } from "../UnsupportedContent";
 import { cachedBundleMDX } from "./cache";
-import { AttributeValue, JSXElement, ParsedMarkdownElement } from "./types";
+import type {
+  AttributeValue,
+  JSXElement,
+  ParsedMarkdownElement,
+} from "./types";
 
 function buildMdxElement(
   name: string,
@@ -529,7 +530,7 @@ function applyIndentation(mdx: string, indentLevel: number): string {
 const FernEditorMDXRenderer = ({
   mdx,
   onUpdate,
-}: FernEditorMDXRendererProps) => {
+}: FernEditorMDXRendererProps): JSX.Element => {
   return <FernEditorMDXRendererInternal mdx={mdx} onUpdate={onUpdate} />;
 };
 

--- a/packages/fern-dashboard/src/components/editor/editor-mdx-renderer/types.ts
+++ b/packages/fern-dashboard/src/components/editor/editor-mdx-renderer/types.ts
@@ -1,4 +1,4 @@
-import { MdxJsxExpressionAttribute } from "@fern-docs/mdx";
+import type { MdxJsxExpressionAttribute } from "@fern-docs/mdx";
 
 // example: intent="warning"
 export interface StringAttribute {

--- a/packages/fern-dashboard/src/components/editor/extension-custom-element/CSSContext.tsx
+++ b/packages/fern-dashboard/src/components/editor/extension-custom-element/CSSContext.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode, createContext, useContext } from "react";
+import type { ReactNode } from "react";
+import React, { createContext, useContext } from "react";
 
 interface CSSConfig {
   inline?: string[];
@@ -12,13 +13,13 @@ export const CSSProvider = ({
 }: {
   children: ReactNode;
   cssConfig?: CSSConfig;
-}) => {
+}): JSX.Element => {
   return (
     <CSSContext.Provider value={cssConfig}>{children}</CSSContext.Provider>
   );
 };
 
-export const useCSS = () => {
+export const useCSS = (): CSSConfig => {
   const context = useContext(CSSContext);
   if (context === undefined) {
     return { inline: [] };

--- a/packages/fern-dashboard/src/components/editor/extension-custom-element/CustomElementNodeView.tsx
+++ b/packages/fern-dashboard/src/components/editor/extension-custom-element/CustomElementNodeView.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
-import { NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewWrapper } from "@tiptap/react";
 
 import FernEditorMDXRenderer from "@/components/editor/editor-mdx-renderer/FernEditorMDXRenderer";
 import { ErrorBoundary } from "@/docs/components/error-boundary";
@@ -8,7 +9,7 @@ import { useFileResolver } from "@/providers/FileResolverContext";
 
 import { UnsupportedContent } from "../UnsupportedContent";
 
-export const CustomElementNodeView = (props: NodeViewProps) => {
+export const CustomElementNodeView = (props: NodeViewProps): JSX.Element => {
   const { node, updateAttributes } = props;
   const { attrs } = node;
 

--- a/packages/fern-dashboard/src/components/editor/floating-menu-options.ts
+++ b/packages/fern-dashboard/src/components/editor/floating-menu-options.ts
@@ -1,4 +1,4 @@
-import { Editor } from "@tiptap/react";
+import type { Editor } from "@tiptap/react";
 import {
   ChevronDown,
   ChevronsDown,
@@ -28,7 +28,7 @@ import { EMPTY_PARAM_FIELD_CONTENT } from "@/docs/mdx/components/parameters/Para
 import { EMPTY_STEPS_CONTENT } from "@/docs/mdx/components/steps";
 import { EMPTY_TABS_CONTENT } from "@/docs/mdx/components/tabs/Tabs";
 
-import { SuggestionItem } from "../tiptap-ui-utils/suggestion-menu";
+import type { SuggestionItem } from "../tiptap-ui-utils/suggestion-menu";
 import { createCustomElementNode } from "./extension-custom-element/create-custom-element-node";
 
 const handleCustomNodeInsert = (

--- a/packages/fern-dashboard/src/components/icon/Icon.tsx
+++ b/packages/fern-dashboard/src/components/icon/Icon.tsx
@@ -1,3 +1,4 @@
+import type { LucideProps } from "lucide-react";
 import {
   Bold,
   Code,
@@ -9,7 +10,6 @@ import {
   Link,
   List,
   ListOrdered,
-  LucideProps,
   MessageSquareQuote,
   Plus,
   Strikethrough,
@@ -18,10 +18,28 @@ import {
 } from "lucide-react";
 
 import { HeadingDropdown } from "./custom/HeadingDropdown";
-import { CustomIconProps } from "./custom/types";
+import type { CustomIconProps } from "./custom/types";
+
+type IconName =
+  | "Bold"
+  | "Code"
+  | "Heading1"
+  | "Heading2"
+  | "Heading3"
+  | "Image"
+  | "Italic"
+  | "Link"
+  | "List"
+  | "ListOrdered"
+  | "MessageSquareQuote"
+  | "Plus"
+  | "Strikethrough"
+  | "Type"
+  | "Underline"
+  | "HeadingDropdown";
 
 // Map icon names to their corresponding components
-const ICONS = {
+const ICONS: Record<IconName, React.ComponentType<LucideProps>> = {
   Bold,
   Code,
   Heading1,
@@ -40,9 +58,6 @@ const ICONS = {
   HeadingDropdown,
 };
 
-// Infer icon names type
-export type IconName = keyof typeof ICONS;
-
 // Maintain compatibility between Lucide React props and custom icon props
 type CommonIconProps = LucideProps & CustomIconProps;
 
@@ -52,7 +67,7 @@ export declare namespace Icon {
   }
 }
 
-export function Icon({ variant, ...props }: Icon.Props) {
+export function Icon({ variant, ...props }: Icon.Props): JSX.Element {
   const Component = ICONS[variant];
   const propsWithDefaults = defaultIconProps(props);
   return <Component {...propsWithDefaults} />;

--- a/packages/fern-dashboard/src/components/icon/custom/HeadingDropdown.tsx
+++ b/packages/fern-dashboard/src/components/icon/custom/HeadingDropdown.tsx
@@ -1,6 +1,6 @@
-import { CustomIconProps } from "./types";
+import type { CustomIconProps } from "./types";
 
-export function HeadingDropdown(props: CustomIconProps) {
+export function HeadingDropdown(props: CustomIconProps): JSX.Element {
   return (
     <svg
       width={props.size}

--- a/packages/fern-dashboard/src/components/icon/custom/types.ts
+++ b/packages/fern-dashboard/src/components/icon/custom/types.ts
@@ -1,4 +1,4 @@
-import { LucideProps } from "lucide-react";
+import type { LucideProps } from "lucide-react";
 
 // Pick a subset of LucideProps that are relevant to custom icons
 export type CustomIconProps = Pick<LucideProps, "size" | "color">;

--- a/packages/fern-dashboard/src/components/layout/DocsSiteSelect.tsx
+++ b/packages/fern-dashboard/src/components/layout/DocsSiteSelect.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 
 import { useRouter } from "@bprogress/next/app";
 
-import { FdrAPI } from "@fern-api/fdr-sdk/client/types";
+import type { FdrAPI } from "@fern-api/fdr-sdk/client/types";
 
 import {
   Select,
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/select";
 import { constructDocsUrlParam } from "@/utils/constructDocsUrlParam";
 import { getDocsSiteUrl } from "@/utils/getDocsSiteUrl";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 import { useOrgNameFromPathname } from "@/utils/useOrgNameFromPathname";
 
 export declare namespace DocsSiteSelect {
@@ -28,7 +28,7 @@ export declare namespace DocsSiteSelect {
 export const DocsSiteSelect = ({
   currentDocsUrl,
   docsSites,
-}: DocsSiteSelect.Props) => {
+}: DocsSiteSelect.Props): JSX.Element => {
   const orgName = useOrgNameFromPathname();
 
   const [localValue, setLocalValue] = useState(currentDocsUrl);

--- a/packages/fern-dashboard/src/components/layout/MaybeDocsHeaderItems.tsx
+++ b/packages/fern-dashboard/src/components/layout/MaybeDocsHeaderItems.tsx
@@ -1,8 +1,8 @@
 import "server-only";
 
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { getAuthenticatedSessionOrRedirect } from "@/app/services/dal/organization";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 import { DocsSiteSwitcher } from "./DocsSiteSwitcher";
 
@@ -12,7 +12,7 @@ export async function MaybeDocsHeaderItems({
 }: Readonly<{
   docsUrl?: DocsUrl;
   orgName: Auth0OrgName;
-}>) {
+}>): Promise<JSX.Element | null> {
   if (docsUrl == null) {
     return null;
   }

--- a/packages/fern-dashboard/src/components/layout/SidepanelContext.tsx
+++ b/packages/fern-dashboard/src/components/layout/SidepanelContext.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
 import {
-  ReactNode,
   createContext,
   useCallback,
   useContext,

--- a/packages/fern-dashboard/src/components/login-page/LoginImage.tsx
+++ b/packages/fern-dashboard/src/components/login-page/LoginImage.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import Image, { StaticImageData } from "next/image";
+import type { StaticImageData } from "next/image";
+import Image from "next/image";
+import type { JSX } from "react";
 
 import { useIsFirstClientSideRender } from "@/utils/useIsFirstClientSideRender";
 
@@ -51,7 +53,7 @@ function CrossfadeThemeImage({
   );
 }
 
-export function LoginImage() {
+export function LoginImage(): JSX.Element | null {
   // render `null` on the first render to match the SSR and avoid hydration errors
   const isFirstClientSideRender = useIsFirstClientSideRender();
   if (isFirstClientSideRender) {

--- a/packages/fern-dashboard/src/components/members/InviteUserDialog.tsx
+++ b/packages/fern-dashboard/src/components/members/InviteUserDialog.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import PlusIcon from "@heroicons/react/24/outline/PlusIcon";
 
-import { Auth0Organization } from "@/app/services/auth0/types";
+import type { Auth0Organization } from "@/app/services/auth0/types";
 
 import { Button } from "../ui/button";
 import { Dialog, DialogContent, DialogTrigger } from "../ui/dialog";
@@ -14,7 +14,7 @@ export declare namespace InviteUserDialog {
   }
 }
 
-export function InviteUserDialog({ org }: InviteUserDialog.Props) {
+export function InviteUserDialog({ org }: InviteUserDialog.Props): JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
 
   return (

--- a/packages/fern-dashboard/src/components/members/InviteUserDialogContent.tsx
+++ b/packages/fern-dashboard/src/components/members/InviteUserDialogContent.tsx
@@ -9,8 +9,9 @@ import { toast } from "sonner";
 
 import { createInviteLink } from "@/app/actions/createInviteLink";
 import { inviteUserToOrg } from "@/app/actions/inviteUserToOrg";
-import { Auth0Organization } from "@/app/services/auth0/types";
-import { ReactQueryKey, inferQueryData } from "@/state/queryKeys";
+import type { Auth0Organization } from "@/app/services/auth0/types";
+import type { inferQueryData } from "@/state/queryKeys";
+import { ReactQueryKey } from "@/state/queryKeys";
 import { getOrgDisplayName } from "@/utils/getOrgDisplayName";
 import { useOrgNameFromPathname } from "@/utils/useOrgNameFromPathname";
 
@@ -37,7 +38,7 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 export function InviteUserDialogContent({
   org,
   close,
-}: InviteUserDialogContent.Props) {
+}: InviteUserDialogContent.Props): JSX.Element {
   const orgName = useOrgNameFromPathname();
   const queryKey = ReactQueryKey.orgInvitations(orgName);
 

--- a/packages/fern-dashboard/src/components/members/InviteeRow.tsx
+++ b/packages/fern-dashboard/src/components/members/InviteeRow.tsx
@@ -4,8 +4,9 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { rescindInvitation } from "@/app/actions/rescindInvitation";
-import { ReactQueryKey, inferQueryData } from "@/state/queryKeys";
-import { OrgInvitation } from "@/state/types";
+import type { inferQueryData } from "@/state/queryKeys";
+import { ReactQueryKey } from "@/state/queryKeys";
+import type { OrgInvitation } from "@/state/types";
 import { useOrgNameFromPathname } from "@/utils/useOrgNameFromPathname";
 
 import { DropdownMenuItem } from "../ui/dropdown-menu";
@@ -17,7 +18,7 @@ export declare namespace InviteeRow {
   }
 }
 
-export function InviteeRow({ invitation }: InviteeRow.Props) {
+export function InviteeRow({ invitation }: InviteeRow.Props): JSX.Element {
   const orgName = useOrgNameFromPathname();
   const queryKey = ReactQueryKey.orgInvitations(orgName);
 

--- a/packages/fern-dashboard/src/components/members/MemberRow.tsx
+++ b/packages/fern-dashboard/src/components/members/MemberRow.tsx
@@ -2,12 +2,13 @@
 
 import UserMinusIcon from "@heroicons/react/24/outline/UserMinusIcon";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { GetMembers200ResponseOneOfInner } from "auth0";
+import type { GetMembers200ResponseOneOfInner } from "auth0";
 import { toast } from "sonner";
 
 import { removeUserFromOrg } from "@/app/actions/removeUserFromOrg";
 import { Auth0UserID } from "@/app/services/auth0/types";
-import { ReactQueryKey, inferQueryData } from "@/state/queryKeys";
+import type { inferQueryData } from "@/state/queryKeys";
+import { ReactQueryKey } from "@/state/queryKeys";
 import { useOrgNameFromPathname } from "@/utils/useOrgNameFromPathname";
 
 import { DropdownMenuItem } from "../ui/dropdown-menu";
@@ -20,7 +21,10 @@ export declare namespace MemberRow {
   }
 }
 
-export function MemberRow({ member, currentUserId }: MemberRow.Props) {
+export function MemberRow({
+  member,
+  currentUserId,
+}: MemberRow.Props): JSX.Element {
   const orgName = useOrgNameFromPathname();
   const queryKey = ReactQueryKey.orgMembers(orgName);
 

--- a/packages/fern-dashboard/src/components/members/MembersPage.tsx
+++ b/packages/fern-dashboard/src/components/members/MembersPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Auth0SessionData } from "@/app/services/auth0/getCurrentSession";
+import type { Auth0SessionData } from "@/app/services/auth0/getCurrentSession";
 import { useOrgInvitations } from "@/state/useOrgInvitations";
 import { useOrgMembers } from "@/state/useOrgMembers";
 import { useCurrentOrganization } from "@/state/useOrganizations";
@@ -15,7 +15,7 @@ export declare namespace MembersPage {
   }
 }
 
-export function MembersPage({ session }: MembersPage.Props) {
+export function MembersPage({ session }: MembersPage.Props): JSX.Element {
   const org = useCurrentOrganization();
 
   const invitations = useOrgInvitations();

--- a/packages/fern-dashboard/src/components/members/MembersTable.tsx
+++ b/packages/fern-dashboard/src/components/members/MembersTable.tsx
@@ -2,12 +2,13 @@
 
 import React from "react";
 
-import { GetMembers200ResponseOneOfInner } from "auth0";
+import type { GetMembers200ResponseOneOfInner } from "auth0";
 
-import { Loadable, getLoadableValue } from "@fern-ui/loadable";
+import type { Loadable } from "@fern-ui/loadable";
+import { getLoadableValue } from "@fern-ui/loadable";
 
-import { Auth0UserID } from "@/app/services/auth0/types";
-import { OrgInvitation } from "@/state/types";
+import type { Auth0UserID } from "@/app/services/auth0/types";
+import type { OrgInvitation } from "@/state/types";
 
 import { InviteeRow } from "./InviteeRow";
 import { MemberRow } from "./MemberRow";
@@ -25,7 +26,7 @@ export function MembersTable({
   userId,
   members,
   invitations,
-}: MembersTable.Props) {
+}: MembersTable.Props): JSX.Element {
   const loadedInvitations = getLoadableValue(invitations);
   const loadedMembers = getLoadableValue(members);
 

--- a/packages/fern-dashboard/src/components/posthog/PostHogIdentify.tsx
+++ b/packages/fern-dashboard/src/components/posthog/PostHogIdentify.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 
-import { User } from "@auth0/nextjs-auth0/types";
+import type { User } from "@auth0/nextjs-auth0/types";
 import { usePostHog } from "posthog-js/react";
 
 export declare namespace PostHogIdentify {

--- a/packages/fern-dashboard/src/components/posthog/feature-flags/server-side.tsx
+++ b/packages/fern-dashboard/src/components/posthog/feature-flags/server-side.tsx
@@ -1,10 +1,11 @@
 import { redirect } from "next/navigation";
+import type { JSX } from "react";
 
 import { getCurrentSessionOrThrow } from "@/app/services/auth0/getCurrentSession";
-import { Auth0OrgName, Auth0UserID } from "@/app/services/auth0/types";
+import type { Auth0OrgName, Auth0UserID } from "@/app/services/auth0/types";
 
 import { getServerSidePosthog } from "../getServerSidePosthog";
-import { PosthogFeatureFlag, PosthogFeatureFlags } from "./flags";
+import type { PosthogFeatureFlag, PosthogFeatureFlags } from "./flags";
 
 export declare namespace FeatureFlaggedServerSide {
   export interface Props {
@@ -20,7 +21,7 @@ export async function FeatureFlaggedServerSide({
   redirectWhenDisabled = false,
   orgName,
   children,
-}: FeatureFlaggedServerSide.Props) {
+}: FeatureFlaggedServerSide.Props): Promise<JSX.Element | null> {
   const session = await getCurrentSessionOrThrow();
   const isEnabled = await isFeatureFlagEnabledForUser(
     flag,
@@ -43,7 +44,7 @@ export async function isFeatureFlagEnabledForUser(
   featureFlag: PosthogFeatureFlag,
   userId: Auth0UserID,
   orgName: Auth0OrgName
-) {
+): Promise<boolean | undefined> {
   const posthog = getServerSidePosthog();
   return await posthog.isFeatureEnabled(featureFlag, userId, {
     personProperties: {
@@ -52,7 +53,9 @@ export async function isFeatureFlagEnabledForUser(
   });
 }
 
-export async function getAllFeatureFlags(userId: Auth0UserID) {
+export async function getAllFeatureFlags(
+  userId: Auth0UserID
+): Promise<PosthogFeatureFlags> {
   const posthog = getServerSidePosthog();
   const flags = await posthog.getAllFlags(userId);
   return flags as PosthogFeatureFlags;

--- a/packages/fern-dashboard/src/components/pylon/PylonSetup.tsx
+++ b/packages/fern-dashboard/src/components/pylon/PylonSetup.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 
-import { Auth0User } from "@/app/services/auth0/types";
+import type { Auth0User } from "@/app/services/auth0/types";
 
 import "./PylonSetup.scss";
 import { HIDE_PYLON_CLASS_NAME } from "./constants";

--- a/packages/fern-dashboard/src/components/sdks-page/SDKsZeroState.tsx
+++ b/packages/fern-dashboard/src/components/sdks-page/SDKsZeroState.tsx
@@ -1,4 +1,4 @@
-import { User } from "@auth0/nextjs-auth0/types";
+import type { User } from "@auth0/nextjs-auth0/types";
 import { PlusIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -11,7 +11,9 @@ export declare namespace SDKsZeroState {
   }
 }
 
-export async function SDKsZeroState({ user }: SDKsZeroState.Props) {
+export async function SDKsZeroState({
+  user,
+}: SDKsZeroState.Props): Promise<JSX.Element> {
   let welcomeString = "Welcome";
   const firstName = getFirstName(user);
   if (firstName != null) {

--- a/packages/fern-dashboard/src/components/sdks-page/SDKsZeroStateImage.tsx
+++ b/packages/fern-dashboard/src/components/sdks-page/SDKsZeroStateImage.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import Image, { StaticImageData } from "next/image";
+import type { StaticImageData } from "next/image";
+import Image from "next/image";
 
 import { useIsFirstClientSideRender } from "@/utils/useIsFirstClientSideRender";
 
@@ -60,7 +61,7 @@ function CrossfadeThemeImage({
   );
 }
 
-export function SDKsZeroStateImage() {
+export function SDKsZeroStateImage(): JSX.Element {
   const imgLight = exampleSDKsLight as unknown as {
     width: number;
     height: number;

--- a/packages/fern-dashboard/src/components/settings/ArchiveSiteButton.tsx
+++ b/packages/fern-dashboard/src/components/settings/ArchiveSiteButton.tsx
@@ -8,7 +8,7 @@ import { toast } from "sonner";
 import { archiveSite } from "@/app/actions/archiveSite";
 import { Auth0OrgName } from "@/app/services/auth0/types";
 import { delay } from "@/utils/delay";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 import { Button } from "../ui/button";
 
@@ -22,7 +22,7 @@ export declare namespace ArchiveSiteButton {
 export function ArchiveSiteButton({
   docsUrl,
   orgName,
-}: ArchiveSiteButton.Props) {
+}: ArchiveSiteButton.Props): JSX.Element {
   const [isArchiving, setIsArchiving] = useState(false);
   const router = useRouter();
 

--- a/packages/fern-dashboard/src/components/settings/Settings.tsx
+++ b/packages/fern-dashboard/src/components/settings/Settings.tsx
@@ -1,6 +1,6 @@
 import { isAskAiEnabled } from "@/app/actions/toggleAskAi";
 import { Auth0OrgName } from "@/app/services/auth0/types";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 import { ArchiveSiteButton } from "./ArchiveSiteButton";
 import { ToggleAskAiButton } from "./ToggleAskAiButton";
@@ -13,7 +13,7 @@ export async function Settings({
   docsUrl: DocsUrl;
   orgName: Auth0OrgName;
   hasFernEmail: boolean;
-}) {
+}): Promise<JSX.Element> {
   const askAiStatus = hasFernEmail
     ? await isAskAiEnabled({ domain: docsUrl })
     : null;

--- a/packages/fern-dashboard/src/components/settings/ToggleAskAiButton.tsx
+++ b/packages/fern-dashboard/src/components/settings/ToggleAskAiButton.tsx
@@ -10,7 +10,7 @@ import {
   reindexAskAi,
   toggleAskAi,
 } from "@/app/actions/toggleAskAi";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 import { useOrgNameFromPathname } from "@/utils/useOrgNameFromPathname";
 
 import { Button } from "../ui/button";
@@ -25,7 +25,7 @@ export declare namespace ToggleAskAiButton {
 export function ToggleAskAiButton({
   docsUrl,
   initialAskAiStatus,
-}: ToggleAskAiButton.Props) {
+}: ToggleAskAiButton.Props): JSX.Element {
   const [isEnabled, setIsEnabled] = useState<boolean | null>(
     initialAskAiStatus?.ask_ai_enabled ?? null
   );

--- a/packages/fern-dashboard/src/components/ui/SearchableDropdown.tsx
+++ b/packages/fern-dashboard/src/components/ui/SearchableDropdown.tsx
@@ -1,4 +1,5 @@
-import { ReactNode, useState } from "react";
+import type { ReactNode } from "react";
+import { useState } from "react";
 
 import { SearchIcon } from "lucide-react";
 
@@ -33,7 +34,7 @@ export function SearchableDropdown<T>({
   renderItem,
   getItemKey,
   shouldShowSearch = true,
-}: SearchableDropdownProps<T>) {
+}: SearchableDropdownProps<T>): JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
 
   return (

--- a/packages/fern-dashboard/src/components/ui/StatusBadge.tsx
+++ b/packages/fern-dashboard/src/components/ui/StatusBadge.tsx
@@ -1,4 +1,4 @@
-import { GithubPrStatus } from "@/app/services/github/types";
+import type { GithubPrStatus } from "@/app/services/github/types";
 import { cn } from "@/utils/utils";
 
 export type StatusBadgeType =
@@ -74,7 +74,7 @@ export function StatusBadge({
   onClick,
   afterSlot,
   hideDot,
-}: StatusBadgeProps) {
+}: StatusBadgeProps): React.JSX.Element {
   const config = statusConfig[status];
 
   return (

--- a/packages/fern-dashboard/src/components/ui/sonner.tsx
+++ b/packages/fern-dashboard/src/components/ui/sonner.tsx
@@ -2,9 +2,10 @@
 
 import { useTheme } from "next-themes";
 
-import { Toaster as Sonner, ToasterProps } from "sonner";
+import type { ToasterProps } from "sonner";
+import { Toaster as Sonner } from "sonner";
 
-const Toaster = ({ ...props }: ToasterProps) => {
+const Toaster = ({ ...props }: ToasterProps): JSX.Element => {
   const { resolvedTheme = "light" } = useTheme();
 
   return (

--- a/packages/fern-dashboard/src/docs/components/FernLinkCard.tsx
+++ b/packages/fern-dashboard/src/docs/components/FernLinkCard.tsx
@@ -1,8 +1,9 @@
-import { LinkProps } from "next/link";
-import { PropsWithChildren, forwardRef } from "react";
+import type { LinkProps } from "next/link";
+import type { PropsWithChildren } from "react";
+import { forwardRef } from "react";
 
 import { cn } from "@fern-docs/components";
-import { FernCardProps } from "@fern-docs/components";
+import type { FernCardProps } from "@fern-docs/components";
 import { FernLink } from "@fern-docs/components/FernLink";
 
 export const FernLinkCard = forwardRef<

--- a/packages/fern-dashboard/src/docs/components/HorizontalOverflowMask.tsx
+++ b/packages/fern-dashboard/src/docs/components/HorizontalOverflowMask.tsx
@@ -1,4 +1,5 @@
-import React, { PropsWithChildren, useEffect, useRef, useState } from "react";
+import type { PropsWithChildren } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import fastdom from "fastdom";

--- a/packages/fern-dashboard/src/docs/components/contexts/local-preview.tsx
+++ b/packages/fern-dashboard/src/docs/components/contexts/local-preview.tsx
@@ -1,11 +1,7 @@
 "use client";
 
-import {
-  PropsWithChildren,
-  ReactElement,
-  createContext,
-  useContext,
-} from "react";
+import type { PropsWithChildren, ReactElement } from "react";
+import { createContext, useContext } from "react";
 
 const LocalPreviewContext = createContext<boolean>(false);
 

--- a/packages/fern-dashboard/src/docs/components/error-boundary.tsx
+++ b/packages/fern-dashboard/src/docs/components/error-boundary.tsx
@@ -1,6 +1,5 @@
-"use client";
-
-import React, { PropsWithChildren, useEffect } from "react";
+import type { PropsWithChildren } from "react";
+import React, { useEffect } from "react";
 import { ErrorBoundary as ReactErrorBoundary } from "react-error-boundary";
 
 import * as Sentry from "@sentry/nextjs";
@@ -21,7 +20,7 @@ export function ErrorBoundaryFallback({
   className?: string;
   error: Error & { digest?: string };
   resetErrorBoundary?: () => void;
-}) {
+}): JSX.Element {
   // React Error Boundaries require manual Sentry integration because
   // Sentry's automatic client-side capture doesn't extend to caught React errors
   useEffect(() => {
@@ -62,7 +61,7 @@ export function ErrorBoundary({
 }: PropsWithChildren<{
   onResetAction?: () => void;
   fallback?: React.ReactNode;
-}>) {
+}>): JSX.Element {
   if (fallback != null) {
     return (
       <ReactErrorBoundary
@@ -92,8 +91,10 @@ export function ErrorBoundary({
 export function withErrorBoundary<T extends React.ComponentType<any>>(
   Component: T,
   fallback?: React.ReactNode
-) {
-  return function WithErrorBoundary(props: React.ComponentProps<T>) {
+): (props: React.ComponentProps<T>) => JSX.Element {
+  return function WithErrorBoundary(
+    props: React.ComponentProps<T>
+  ): JSX.Element {
     return (
       <ErrorBoundary fallback={fallback}>
         <Component {...props} />

--- a/packages/fern-dashboard/src/docs/components/util/getMatchablePermutationsForEndpoint.test.ts
+++ b/packages/fern-dashboard/src/docs/components/util/getMatchablePermutationsForEndpoint.test.ts
@@ -1,10 +1,9 @@
 import { getMatchablePermutationsForEndpoint } from "@fern-api/docs-server/processRequestSnippetComponents";
-import {
+import type {
   EndpointDefinition,
-  EnvironmentId,
   PathPart,
-  PropertyKey,
 } from "@fern-api/fdr-sdk/api-definition";
+import { EnvironmentId, PropertyKey } from "@fern-api/fdr-sdk/api-definition";
 
 function literal(value: string): PathPart.Literal {
   return {

--- a/packages/fern-dashboard/src/docs/components/util/processIcon.tsx
+++ b/packages/fern-dashboard/src/docs/components/util/processIcon.tsx
@@ -1,6 +1,6 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
-import { NavigationNode } from "@fern-api/fdr-sdk/navigation";
+import type { NavigationNode } from "@fern-api/fdr-sdk/navigation";
 import { hasMetadata } from "@fern-api/fdr-sdk/navigation";
 import { NoZoom } from "@fern-docs/components/contexts/NoZoom";
 

--- a/packages/fern-dashboard/src/docs/mdx/components/badge/Badge.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/badge/Badge.tsx
@@ -1,6 +1,7 @@
-import { ComponentPropsWithoutRef, forwardRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
+import { forwardRef } from "react";
 
-import { SemanticColor } from "@fern-docs/components";
+import type { SemanticColor } from "@fern-docs/components";
 import {
   Badge as BadgeComponent,
   SemanticBadge,

--- a/packages/fern-dashboard/src/docs/mdx/components/bleed/Bleed.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/bleed/Bleed.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, ReactElement } from "react";
+import type { PropsWithChildren, ReactElement } from "react";
 
 import { cn } from "@fern-docs/components";
 

--- a/packages/fern-dashboard/src/docs/mdx/components/button/Button.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/button/Button.tsx
@@ -1,4 +1,5 @@
-import { ReactElement, ReactNode, useRef } from "react";
+import type { ReactElement, ReactNode } from "react";
+import { useRef } from "react";
 
 import { cn } from "@fern-docs/components";
 import { FernButton } from "@fern-docs/components";

--- a/packages/fern-dashboard/src/docs/mdx/components/button/ButtonGroup.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/button/ButtonGroup.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, ReactElement } from "react";
+import type { ComponentProps, ReactElement } from "react";
 
 import { cn } from "@fern-docs/components";
 import { FernButtonGroup } from "@fern-docs/components";

--- a/packages/fern-dashboard/src/docs/mdx/components/callout/Callout.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/callout/Callout.tsx
@@ -1,10 +1,5 @@
-import {
-  FC,
-  PropsWithChildren,
-  ReactElement,
-  isValidElement,
-  useRef,
-} from "react";
+import type { FC, PropsWithChildren, ReactElement } from "react";
+import { isValidElement, useRef } from "react";
 
 import {
   Bell,

--- a/packages/fern-dashboard/src/docs/mdx/components/client-libraries/ClientLibraries.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/client-libraries/ClientLibraries.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, FC } from "react";
+import type { ComponentProps, FC } from "react";
 
 import { FernSdk } from "@fern-docs/components";
 

--- a/packages/fern-dashboard/src/docs/mdx/components/columns/ColumnGroup.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/columns/ColumnGroup.tsx
@@ -1,4 +1,5 @@
-import { FC, type PropsWithChildren } from "react";
+import type { FC } from "react";
+import type { PropsWithChildren } from "react";
 
 import { cn } from "@fern-docs/components";
 

--- a/packages/fern-dashboard/src/docs/mdx/components/download/Download.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/download/Download.tsx
@@ -1,8 +1,9 @@
-import React, { ComponentProps, PropsWithChildren } from "react";
+import type { ComponentProps, PropsWithChildren, ReactNode } from "react";
+import React from "react";
 
 import { last } from "es-toolkit/array";
 
-import { FernLink } from "@fern-docs/components/FernLink";
+import type { FernLink } from "@fern-docs/components/FernLink";
 
 import { Button } from "../button";
 import { Card } from "../card";
@@ -12,7 +13,7 @@ export function Download({
   children,
   src,
   filename,
-}: PropsWithChildren<{ src?: string; filename?: string }>) {
+}: PropsWithChildren<{ src?: string; filename?: string }>): ReactNode {
   if (!src) {
     return children;
   }

--- a/packages/fern-dashboard/src/docs/mdx/components/feature/index.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/feature/index.tsx
@@ -1,6 +1,6 @@
 import { Feature as FeatureComponent } from "@fern-docs/components/feature-flags/Feature";
 import { FeatureFlagDebug } from "@fern-docs/components/feature-flags/FeatureFlagDebug";
-import { FeatureProps } from "@fern-docs/components/feature-flags/types";
+import type { FeatureProps } from "@fern-docs/components/feature-flags/types";
 
 export const Feature = (props: FeatureProps) => (
   <FeatureFlagDebug {...props}>

--- a/packages/fern-dashboard/src/docs/mdx/components/frame/Frame.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/frame/Frame.tsx
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren } from "react";
+import type { FC, PropsWithChildren } from "react";
 
 import { cn } from "@fern-docs/components";
 

--- a/packages/fern-dashboard/src/docs/mdx/components/html-table/Table.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/html-table/Table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { ComponentProps, useState } from "react";
+import type { ComponentProps } from "react";
+import { useState } from "react";
 
 import * as Dialog from "@radix-ui/react-dialog";
 import * as Tooltip from "@radix-ui/react-tooltip";
@@ -9,7 +10,10 @@ import { Expand } from "lucide-react";
 import { cn } from "@fern-docs/components";
 import { FernButton, FernScrollArea } from "@fern-docs/components";
 
-export function Table({ className, ...rest }: ComponentProps<"table">) {
+export function Table({
+  className,
+  ...rest
+}: ComponentProps<"table">): React.JSX.Element {
   const [isFullScreen, setIsFullScreen] = useState(false);
 
   return (

--- a/packages/fern-dashboard/src/docs/mdx/components/html/image.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/html/image.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { ComponentProps, ReactElement, forwardRef, useContext } from "react";
+import type { ComponentProps, ReactElement } from "react";
+import { forwardRef, useContext } from "react";
 import Zoom from "react-medium-image-zoom";
 
 import { cn } from "@fern-docs/components";

--- a/packages/fern-dashboard/src/docs/mdx/components/if/If.test.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/if/If.test.tsx
@@ -4,10 +4,11 @@
 import React from "react";
 
 import { render } from "@testing-library/react";
-import { Atom, atom } from "jotai";
+import type { Atom } from "jotai";
+import { atom } from "jotai";
 import { freezeAtom } from "jotai/utils";
 
-import { FernUser } from "@fern-api/docs-auth";
+import type { FernUser } from "@fern-api/docs-auth";
 
 import { If } from "./If";
 

--- a/packages/fern-dashboard/src/docs/mdx/components/if/If.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/if/If.tsx
@@ -1,8 +1,8 @@
-import { PropsWithChildren, ReactNode } from "react";
+import type { PropsWithChildren, ReactNode } from "react";
 
-import { Atom } from "jotai";
+import type { Atom } from "jotai";
 
-import { FernUser } from "@fern-api/docs-auth";
+import type { FernUser } from "@fern-api/docs-auth";
 import { useFernUser } from "@fern-docs/components/state/fern-user";
 
 export interface IfProps {

--- a/packages/fern-dashboard/src/docs/mdx/components/iframe/IFrame.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/iframe/IFrame.tsx
@@ -1,12 +1,5 @@
-import {
-  ComponentProps,
-  ReactElement,
-  RefObject,
-  forwardRef,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import type { ComponentProps, ReactElement, RefObject } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import * as Tooltip from "@radix-ui/react-tooltip";

--- a/packages/fern-dashboard/src/docs/mdx/components/index.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { ComponentProps } from "react";
+import type { ComponentProps } from "react";
+import React from "react";
 
 import { NodeViewWrapper } from "@tiptap/react";
 

--- a/packages/fern-dashboard/src/docs/mdx/components/mermaid/Mermaid.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/mermaid/Mermaid.tsx
@@ -1,4 +1,5 @@
-import { ReactElement, useEffect, useRef, useState } from "react";
+import type { ReactElement } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useResolvedTheme } from "@/docs/hooks/use-theme";
 

--- a/packages/fern-dashboard/src/docs/mdx/components/steps/Step.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/steps/Step.tsx
@@ -1,12 +1,7 @@
 "use client";
 
-import React, {
-  ComponentProps,
-  ReactElement,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import type { ComponentProps, ReactElement } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { Check, Link2 } from "lucide-react";
 import { AnimatePresence, LazyMotion, domAnimation } from "motion/react";

--- a/packages/fern-dashboard/src/docs/mdx/components/steps/Steps.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/steps/Steps.tsx
@@ -1,6 +1,5 @@
+import type { ComponentProps, ReactElement } from "react";
 import React, {
-  ComponentProps,
-  ReactElement,
   createContext,
   useCallback,
   useContext,

--- a/packages/fern-dashboard/src/docs/mdx/components/tabs/Tabs.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/tabs/Tabs.tsx
@@ -1,5 +1,5 @@
+import type { ReactNode } from "react";
 import {
-  ReactNode,
   createContext,
   useCallback,
   useContext,

--- a/packages/fern-dashboard/src/docs/mdx/components/tooltip/Tooltip.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, ReactElement, ReactNode } from "react";
+import type { PropsWithChildren, ReactElement, ReactNode } from "react";
 
 import { FernTooltip, FernTooltipProvider } from "@fern-docs/components";
 

--- a/packages/fern-dashboard/src/docs/mdx/components/waveform/WaveformComplex.tsx
+++ b/packages/fern-dashboard/src/docs/mdx/components/waveform/WaveformComplex.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import {
-  ReactNode,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import type { ReactNode } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { OrthographicCamera } from "@react-three/drei";
 import { Canvas, useFrame, useThree } from "@react-three/fiber";

--- a/packages/fern-dashboard/src/docs/state/search.tsx
+++ b/packages/fern-dashboard/src/docs/state/search.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 
 import { composeEventHandlers } from "@radix-ui/primitive";
-import { atom, useAtomValue, useSetAtom } from "jotai";
+import { type PrimitiveAtom, atom, useAtomValue, useSetAtom } from "jotai";
 import { useHydrateAtoms } from "jotai/utils";
 
 import { isLocal } from "@fern-api/docs-server/isLocal";
@@ -11,9 +11,11 @@ import { isSelfHosted } from "@fern-api/docs-server/isSelfHosted";
 import { FERN_SEARCH_BUTTON_ID } from "@fern-docs/components/constants";
 import { DesktopSearchButton } from "@fern-docs/search-ui/components/desktop/desktop-search-button";
 
-export const searchDialogOpenAtom = atom(false);
-export const searchInitializedAtom = atom(false);
-export const isAskAiEnabledAtom = atom(false);
+export const searchDialogOpenAtom: PrimitiveAtom<boolean> =
+  atom<boolean>(false);
+export const searchInitializedAtom: PrimitiveAtom<boolean> =
+  atom<boolean>(false);
+export const isAskAiEnabledAtom: PrimitiveAtom<boolean> = atom<boolean>(false);
 
 export const SetIsAskAiEnabled = ({
   isAskAiEnabled,
@@ -26,11 +28,12 @@ export const SetIsAskAiEnabled = ({
   return null;
 };
 
-export const useIsAskAiEnabled = () => {
+export const useIsAskAiEnabled = (): boolean => {
   return useAtomValue(isAskAiEnabledAtom);
 };
 
-export const isDefaultSearchFilterOnAtom = atom(false);
+export const isDefaultSearchFilterOnAtom: PrimitiveAtom<boolean> =
+  atom<boolean>(false);
 
 export const SetIsDefaultSearchFilterOn = ({
   isDefaultSearchFilterOn,
@@ -43,11 +46,11 @@ export const SetIsDefaultSearchFilterOn = ({
   return null;
 };
 
-export const useIsDefaultSearchFilterOn = () => {
+export const useIsDefaultSearchFilterOn = (): boolean => {
   return useAtomValue(isDefaultSearchFilterOnAtom);
 };
 
-searchInitializedAtom.onMount = (setInitialized) => {
+searchInitializedAtom.onMount = (setInitialized: (value: boolean) => void) => {
   if (typeof window === "undefined") {
     return;
   }
@@ -67,9 +70,9 @@ searchInitializedAtom.onMount = (setInitialized) => {
   };
 };
 
-export const SearchV2Trigger = React.memo(function SearchV2Trigger(
+export function SearchV2Trigger(
   props: React.ComponentProps<typeof DesktopSearchButton>
-) {
+): React.JSX.Element {
   const isInitialized = useAtomValue(searchInitializedAtom);
   const toggleSearchDialog = useToggleSearchDialog();
   const isLocalEnvironment = isLocal();
@@ -88,7 +91,7 @@ export const SearchV2Trigger = React.memo(function SearchV2Trigger(
       placeholder={placeholder}
     />
   );
-});
+}
 
 export function useIsSearchDialogOpen(): boolean {
   return useAtomValue(searchDialogOpenAtom);

--- a/packages/fern-dashboard/src/editor/mdx/plugins/rehype-editor-components.ts
+++ b/packages/fern-dashboard/src/editor/mdx/plugins/rehype-editor-components.ts
@@ -1,10 +1,5 @@
-import {
-  CONTINUE,
-  Hast,
-  Unified,
-  isMdxJsxElementHast,
-  visit,
-} from "@fern-docs/mdx";
+import type { Hast, Unified } from "@fern-docs/mdx";
+import { CONTINUE, isMdxJsxElementHast, visit } from "@fern-docs/mdx";
 
 /**
  * Rehype plugin that converts component names for the editor environment.

--- a/packages/fern-dashboard/src/providers/BranchContext.tsx
+++ b/packages/fern-dashboard/src/providers/BranchContext.tsx
@@ -1,18 +1,22 @@
 "use client";
 
-import { ReactNode, createContext, useContext, useState } from "react";
+import type { Context, JSX, ReactNode } from "react";
+import { createContext, useContext, useState } from "react";
 
-export const BranchContext = createContext<{
+type BranchContextValue = {
   branch: string;
   setBranch: (branch: string) => void;
   branchFailed: boolean;
-}>({
-  branch: "",
-  setBranch: (_branch: string) => {
-    return;
-  },
-  branchFailed: false,
-});
+};
+
+export const BranchContext: Context<BranchContextValue> =
+  createContext<BranchContextValue>({
+    branch: "",
+    setBranch: (_branch: string) => {
+      return;
+    },
+    branchFailed: false,
+  });
 
 export function BranchProvider({
   branch,
@@ -22,7 +26,7 @@ export function BranchProvider({
   branch: string;
   branchFailed: boolean;
   children: ReactNode;
-}) {
+}): JSX.Element {
   const [currBranch, setBranchStore] = useState<string>(branch);
 
   function setBranch(branch: string) {
@@ -38,6 +42,6 @@ export function BranchProvider({
   );
 }
 
-export function useBranch() {
+export function useBranch(): BranchContextValue {
   return useContext(BranchContext);
 }

--- a/packages/fern-dashboard/src/providers/CurrentPageContext.tsx
+++ b/packages/fern-dashboard/src/providers/CurrentPageContext.tsx
@@ -1,18 +1,26 @@
 "use client";
 
-import { ReactNode, createContext, useContext, useState } from "react";
+import type { Context, ReactNode } from "react";
+import { createContext, useContext, useState } from "react";
 
-export const CurrentPageContext = createContext<{
+type CurrentPageContextValue = {
   currentFilename: string | null;
   setCurrentFilename: (filename: string) => void;
-}>({
-  currentFilename: null,
-  setCurrentFilename: () => {
-    return;
-  },
-});
+};
 
-export function CurrentPageProvider({ children }: { children: ReactNode }) {
+export const CurrentPageContext: Context<CurrentPageContextValue> =
+  createContext<CurrentPageContextValue>({
+    currentFilename: null,
+    setCurrentFilename: () => {
+      return;
+    },
+  });
+
+export function CurrentPageProvider({
+  children,
+}: {
+  children: ReactNode;
+}): JSX.Element {
   const [currentFilename, setCurrentFilename] = useState<string | null>(null);
 
   return (
@@ -24,6 +32,6 @@ export function CurrentPageProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export function useCurrentPage() {
+export function useCurrentPage(): CurrentPageContextValue {
   return useContext(CurrentPageContext);
 }

--- a/packages/fern-dashboard/src/providers/DevModeProvider.tsx
+++ b/packages/fern-dashboard/src/providers/DevModeProvider.tsx
@@ -1,18 +1,26 @@
 "use client";
 
-import { ReactNode, createContext, useContext, useState } from "react";
+import type { Context, ReactNode } from "react";
+import { createContext, useContext, useState } from "react";
 
-export const DevModeContext = createContext<{
+type DevModeContextValue = {
   panelOpen: boolean;
   setPanelOpen: (panelOpen: boolean) => void;
-}>({
-  panelOpen: false,
-  setPanelOpen: (_panelOpen: boolean) => {
-    return;
-  },
-});
+};
 
-export function DevModeProvider({ children }: { children: ReactNode }) {
+export const DevModeContext: Context<DevModeContextValue> =
+  createContext<DevModeContextValue>({
+    panelOpen: false,
+    setPanelOpen: (_panelOpen: boolean) => {
+      return;
+    },
+  });
+
+export function DevModeProvider({
+  children,
+}: {
+  children: ReactNode;
+}): React.JSX.Element {
   const [panelOpen, setPanelOpenStore] = useState<boolean>(false);
 
   function setPanelOpen(panelOpen: boolean) {
@@ -26,6 +34,6 @@ export function DevModeProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export function useDevMode() {
+export function useDevMode(): DevModeContextValue {
   return useContext(DevModeContext);
 }

--- a/packages/fern-dashboard/src/providers/FileResolverContext.tsx
+++ b/packages/fern-dashboard/src/providers/FileResolverContext.tsx
@@ -1,15 +1,19 @@
 "use client";
 
+import type { Context } from "react";
 import { createContext, useContext } from "react";
 
 import { DashboardFileResolver } from "@fern-api/docs-server/dashboard-file-resolver";
-import { FileData } from "@fern-api/docs-utils/types/file-data";
+import type { FileData } from "@fern-api/docs-utils/types/file-data";
 
-export const FileResolverContext = createContext<{
+type FileResolverContextValue = {
   resolveFileSrc: DashboardFileResolver["getResolvedFileData"];
-}>({
-  resolveFileSrc: () => undefined,
-});
+};
+
+export const FileResolverContext: Context<FileResolverContextValue> =
+  createContext<FileResolverContextValue>({
+    resolveFileSrc: () => undefined,
+  });
 
 export const FileResolverProvider = ({
   children,
@@ -17,7 +21,7 @@ export const FileResolverProvider = ({
 }: {
   children: React.ReactNode;
   files: Record<string, FileData>;
-}) => {
+}): React.JSX.Element => {
   const fileResolver = new DashboardFileResolver(files);
 
   const resolveFileSrc = (src: string | undefined) =>
@@ -30,6 +34,6 @@ export const FileResolverProvider = ({
   );
 };
 
-export const useFileResolver = () => {
+export const useFileResolver = (): FileResolverContextValue => {
   return useContext(FileResolverContext);
 };

--- a/packages/fern-dashboard/src/providers/GitHubRepoContext.tsx
+++ b/packages/fern-dashboard/src/providers/GitHubRepoContext.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext } from "react";
 
-import { GithubSourceRepo } from "@/app/services/github/types";
+import type { GithubSourceRepo } from "@/app/services/github/types";
 
 interface GitHubRepoContextValue {
   branch: string;

--- a/packages/fern-dashboard/src/providers/GitPRContext.tsx
+++ b/packages/fern-dashboard/src/providers/GitPRContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import type { ReactNode } from "react";
 import {
-  ReactNode,
   createContext,
   useCallback,
   useContext,
@@ -11,7 +11,7 @@ import {
 
 import { useOrgName } from "@/app/[orgName]/context/OrgNameContext";
 import { DashboardApiClient } from "@/app/services/dashboard-api/client";
-import { GithubPrStatus } from "@/app/services/github/types";
+import type { GithubPrStatus } from "@/app/services/github/types";
 
 export const GitPRContext = createContext<{
   gitPrUrl: string | undefined;

--- a/packages/fern-dashboard/src/providers/PagesStore.ts
+++ b/packages/fern-dashboard/src/providers/PagesStore.ts
@@ -1,6 +1,6 @@
-import * as FernNavigation from "@fern-api/fdr-sdk/navigation";
-import { NodeId } from "@fern-api/fdr-sdk/navigation";
-import {
+import type * as FernNavigation from "@fern-api/fdr-sdk/navigation";
+import type { NodeId } from "@fern-api/fdr-sdk/navigation";
+import type {
   BuildPageDataProps,
   BuildPageDataResult,
   NavigationContext,
@@ -8,12 +8,12 @@ import {
   PageData,
   SectionWithHierarchy,
 } from "@fern-docs/components";
-import {
+import type {
   ChangedNodes,
   Frontmatter,
   MdxToHtmlResponse,
-  htmlToMdx,
 } from "@fern-docs/mdx";
+import { htmlToMdx } from "@fern-docs/mdx";
 
 import {
   compareFrontmatter,
@@ -22,7 +22,7 @@ import {
   createPageKey,
   createPageMetadata,
 } from "../utils/pagesStoreUtils";
-import { SaveEvent } from "./types";
+import type { SaveEvent } from "./types";
 
 type Filename = string;
 
@@ -242,7 +242,11 @@ export class PagesStore {
   }
 
   /** Prepare commit data for changed files */
-  prepareCommit(changedMdxFiles: Record<string, string>) {
+  prepareCommit(changedMdxFiles: Record<string, string>): {
+    changedFiles: Record<string, string>;
+    deletedFiles: string[];
+    docsYmlContent?: string | undefined;
+  } {
     return this._requireNavigationStore().prepareCommit(changedMdxFiles);
   }
 

--- a/packages/fern-dashboard/src/providers/PagesStoreContext.tsx
+++ b/packages/fern-dashboard/src/providers/PagesStoreContext.tsx
@@ -1,16 +1,12 @@
 "use client";
 
-import {
-  ReactNode,
-  createContext,
-  useContext,
-  useRef,
-  useSyncExternalStore,
-} from "react";
+import type { ReactNode } from "react";
+import { createContext, useContext, useRef, useSyncExternalStore } from "react";
 
 import { useNavigation } from "@fern-docs/components";
 
-import { PagesSnapshot, PagesStore } from "./PagesStore";
+import type { PagesSnapshot } from "./PagesStore";
+import { PagesStore } from "./PagesStore";
 
 export type { PagesSnapshot };
 
@@ -28,7 +24,7 @@ export interface PagesStoreProviderProps {
 export function PagesStoreProvider({
   children,
   branchName,
-}: PagesStoreProviderProps) {
+}: PagesStoreProviderProps): JSX.Element {
   const { _navigationStore } = useNavigation();
   const storeRef = useRef<PagesStore>(new PagesStore(_navigationStore));
 

--- a/packages/fern-dashboard/src/providers/PosthogProvider.tsx
+++ b/packages/fern-dashboard/src/providers/PosthogProvider.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useParams } from "next/navigation";
+import type { JSX } from "react";
 import React, { useEffect } from "react";
 
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 
-import { Auth0SessionData } from "@/app/services/auth0/getCurrentSession";
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0SessionData } from "@/app/services/auth0/getCurrentSession";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { PostHogIdentify } from "@/components/posthog/PostHogIdentify";
 import { PostHogPageView } from "@/components/posthog/PostHogPageView";
 import { isProduction } from "@/utils/environment";
@@ -19,7 +20,10 @@ export declare namespace PostHogProvider {
   }
 }
 
-export function PostHogProvider({ session, children }: PostHogProvider.Props) {
+export function PostHogProvider({
+  session,
+  children,
+}: PostHogProvider.Props): JSX.Element {
   const isPosthogTrackingEnabled =
     process.env.NEXT_PUBLIC_POSTHOG_TRACKING_ENABLED === "true";
 

--- a/packages/fern-dashboard/src/state/convertQueryResultToLoadable.ts
+++ b/packages/fern-dashboard/src/state/convertQueryResultToLoadable.ts
@@ -1,12 +1,7 @@
-import { UseQueryResult } from "@tanstack/react-query";
+import type { UseQueryResult } from "@tanstack/react-query";
 
-import {
-  Loadable,
-  failed,
-  loaded,
-  loading,
-  notStartedLoading,
-} from "@fern-ui/loadable";
+import type { Loadable } from "@fern-ui/loadable";
+import { failed, loaded, loading, notStartedLoading } from "@fern-ui/loadable";
 
 export function convertQueryResultToLoadable<T, E = Error>(
   queryResult: UseQueryResult<T, E>

--- a/packages/fern-dashboard/src/state/queryKeys.ts
+++ b/packages/fern-dashboard/src/state/queryKeys.ts
@@ -1,22 +1,23 @@
-import { getDocsUrlOwner } from "@/app/api/get-docs-url-owner/route";
-import { getGithubSourceMetadata } from "@/app/api/get-github-source-metadata/route";
-import { getMyOrganizations } from "@/app/api/get-my-organizations/route";
-import { getOrgMembers } from "@/app/api/get-org-members/route";
-import { getHomepageImageUrl } from "@/app/api/homepage-images/get/route";
-import { Theme } from "@/app/api/homepage-images/types";
-import { Auth0OrgName } from "@/app/services/auth0/types";
-import { DocsUrl } from "@/utils/types";
+import type { getDocsUrlOwner } from "@/app/api/get-docs-url-owner/route";
+import type { getGithubSourceMetadata } from "@/app/api/get-github-source-metadata/route";
+import type { getMyOrganizations } from "@/app/api/get-my-organizations/route";
+import type { getOrgMembers } from "@/app/api/get-org-members/route";
+import type { getHomepageImageUrl } from "@/app/api/homepage-images/get/route";
+import type { Theme } from "@/app/api/homepage-images/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
+import type { DocsUrl } from "@/utils/types";
 
-import { OrgInvitation } from "./types";
+import type { OrgInvitation } from "./types";
 
 export type ReactQueryKey<T> = string[] & { __queryData: Awaited<T> };
 
 export const ReactQueryKey = {
-  orgInvitations: (orgName: Auth0OrgName) =>
+  orgInvitations: (orgName: Auth0OrgName): ReactQueryKey<OrgInvitation[]> =>
     queryKey<OrgInvitation[]>("org-invitations", orgName),
-  orgMembers: (orgName: Auth0OrgName) =>
+  orgMembers: (orgName: Auth0OrgName): ReactQueryKey<getOrgMembers.Response> =>
     queryKey<getOrgMembers.Response>("org-members", orgName),
-  myOrganizations: () => queryKey<getMyOrganizations.Response>("my-orgs"),
+  myOrganizations: (): ReactQueryKey<getMyOrganizations.Response> =>
+    queryKey<getMyOrganizations.Response>("my-orgs"),
   homepageImageUrl: ({
     orgName,
     docsUrls,
@@ -25,21 +26,24 @@ export const ReactQueryKey = {
     orgName: Auth0OrgName;
     docsUrls: DocsUrl[];
     theme: Theme;
-  }) =>
+  }): ReactQueryKey<getHomepageImageUrl.Response> =>
     queryKey<getHomepageImageUrl.Response>(
       "homepage-image-url",
       orgName,
       ...docsUrls,
       theme
     ),
-  docsUrlOwner: (docsUrl: DocsUrl) =>
+  docsUrlOwner: (docsUrl: DocsUrl): ReactQueryKey<getDocsUrlOwner.Response> =>
     queryKey<getDocsUrlOwner.Response>("docs-url-owner", docsUrl),
-  orgSvgLogo: (svgUrl: string) => queryKey<string>("org-svg", svgUrl),
-  githubSourceRepo: (githubUrl: string) =>
+  orgSvgLogo: (svgUrl: string): ReactQueryKey<string> =>
+    queryKey<string>("org-svg", svgUrl),
+  githubSourceRepo: (
+    githubUrl: string
+  ): ReactQueryKey<getGithubSourceMetadata.Response> =>
     queryKey<getGithubSourceMetadata.Response>("github-source-repo", githubUrl),
 } as const;
 
-function queryKey<T>(...key: string[]) {
+function queryKey<T>(...key: string[]): ReactQueryKey<T> {
   const frozenKey = Object.freeze(key);
   return frozenKey as ReactQueryKey<T>;
 }

--- a/packages/fern-dashboard/src/state/useDocsUrlOwner.ts
+++ b/packages/fern-dashboard/src/state/useDocsUrlOwner.ts
@@ -1,12 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 
+import type { Loadable } from "@fern-ui/loadable";
+
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 import { DashboardApiClient } from "@/app/services/dashboard-api/client";
-import { DocsUrl } from "@/utils/types";
+import type { DocsUrl } from "@/utils/types";
 
 import { convertQueryResultToLoadable } from "./convertQueryResultToLoadable";
-import { ReactQueryKey, inferQueryData } from "./queryKeys";
+import type { inferQueryData } from "./queryKeys";
+import { ReactQueryKey } from "./queryKeys";
 
-export function useDocsUrlOwner(docsUrl: DocsUrl) {
+export function useDocsUrlOwner(docsUrl: DocsUrl): Loadable<{
+  orgName: Auth0OrgName | undefined;
+}> {
   const QUERY_KEY = ReactQueryKey.docsUrlOwner(docsUrl);
 
   return convertQueryResultToLoadable(

--- a/packages/fern-dashboard/src/state/useHomepageImageUrl.ts
+++ b/packages/fern-dashboard/src/state/useHomepageImageUrl.ts
@@ -1,14 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { FdrAPI } from "@fern-api/fdr-sdk/client/types";
+import type { FdrAPI } from "@fern-api/fdr-sdk/client/types";
+import type { Loadable } from "@fern-ui/loadable";
 
-import { Theme } from "@/app/api/homepage-images/types";
+import type { Theme } from "@/app/api/homepage-images/types";
 import { DashboardApiClient } from "@/app/services/dashboard-api/client";
 import { convertFdrDocsSiteUrlToDocsUrl } from "@/utils/getDocsSiteUrl";
 import { useOrgNameFromPathname } from "@/utils/useOrgNameFromPathname";
 
 import { convertQueryResultToLoadable } from "./convertQueryResultToLoadable";
-import { ReactQueryKey, inferQueryData } from "./queryKeys";
+import type { inferQueryData } from "./queryKeys";
+import { ReactQueryKey } from "./queryKeys";
 
 export function useHomepageImageUrl({
   docsSite,
@@ -16,7 +18,9 @@ export function useHomepageImageUrl({
 }: {
   docsSite: FdrAPI.dashboard.DocsSite;
   theme: Theme;
-}) {
+}): Loadable<{
+  imageUrl: string;
+}> {
   const orgName = useOrgNameFromPathname();
   const docsUrls = docsSite.urls.map(convertFdrDocsSiteUrlToDocsUrl);
   const QUERY_KEY = ReactQueryKey.homepageImageUrl({

--- a/packages/fern-dashboard/src/state/useOrgInvitations.ts
+++ b/packages/fern-dashboard/src/state/useOrgInvitations.ts
@@ -2,14 +2,17 @@
 
 import { useQuery } from "@tanstack/react-query";
 
+import type { Loadable } from "@fern-ui/loadable";
+
 import { DashboardApiClient } from "@/app/services/dashboard-api/client";
 import { useOrgNameFromPathname } from "@/utils/useOrgNameFromPathname";
 
 import { convertQueryResultToLoadable } from "./convertQueryResultToLoadable";
-import { ReactQueryKey, inferQueryData } from "./queryKeys";
-import { OrgInvitation } from "./types";
+import type { inferQueryData } from "./queryKeys";
+import { ReactQueryKey } from "./queryKeys";
+import type { OrgInvitation } from "./types";
 
-export function useOrgInvitations() {
+export function useOrgInvitations(): Loadable<OrgInvitation[]> {
   const orgName = useOrgNameFromPathname();
   const queryKey = ReactQueryKey.orgInvitations(orgName);
 

--- a/packages/fern-dashboard/src/state/useOrganizations.tsx
+++ b/packages/fern-dashboard/src/state/useOrganizations.tsx
@@ -2,16 +2,22 @@
 
 import { useQuery } from "@tanstack/react-query";
 
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Loadable } from "@fern-ui/loadable";
+
+import type {
+  Auth0OrgName,
+  Auth0Organization,
+} from "@/app/services/auth0/types";
 import { DashboardApiClient } from "@/app/services/dashboard-api/client";
 import { useOrgNameFromPathname } from "@/utils/useOrgNameFromPathname";
 
 import { convertQueryResultToLoadable } from "./convertQueryResultToLoadable";
-import { ReactQueryKey, inferQueryData } from "./queryKeys";
+import type { inferQueryData } from "./queryKeys";
+import { ReactQueryKey } from "./queryKeys";
 
 const QUERY_KEY = ReactQueryKey.myOrganizations();
 
-export function useOrganizations() {
+export function useOrganizations(): Loadable<Auth0Organization[]> {
   return convertQueryResultToLoadable(
     useQuery<inferQueryData<typeof QUERY_KEY>>({
       queryKey: QUERY_KEY,
@@ -20,7 +26,9 @@ export function useOrganizations() {
   );
 }
 
-export function useOrganization(orgName: Auth0OrgName) {
+export function useOrganization(
+  orgName: Auth0OrgName
+): Auth0Organization | undefined {
   const organizations = useOrganizations();
   if (organizations.type !== "loaded") {
     return undefined;
@@ -28,7 +36,7 @@ export function useOrganization(orgName: Auth0OrgName) {
   return organizations.value.find((org) => org.name === orgName);
 }
 
-export function useCurrentOrganization() {
+export function useCurrentOrganization(): Auth0Organization | undefined {
   const orgName = useOrgNameFromPathname();
   return useOrganization(orgName);
 }

--- a/packages/fern-dashboard/src/utils/constructDocsUrlParam.ts
+++ b/packages/fern-dashboard/src/utils/constructDocsUrlParam.ts
@@ -1,5 +1,5 @@
-import { DocsUrl } from "./types";
+import type { DocsUrl } from "./types";
 
-export function constructDocsUrlParam(docsUrl: DocsUrl) {
+export function constructDocsUrlParam(docsUrl: DocsUrl): string {
   return encodeURIComponent(docsUrl);
 }

--- a/packages/fern-dashboard/src/utils/editor-routing.ts
+++ b/packages/fern-dashboard/src/utils/editor-routing.ts
@@ -1,6 +1,6 @@
-import { Auth0OrgName } from "@/app/services/auth0/types";
+import type { Auth0OrgName } from "@/app/services/auth0/types";
 
-import { EncodedDocsUrl } from "./types";
+import type { EncodedDocsUrl } from "./types";
 
 export const ROOT_SLUG_ALIAS = "root";
 

--- a/packages/fern-dashboard/src/utils/getDocsSiteUrl.ts
+++ b/packages/fern-dashboard/src/utils/getDocsSiteUrl.ts
@@ -1,6 +1,6 @@
-import { FdrAPI } from "@fern-api/fdr-sdk/client/types";
+import type { FdrAPI } from "@fern-api/fdr-sdk/client/types";
 
-import { DocsUrl } from "./types";
+import type { DocsUrl } from "./types";
 
 export function getDocsSiteUrl({
   mainUrl,

--- a/packages/fern-dashboard/src/utils/getOrgDisplayName.ts
+++ b/packages/fern-dashboard/src/utils/getOrgDisplayName.ts
@@ -1,5 +1,7 @@
-import { Auth0Organization } from "@/app/services/auth0/types";
+import type { Auth0Organization } from "@/app/services/auth0/types";
 
-export function getOrgDisplayName(org: Auth0Organization | undefined) {
+export function getOrgDisplayName(
+  org: Auth0Organization | undefined
+): string | undefined {
   return org?.display_name ?? org?.name;
 }

--- a/packages/fern-dashboard/src/utils/pagesStoreUtils.ts
+++ b/packages/fern-dashboard/src/utils/pagesStoreUtils.ts
@@ -1,7 +1,7 @@
-import { NodeId } from "@fern-api/fdr-sdk/navigation";
-import { MdxToHtmlResponse } from "@fern-docs/mdx";
+import type { NodeId } from "@fern-api/fdr-sdk/navigation";
+import type { MdxToHtmlResponse } from "@fern-docs/mdx";
 
-import {
+import type {
   PageContents,
   PageDependencies,
   PageMetadata,

--- a/packages/fern-dashboard/src/utils/parseDocsUrlParam.ts
+++ b/packages/fern-dashboard/src/utils/parseDocsUrlParam.ts
@@ -1,4 +1,4 @@
-import { DocsUrl } from "./types";
+import type { DocsUrl } from "./types";
 
 export function parseDocsUrlParam({ docsUrl }: { docsUrl: string }): DocsUrl {
   return decodeURIComponent(docsUrl) as DocsUrl;

--- a/packages/fern-dashboard/tsconfig.json
+++ b/packages/fern-dashboard/tsconfig.json
@@ -8,7 +8,10 @@
     "types": ["node", "next", "vitest/globals"],
     "strictNullChecks": true,
     "skipLibCheck": true,
-    "plugins": [{ "name": "next" }]
+    "plugins": [{ "name": "next" }],
+    "verbatimModuleSyntax": true,
+    "isolatedDeclarations": true,
+    "allowJs": false
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Short description of the changes made
- enabled verbatimModuleSyntax and isolatedDeclarations on fern-dashboard
- fixed all type-checking errors in fern-dashboard

## What was the motivation & context behind this PR?
- verbatimModuleSyntax helps the compiler know when to _stop_ crawling for modules
- isolatedDeclarations speeds up typescript by letting it avoid crawling additional modules for type inference.