### PR TITLE
feat(docs): serve agents that accept text/plain or text/markdown right

### DIFF
--- a/packages/fern-docs/bundle/src/middleware.ts
+++ b/packages/fern-docs/bundle/src/middleware.ts
@@ -250,6 +250,20 @@ export const middleware: NextMiddleware = async (request) => {
   }
 
   /**
+   * Content negotiation: If Accept header contains text/plain or text/markdown,
+   * serve the llms.txt version instead
+   */
+  const acceptHeader = request.headers.get("accept");
+  if (
+    acceptHeader &&
+    (acceptHeader.includes("text/plain") ||
+      acceptHeader.includes("text/markdown"))
+  ) {
+    const slug = removeLeadingSlash(pathname);
+    return rewrite(withDomain("/api/fern-docs/llms.txt"), { slug });
+  }
+
+  /**
    * At this point, conform the trailing slash setting or else redirect
    */
   if (isTrailingSlashEnabled() !== request.nextUrl.pathname.endsWith("/")) {


### PR DESCRIPTION
## What was the motivation & context behind this PR?

serve those agents right

## How has this PR been tested?

```
kennyderek@Kennys-MacBook-Pro fern % curl -H "User-Agent: axios/1.8.4" \
     -H "Accept: application/json, text/plain, */*" \
     http://localhost:3000/reference/rerank
# Cohere Documentation

> Cohere's API documentation helps developers easily integrate natural language processing and generation into their products.

export const LandingPageCard = ({ href, title, imgSrc, description }) => (
  <div className="rounded-lg bg-[#F5F4F2] dark:bg-[#0F0F0F] px-6 py-5 hover:bg-[#E9E6DE] dark:hover:bg-[#292929] md:p-8">
    <a
      href={href}
      target="_self"
      className="flex h-full flex-col justify-between"
      style={{ textDecoration: 'none' }}
    >
      <div className="mb-5 flex flex-col justify-between gap-5">
        <h2 className="lg:min-h-20 [@media(min-width:1181px)]:min-h-0">
          {title}
        </h2>

```
