### PR TITLE
feat: Add hyperlink support to visual editor

### DIFF
--- a/packages/fern-dashboard/package.json
+++ b/packages/fern-dashboard/package.json
@@ -87,6 +87,7 @@
     "@tiptap/extension-drag-handle": "^3.0.9",
     "@tiptap/extension-drag-handle-react": "^3.0.9",
     "@tiptap/extension-file-handler": "^3.4.1",
+    "@tiptap/extension-link": "^3.6.5",
     "@tiptap/extension-placeholder": "^3.0.5",
     "@tiptap/pm": "3.4.4",
     "@tiptap/react": "3.4.4",

--- a/packages/fern-dashboard/src/components/editor/BubbleMenu.tsx
+++ b/packages/fern-dashboard/src/components/editor/BubbleMenu.tsx
@@ -1,9 +1,12 @@
 import type { MouseEventHandler } from "react";
+import { useEffect, useState } from "react";
 
 import { useCurrentEditor } from "@tiptap/react";
 import { BubbleMenu as EditorBubbleMenu } from "@tiptap/react/menus";
 
 import { Icon } from "@/components/icon/Icon";
+
+import { LinkPopover } from "./LinkPopover";
 
 type BubbleMenuAction =
     | "setNodeType"
@@ -18,6 +21,20 @@ type BubbleMenuAction =
 
 export default function BubbleMenu() {
     const { editor } = useCurrentEditor();
+    const [showLinkPopover, setShowLinkPopover] = useState(false);
+
+    // Listen for Command+K keyboard shortcut
+    useEffect(() => {
+        const handleOpenLinkPopover = () => {
+            setShowLinkPopover(true);
+        };
+
+        window.addEventListener("tiptap:openLinkPopover", handleOpenLinkPopover);
+
+        return () => {
+            window.removeEventListener("tiptap:openLinkPopover", handleOpenLinkPopover);
+        };
+    }, []);
 
     function menuItemClickHandler(action: BubbleMenuAction) {
         return () => {
@@ -41,8 +58,7 @@ export default function BubbleMenu() {
                     editor.chain().focus().toggleStrike().run();
                     break;
                 case "setLink":
-                    // TODO: This should open an additional popover to edit the link
-                    editor.chain().focus().setLink({ href: "https://www.google.com" }).run();
+                    setShowLinkPopover(true);
                     break;
                 case "toggleCode":
                     editor.chain().focus().toggleCode().run();
@@ -57,54 +73,65 @@ export default function BubbleMenu() {
         };
     }
 
-    return (
-        <EditorBubbleMenu
-            options={{ placement: "top-start" }}
-            shouldShow={({ editor: { isFocused }, state: { selection } }) => {
-                // Don't show the bubble menu if the selection is an image or image upload
-                if (
-                    // @ts-expect-error - type issue with tiptap
-                    selection?.node?.type?.name === "custom-element-v2" ||
-                    // @ts-expect-error - type issue with tiptap
-                    selection?.node?.type?.name === "mediaUpload"
-                ) {
-                    return false;
-                }
+    if (!editor) {
+        return null;
+    }
 
-                // Check if we have an active selection
-                return isFocused && !selection.empty;
-            }}
-        >
-            <div className="border-1 rounded-2 text-gray-1100 flex items-center gap-px border-gray-500 bg-white p-1 shadow-sm">
-                <BubbleMenuItem iconProps={{ variant: "Heading1" }} onClick={menuItemClickHandler("setNodeType")} />
-                <BubbleMenuSeparator />
-                <BubbleMenuItem iconProps={{ variant: "Bold" }} onClick={menuItemClickHandler("toggleBold")} />
-                <BubbleMenuItem iconProps={{ variant: "Italic" }} onClick={menuItemClickHandler("toggleItalic")} />
-                <BubbleMenuItem
-                    iconProps={{ variant: "Underline" }}
-                    onClick={menuItemClickHandler("toggleUnderline")}
-                />
-                {/* 
-        TODO: Add strikethrough
-        <BubbleMenuItem
-          iconProps={{ variant: "Strikethrough" }}
-          onClick={menuItemClickHandler("toggleStrike")}
-        /> */}
-                {/*
-        TODO: Add link
-         <BubbleMenuItem
-          iconProps={{ variant: "Link" }}
-          onClick={menuItemClickHandler("setLink")}
-        /> */}
-                <BubbleMenuItem iconProps={{ variant: "Code" }} onClick={menuItemClickHandler("toggleCode")} />
-                <BubbleMenuSeparator />
-                <BubbleMenuItem iconProps={{ variant: "List" }} onClick={menuItemClickHandler("toggleBulletList")} />
-                <BubbleMenuItem
-                    iconProps={{ variant: "ListOrdered" }}
-                    onClick={menuItemClickHandler("toggleOrderedList")}
-                />
-            </div>
-        </EditorBubbleMenu>
+    return (
+        <>
+            <EditorBubbleMenu
+                options={{ placement: "top-start" }}
+                shouldShow={({ editor: { isFocused }, state: { selection } }) => {
+                    // Don't show the bubble menu if the link popover is open
+                    if (showLinkPopover) {
+                        return false;
+                    }
+
+                    // Don't show the bubble menu if the selection is an image or image upload
+                    if (
+                        // @ts-expect-error - type issue with tiptap
+                        selection?.node?.type?.name === "custom-element-v2" ||
+                        // @ts-expect-error - type issue with tiptap
+                        selection?.node?.type?.name === "mediaUpload"
+                    ) {
+                        return false;
+                    }
+
+                    // Check if we have an active selection
+                    return isFocused && !selection.empty;
+                }}
+            >
+                <div className="border-1 rounded-2 text-gray-1100 flex items-center gap-px border-gray-500 bg-white p-1 shadow-sm">
+                    <BubbleMenuItem
+                        iconProps={{ variant: "Heading1" }}
+                        onClick={menuItemClickHandler("setNodeType")}
+                    />
+                    <BubbleMenuSeparator />
+                    <BubbleMenuItem iconProps={{ variant: "Bold" }} onClick={menuItemClickHandler("toggleBold")} />
+                    <BubbleMenuItem iconProps={{ variant: "Italic" }} onClick={menuItemClickHandler("toggleItalic")} />
+                    <BubbleMenuItem
+                        iconProps={{ variant: "Underline" }}
+                        onClick={menuItemClickHandler("toggleUnderline")}
+                    />
+                    <BubbleMenuItem iconProps={{ variant: "Link" }} onClick={menuItemClickHandler("setLink")} />
+                    <BubbleMenuItem iconProps={{ variant: "Code" }} onClick={menuItemClickHandler("toggleCode")} />
+                    <BubbleMenuSeparator />
+                    <BubbleMenuItem
+                        iconProps={{ variant: "List" }}
+                        onClick={menuItemClickHandler("toggleBulletList")}
+                    />
+                    <BubbleMenuItem
+                        iconProps={{ variant: "ListOrdered" }}
+                        onClick={menuItemClickHandler("toggleOrderedList")}
+                    />
+                </div>
+            </EditorBubbleMenu>
+            {showLinkPopover && (
+                <EditorBubbleMenu options={{ placement: "top-start" }}>
+                    <LinkPopover editor={editor} onClose={() => setShowLinkPopover(false)} />
+                </EditorBubbleMenu>
+            )}
+        </>
     );
 }
 

--- a/packages/fern-dashboard/src/components/editor/LinkPopover.tsx
+++ b/packages/fern-dashboard/src/components/editor/LinkPopover.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { Editor } from "@tiptap/react";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/icon/Icon";
+
+export declare namespace LinkPopover {
+    export interface Props {
+        editor: Editor;
+        onClose: () => void;
+    }
+}
+
+export function LinkPopover({ editor, onClose }: LinkPopover.Props) {
+    const [url, setUrl] = useState("");
+    const [isEditing, setIsEditing] = useState(false);
+
+    useEffect(() => {
+        // Get the current link URL if we're editing an existing link
+        const { href } = editor.getAttributes("link");
+        if (href) {
+            setUrl(href);
+            setIsEditing(true);
+        }
+    }, [editor]);
+
+    const handleSetLink = useCallback(() => {
+        if (!url) {
+            // Remove link if URL is empty
+            editor.chain().focus().unsetLink().run();
+            onClose();
+            return;
+        }
+
+        // Add https:// if no protocol is specified
+        const finalUrl = url.match(/^https?:\/\//) ? url : `https://${url}`;
+
+        editor.chain().focus().setLink({ href: finalUrl }).run();
+        onClose();
+    }, [editor, url, onClose]);
+
+    const handleRemoveLink = useCallback(() => {
+        editor.chain().focus().unsetLink().run();
+        onClose();
+    }, [editor, onClose]);
+
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent) => {
+            if (e.key === "Enter") {
+                e.preventDefault();
+                handleSetLink();
+            } else if (e.key === "Escape") {
+                e.preventDefault();
+                onClose();
+            }
+        },
+        [handleSetLink, onClose]
+    );
+
+    return (
+        <div className="border-1 rounded-2 flex min-w-[300px] flex-col gap-2 border-gray-500 bg-white p-3 shadow-lg">
+            <div className="flex items-center gap-2">
+                <input
+                    type="text"
+                    value={url}
+                    onChange={(e) => setUrl(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    placeholder="Enter URL"
+                    className="border-1 rounded-1 flex-1 border-gray-400 px-2 py-1 text-sm focus:border-blue-600 focus:outline-none"
+                    autoFocus
+                />
+            </div>
+            <div className="flex items-center justify-end gap-2">
+                {isEditing && (
+                    <Button variant="ghost" size="sm" onClick={handleRemoveLink}>
+                        <Icon variant="Trash2" size={16} />
+                        Remove
+                    </Button>
+                )}
+                <Button variant="ghost" size="sm" onClick={onClose}>
+                    Cancel
+                </Button>
+                <Button size="sm" onClick={handleSetLink}>
+                    {isEditing ? "Update" : "Add"} Link
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/packages/fern-dashboard/src/components/editor/TiptapEditor.tsx
+++ b/packages/fern-dashboard/src/components/editor/TiptapEditor.tsx
@@ -26,6 +26,7 @@ import { createCodeBlockComponent } from "./extension-code-block/CodeBlockCompon
 import type { LowlightInstance } from "./extension-code-block/types";
 import CustomElement from "./extension-custom-element";
 import { FVEAttributesExtension } from "./extension-fve-attributes";
+import { LinkExtensionWithShortcut } from "./extension-link/LinkExtensionWithShortcut";
 import { LowlightPlugin } from "./tiptap-node/lowlight/lowlight-plugin";
 import {
     ConfiguredFileHandler,
@@ -60,6 +61,14 @@ const extensions = [
         },
         gapcursor: false,
         codeBlock: false
+    }),
+    LinkExtensionWithShortcut.configure({
+        openOnClick: false,
+        autolink: true,
+        linkOnPaste: true,
+        HTMLAttributes: {
+            class: "text-blue-600 underline cursor-pointer hover:text-blue-800"
+        }
     }),
     FVEAttributesExtension.configure({
         types: dataAttributeNodeTypes

--- a/packages/fern-dashboard/src/components/editor/extension-link/LinkExtensionWithShortcut.ts
+++ b/packages/fern-dashboard/src/components/editor/extension-link/LinkExtensionWithShortcut.ts
@@ -1,0 +1,24 @@
+import Link from "@tiptap/extension-link";
+
+/**
+ * Extended Link extension that adds Command+K keyboard shortcut support.
+ * This allows users to quickly add or edit links by pressing Cmd+K (Mac) or Ctrl+K (Windows/Linux).
+ */
+export const LinkExtensionWithShortcut = Link.extend({
+    addKeyboardShortcuts() {
+        return {
+            "Mod-k": () => {
+                // Get the current link if one exists
+                const { href } = this.editor.getAttributes("link");
+
+                // Dispatch a custom event that the BubbleMenu can listen to
+                const event = new CustomEvent("tiptap:openLinkPopover", {
+                    detail: { href }
+                });
+                window.dispatchEvent(event);
+
+                return true;
+            }
+        };
+    }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1198,6 +1198,9 @@ importers:
       '@tiptap/extension-file-handler':
         specifier: ^3.4.1
         version: 3.4.1(@tiptap/core@3.4.4(@tiptap/pm@3.4.4))(@tiptap/extension-text-style@3.4.1(@tiptap/core@3.4.4(@tiptap/pm@3.4.4)))(@tiptap/pm@3.4.4)
+      '@tiptap/extension-link':
+        specifier: ^3.6.5
+        version: 3.6.5(@tiptap/core@3.4.4(@tiptap/pm@3.4.4))(@tiptap/pm@3.4.4)
       '@tiptap/extension-placeholder':
         specifier: ^3.0.5
         version: 3.0.5(@tiptap/extensions@3.0.5(@tiptap/core@3.4.4(@tiptap/pm@3.4.4))(@tiptap/pm@3.4.4))
@@ -9606,11 +9609,11 @@ packages:
     peerDependencies:
       '@tiptap/core': ^3.0.5
 
-  '@tiptap/extension-link@3.0.5':
-    resolution: {integrity: sha512-4nY6+NP4cPb6s9fdPDElBgmDd+t5+EFTRh+jNtrF0xb/QKolnWVE9/QaTiz1MaagCZy10eYzDQmD+d+BwrIBDA==}
+  '@tiptap/extension-link@3.6.5':
+    resolution: {integrity: sha512-VLCDNwxLC1IPnWT3HLLJUg1Hflf8A2jfs7aNF4vyMTWmKnrk1zmN+VyXQTAkrqr27qE5FnmLhHOYF3SNolNucw==}
     peerDependencies:
-      '@tiptap/core': ^3.0.5
-      '@tiptap/pm': ^3.0.5
+      '@tiptap/core': ^3.6.5
+      '@tiptap/pm': ^3.6.5
 
   '@tiptap/extension-list-item@3.0.5':
     resolution: {integrity: sha512-sLqnv2P8j36wXnVmQTFoBg4HXtRY8GEj3bSEK6k0csNb4D8CXVS6jUkl10azLh/oleRyaEVyhi6tI7aZJAkcMA==}
@@ -16644,6 +16647,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch-native@1.6.6:
     resolution: {integrity: sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==}
@@ -29183,7 +29187,7 @@ snapshots:
     dependencies:
       '@tiptap/core': 3.4.4(@tiptap/pm@3.4.4)
 
-  '@tiptap/extension-link@3.0.5(@tiptap/core@3.4.4(@tiptap/pm@3.4.4))(@tiptap/pm@3.4.4)':
+  '@tiptap/extension-link@3.6.5(@tiptap/core@3.4.4(@tiptap/pm@3.4.4))(@tiptap/pm@3.4.4)':
     dependencies:
       '@tiptap/core': 3.4.4(@tiptap/pm@3.4.4)
       '@tiptap/pm': 3.4.4
@@ -29293,7 +29297,7 @@ snapshots:
       '@tiptap/extension-heading': 3.0.5(@tiptap/core@3.4.4(@tiptap/pm@3.4.4))
       '@tiptap/extension-horizontal-rule': 3.0.5(@tiptap/core@3.4.4(@tiptap/pm@3.4.4))(@tiptap/pm@3.4.4)
       '@tiptap/extension-italic': 3.0.5(@tiptap/core@3.4.4(@tiptap/pm@3.4.4))
-      '@tiptap/extension-link': 3.0.5(@tiptap/core@3.4.4(@tiptap/pm@3.4.4))(@tiptap/pm@3.4.4)
+      '@tiptap/extension-link': 3.6.5(@tiptap/core@3.4.4(@tiptap/pm@3.4.4))(@tiptap/pm@3.4.4)
       '@tiptap/extension-list': 3.0.5(@tiptap/core@3.4.4(@tiptap/pm@3.4.4))(@tiptap/pm@3.4.4)
       '@tiptap/extension-list-item': 3.0.5(@tiptap/extension-list@3.0.5(@tiptap/core@3.4.4(@tiptap/pm@3.4.4))(@tiptap/pm@3.4.4))
       '@tiptap/extension-list-keymap': 3.0.5(@tiptap/extension-list@3.0.5(@tiptap/core@3.4.4(@tiptap/pm@3.4.4))(@tiptap/pm@3.4.4))


### PR DESCRIPTION
## Summary
Implements hyperlink functionality in the TipTap visual editor, addressing the feature request from Lilian. Users can now add and edit hyperlinks directly in the editor without needing to switch to dev mode or manually type markdown syntax.

## Features
✨ **Command+K keyboard shortcut**: Press `Cmd+K` (Mac) or `Ctrl+K` (Windows/Linux) to quickly add or edit links
🔗 **Link button in bubble menu**: Click the link icon when text is selected to open the link editor
📝 **Intuitive link popover**: Clean UI for entering/editing URLs with automatic `https://` prefix
🎨 **Visual styling**: Links appear with blue underline and hover effects for easy identification
🔄 **Auto-link & link-on-paste**: Automatically converts URLs when pasted into the editor

## Demo
### Adding a link
1. Select text in the editor
2. Press `Cmd+K` or click the 🔗 link icon in the bubble menu
3. Enter the URL (e.g., `buildwithfern.com` or `https://buildwithfern.com`)
4. Press `Enter` or click "Add Link"

### Editing a link
1. Select the linked text
2. Press `Cmd+K` or click the 🔗 link icon
3. Modify the URL
4. Press `Enter` or click "Update Link"

### Removing a link
1. Select the linked text
2. Press `Cmd+K` or click the 🔗 link icon
3. Click "Remove" button

## Changes
**Dependencies:**
- Added `@tiptap/extension-link@^3.6.5`

**New Files:**
- `LinkPopover.tsx`: Link editing UI component with URL input and actions
- `extension-link/LinkExtensionWithShortcut.ts`: Custom TipTap extension with Command+K support

**Modified Files:**
- `TiptapEditor.tsx`: Integrated link extension with configuration
- `BubbleMenu.tsx`: Added link button and popover handling

## Technical Implementation
- **Custom event system**: Uses browser events for keyboard shortcut → popover communication
- **URL validation**: Automatically prepends `https://` if no protocol is specified
- **Link state management**: Detects existing links for edit vs. create workflows
- **Keyboard navigation**: Enter to confirm, Escape to cancel
- **Link configuration**: 
  - `openOnClick: false` - Prevents accidental navigation while editing
  - `autolink: true` - Auto-converts typed URLs
  - `linkOnPaste: true` - Creates links when URLs are pasted

## Related
Addresses Slack thread from Lilian about hyperlink support in the visual editor (Wednesday at 10:04 AM).

Before: Users had to either:
- Type full URLs (ugly: `https://example.com/very/long/path`)
- Switch to dev mode and use markdown syntax `[word](link)`

After: Users can select text and press `Cmd+K` or click the link icon!

🤖 Generated with [Claude Code](https://claude.com/claude-code)