### PR TITLE
fix(docs): do not cache favicon on hosts that have multi-domain re-routing

### DIFF
--- a/packages/commons/docs-loader/src/readonly-docs-loader.ts
+++ b/packages/commons/docs-loader/src/readonly-docs-loader.ts
@@ -551,7 +551,6 @@ const getApi = async (domainKey: string, id: string) => {
       notFound();
     }
   }
-  console.log("CALLING V1 TO LATEST")
   const flags = await cachedGetEdgeFlags(domainKey);
   return ApiDefinitionV1ToLatest.from(v1, flags).migrate();
 };
@@ -570,12 +569,11 @@ const createGetPrunedApiCached = (
       try {
         if (nodes.length === 1 && nodes[0]) {
           const key = `api:${id}:${createEndpointCacheKey(nodes[0])}`;
-          // const cached = await kvGet<ApiDefinition.ApiDefinition>(
-          //   domainKey,
-          //   key,
-          //   cacheConfig.cacheKeySuffix
-          // );
-          const cached = null;
+          const cached = await kvGet<ApiDefinition.ApiDefinition>(
+            domainKey,
+            key,
+            cacheConfig.cacheKeySuffix
+          );
           if (cached != null) {
             const metadata = await getMetadata(cacheConfig)(domainKey);
             const dynamicIr = await getDynamicIr(id)(

--- a/packages/commons/docs-loader/src/readonly-docs-loader.ts
+++ b/packages/commons/docs-loader/src/readonly-docs-loader.ts
@@ -551,6 +551,7 @@ const getApi = async (domainKey: string, id: string) => {
       notFound();
     }
   }
+  console.log("CALLING V1 TO LATEST")
   const flags = await cachedGetEdgeFlags(domainKey);
   return ApiDefinitionV1ToLatest.from(v1, flags).migrate();
 };
@@ -569,11 +570,12 @@ const createGetPrunedApiCached = (
       try {
         if (nodes.length === 1 && nodes[0]) {
           const key = `api:${id}:${createEndpointCacheKey(nodes[0])}`;
-          const cached = await kvGet<ApiDefinition.ApiDefinition>(
-            domainKey,
-            key,
-            cacheConfig.cacheKeySuffix
-          );
+          // const cached = await kvGet<ApiDefinition.ApiDefinition>(
+          //   domainKey,
+          //   key,
+          //   cacheConfig.cacheKeySuffix
+          // );
+          const cached = null;
           if (cached != null) {
             const metadata = await getMetadata(cacheConfig)(domainKey);
             const dynamicIr = await getDynamicIr(id)(

--- a/packages/fdr-sdk/src/api-definition/endpoint-context.ts
+++ b/packages/fdr-sdk/src/api-definition/endpoint-context.ts
@@ -21,7 +21,7 @@ export type EndpointContext = {
   node: EndpointNode;
   endpoint: EndpointDefinition;
   globalHeaders: ObjectProperty[];
-  auth: AuthScheme | undefined;
+  auths: AuthScheme[];
   types: Record<TypeId, TypeDefinition>;
 };
 
@@ -40,7 +40,7 @@ export function createEndpointContext(
   return {
     node,
     endpoint,
-    auth: endpoint.auth?.map((id) => api.auths[id])[0],
+    auths: endpoint.auth?.map((id) => api.auths[id]).filter((auth): auth is AuthScheme => auth != null) ?? [],
     globalHeaders: api.globalHeaders ?? [],
     types: api.types,
   };
@@ -50,7 +50,7 @@ export type WebSocketContext = {
   node: WebSocketNode;
   channel: WebSocketChannel;
   globalHeaders: ObjectProperty[];
-  auth: AuthScheme | undefined;
+  auths: AuthScheme[];
   types: Record<TypeId, TypeDefinition>;
 };
 
@@ -69,7 +69,7 @@ export function createWebSocketContext(
   return {
     node,
     channel,
-    auth: channel.auth?.map((id) => api.auths[id])[0],
+    auths: channel.auth?.map((id) => api.auths[id]).filter((auth): auth is AuthScheme => auth != null) ?? [],
     globalHeaders: api.globalHeaders ?? [],
     types: api.types,
   };

--- a/packages/fdr-sdk/src/api-definition/endpoint-context.ts
+++ b/packages/fdr-sdk/src/api-definition/endpoint-context.ts
@@ -40,7 +40,10 @@ export function createEndpointContext(
   return {
     node,
     endpoint,
-    auths: endpoint.auth?.map((id) => api.auths[id]).filter((auth): auth is AuthScheme => auth != null) ?? [],
+    auths:
+      endpoint.auth
+        ?.map((id) => api.auths[id])
+        .filter((auth): auth is AuthScheme => auth != null) ?? [],
     globalHeaders: api.globalHeaders ?? [],
     types: api.types,
   };
@@ -69,7 +72,10 @@ export function createWebSocketContext(
   return {
     node,
     channel,
-    auths: channel.auth?.map((id) => api.auths[id]).filter((auth): auth is AuthScheme => auth != null) ?? [],
+    auths:
+      channel.auth
+        ?.map((id) => api.auths[id])
+        .filter((auth): auth is AuthScheme => auth != null) ?? [],
     globalHeaders: api.globalHeaders ?? [],
     types: api.types,
   };

--- a/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
+++ b/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
@@ -149,6 +149,8 @@ export class ApiDefinitionV1ToLatest {
         this.migrateSubpackage(subpackage);
     });
 
+    console.log("v1 has authSchemes?", this.v1.authSchemes);
+
     return {
       id: this.v1.id,
       endpoints: this.endpoints,
@@ -156,7 +158,7 @@ export class ApiDefinitionV1ToLatest {
       webhooks: this.webhooks,
       types: this.types,
       subpackages: this.subpackages,
-      auths: this.v1.auth ? { [AUTH_SCHEME_ID]: this.v1.auth } : {},
+      auths: this.v1.authSchemes ? this.v1.authSchemes : this.v1.auth ? { [AUTH_SCHEME_ID]: this.v1.auth } : {},
       globalHeaders: this.migrateParameters(this.v1.globalHeaders),
       snippetsConfiguration: this.v1.snippetsConfiguration,
     };
@@ -195,6 +197,9 @@ export class ApiDefinitionV1ToLatest {
     v1: APIV1Read.EndpointDefinition,
     namespace: V2.SubpackageId[]
   ): V2.EndpointDefinition => {
+    console.log("KENNY HERE", id);
+    console.log("v1.authV2", v1.authV2);
+    console.log("v1.authed", v1.authed);
     const toRet: V2.EndpointDefinition = {
       id,
       namespace,
@@ -204,7 +209,7 @@ export class ApiDefinitionV1ToLatest {
       availability: v1.availability,
       method: v1.method,
       path: v1.path.parts.filter((part) => part.value !== ""),
-      auth: v1.authed ? [AUTH_SCHEME_ID] : undefined,
+      auth: v1.authV2 ? v1.authV2 : v1.authed ? [AUTH_SCHEME_ID] : undefined,
       defaultEnvironment: v1.defaultEnvironment,
       environments: v1.environments,
       pathParameters: this.migrateParameters(v1.path.pathParameters),

--- a/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
+++ b/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
@@ -156,7 +156,11 @@ export class ApiDefinitionV1ToLatest {
       webhooks: this.webhooks,
       types: this.types,
       subpackages: this.subpackages,
-      auths: this.v1.authSchemes ? this.v1.authSchemes : this.v1.auth ? { [AUTH_SCHEME_ID]: this.v1.auth } : {},
+      auths: this.v1.authSchemes
+        ? this.v1.authSchemes
+        : this.v1.auth
+          ? { [AUTH_SCHEME_ID]: this.v1.auth }
+          : {},
       globalHeaders: this.migrateParameters(this.v1.globalHeaders),
       snippetsConfiguration: this.v1.snippetsConfiguration,
     };

--- a/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
+++ b/packages/fdr-sdk/src/api-definition/migrators/v1ToV2.ts
@@ -149,8 +149,6 @@ export class ApiDefinitionV1ToLatest {
         this.migrateSubpackage(subpackage);
     });
 
-    console.log("v1 has authSchemes?", this.v1.authSchemes);
-
     return {
       id: this.v1.id,
       endpoints: this.endpoints,
@@ -197,9 +195,6 @@ export class ApiDefinitionV1ToLatest {
     v1: APIV1Read.EndpointDefinition,
     namespace: V2.SubpackageId[]
   ): V2.EndpointDefinition => {
-    console.log("KENNY HERE", id);
-    console.log("v1.authV2", v1.authV2);
-    console.log("v1.authed", v1.authed);
     const toRet: V2.EndpointDefinition = {
       id,
       namespace,

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/favicon.ico/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/favicon.ico/route.ts
@@ -34,14 +34,18 @@ export async function GET(
         // Disable caching for FERN_DOCS_ORIGINS hosts and localhost:3000
         const isFernDocsOrigin = FERN_DOCS_ORIGINS.includes(host);
         const isLocalhost = host === "localhost:3000";
-        const cacheControl = (isFernDocsOrigin || isLocalhost)
-          ? "no-cache, no-store, must-revalidate" 
-          : "public, max-age=31536000";
+        const cacheControl =
+          isFernDocsOrigin || isLocalhost
+            ? "no-cache, no-store, must-revalidate"
+            : "public, max-age=31536000";
 
-        console.log(`[favicon:${domain}] Host: ${host}, Cache-Control: ${cacheControl}`, {
-          isFernDocsOrigin,
-          isLocalhost,
-        });
+        console.log(
+          `[favicon:${domain}] Host: ${host}, Cache-Control: ${cacheControl}`,
+          {
+            isFernDocsOrigin,
+            isLocalhost,
+          }
+        );
 
         return new NextResponse(faviconBuffer, {
           status: 200,

--- a/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/favicon.ico/route.ts
+++ b/packages/fern-docs/bundle/src/app/[host]/[domain]/api/fern-docs/favicon.ico/route.ts
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
 import { createCachedDocsLoader } from "@fern-api/docs-loader";
-import { COOKIE_FERN_TOKEN } from "@fern-api/docs-utils";
+import { COOKIE_FERN_TOKEN, FERN_DOCS_ORIGINS } from "@fern-api/docs-utils";
 
 export async function GET(
   req: NextRequest,
@@ -31,12 +31,24 @@ export async function GET(
       if (faviconResponse.ok) {
         const faviconBuffer = await faviconResponse.arrayBuffer();
 
+        // Disable caching for FERN_DOCS_ORIGINS hosts and localhost:3000
+        const isFernDocsOrigin = FERN_DOCS_ORIGINS.includes(host);
+        const isLocalhost = host === "localhost:3000";
+        const cacheControl = (isFernDocsOrigin || isLocalhost)
+          ? "no-cache, no-store, must-revalidate" 
+          : "public, max-age=31536000";
+
+        console.log(`[favicon:${domain}] Host: ${host}, Cache-Control: ${cacheControl}`, {
+          isFernDocsOrigin,
+          isLocalhost,
+        });
+
         return new NextResponse(faviconBuffer, {
           status: 200,
           headers: {
             "Content-Type":
               faviconResponse.headers.get("Content-Type") || "image/x-icon",
-            "Cache-Control": "public, max-age=31536000",
+            "Cache-Control": cacheControl,
           },
         });
       }

--- a/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointAuthSection.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointAuthSection.tsx
@@ -1,7 +1,86 @@
 import * as ApiDefinition from "@fern-api/fdr-sdk/api-definition";
 import { visitDiscriminatedUnion } from "@fern-api/ui-core-utils";
 
+import { FernCollapseWithButtonUncontrolled } from "../type-definitions/FernCollapseWithButtonUncontrolled";
+import { PropertyRenderer } from "../type-definitions/ObjectProperty";
+import { WithSeparator } from "../type-definitions/TypeDefinitionDetails";
 import { EndpointSection } from "./EndpointSection";
+
+interface AuthSchemeDisplay {
+  name: string;
+  description: string;
+  availability: ApiDefinition.Availability | undefined;
+  typeShorthand: string;
+}
+
+function authSchemeToDisplay(
+  auth: ApiDefinition.AuthScheme
+): AuthSchemeDisplay {
+  return visitDiscriminatedUnion(auth)._visit<AuthSchemeDisplay>({
+    basicAuth: (basicAuth) => ({
+      name: "Authorization",
+      description:
+        basicAuth.description ??
+        "Basic authentication of the form `Basic <username:password>`.",
+      availability: undefined,
+      typeShorthand: "Basic",
+    }),
+    bearerAuth: (bearerAuth) => ({
+      name: "Authorization",
+      description:
+        bearerAuth.description ??
+        "Bearer authentication of the form `Bearer <token>`, where token is your auth token.",
+      availability: undefined,
+      typeShorthand: "Bearer",
+    }),
+    header: (value) => ({
+      name: value.headerWireValue,
+      description:
+        value.description ??
+        (value.prefix != null
+          ? `Header authentication of the form \`${value.prefix} <token>\``
+          : "API Key authentication via header"),
+      availability: undefined,
+      typeShorthand: value.prefix || "string",
+    }),
+    oAuth: (value) =>
+      visitDiscriminatedUnion(value.value, "type")._visit({
+        clientCredentials: (clientCredentialsValue) =>
+          visitDiscriminatedUnion(clientCredentialsValue.value, "type")._visit({
+            referencedEndpoint: (oauth) => ({
+              name:
+                clientCredentialsValue.value.headerName || "Authorization",
+              description:
+                oauth.description ??
+                `OAuth authentication of the form \`${clientCredentialsValue.value.tokenPrefix ? `${clientCredentialsValue.value.tokenPrefix ?? "Bearer"} ` : ""}<token>\`.`,
+              availability: undefined,
+              typeShorthand:
+                clientCredentialsValue.value.tokenPrefix || "Bearer",
+            }),
+          }),
+      }),
+  });
+}
+
+function AuthSchemeVariant({
+  auth,
+}: {
+  auth: ApiDefinition.AuthScheme;
+}) {
+  const display = authSchemeToDisplay(auth);
+  return (
+    <PropertyRenderer
+      name={display.name}
+      description={display.description}
+      availability={display.availability}
+      typeShorthand={
+        <span className="fern-api-property-type font-mono text-xs text-(color:--grayscale-a11)">
+          {display.typeShorthand}
+        </span>
+      }
+    />
+  );
+}
 
 export function EndpointAuthSection({ auths }: { auths: ApiDefinition.AuthScheme[] }) {
   if (auths.length === 0) {
@@ -10,75 +89,16 @@ export function EndpointAuthSection({ auths }: { auths: ApiDefinition.AuthScheme
 
   return (
     <EndpointSection title="Authentication">
-      <div className="space-y-4">
-        {auths.length > 1 && (
-          <div className="text-sm text-(color:--grayscale-a11)">
-            This endpoint supports multiple authentication methods. Use any one of the following:
-          </div>
-        )}
-        {auths.map((auth, index) => (
-          <div key={index} className="rounded-lg border border-(color:--grayscale-a6) p-4">
-            {visitDiscriminatedUnion(auth)._visit({
-              basicAuth: (basicAuth) => (
-                <>
-                  <div className="font-semibold mb-2">Basic Authentication</div>
-                  <div className="text-sm text-(color:--grayscale-a11)">
-                    {basicAuth.description ?? "Basic authentication of the form `Basic <username:password>`."}
-                  </div>
-                  <div className="mt-2 text-sm font-mono bg-(color:--grayscale-a3) p-2 rounded">
-                    Authorization: Basic {"<username:password>"}
-                  </div>
-                </>
-              ),
-              bearerAuth: (bearerAuth) => (
-                <>
-                  <div className="font-semibold mb-2">Bearer Token</div>
-                  <div className="text-sm text-(color:--grayscale-a11)">
-                    {bearerAuth.description ?? "Bearer authentication of the form `Bearer <token>`, where token is your auth token."}
-                  </div>
-                  <div className="mt-2 text-sm font-mono bg-(color:--grayscale-a3) p-2 rounded">
-                    Authorization: Bearer {"<token>"}
-                  </div>
-                </>
-              ),
-              header: (value) => (
-                <>
-                  <div className="font-semibold mb-2">{value.headerWireValue} Header</div>
-                  <div className="text-sm text-(color:--grayscale-a11)">
-                    {value.description ??
-                      (value.prefix != null
-                        ? `Header authentication of the form \`${value.prefix} <token>\``
-                        : "API Key authentication via header")}
-                  </div>
-                  <div className="mt-2 text-sm font-mono bg-(color:--grayscale-a3) p-2 rounded">
-                    {value.headerWireValue}: {value.prefix ? `${value.prefix} ` : ""}{"<token>"}
-                  </div>
-                </>
-              ),
-              oAuth: (value) =>
-                visitDiscriminatedUnion(value.value, "type")._visit({
-                  clientCredentials: (clientCredentialsValue) =>
-                    visitDiscriminatedUnion(clientCredentialsValue.value, "type")._visit({
-                      referencedEndpoint: (oauth) => (
-                        <>
-                          <div className="font-semibold mb-2">OAuth 2.0</div>
-                          <div className="text-sm text-(color:--grayscale-a11)">
-                            {oauth.description ??
-                              `OAuth authentication of the form \`${clientCredentialsValue.value.tokenPrefix ? `${clientCredentialsValue.value.tokenPrefix ?? "Bearer"} ` : ""}<token>\`.`}
-                          </div>
-                          <div className="mt-2 text-sm font-mono bg-(color:--grayscale-a3) p-2 rounded">
-                            {clientCredentialsValue.value.headerName || "Authorization"}:{" "}
-                            {clientCredentialsValue.value.tokenPrefix ? `${clientCredentialsValue.value.tokenPrefix} ` : ""}
-                            {"<token>"}
-                          </div>
-                        </>
-                      ),
-                    }),
-                }),
-            })}
-          </div>
-        ))}
-      </div>
+      <FernCollapseWithButtonUncontrolled
+        showText={`Show ${auths.length} ${auths.length === 1 ? "method" : "methods"}`}
+        hideText={`Hide ${auths.length} ${auths.length === 1 ? "method" : "methods"}`}
+      >
+        <WithSeparator separatorText={auths.length > 1 ? "OR" : undefined}>
+          {auths.map((auth, index) => (
+            <AuthSchemeVariant key={index} auth={auth} />
+          ))}
+        </WithSeparator>
+      </FernCollapseWithButtonUncontrolled>
     </EndpointSection>
   );
 }

--- a/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointAuthSection.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointAuthSection.tsx
@@ -1,0 +1,84 @@
+import * as ApiDefinition from "@fern-api/fdr-sdk/api-definition";
+import { visitDiscriminatedUnion } from "@fern-api/ui-core-utils";
+
+import { EndpointSection } from "./EndpointSection";
+
+export function EndpointAuthSection({ auths }: { auths: ApiDefinition.AuthScheme[] }) {
+  if (auths.length === 0) {
+    return null;
+  }
+
+  return (
+    <EndpointSection title="Authentication">
+      <div className="space-y-4">
+        {auths.length > 1 && (
+          <div className="text-sm text-(color:--grayscale-a11)">
+            This endpoint supports multiple authentication methods. Use any one of the following:
+          </div>
+        )}
+        {auths.map((auth, index) => (
+          <div key={index} className="rounded-lg border border-(color:--grayscale-a6) p-4">
+            {visitDiscriminatedUnion(auth)._visit({
+              basicAuth: (basicAuth) => (
+                <>
+                  <div className="font-semibold mb-2">Basic Authentication</div>
+                  <div className="text-sm text-(color:--grayscale-a11)">
+                    {basicAuth.description ?? "Basic authentication of the form `Basic <username:password>`."}
+                  </div>
+                  <div className="mt-2 text-sm font-mono bg-(color:--grayscale-a3) p-2 rounded">
+                    Authorization: Basic {"<username:password>"}
+                  </div>
+                </>
+              ),
+              bearerAuth: (bearerAuth) => (
+                <>
+                  <div className="font-semibold mb-2">Bearer Token</div>
+                  <div className="text-sm text-(color:--grayscale-a11)">
+                    {bearerAuth.description ?? "Bearer authentication of the form `Bearer <token>`, where token is your auth token."}
+                  </div>
+                  <div className="mt-2 text-sm font-mono bg-(color:--grayscale-a3) p-2 rounded">
+                    Authorization: Bearer {"<token>"}
+                  </div>
+                </>
+              ),
+              header: (value) => (
+                <>
+                  <div className="font-semibold mb-2">{value.headerWireValue} Header</div>
+                  <div className="text-sm text-(color:--grayscale-a11)">
+                    {value.description ??
+                      (value.prefix != null
+                        ? `Header authentication of the form \`${value.prefix} <token>\``
+                        : "API Key authentication via header")}
+                  </div>
+                  <div className="mt-2 text-sm font-mono bg-(color:--grayscale-a3) p-2 rounded">
+                    {value.headerWireValue}: {value.prefix ? `${value.prefix} ` : ""}{"<token>"}
+                  </div>
+                </>
+              ),
+              oAuth: (value) =>
+                visitDiscriminatedUnion(value.value, "type")._visit({
+                  clientCredentials: (clientCredentialsValue) =>
+                    visitDiscriminatedUnion(clientCredentialsValue.value, "type")._visit({
+                      referencedEndpoint: (oauth) => (
+                        <>
+                          <div className="font-semibold mb-2">OAuth 2.0</div>
+                          <div className="text-sm text-(color:--grayscale-a11)">
+                            {oauth.description ??
+                              `OAuth authentication of the form \`${clientCredentialsValue.value.tokenPrefix ? `${clientCredentialsValue.value.tokenPrefix ?? "Bearer"} ` : ""}<token>\`.`}
+                          </div>
+                          <div className="mt-2 text-sm font-mono bg-(color:--grayscale-a3) p-2 rounded">
+                            {clientCredentialsValue.value.headerName || "Authorization"}:{" "}
+                            {clientCredentialsValue.value.tokenPrefix ? `${clientCredentialsValue.value.tokenPrefix} ` : ""}
+                            {"<token>"}
+                          </div>
+                        </>
+                      ),
+                    }),
+                }),
+            })}
+          </div>
+        ))}
+      </div>
+    </EndpointSection>
+  );
+}

--- a/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointAuthSection.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointAuthSection.tsx
@@ -48,8 +48,7 @@ function authSchemeToDisplay(
         clientCredentials: (clientCredentialsValue) =>
           visitDiscriminatedUnion(clientCredentialsValue.value, "type")._visit({
             referencedEndpoint: (oauth) => ({
-              name:
-                clientCredentialsValue.value.headerName || "Authorization",
+              name: clientCredentialsValue.value.headerName || "Authorization",
               description:
                 oauth.description ??
                 `OAuth authentication of the form \`${clientCredentialsValue.value.tokenPrefix ? `${clientCredentialsValue.value.tokenPrefix ?? "Bearer"} ` : ""}<token>\`.`,
@@ -62,11 +61,7 @@ function authSchemeToDisplay(
   });
 }
 
-function AuthSchemeVariant({
-  auth,
-}: {
-  auth: ApiDefinition.AuthScheme;
-}) {
+function AuthSchemeVariant({ auth }: { auth: ApiDefinition.AuthScheme }) {
   const display = authSchemeToDisplay(auth);
   return (
     <PropertyRenderer
@@ -74,7 +69,7 @@ function AuthSchemeVariant({
       description={display.description}
       availability={display.availability}
       typeShorthand={
-        <span className="fern-api-property-type font-mono text-xs text-(color:--grayscale-a11)">
+        <span className="fern-api-property-type text-(color:--grayscale-a11) font-mono text-xs">
           {display.typeShorthand}
         </span>
       }
@@ -82,7 +77,11 @@ function AuthSchemeVariant({
   );
 }
 
-export function EndpointAuthSection({ auths }: { auths: ApiDefinition.AuthScheme[] }) {
+export function EndpointAuthSection({
+  auths,
+}: {
+  auths: ApiDefinition.AuthScheme[];
+}) {
   if (auths.length === 0) {
     return null;
   }

--- a/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointContentLeft.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointContentLeft.tsx
@@ -35,10 +35,7 @@ export async function EndpointContentLeft({
   showAuth: boolean;
   showErrors: boolean;
 }) {
-  const headers = [
-    ...globalHeaders,
-    ...(endpoint.requestHeaders ?? []),
-  ];
+  const headers = [...globalHeaders, ...(endpoint.requestHeaders ?? [])];
 
   return (
     <>

--- a/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointContentLeft.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointContentLeft.tsx
@@ -12,6 +12,7 @@ import {
   TypeDefinitionResponse,
 } from "../type-definitions/TypeDefinitionContext";
 import { WithSeparator } from "../type-definitions/TypeDefinitionDetails";
+import { EndpointAuthSection } from "./EndpointAuthSection";
 import { EndpointErrorGroup } from "./EndpointErrorGroup";
 import { EndpointMultipleRequestSection } from "./EndpointMultipleRequestSection";
 import { EndpointMultipleResponseSection } from "./EndpointMultipleResponseSection";
@@ -36,99 +37,7 @@ export async function EndpointContentLeft({
   showAuth: boolean;
   showErrors: boolean;
 }) {
-  console.log("EndpointContentLeft")
-  console.log("kenny")
-  console.log(JSON.stringify({ endpoint, types, auths, globalHeaders }, null, 2))
-  console.log("endpoint.auth raw:", endpoint.auth);
-  console.log("context.auths:", auths);
-
-  const authHeaders: ApiDefinition.ObjectProperty[] = [];
-  if (showAuth && auths.length > 0) {
-    const stringShape: ApiDefinition.TypeShape = {
-      type: "alias",
-      value: {
-        type: "primitive",
-        value: {
-          type: "string",
-          format: undefined,
-          regex: undefined,
-          minLength: undefined,
-          maxLength: undefined,
-          default: undefined,
-        },
-      },
-    };
-
-    for (const auth of auths) {
-      const authHeader = visitDiscriminatedUnion(
-        auth
-      )._visit<ApiDefinition.ObjectProperty>({
-        basicAuth: (basicAuth) => {
-          return {
-            key: ApiDefinition.PropertyKey("Authorization"),
-            description:
-              basicAuth.description ??
-              "Basic authentication of the form `Basic <username:password>`.",
-            hidden: false,
-            valueShape: stringShape,
-            availability: undefined,
-            propertyAccess: undefined,
-          };
-        },
-        bearerAuth: (bearerAuth) => {
-          return {
-            key: ApiDefinition.PropertyKey("Authorization"),
-            description:
-              bearerAuth.description ??
-              "Bearer authentication of the form `Bearer <token>`, where token is your auth token.",
-            hidden: false,
-            valueShape: stringShape,
-            availability: undefined,
-            propertyAccess: undefined,
-          };
-        },
-        header: (value) => {
-          return {
-            key: ApiDefinition.PropertyKey(value.headerWireValue),
-            description:
-              (value.description ?? value.prefix != null)
-                ? `Header authentication of the form \`${value.prefix} <token>\``
-                : undefined,
-            hidden: false,
-            valueShape: stringShape,
-            availability: undefined,
-            propertyAccess: undefined,
-          };
-        },
-        oAuth: (value) => {
-          return visitDiscriminatedUnion(value.value, "type")._visit({
-            clientCredentials: (clientCredentialsValue) =>
-              visitDiscriminatedUnion(
-                clientCredentialsValue.value,
-                "type"
-              )._visit({
-                referencedEndpoint: (oauth) => ({
-                  key: ApiDefinition.PropertyKey(
-                    clientCredentialsValue.value.headerName || "Authorization"
-                  ),
-                  description:
-                    oauth.description ??
-                    `OAuth authentication of the form \`${clientCredentialsValue.value.tokenPrefix ? `${clientCredentialsValue.value.tokenPrefix ?? "Bearer"} ` : ""}<token>\`.`,
-                  hidden: false,
-                  valueShape: stringShape,
-                  availability: undefined,
-                  propertyAccess: undefined,
-                }),
-              }),
-          });
-        },
-      });
-      authHeaders.push(authHeader);
-    }
-  }
-
   const headers = [
-    ...authHeaders,
     ...globalHeaders,
     ...(endpoint.requestHeaders ?? []),
   ];
@@ -136,6 +45,11 @@ export async function EndpointContentLeft({
   return (
     <>
       <TypeDefinitionAnchorPart part="request">
+        {showAuth && auths.length > 0 && (
+          <TypeDefinitionAnchorPart part="auth">
+            <EndpointAuthSection auths={auths} />
+          </TypeDefinitionAnchorPart>
+        )}
         {endpoint.pathParameters && endpoint.pathParameters.length > 0 && (
           <TypeDefinitionAnchorPart part="path">
             <EndpointSection title="Path parameters">
@@ -156,35 +70,14 @@ export async function EndpointContentLeft({
           <TypeDefinitionAnchorPart part="header">
             <EndpointSection title="Headers">
               <WithSeparator>
-                {headers.map((parameter) => {
-                  // let isAuth = false;
-                  if (
-                    auths.some((auth) =>
-                      auth.type === "header" &&
-                      parameter.key === auth.headerWireValue
-                    ) ||
-                    parameter.key === "Authorization"
-                  ) {
-                    // isAuth = true;
-                  }
-
-                  // {isAuth && (
-                  //   <div className="absolute right-0 top-3">
-                  //     <div className="bg-(color:--red-a3) flex h-5 items-center rounded-3 px-2">
-                  //       <span className="text-(color:--red-a11) text-xs">Auth</span>
-                  //     </div>
-                  //   </div>
-                  // )}
-
-                  return (
-                    <TypeDefinitionAnchorPart
-                      key={parameter.key}
-                      part={parameter.key}
-                    >
-                      <ObjectProperty property={parameter} types={types} />
-                    </TypeDefinitionAnchorPart>
-                  );
-                })}
+                {headers.map((parameter) => (
+                  <TypeDefinitionAnchorPart
+                    key={parameter.key}
+                    part={parameter.key}
+                  >
+                    <ObjectProperty property={parameter} types={types} />
+                  </TypeDefinitionAnchorPart>
+                ))}
               </WithSeparator>
             </EndpointSection>
           </TypeDefinitionAnchorPart>

--- a/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointContentLeft.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointContentLeft.tsx
@@ -28,7 +28,7 @@ export interface HoveringProps {
 }
 
 export async function EndpointContentLeft({
-  context: { endpoint, types, auth, globalHeaders },
+  context: { endpoint, types, auths, globalHeaders },
   showAuth,
   showErrors,
 }: {
@@ -36,8 +36,14 @@ export async function EndpointContentLeft({
   showAuth: boolean;
   showErrors: boolean;
 }) {
-  let authHeader: ApiDefinition.ObjectProperty | undefined;
-  if (auth && showAuth) {
+  console.log("EndpointContentLeft")
+  console.log("kenny")
+  console.log(JSON.stringify({ endpoint, types, auths, globalHeaders }, null, 2))
+  console.log("endpoint.auth raw:", endpoint.auth);
+  console.log("context.auths:", auths);
+
+  const authHeaders: ApiDefinition.ObjectProperty[] = [];
+  if (showAuth && auths.length > 0) {
     const stringShape: ApiDefinition.TypeShape = {
       type: "alias",
       value: {
@@ -52,73 +58,77 @@ export async function EndpointContentLeft({
         },
       },
     };
-    authHeader = visitDiscriminatedUnion(
-      auth
-    )._visit<ApiDefinition.ObjectProperty>({
-      basicAuth: (basicAuth) => {
-        return {
-          key: ApiDefinition.PropertyKey("Authorization"),
-          description:
-            basicAuth.description ??
-            "Basic authentication of the form `Basic <username:password>`.",
-          hidden: false,
-          valueShape: stringShape,
-          availability: undefined,
-          propertyAccess: undefined,
-        };
-      },
-      bearerAuth: (bearerAuth) => {
-        return {
-          key: ApiDefinition.PropertyKey("Authorization"),
-          description:
-            bearerAuth.description ??
-            "Bearer authentication of the form `Bearer <token>`, where token is your auth token.",
-          hidden: false,
-          valueShape: stringShape,
-          availability: undefined,
-          propertyAccess: undefined,
-        };
-      },
-      header: (value) => {
-        return {
-          key: ApiDefinition.PropertyKey(value.headerWireValue),
-          description:
-            (value.description ?? value.prefix != null)
-              ? `Header authentication of the form \`${value.prefix} <token>\``
-              : undefined,
-          hidden: false,
-          valueShape: stringShape,
-          availability: undefined,
-          propertyAccess: undefined,
-        };
-      },
-      oAuth: (value) => {
-        return visitDiscriminatedUnion(value.value, "type")._visit({
-          clientCredentials: (clientCredentialsValue) =>
-            visitDiscriminatedUnion(
-              clientCredentialsValue.value,
-              "type"
-            )._visit({
-              referencedEndpoint: (oauth) => ({
-                key: ApiDefinition.PropertyKey(
-                  clientCredentialsValue.value.headerName || "Authorization"
-                ),
-                description:
-                  oauth.description ??
-                  `OAuth authentication of the form \`${clientCredentialsValue.value.tokenPrefix ? `${clientCredentialsValue.value.tokenPrefix ?? "Bearer"} ` : ""}<token>\`.`,
-                hidden: false,
-                valueShape: stringShape,
-                availability: undefined,
-                propertyAccess: undefined,
+
+    for (const auth of auths) {
+      const authHeader = visitDiscriminatedUnion(
+        auth
+      )._visit<ApiDefinition.ObjectProperty>({
+        basicAuth: (basicAuth) => {
+          return {
+            key: ApiDefinition.PropertyKey("Authorization"),
+            description:
+              basicAuth.description ??
+              "Basic authentication of the form `Basic <username:password>`.",
+            hidden: false,
+            valueShape: stringShape,
+            availability: undefined,
+            propertyAccess: undefined,
+          };
+        },
+        bearerAuth: (bearerAuth) => {
+          return {
+            key: ApiDefinition.PropertyKey("Authorization"),
+            description:
+              bearerAuth.description ??
+              "Bearer authentication of the form `Bearer <token>`, where token is your auth token.",
+            hidden: false,
+            valueShape: stringShape,
+            availability: undefined,
+            propertyAccess: undefined,
+          };
+        },
+        header: (value) => {
+          return {
+            key: ApiDefinition.PropertyKey(value.headerWireValue),
+            description:
+              (value.description ?? value.prefix != null)
+                ? `Header authentication of the form \`${value.prefix} <token>\``
+                : undefined,
+            hidden: false,
+            valueShape: stringShape,
+            availability: undefined,
+            propertyAccess: undefined,
+          };
+        },
+        oAuth: (value) => {
+          return visitDiscriminatedUnion(value.value, "type")._visit({
+            clientCredentials: (clientCredentialsValue) =>
+              visitDiscriminatedUnion(
+                clientCredentialsValue.value,
+                "type"
+              )._visit({
+                referencedEndpoint: (oauth) => ({
+                  key: ApiDefinition.PropertyKey(
+                    clientCredentialsValue.value.headerName || "Authorization"
+                  ),
+                  description:
+                    oauth.description ??
+                    `OAuth authentication of the form \`${clientCredentialsValue.value.tokenPrefix ? `${clientCredentialsValue.value.tokenPrefix ?? "Bearer"} ` : ""}<token>\`.`,
+                  hidden: false,
+                  valueShape: stringShape,
+                  availability: undefined,
+                  propertyAccess: undefined,
+                }),
               }),
-            }),
-        });
-      },
-    });
+          });
+        },
+      });
+      authHeaders.push(authHeader);
+    }
   }
 
   const headers = [
-    ...(authHeader ? [authHeader] : []),
+    ...authHeaders,
     ...globalHeaders,
     ...(endpoint.requestHeaders ?? []),
   ];
@@ -149,8 +159,10 @@ export async function EndpointContentLeft({
                 {headers.map((parameter) => {
                   // let isAuth = false;
                   if (
-                    (auth?.type === "header" &&
-                      parameter.key === auth?.headerWireValue) ||
+                    auths.some((auth) =>
+                      auth.type === "header" &&
+                      parameter.key === auth.headerWireValue
+                    ) ||
                     parameter.key === "Authorization"
                   ) {
                     // isAuth = true;

--- a/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointContentLeft.tsx
+++ b/packages/fern-docs/bundle/src/components/api-reference/endpoints/EndpointContentLeft.tsx
@@ -1,8 +1,6 @@
 import "server-only";
 
-import * as ApiDefinition from "@fern-api/fdr-sdk/api-definition";
 import { EndpointContext } from "@fern-api/fdr-sdk/api-definition";
-import { visitDiscriminatedUnion } from "@fern-api/ui-core-utils";
 
 import { MdxServerComponentProseSuspense } from "@/mdx/components/server-component";
 

--- a/packages/fern-docs/bundle/src/components/playground/ExplorerContent.tsx
+++ b/packages/fern-docs/bundle/src/components/playground/ExplorerContent.tsx
@@ -49,11 +49,11 @@ export async function ExplorerContent({
   if (node.type === "endpoint") {
     const context = createEndpointContext(node, api);
     if (!context) return null;
-    const authForm = context.auth != null && (
+    const authForm = context.auths[0] != null && (
       <PlaygroundAuthorizationFormCard
         loader={loader}
         apiDefinitionId={node.apiDefinitionId}
-        auth={context.auth}
+        auth={context.auths[0]}
       />
     );
     return (
@@ -66,11 +66,11 @@ export async function ExplorerContent({
   } else if (node.type === "webSocket") {
     const context = createWebSocketContext(node, api);
     if (!context) return null;
-    const authForm = context.auth != null && (
+    const authForm = context.auths[0] != null && (
       <PlaygroundAuthorizationFormCard
         loader={loader}
         apiDefinitionId={node.apiDefinitionId}
-        auth={context.auth}
+        auth={context.auths[0]}
       />
     );
     return <PlaygroundWebSocket context={context} authForm={authForm} />;

--- a/packages/fern-docs/bundle/src/components/playground/code-snippets/builders/curl.ts
+++ b/packages/fern-docs/bundle/src/components/playground/code-snippets/builders/curl.ts
@@ -36,7 +36,7 @@ export class CurlSnippetBuilder extends PlaygroundCodeSnippetBuilder {
         searchParams: this.formState.queryParameters,
         headers: this.formState.headers,
         basicAuth:
-          this.context.auth?.type === "basicAuth"
+          this.context.auths[0]?.type === "basicAuth"
             ? this.authState.basicAuth
             : undefined,
         body: this.#convertFormStateToBody(),

--- a/packages/fern-docs/bundle/src/components/playground/code-snippets/code-snippets.test.ts
+++ b/packages/fern-docs/bundle/src/components/playground/code-snippets/code-snippets.test.ts
@@ -136,7 +136,7 @@ describe("PlaygroundCodeSnippetBuilder", () => {
   const context: EndpointContext = {
     node,
     endpoint,
-    auth: undefined,
+    auths: [],
     types: {},
     globalHeaders: [],
   };

--- a/packages/fern-docs/bundle/src/components/playground/code-snippets/resolver.ts
+++ b/packages/fern-docs/bundle/src/components/playground/code-snippets/resolver.ts
@@ -88,9 +88,9 @@ export class PlaygroundCodeSnippetResolver {
     setOAuthValue: (value: (prev: any) => any) => void
   ) {
     const authHeaders = buildAuthHeaders(
-      this.context.auth != null &&
-        shouldRenderAuth(this.context.endpoint, this.context.auth)
-        ? this.context.auth
+      this.context.auths[0] != null &&
+        shouldRenderAuth(this.context.endpoint, this.context.auths[0])
+        ? this.context.auths[0]
         : undefined,
       authState,
       { redacted: isAuthHeadersRedacted },

--- a/packages/fern-docs/bundle/src/components/playground/endpoint/PlaygroundEndpoint.tsx
+++ b/packages/fern-docs/bundle/src/components/playground/endpoint/PlaygroundEndpoint.tsx
@@ -58,7 +58,8 @@ export const PlaygroundEndpoint = ({
   dynamicIRsByLanguage: DynamicIRsByLanguage | undefined;
 }) => {
   const resolvedPlaygroundState = useResolvedPlaygroundState();
-  const { node, endpoint, auth } = context;
+  const { node, endpoint, auths } = context;
+  const auth = auths[0];
 
   const [formState, setFormState] = usePlaygroundEndpointFormState(context);
 

--- a/packages/fern-docs/bundle/src/components/playground/websocket/PlaygroundWebSocket.tsx
+++ b/packages/fern-docs/bundle/src/components/playground/websocket/PlaygroundWebSocket.tsx
@@ -113,7 +113,7 @@ export const PlaygroundWebSocket: FC<PlaygroundWebSocketProps> = ({
 
       socket.current.onopen = () => {
         const authState = jotaiStore.get(PLAYGROUND_AUTH_STATE_ATOM);
-        const authHeaders = buildAuthHeaders(context.auth, authState, {
+        const authHeaders = buildAuthHeaders(context.auths[0], authState, {
           redacted: false,
         });
         const headers = {
@@ -169,7 +169,7 @@ export const PlaygroundWebSocket: FC<PlaygroundWebSocketProps> = ({
   }, [
     baseUrl,
     context.channel.path,
-    context.auth,
+    context.auths,
     formState.pathParameters,
     formState.queryParameters,
     formState.headers,

--- a/packages/fern-docs/bundle/src/components/playground/websocket/PlaygroundWebSocketHandshakeForm.tsx
+++ b/packages/fern-docs/bundle/src/components/playground/websocket/PlaygroundWebSocketHandshakeForm.tsx
@@ -56,7 +56,7 @@ export const PlaygroundWebSocketHandshakeForm: FC<
 
   if (
     error == null &&
-    context.auth == null &&
+    context.auths.length === 0 &&
     (context.channel.requestHeaders == null ||
       context.channel.requestHeaders.length === 0) &&
     (context.channel.pathParameters == null ||


### PR DESCRIPTION
## Short description of the changes made

## What was the motivation & context behind this PR?

## How has this PR been tested?

bashed on localhost:3000, it works better than before. Still some issues on same-tab refreshing, but I think that's unavoidable
