### PR TITLE
Fix localStorage quota exceeded error in NavigationStorage

### DIFF
--- a/packages/fern-docs/components/src/navigation/NavigationStorage.ts
+++ b/packages/fern-docs/components/src/navigation/NavigationStorage.ts
@@ -134,8 +134,54 @@ class LocalStorage implements Storage {
 
     set(key: string, value: string): void {
         this.safeOperation(() => {
-            localStorage.setItem(this._storageKey + key, value);
+            try {
+                localStorage.setItem(this._storageKey + key, value);
+            } catch (error) {
+                // If QuotaExceededError, try to make space by removing old entries
+                if (error instanceof DOMException && error.name === "QuotaExceededError") {
+                    console.warn("LocalStorage quota exceeded, cleaning up old entries...");
+                    this.cleanupOldEntries();
+                    // Retry after cleanup
+                    try {
+                        localStorage.setItem(this._storageKey + key, value);
+                    } catch (retryError) {
+                        console.error("Failed to set item even after cleanup:", retryError);
+                        throw retryError;
+                    }
+                } else {
+                    throw error;
+                }
+            }
         }, undefined);
+    }
+
+    /**
+     * Clean up old navigation storage entries to free up space
+     * Keeps only the 5 most recent entries
+     */
+    private cleanupOldEntries(): void {
+        const keys = this.getAllKeys();
+
+        // Extract entries with timestamps from the key format: fern-navigation-storage:YYYY-MM-DD-username-xxx
+        const entries = keys
+            .map((key) => {
+                const withoutPrefix = key.replace(this._storageKey, "");
+                // Extract date from key (format: YYYY-MM-DD-...)
+                const dateMatch = withoutPrefix.match(/^(\d{4}-\d{2}-\d{2})/);
+                return {
+                    key,
+                    date: dateMatch ? new Date(dateMatch[1]) : new Date(0)
+                };
+            })
+            .sort((a, b) => b.date.getTime() - a.date.getTime()); // Sort by date descending
+
+        // Keep only the 5 most recent, remove the rest
+        const entriesToRemove = entries.slice(5);
+
+        console.log(`Removing ${entriesToRemove.length} old navigation storage entries`);
+        entriesToRemove.forEach((entry) => {
+            localStorage.removeItem(entry.key);
+        });
     }
 
     getAllKeys(): string[] {


### PR DESCRIPTION
## Problem
The NavigationStorage was exceeding browser localStorage quota (typically 5-10MB), causing the error:

```
QuotaExceededError: Failed to execute 'setItem' on 'Storage': 
Setting the value of 'fern-navigation-storage:...' exceeded the quota.
```

This broke the entire editor experience as it couldn't save navigation state.

### Root Cause
NavigationStorage stores MDX and HTML content for each page in localStorage. When users work on documentation with many pages or large content, this quickly exceeds the 5-10MB quota.

## Solution

### 1. Catch QuotaExceededError Specifically
```typescript
try {
    localStorage.setItem(this._storageKey + key, value);
} catch (error) {
    if (error instanceof DOMException && error.name === "QuotaExceededError") {
        // Handle quota error
    }
}
```

### 2. Auto-cleanup Old Entries
Added `cleanupOldEntries()` method that:
- Gets all navigation storage keys
- Extracts dates from key format: `fern-navigation-storage:YYYY-MM-DD-username-xxx`
- Sorts entries by date (most recent first)
- **Keeps only the 5 most recent entries**
- Removes the rest

### 3. Retry After Cleanup
After cleaning up old entries, retry the `setItem` operation. If it still fails, log error and gracefully fail.

## Impact

✅ **Editor no longer crashes** when localStorage is full
✅ **Automatic space management** - old sessions are cleaned up
✅ **Graceful degradation** - logs errors but doesn't break
✅ **Keeps recent work** - preserves the 5 most recent sessions

## Code Changes

**File:** `packages/fern-docs/components/src/navigation/NavigationStorage.ts`

- Modified `LocalStorage.set()` to catch QuotaExceededError
- Added `cleanupOldEntries()` private method
- Implemented retry logic after cleanup

## Testing

- [ ] Test with full localStorage (fill it manually)
- [ ] Verify auto-cleanup triggers correctly  
- [ ] Confirm retry succeeds after cleanup
- [ ] Check that 5 most recent entries are kept
- [ ] Verify editor continues working after quota exceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)